### PR TITLE
Fix crash in tests when caches has been torn down

### DIFF
--- a/Source/ManagedObjectContext/ZMTestSession.m
+++ b/Source/ManagedObjectContext/ZMTestSession.m
@@ -92,9 +92,9 @@ NSString *const ZMPersistedClientIdKey = @"PersistedClientId";
 
 - (void)tearDown;
 {
+    [self wipeCaches];
     ZMConversationDefaultLastReadEventIDSaveDelay = self.originalConversationLastReadEventIDTimerValue;
     [self resetState];
-    [self wipeCaches];
 }
 
 - (void)resetState

--- a/Source/Model/Message/AssetCache.swift
+++ b/Source/Model/Message/AssetCache.swift
@@ -1,10 +1,19 @@
-
 //
-//  AssetDirectory.swift
-//  zmessaging-cocoa
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Marco Conti on 07/10/15.
-//  Copyright (c) 2015 Zeta Project Gmbh. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation
@@ -16,9 +25,9 @@ private let NSManagedObjectContextImageAssetCacheKey = "zm_imageAssetCache"
 
 extension NSManagedObjectContext
 {
-    public var zm_imageAssetCache : ImageAssetCache {
+    public var zm_imageAssetCache : ImageAssetCache! {
         get {
-            return self.userInfo[NSManagedObjectContextImageAssetCacheKey] as! ImageAssetCache
+            return self.userInfo[NSManagedObjectContextImageAssetCacheKey] as? ImageAssetCache
         }
         
         set {

--- a/Source/Utilis/UserImageLocalCache.swift
+++ b/Source/Utilis/UserImageLocalCache.swift
@@ -53,9 +53,9 @@ let NSManagedObjectContextUserImageCacheKey = "zm_userImageCacheKey"
 
 extension NSManagedObjectContext
 {
-    public var zm_userImageCache : UserImageLocalCache {
+    public var zm_userImageCache : UserImageLocalCache! {
         get {
-            return self.userInfo[NSManagedObjectContextUserImageCacheKey] as! UserImageLocalCache
+            return self.userInfo[NSManagedObjectContextUserImageCacheKey] as? UserImageLocalCache
         }
         
         set {


### PR DESCRIPTION
Extracted from https://github.com/wireapp/wire-ios-data-model/pull/29

This PR fixes some random crashes in the tests when the caches has been torn down after a test but are still being accessed by an still running dispatch group.