### PR TITLE
Do not clear the sender when removing a message caused by an edit

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -46,7 +46,7 @@ extension ZMMessage {
         ZMConversation.appendHideMessageToSelfConversation(self)
 
         // To avoid reinserting when receiving an edit we delete the message locally
-        removeMessage()
+        removeMessageClearingSender(true)
         managedObjectContext?.deleteObject(self)
     }
     
@@ -63,7 +63,7 @@ extension ZMMessage {
         let deletedMessage = ZMGenericMessage(deleteMessage: nonce.transportString(), nonce: NSUUID().transportString())
         
         conversation.appendGenericMessage(deletedMessage, expires:false, hidden: true)
-        removeMessage()
+        removeMessageClearingSender(true)
     }
     
     public static func edit(message: ZMConversationMessage, newText: String) -> ZMMessage? {
@@ -84,7 +84,7 @@ extension ZMMessage {
         let oldIndex = conversation.messages.indexOfObject(self)
         let newIndex = conversation.messages.indexOfObject(newMessage)
         conversation.mutableMessages.moveObjectsAtIndexes(NSIndexSet(index:newIndex), toIndex: oldIndex)
-        
+
         hiddenInConversation = conversation
         visibleInConversation = nil
         newMessage.linkPreviewState = .WaitingToBeProcessed

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -1117,7 +1117,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 #pragma mark - Deletion
 @implementation ZMAssetClientMessage (Deletion)
 
-- (void)removeMessage {
+- (void)removeMessageClearingSender:(BOOL)clearingSender {
     if(self.imageMessageData != nil) {
         [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatOriginal encrypted:NO];
         [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatPreview encrypted:NO];
@@ -1140,7 +1140,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     self.associatedTaskIdentifier = nil;
     self.preprocessedSize = CGSizeZero;
 
-    [super removeMessage];
+    [super removeMessageClearingSender:clearingSender];
 }
 
 @end

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -207,12 +207,12 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     [self addData:message.data];
 }
 
-- (void)removeMessage
+- (void)removeMessageClearingSender:(BOOL)clearingSender
 {
     _genericMessage = nil;
     self.dataSet = [NSOrderedSet orderedSet];
     self.genericMessage = nil;
-    [super removeMessage];
+    [super removeMessageClearingSender:clearingSender];
 }
 
 - (void)expire
@@ -293,7 +293,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
         }
         NSUUID *originalID = [NSUUID uuidWithTransportString:self.genericMessage.edited.replacingMessageId];
         ZMMessage *original = [ZMMessage fetchMessageWithNonce:originalID forConversation:self.conversation inManagedObjectContext:self.managedObjectContext];
-        [original removeMessage];
+        [original removeMessageClearingSender:NO];
     } else {
         [super updateWithPostPayload:payload updatedKeys:nil];
     }

--- a/Source/Model/Message/ZMImageMessage.m
+++ b/Source/Model/Message/ZMImageMessage.m
@@ -148,7 +148,7 @@
     return self;
 }
 
-- (void)removeMessage
+- (void)removeMessageClearingSender:(BOOL)clearingSender
 {
     [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatPreview encrypted:NO];
     [self.managedObjectContext.zm_imageAssetCache deleteAssetData:self.nonce format:ZMImageFormatMedium encrypted:NO];
@@ -157,7 +157,7 @@
     self.originalSize = CGSizeZero;
     self.mediumRemoteIdentifier = nil;
 
-    [super removeMessage];
+    [super removeMessageClearingSender:clearingSender];
 }
 
 @end

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -74,7 +74,9 @@ extern NSString * const ZMMessageConfirmationKey;
 - (void)resend;
 - (BOOL)shouldGenerateUnreadCount;
 
-- (void)removeMessage;
+/// Removes the message and deletes associated content
+/// @param clearingSender Wether information about the sender should be removed or not
+- (void)removeMessageClearingSender:(BOOL)clearingSender;
 
 /// Removes the message only for clients of the selfUser
 + (void)removeMessageWithRemotelyHiddenMessage:(ZMMessageHide *)hiddenMessage

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -75,7 +75,7 @@ extern NSString * const ZMMessageConfirmationKey;
 - (BOOL)shouldGenerateUnreadCount;
 
 /// Removes the message and deletes associated content
-/// @param clearingSender Wether information about the sender should be removed or not
+/// @param clearingSender Whether information about the sender should be removed or not
 - (void)removeMessageClearingSender:(BOOL)clearingSender;
 
 /// Removes the message only for clients of the selfUser

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -345,12 +345,15 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     return [ZMConversation conversationWithRemoteID:conversationUUID createIfNeeded:YES inContext:moc];
 }
 
-- (void)removeMessage
+- (void)removeMessageClearingSender:(BOOL)clearingSender
 {
     self.hiddenInConversation = self.conversation;
     self.visibleInConversation = nil;
-    self.sender = nil;
-    self.senderClientID = nil;
+
+    if (clearingSender) {
+        self.sender = nil;
+        self.senderClientID = nil;
+    }
 }
 
 + (void)removeMessageWithRemotelyHiddenMessage:(ZMMessageHide *)hiddenMessage fromUser:(ZMUser *)user inManagedObjectContext:(NSManagedObjectContext *)moc;
@@ -368,7 +371,7 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     
     // To avoid reinserting when receiving an edit we delete the message locally
     if (message != nil) {
-        [message removeMessage];
+        [message removeMessageClearingSender:YES];
         [moc deleteObject:message];
     }
 }
@@ -401,7 +404,7 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
         [conversation appendDeletedForEveryoneSystemMessageWithTimestamp:message.serverTimestamp sender:message.sender];
     }
 
-    [message removeMessage];
+    [message removeMessageClearingSender:YES];
 }
 
 + (ZMMessage *)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage *)genericEditMessage inConversation:(ZMConversation *)conversation senderID:(NSUUID *)senderID inManagedObjectContext:(NSManagedObjectContext *)moc;
@@ -417,7 +420,8 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
         return nil;
     }
 
-    [message removeMessage];
+    // We do not want to clear the sender in case of an edit, as the message will still be visible
+    [message removeMessageClearingSender:NO];
     return message;
 }
 
@@ -772,10 +776,10 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     return nil;
 }
 
-- (void)removeMessage
+- (void)removeMessageClearingSender:(BOOL)clearingSender
 {
     self.text = nil;
-    [super removeMessage];
+    [super removeMessageClearingSender:clearingSender];
 }
 
 @end

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -29,6 +29,11 @@ class ZMAssetClientMessageTests : BaseZMClientMessageTests {
         self.setUpCaches()
     }
     
+    override func tearDown() {
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        super.tearDown()
+    }
+    
     func appendImageMessage() {
         let imageData = verySmallJPEGData()
         let messageNonce = NSUUID.createUUID()

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -240,8 +240,7 @@
     XCTAssertNil(clientMessage.genericMessage);
     XCTAssertEqual(clientMessage.dataSet.count, 0lu);
     XCTAssertNil(message.textMessageData);
-    XCTAssertNil(message.sender);
-    XCTAssertNil(message.senderClientID);
+    XCTAssertNotNil(message.sender);
 }
 
 - (void)testThatItDoesNotOverwritesEditedTextWhenMessageExpiresButReplacesNonce
@@ -410,8 +409,7 @@
         XCTAssertNil(clientMessage.genericMessage);
         XCTAssertEqual(clientMessage.dataSet.count, 0lu);
         XCTAssertNil(message.textMessageData);
-        XCTAssertNil(message.sender);
-        XCTAssertNil(message.senderClientID);
+        XCTAssertNotNil(message.sender);
     } else {
         XCTAssertNotNil(message.textMessageData.messageText);
         XCTAssertEqualObjects(message.nonce, oldNonce);
@@ -463,8 +461,7 @@
         XCTAssertNil(clientMessage.genericMessage);
         XCTAssertEqual(clientMessage.dataSet.count, 0lu);
         XCTAssertNil(message.textMessageData);
-        XCTAssertNil(message.sender);
-        XCTAssertNil(message.senderClientID);
+        XCTAssertNotNil(message.sender);
     } else {
         XCTAssertNil(newMessage);
     }

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -2345,13 +2345,22 @@ NSString * const ReactionsKey = @"reactions";
     
     //when
     [self performPretendingUiMocIsSyncMoc:^{
-        [testMessage removeMessage];
+        [testMessage removeMessageClearingSender:YES];
     }];
     [self.uiMOC saveOrRollback];
     
     //then
     ZMMessage *fetchedMessage = [ZMMessage fetchMessageWithNonce:nonce forConversation:conversation inManagedObjectContext:self.uiMOC];
-    return fetchedMessage.visibleInConversation == nil && [fetchedMessage.hiddenInConversation isEqual:conversation];
+    BOOL removed = fetchedMessage.visibleInConversation == nil &&
+                  [fetchedMessage.hiddenInConversation isEqual:conversation] &&
+                   fetchedMessage.sender == nil;
+
+    if ([fetchedMessage isKindOfClass:ZMClientMessage.class]) {
+        ZMClientMessage *clientMessage = (ZMClientMessage *)fetchedMessage;
+        removed &= clientMessage.dataSet.count == 0 && clientMessage.genericMessage == nil;
+    }
+
+    return removed;
 }
 
 - (void)testThatATextMessageIsRemovedWhenAskForDeletion;
@@ -2387,6 +2396,38 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertTrue(removed);
 }
 
+- (void)testThatAnPreE2EETextMessageIsRemovedWhenAskedForDeletion;
+{
+    // when
+    BOOL removed = [self checkThatAMessageIsRemoved:^ZMMessage *{
+        return [ZMTextMessage insertNewObjectInManagedObjectContext:self.uiMOC];
+    }];
+    
+    // then
+    XCTAssertTrue(removed);
+}
+
+- (void)testThatAnPreE2EEImageMessageIsRemovedWhenAskedForDeletion;
+{
+    // when
+    BOOL removed = [self checkThatAMessageIsRemoved:^ZMMessage *{
+        return [ZMImageMessage insertNewObjectInManagedObjectContext:self.uiMOC];
+    }];
+    
+    // then
+    XCTAssertTrue(removed);
+}
+
+- (void)testThatAnPreE2EEKnockMessageIsRemovedWhenAskedForDeletion;
+{
+    // when
+    BOOL removed = [self checkThatAMessageIsRemoved:^ZMMessage *{
+        return [ZMKnockMessage insertNewObjectInManagedObjectContext:self.uiMOC];
+    }];
+    
+    // then
+    XCTAssertTrue(removed);
+}
 
 - (void)testThatAMessageIsRemovedWhenAskForDeletionWithMessageHide;
 {


### PR DESCRIPTION
### [7166](https://wearezeta.atlassian.net/browse/ZIOS-7166): Remotely edited message removes the sender avatar and name
___

* We previously removed the sender remote identifier from a message when calling `[ZMMessage removeMessage]` on it, but in case of an edit we still need this information to update the new message with the correct sender identifier. This lead to an edited message not displaying the sender name / image.
* The `[ZMMessage removeMessage]` has been renamed to `[ZMMessage removeMessageClearingSender:]` and the parameter indicates weather the sender information should be removed.
* This also fixes some flaky test for asset client messages.