### PR TITLE
Clear all message data on deletion

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -1118,6 +1118,13 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
         [self.managedObjectContext.zm_fileAssetCache deleteAssetData:self.nonce fileName:self.filename encrypted:NO];
         [self.managedObjectContext.zm_fileAssetCache deleteAssetData:self.nonce fileName:self.filename encrypted:YES];
     }
+
+    self.dataSet = [NSOrderedSet orderedSet];
+    self.cachedGenericAssetMessage = nil;
+    self.assetId = nil;
+    self.associatedTaskIdentifier = nil;
+    self.preprocessedSize = CGSizeZero;
+
     [super removeMessage];
 }
 

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -1117,6 +1117,10 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     if(self.fileMessageData != nil) {
         [self.managedObjectContext.zm_fileAssetCache deleteAssetData:self.nonce fileName:self.filename encrypted:NO];
         [self.managedObjectContext.zm_fileAssetCache deleteAssetData:self.nonce fileName:self.filename encrypted:YES];
+
+        // Delete thumbnail data
+        [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatOriginal encrypted:NO];
+        [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatOriginal encrypted:YES];
     }
 
     self.dataSet = [NSOrderedSet orderedSet];

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -211,6 +211,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 {
     _genericMessage = nil;
     self.dataSet = [NSOrderedSet orderedSet];
+    self.genericMessage = nil;
     [super removeMessage];
 }
 

--- a/Source/Model/Message/ZMImageMessage.m
+++ b/Source/Model/Message/ZMImageMessage.m
@@ -148,6 +148,18 @@
     return self;
 }
 
+- (void)removeMessage
+{
+    [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatPreview encrypted:NO];
+    [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatMedium encrypted:NO];
+    [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatOriginal encrypted:NO];
+
+    self.originalSize = CGSizeZero;
+    self.mediumRemoteIdentifier = nil;
+
+    [super removeMessage];
+}
+
 @end
 
 
@@ -322,7 +334,6 @@
 {
     return [NSOrderedSet orderedSetWithObjects:@(ZMImageFormatPreview), @(ZMImageFormatMedium), nil];
 }
-
 
 - (void)processingDidFinish;
 {

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -339,6 +339,8 @@ NSString * const ZMMessageSenderClientIDKey = @"senderClientID";
 {
     self.hiddenInConversation = self.conversation;
     self.visibleInConversation = nil;
+    self.sender = nil;
+    self.senderClientID = nil;
 }
 
 + (void)removeMessageWithRemotelyHiddenMessage:(ZMMessageHide *)hiddenMessage fromUser:(ZMUser *)user inManagedObjectContext:(NSManagedObjectContext *)moc;

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -749,6 +749,12 @@ NSString * const ZMMessageSenderClientIDKey = @"senderClientID";
     return nil;
 }
 
+- (void)removeMessage
+{
+    self.text = nil;
+    [super removeMessage];
+}
+
 @end
 
 

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -24,7 +24,7 @@ import XCTest
 
 class ZMClientMessageTests_Deletion: BaseZMMessageTests {
     
-    func testThatItDeletesAMessageFromTheManagedObjectContext() {
+    func testThatItDeletesAMessage() {
         // given
         let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
         guard let sut = conversation.appendMessageWithText(name!) as? ZMMessage else { return XCTFail() }
@@ -41,11 +41,18 @@ class ZMClientMessageTests_Deletion: BaseZMMessageTests {
         assertDeletedContent(ofMessage: sut as! ZMOTRMessage, inConversation: conversation)
     }
     
-    func testThatItDeletesAnAssetMessageFromTheManagedObjectContext() {
+    func testThatItDeletesAnAssetMessage_Image() {
         // given
         setUpCaches()
         let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
         guard let sut = conversation.appendOTRMessageWithImageData(mediumJPEGData(), nonce: .createUUID()) else { return XCTFail() }
+        
+        let cache = uiMOC.zm_imageAssetCache
+        cache.storeAssetData(sut.nonce, format: .Preview, encrypted: false, data: verySmallJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Medium, encrypted: false, data: mediumJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Original, encrypted: false, data: mediumJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Preview, encrypted: true, data: verySmallJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Medium, encrypted: true, data: mediumJPEGData())
         
         // when
         performPretendingUiMocIsSyncMoc {
@@ -57,6 +64,132 @@ class ZMClientMessageTests_Deletion: BaseZMMessageTests {
         
         // then
         assertDeletedContent(ofMessage: sut, inConversation: conversation)
+        wipeCaches()
+    }
+    
+    func testThatItDeletesAnAssetMessage_File() {
+        // given
+        setUpCaches()
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        let data = "Hello World".dataUsingEncoding(NSUTF8StringEncoding)!
+        let documents = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true).first!
+        let url = NSURL(fileURLWithPath: documents).URLByAppendingPathComponent("file.dat")
+
+        defer { try! NSFileManager.defaultManager().removeItemAtURL(url) }
+
+        data.writeToURL(url, atomically: true)
+        let fileMetaData = ZMFileMetadata(fileURL: url, thumbnail: verySmallJPEGData())
+        guard let sut = conversation.appendOTRMessageWithFileMetadata(fileMetaData, nonce: .createUUID()) else { return XCTFail() }
+
+        let cache = uiMOC.zm_imageAssetCache
+        let fileCache = uiMOC.zm_fileAssetCache
+        
+        cache.storeAssetData(sut.nonce, format: .Original, encrypted: true, data: verySmallJPEGData())
+        fileCache.storeAssetData(sut.nonce, fileName: "file.dat", encrypted: true, data: mediumJPEGData())
+        
+        XCTAssertNotNil(cache.assetData(sut.nonce, format: .Original, encrypted: false))
+        XCTAssertNotNil(fileCache.assetData(sut.nonce, fileName: "file.dat", encrypted: false))
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            sut.deleteForEveryone()
+        }
+        
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        assertDeletedContent(ofMessage: sut, inConversation: conversation, fileName: "file.dat")
+        wipeCaches()
+    }
+    
+    func testThatItDeletesAPreEndtoEndPlainTextMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        let sut = ZMTextMessage.insertNewObjectInManagedObjectContext(uiMOC) // Pre e2ee plain text message
+        
+        sut.visibleInConversation = conversation
+        sut.nonce = .createUUID()
+        sut.sender = selfUser
+
+        // when
+        performPretendingUiMocIsSyncMoc {
+            sut.deleteForEveryone()
+        }
+
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertTrue(sut.hasBeenDeleted)
+        XCTAssertNil(sut.visibleInConversation)
+        XCTAssertEqual(sut.hiddenInConversation, conversation)
+        XCTAssertNil(sut.text)
+        XCTAssertNil(sut.messageText)
+        XCTAssertNil(sut.sender)
+        XCTAssertNil(sut.senderClientID)
+    }
+    
+    func testThatItDeletesAPreEndtoEndKnockMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        let sut = ZMKnockMessage.insertNewObjectInManagedObjectContext(uiMOC) // Pre e2ee knock message
+        
+        sut.visibleInConversation = conversation
+        sut.nonce = .createUUID()
+        sut.sender = selfUser
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            sut.deleteForEveryone()
+        }
+        
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertTrue(sut.hasBeenDeleted)
+        XCTAssertNil(sut.visibleInConversation)
+        XCTAssertEqual(sut.hiddenInConversation, conversation)
+        XCTAssertNil(sut.sender)
+        XCTAssertNil(sut.senderClientID)
+    }
+    
+    func testThatItDeletesAPreEndToEndImageMessage() {
+        // given
+        setUpCaches()
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        let sut = ZMImageMessage.insertNewObjectInManagedObjectContext(uiMOC) // Pre e2ee image message
+        
+        sut.visibleInConversation = conversation
+        sut.nonce = .createUUID()
+        sut.sender = selfUser
+        
+        let cache = uiMOC.zm_imageAssetCache
+        cache.storeAssetData(sut.nonce, format: .Preview, encrypted: false, data: verySmallJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Medium, encrypted: false, data: mediumJPEGData())
+        cache.storeAssetData(sut.nonce, format: .Original, encrypted: false, data: mediumJPEGData())
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            sut.deleteForEveryone()
+        }
+        
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        // then
+        XCTAssertTrue(sut.hasBeenDeleted)
+        XCTAssertNil(sut.visibleInConversation)
+        XCTAssertEqual(sut.hiddenInConversation, conversation)
+        XCTAssertNil(sut.mediumRemoteIdentifier)
+        XCTAssertNil(sut.mediumData)
+        XCTAssertNil(sut.sender)
+        XCTAssertNil(sut.senderClientID)
+        
+        XCTAssertNil(cache.assetData(sut.nonce, format: .Original, encrypted: false))
+        XCTAssertNil(cache.assetData(sut.nonce, format: .Medium, encrypted: false))
+        XCTAssertNil(cache.assetData(sut.nonce, format: .Preview, encrypted: false))
         wipeCaches()
     }
     
@@ -291,7 +424,7 @@ extension ZMClientMessageTests_Deletion {
         return createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: senderID)
     }
     
-    func assertDeletedContent(ofMessage message: ZMOTRMessage, inConversation conversation: ZMConversation, line: UInt = #line) {
+    func assertDeletedContent(ofMessage message: ZMOTRMessage, inConversation conversation: ZMConversation, fileName: String? = nil, line: UInt = #line) {
         XCTAssertTrue(message.hasBeenDeleted, line: line)
         XCTAssertNil(message.visibleInConversation, line: line)
         XCTAssertEqual(message.hiddenInConversation, conversation, line: line)
@@ -309,6 +442,19 @@ extension ZMClientMessageTests_Deletion {
             XCTAssertEqual(assetMessage.size, 0, line: line)
             XCTAssertEqual(assetMessage.mimeType, "", line: line)
             XCTAssertNil(assetMessage.genericAssetMessage, line: line)
+
+            let cache = uiMOC.zm_imageAssetCache
+            XCTAssertNil(cache.assetData(message.nonce, format: .Original, encrypted: false))
+            XCTAssertNil(cache.assetData(message.nonce, format: .Medium, encrypted: false))
+            XCTAssertNil(cache.assetData(message.nonce, format: .Preview, encrypted: false))
+            XCTAssertNil(cache.assetData(message.nonce, format: .Medium, encrypted: true))
+            XCTAssertNil(cache.assetData(message.nonce, format: .Preview, encrypted: true))
+
+            guard let fileName = fileName else { return }
+            let fileCache = uiMOC.zm_fileAssetCache
+            XCTAssertNil(fileCache.assetData(message.nonce, fileName: fileName, encrypted: true))
+            XCTAssertNil(fileCache.assetData(message.nonce, fileName: fileName, encrypted: false))
+            
         } else if let clientMessage = message as? ZMClientMessage {
             XCTAssertNil(clientMessage.genericMessage, line: line)
         }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -577,7 +577,7 @@
     // then
     XCTAssertNil(newMessage);
     XCTAssertNil(message.visibleInConversation);
-    XCTAssertEqual(message.hiddenInConversation, conversation);
+    XCTAssertTrue(message.isZombieObject);
     XCTAssertNil(message.textMessageData);
     XCTAssertNil(message.sender);
     XCTAssertNil(message.senderClientID);

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -67,9 +67,10 @@
         XCTAssertEqualObjects(newMessage.textMessageData.messageText, newText);
         XCTAssertEqualObjects(newMessage.genericMessage.edited.replacingMessageId, originalNonce.transportString);
         XCTAssertNotEqualObjects(newMessage.nonce, originalNonce);
-        
+
         XCTAssertEqual(message.hiddenInConversation, conversation);
         XCTAssertNil(message.visibleInConversation);
+
         XCTAssertEqualObjects(message.textMessageData.messageText, oldText);
     } else {
         XCTAssertEqual(conversation.hiddenMessages.count, 0u);
@@ -234,6 +235,13 @@
     XCTAssertEqual(message.hiddenInConversation, conversation);
     XCTAssertNil(message.visibleInConversation);
     XCTAssertNil(message.textMessageData.messageText);
+
+    ZMClientMessage *clientMessage = (ZMClientMessage *)message;
+    XCTAssertNil(clientMessage.genericMessage);
+    XCTAssertEqual(clientMessage.dataSet.count, 0lu);
+    XCTAssertNil(message.textMessageData);
+    XCTAssertNil(message.sender);
+    XCTAssertNil(message.senderClientID);
 }
 
 - (void)testThatItDoesNotOverwritesEditedTextWhenMessageExpiresButReplacesNonce
@@ -397,6 +405,13 @@
         XCTAssertEqualObjects(message.nonce, oldNonce);
         XCTAssertNil(message.visibleInConversation);
         XCTAssertEqual(message.hiddenInConversation, conversation);
+
+        ZMClientMessage *clientMessage = (ZMClientMessage *)message;
+        XCTAssertNil(clientMessage.genericMessage);
+        XCTAssertEqual(clientMessage.dataSet.count, 0lu);
+        XCTAssertNil(message.textMessageData);
+        XCTAssertNil(message.sender);
+        XCTAssertNil(message.senderClientID);
     } else {
         XCTAssertNotNil(message.textMessageData.messageText);
         XCTAssertEqualObjects(message.nonce, oldNonce);
@@ -443,6 +458,13 @@
         XCTAssertEqualObjects(newMessage.nonce, newNonce);
         XCTAssertEqual(newMessage.visibleInConversation, conversation);
         XCTAssertNil(newMessage.hiddenInConversation);
+
+        ZMClientMessage *clientMessage = (ZMClientMessage *)message;
+        XCTAssertNil(clientMessage.genericMessage);
+        XCTAssertEqual(clientMessage.dataSet.count, 0lu);
+        XCTAssertNil(message.textMessageData);
+        XCTAssertNil(message.sender);
+        XCTAssertNil(message.senderClientID);
     } else {
         XCTAssertNil(newMessage);
     }
@@ -554,6 +576,15 @@
     
     // then
     XCTAssertNil(newMessage);
+    XCTAssertNil(message.visibleInConversation);
+    XCTAssertEqual(message.hiddenInConversation, conversation);
+    XCTAssertNil(message.textMessageData);
+    XCTAssertNil(message.sender);
+    XCTAssertNil(message.senderClientID);
+    
+    ZMClientMessage *clientMessage = (ZMClientMessage *)message;
+    XCTAssertNil(clientMessage.genericMessage);
+    XCTAssertEqual(clientMessage.dataSet.count, 0lu);
 }
 
 

--- a/Tests/ZMDataModelTestTarget/AppDelegate.m
+++ b/Tests/ZMDataModelTestTarget/AppDelegate.m
@@ -36,7 +36,7 @@
     UIViewController *vc = [[UIViewController alloc] init];
     
     UITextView *textView = [[UITextView alloc] init];
-    textView.text = @"This is the test host application for zmessaging-cocoa tests.";
+    textView.text = @"This is the test host application for ZMCDataModel tests.";
     [vc.view addSubview:textView];
     textView.backgroundColor = [UIColor greenColor];
     textView.textContainerInset = UIEdgeInsetsMake(22, 22, 22, 22);


### PR DESCRIPTION
### What's in this Pull Request?
___

When deleting a message for everyone we want to make sure to clear all possible content of the deleted message. 

### Changes
___

* When calling `-removeMessage` on a `ZMMessage` we now also set the `sender` and `senderClientID ` to `nil`, reseting the timestamp would not make sense as a system message will be shown using the same timestamp on receiving devices.
* The same method called on a `ZMAssetClientMessage` did already remove the cashed file data, but did not remove a potentially present thumbnail image. The generic message data set was not removed which means that the asset could have been re-downloaded using the `assetId` and the encryption keys. Now the data set, `assetID`, as well as the generic message cache is cleared.
* When calling the same method on old, pre-e2ee messages (only sent before version 2.0) they only got hidden in the conversation and no content got cleared.  We now clear the cache as well as reset the `mediumRemoteIdentifier` in case old, unencrypted image messages get deleted and reset the text of unencrypted text messages.

### Testing
___

This includes unit tests to verify the deletion behavior, testing this on device is possible by inspecting the database and verifying the content is gone (as well as checking the caches in case for assets).

