### PR TITLE
Fix leak where we would not dealloc memory for a UInt64

### DIFF
--- a/Source/Model/UserClient/UserClient+Protobuf.swift
+++ b/Source/Model/UserClient/UserClient+Protobuf.swift
@@ -24,6 +24,7 @@ extension UserClient {
     
     var hexRemoteIdentifier: UInt64 {
         let pointer = UnsafeMutablePointer<UInt64>.alloc(1)
+        defer { pointer.dealloc(1) }
         NSScanner(string: self.remoteIdentifier).scanHexLongLong(pointer)
         return UInt64(pointer.memory)
     }


### PR DESCRIPTION
This PR fixes a memory leak occurring when generating the hexadecimal of the UserClient identifier.