### PR TITLE
Mark the `reactionChangeInfo` on `MessageObserverToken` as private

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/MessageObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageObserverToken.swift
@@ -118,7 +118,7 @@ extension ZMMessage : ObjectInSnapshot {
     }
     
     public var userChangeInfo : UserChangeInfo?
-    public var reactionChangeInfo : ReactionChangeInfo?
+    private var reactionChangeInfo : ReactionChangeInfo?
     
     public let message : ZMMessage
 }

--- a/Tests/Source/Model/Observer/ObjectObserverToken/MessageObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/MessageObserverTokenTests.swift
@@ -272,7 +272,20 @@ class MessageObserverTokenTests : ZMBaseManagedObjectTest {
             },
             expectedChangedField: "reactionsChanged"
         )
+    }
+    
+    func testThatItNotifiesWhenAReactionIsAddedOnMessageFromADifferentUser() {
+        let message = ZMTextMessage.insertNewObjectInManagedObjectContext(uiMOC)
+        let otherUser = ZMUser.insertNewObjectInManagedObjectContext(uiMOC)
+        otherUser.name = "Hans"
+        otherUser.remoteIdentifier = .createUUID()
         
+        // when
+        checkThatItNotifiesTheObserverOfAChange(
+            message,
+            modifier: { ($0 as? ZMTextMessage)?.addReaction("👻", forUser: otherUser) },
+            expectedChangedField: "reactionsChanged"
+        )
     }
     
     func testThatItNotifiesWhenAReactionIsUpdateForAUserOnMessage() {


### PR DESCRIPTION
# What's in this PR?

**TL;DR: This PR changes the visibility of the `reactionChangeInfo` which should not be exposed to the UI.**

The reaction observation works as follows: Every message observes its reaction relation and adds a reaction observer as soon as a reaction is added to it. If the reactions relation changes the observer fires a change with the flag `reactionsChanged`. The same change is fired when a reaction observed by the message observer changes  (e.g. more users add the same reaction), in this case the observer uses the `reactionChangeInfo` of the reaction observer to determine if a reaction changed (as the reactions relation does not have to change in this case). This change info was publicly exposed, but it should not be used to determine if a change happened as it will be `nil` in case a new reaction has been added. In this case the `reactionsChanged` flag will be set as the relation changed, but only after that will the `ReactionObserver` be added and thus can not fire itself. In order to get notified if a reaction changed only the `reactionChanged` flag should be used which will be true in both cases.