### PR TITLE
return object containing message and info if it needs confirmation

### DIFF
--- a/Source/Model/Message/MessageUpdateResult.swift
+++ b/Source/Model/Message/MessageUpdateResult.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+@objc public class MessageUpdateResult : NSObject {
+
+    public let message : ZMMessage?
+    public let needsConfirmation : Bool
+    public let wasInserted : Bool
+    
+    public init(message : ZMMessage?, needsConfirmation: Bool, wasInserted: Bool) {
+        self.message = message
+        self.needsConfirmation = needsConfirmation
+        self.wasInserted = wasInserted
+        super.init()
+    }
+}
+

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -33,6 +33,7 @@
 @class ZMUpdateEvent;
 @class ZMMessageConfirmation;
 @class ZMReaction;
+@class ZMClientMessage;
 
 @protocol UserClientType;
 
@@ -174,8 +175,8 @@ extern NSString * const ZMMessageConfirmationKey;
 /// Sets a flag to mark the message as being delivered to the backend
 - (void)markAsSent;
 
-/// Inserts a ZMConfirmation message into the conversation that is sent back to the sender
-- (void)confirmReception;
+/// Inserts and returns a ZMConfirmation message into the conversation that is sent back to the sender
+- (ZMClientMessage *)confirmReception;
 
 
 + (instancetype)fetchMessageWithNonce:(NSUUID *)nonce

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -206,10 +206,10 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     self.isExpired = NO;
 }
 
-- (void)confirmReception
+- (ZMClientMessage *)confirmReception
 {
     ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithConfirmation:self.nonce.transportString type:ZMConfirmationTypeDELIVERED nonce:[NSUUID UUID].transportString];
-    [self.conversation appendGenericMessage:genericMessage expires:YES hidden:YES];
+    return [self.conversation appendGenericMessage:genericMessage expires:YES hidden:YES];
 }
 
 - (void)expire;

--- a/Source/Model/Message/ZMOTRMessage.h
+++ b/Source/Model/Message/ZMOTRMessage.h
@@ -20,6 +20,7 @@
 #import "ZMMessage+Internal.h"
 
 @class UserClient;
+@class MessageUpdateResult;
 
 extern NSString * const DeliveredKey;
 
@@ -40,5 +41,13 @@ extern NSString * const DeliveredKey;
                                          inConversation:(ZMConversation *)conversation
                                  inManagedObjectContext:(NSManagedObjectContext *)moc
                                          prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult;
+
++ (MessageUpdateResult *)messageUpdateResultFromUpdateEvent:(ZMUpdateEvent *)updateEvent
+                                     inManagedObjectContext:(NSManagedObjectContext *)moc
+                                             prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult;
+
++ (instancetype)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent
+                              inManagedObjectContext:(NSManagedObjectContext *)moc
+                                      prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult NS_UNAVAILABLE;
 
 @end

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -123,9 +123,10 @@ NSString * const DeliveredKey = @"delivered";
                                 prefetchResult:prefetchResult];
 }
 
-+ (id)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent
-                    inManagedObjectContext:(NSManagedObjectContext *)moc
-                            prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult
+
++ (MessageUpdateResult *)messageUpdateResultFromUpdateEvent:(ZMUpdateEvent *)updateEvent
+                                     inManagedObjectContext:(NSManagedObjectContext *)moc
+                                             prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult
 {
     ZMGenericMessage *message;
     @try {
@@ -216,12 +217,14 @@ NSString * const DeliveredKey = @"delivered";
         [(ZMClientMessage *)clientMessage setUpdatedTimestamp:updateEvent.timeStamp];
     }
     
+    BOOL needsConfirmation = NO;
     if (isNewMessage && !clientMessage.sender.isSelfUser && conversation.conversationType == ZMConversationTypeOneOnOne) {
-        [clientMessage confirmReception];
+        needsConfirmation = YES;
     }
     
-    return clientMessage;
-
+    MessageUpdateResult *result = [[MessageUpdateResult alloc] initWithMessage:clientMessage needsConfirmation:needsConfirmation wasInserted:isNewMessage];
+    return result;
 }
+
 
 @end

--- a/Source/Utilis/ZMUpdateEvent+ZMCDataModel.m
+++ b/Source/Utilis/ZMUpdateEvent+ZMCDataModel.m
@@ -22,7 +22,7 @@
 #import "ZMConversation+Internal.h"
 #import "ZMMessage+Internal.h"
 #import "ZMUser+Internal.h"
-
+#import "ZMGenericMessage+UpdateEvent.h"
 
 @implementation ZMUpdateEvent (ZMCDataModel)
 
@@ -178,28 +178,7 @@
         case ZMUpdateEventConversationOtrMessageAdd:
         case ZMUpdateEventConversationOtrAssetAdd:
         {
-            NSString *base64Content;
-            if (self.type == ZMUpdateEventConversationOtrAssetAdd) {
-                base64Content = [[self.payload optionalDictionaryForKey:@"data"] optionalStringForKey:@"info"];
-            } else {
-                id dataPayload = self.payload[@"data"];
-                if ([dataPayload isKindOfClass:NSDictionary.class]) {
-                    base64Content = [[self.payload dictionaryForKey:@"data"] optionalStringForKey:@"text"];
-                } else {
-                    base64Content = [self.payload optionalStringForKey:@"data"];
-                }
-            }
-            if(base64Content == nil) {
-                return nil;
-            }
-            ZMGenericMessage *message;
-            @try {
-                message = [ZMGenericMessage messageWithBase64String:base64Content];
-            }
-            @catch(NSException *e) {
-                ZMLogError(@"Cannot create message from protobuffer: %@ event: %@", e, self);
-                return nil;
-            }
+            ZMGenericMessage *message = [ZMGenericMessage genericMessageFromUpdateEvent:self];
             return [NSUUID uuidWithTransportString:message.messageId];
         }
         default:

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -3751,7 +3751,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -3787,7 +3787,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then
@@ -3833,7 +3833,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then
@@ -3886,7 +3886,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then
@@ -3923,7 +3923,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then
@@ -3960,7 +3960,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then
@@ -3997,7 +3997,7 @@
         ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:(id)payload uuid:nil];
         
         // when
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.syncMOC prefetchResult:nil];
         [self.syncMOC saveOrRollback];
         
         // then

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1930,7 +1930,7 @@ extension ZMAssetClientMessageTests {
             // when
             var sut : ZMAssetClientMessage? = nil
             self.performPretendingUiMocIsSyncMoc { () -> Void in
-                sut = ZMAssetClientMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+                sut = ZMAssetClientMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil).message as? ZMAssetClientMessage
             }
             
             // then
@@ -1971,7 +1971,7 @@ extension ZMAssetClientMessageTests {
         // when
         var sut: ZMAssetClientMessage!
         performPretendingUiMocIsSyncMoc {
-            sut = ZMAssetClientMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            sut = ZMAssetClientMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil).message as! ZMAssetClientMessage
         }
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         
@@ -2015,7 +2015,7 @@ extension ZMAssetClientMessageTests {
             
             
             // when
-            let sut = ZMAssetClientMessage.createOrUpdateMessageFromUpdateEvent(updateEvent1, inManagedObjectContext: self.syncMOC, prefetchResult: nil)
+            let sut = ZMAssetClientMessage.messageUpdateResultFromUpdateEvent(updateEvent1, inManagedObjectContext: self.syncMOC, prefetchResult: nil).message as! ZMAssetClientMessage
             sut.updateWithUpdateEvent(updateEvent2, forConversation: conversation, isUpdatingExistingMessage: true)
             
             // then
@@ -2051,7 +2051,7 @@ extension ZMAssetClientMessageTests {
             
             
             // when
-            let sut = ZMAssetClientMessage.createOrUpdateMessageFromUpdateEvent(updateEvent1, inManagedObjectContext: self.syncMOC, prefetchResult: nil)
+            let sut = ZMAssetClientMessage.messageUpdateResultFromUpdateEvent(updateEvent1, inManagedObjectContext: self.syncMOC, prefetchResult: nil).message as! ZMAssetClientMessage
             sut.updateWithUpdateEvent(updateEvent2, forConversation: conversation, isUpdatingExistingMessage: true)
             
             // then

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -243,7 +243,7 @@ extension ZMClientMessageTests_Deletion {
         // when
         let updateEvent = createMessageDeletedUpdateEvent(.createUUID(), conversationID: conversation.remoteIdentifier, senderID: selfUser.remoteIdentifier!)
         performPretendingUiMocIsSyncMoc {
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -282,7 +282,7 @@ extension ZMClientMessageTests_Deletion {
         // when
         let updateEvent = createMessageDeletedUpdateEvent(sut.nonce, conversationID: conversation.remoteIdentifier)
         performPretendingUiMocIsSyncMoc { 
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -306,7 +306,7 @@ extension ZMClientMessageTests_Deletion {
         let updateEvent = createMessageDeletedUpdateEvent(sut.nonce, conversationID: conversation.remoteIdentifier, senderID: sut.sender!.remoteIdentifier!)
 
         performPretendingUiMocIsSyncMoc {
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -339,7 +339,7 @@ extension ZMClientMessageTests_Deletion {
         let updateEvent = createMessageDeletedUpdateEvent(message.nonce, conversationID: conversation.remoteIdentifier, senderID: otherUser.remoteIdentifier!)
         
         performPretendingUiMocIsSyncMoc {
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -372,7 +372,7 @@ extension ZMClientMessageTests_Deletion {
         // when
         let updateEvent = createMessageDeletedUpdateEvent(nonce, conversationID: conversation.remoteIdentifier, senderID: sut.sender!.remoteIdentifier!)
         performPretendingUiMocIsSyncMoc {
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(updateEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -384,7 +384,7 @@ extension ZMClientMessageTests_Deletion {
         let genericMessage = ZMGenericMessage(text: name!, nonce: nonce.transportString())
         let nextEvent = createUpdateEvent(nonce, conversationID: conversation.remoteIdentifier, genericMessage: genericMessage)
         performPretendingUiMocIsSyncMoc {
-            ZMOTRMessage.createOrUpdateMessageFromUpdateEvent(nextEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(nextEvent, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -394,7 +394,7 @@
 
     // when
     [self performPretendingUiMocIsSyncMoc:^{
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -445,7 +445,7 @@
     // when
     __block ZMClientMessage *newMessage;
     [self performPretendingUiMocIsSyncMoc:^{
-        newMessage = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        newMessage = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -494,7 +494,7 @@
     // when
     __block ZMClientMessage *newMessage;
     [self performPretendingUiMocIsSyncMoc:^{
-        newMessage = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        newMessage = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
 
@@ -527,7 +527,7 @@
     __block ZMClientMessage *newMessage;
 
     [self performPretendingUiMocIsSyncMoc:^{
-        newMessage = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        newMessage = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
@@ -567,7 +567,7 @@
     __block ZMClientMessage *newMessage;
     
     [self performPretendingUiMocIsSyncMoc:^{
-        newMessage = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        newMessage = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:updateEvent inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.m
@@ -214,7 +214,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -250,7 +250,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -290,7 +290,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -382,7 +382,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -407,7 +407,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -472,7 +472,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -510,7 +510,7 @@
     // when
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
-        sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then
@@ -541,7 +541,7 @@
     
     // when
     [self performPretendingUiMocIsSyncMoc:^{
-        [ZMAssetClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        [ZMAssetClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
     }];
     
     // then
@@ -571,7 +571,7 @@
     
     // when
     [self performPretendingUiMocIsSyncMoc:^{
-        [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        [ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
     }];
     
     // then
@@ -595,7 +595,7 @@
     __block ZMClientMessage *sut;
     [self performPretendingUiMocIsSyncMoc:^{
         [self performIgnoringZMLogError:^{
-            sut = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+            sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
         }];
     }];
     

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -2225,7 +2225,7 @@ NSString * const ReactionsKey = @"reactions";
     // when
     __block ZMClientMessage *message;
     [self performPretendingUiMocIsSyncMoc:^{
-        message = [ZMClientMessage createOrUpdateMessageFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil];
+        message = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
     }];
     
     // then

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		F9331C871CB419B500139ECC /* NSFetchRequest+ZMRelationshipKeyPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = F9331C851CB419B500139ECC /* NSFetchRequest+ZMRelationshipKeyPaths.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9331C881CB419B500139ECC /* NSFetchRequest+ZMRelationshipKeyPaths.m in Sources */ = {isa = PBXBuildFile; fileRef = F9331C861CB419B500139ECC /* NSFetchRequest+ZMRelationshipKeyPaths.m */; };
 		F9331C921CB42FCF00139ECC /* zmessaging.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F9331C8D1CB42FCF00139ECC /* zmessaging.xcdatamodeld */; };
+		F93666FD1D78274D00E15420 /* MessageUpdateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */; };
 		F93A30251D6EFB47005CCB1D /* ZMMessageConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93A30231D6EFB47005CCB1D /* ZMMessageConfirmation.swift */; };
 		F93A302F1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */; };
 		F94A208D1CB51AC90059632A /* ZMSyncMergePolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */; };
@@ -401,6 +402,7 @@
 		F9331C8F1CB42FCF00139ECC /* zmessaging1.27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging1.27.xcdatamodel; sourceTree = "<group>"; };
 		F9331C901CB42FCF00139ECC /* zmessaging1.28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging1.28.xcdatamodel; sourceTree = "<group>"; };
 		F9331C911CB42FCF00139ECC /* zmessaging2.3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.3.xcdatamodel; sourceTree = "<group>"; };
+		F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageUpdateResult.swift; sourceTree = "<group>"; };
 		F93A30231D6EFB47005CCB1D /* ZMMessageConfirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMMessageConfirmation.swift; sourceTree = "<group>"; };
 		F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessageTests+Confirmation.swift"; sourceTree = "<group>"; };
 		F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZMSyncMergePolicyTests.m; path = Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m; sourceTree = SOURCE_ROOT; };
@@ -890,6 +892,7 @@
 				F9A706001CAEE01D00C2F5FE /* ZMMessage.m */,
 				F9A706011CAEE01D00C2F5FE /* ZMOTRMessage.h */,
 				F9A706021CAEE01D00C2F5FE /* ZMOTRMessage.m */,
+				F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
 			);
 			path = Message;
@@ -1816,6 +1819,7 @@
 				F9A706591CAEE01D00C2F5FE /* ZMSyncMergePolicy.m in Sources */,
 				F9A706811CAEE01D00C2F5FE /* ZMMessage.m in Sources */,
 				F9B71F2B1CB264EF001DB03F /* ZMConversation+Transport.m in Sources */,
+				F93666FD1D78274D00E15420 /* MessageUpdateResult.swift in Sources */,
 				541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */,
 				F9A706AB1CAEE01D00C2F5FE /* ObjectObserverTokenRegistry.swift in Sources */,
 				F9A706731CAEE01D00C2F5FE /* AssetEncryption.swift in Sources */,


### PR DESCRIPTION
**In this PR**

Previously we were inserting the confirmation message directly when inserting a message from an updateEvent. From the outside it's intransparent if a confirmation message was inserted or not. In order to send confirmation messages in the background, `wire-ios-sync-engine` needs to know this. 
Therefore we are now returning the original message and the information if a confirmation message should be sent and insert the confirmation message afterwards (in the clientTranscoder of `wire-ios-sync-engine`).

Note: Without the changes on sync-engine this change will break confirmation messages
Merge https://github.com/wireapp/wire-ios-sync-engine/pull/39 after