### PR TITLE
handle unarchiving when creating messages

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -240,7 +240,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 {
     if ([event canUnarchiveConversation:self]){
         self.internalIsArchived = NO;
-        [self updateArchivedChangedTimeStampIfNeeded:event.timeStamp andSync:YES];
+        [self updateArchivedChangedTimeStampIfNeeded:event.timeStamp andSync:NO];
     }
 }
 

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -217,6 +217,8 @@ NSString * const DeliveredKey = @"delivered";
         [(ZMClientMessage *)clientMessage setUpdatedTimestamp:updateEvent.timeStamp];
     }
     
+    [clientMessage unarchiveConversationIfNeeded:conversation];
+    
     BOOL needsConfirmation = NO;
     if (isNewMessage && !clientMessage.sender.isSelfUser && conversation.conversationType == ZMConversationTypeOneOnOne) {
         needsConfirmation = YES;
@@ -226,5 +228,20 @@ NSString * const DeliveredKey = @"delivered";
     return result;
 }
 
+
+- (void)unarchiveConversationIfNeeded:(ZMConversation *)conversation
+{
+    if (!conversation.isArchived || conversation.isSilenced) {
+        return;
+    }
+    
+    BOOL olderThanClearTimestamp = (conversation.clearedTimeStamp != nil) &&
+                                   ([self.serverTimestamp compare:conversation.clearedTimeStamp] == NSOrderedAscending);
+    
+    if (!olderThanClearTimestamp) {
+        conversation.internalIsArchived = NO;
+        [conversation updateArchivedChangedTimeStampIfNeeded:self.serverTimestamp andSync:NO];
+    }
+}
 
 @end

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -101,5 +101,28 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
         }
     }
     
+    func createUpdateEvent(nonce: NSUUID, conversationID: NSUUID, genericMessage: ZMGenericMessage, senderID: NSUUID = .createUUID(), eventSource: ZMUpdateEventSource = .Download) -> ZMUpdateEvent {
+        let payload = [
+            "id": NSUUID.createUUID().transportString(),
+            "conversation": conversationID.transportString(),
+            "from": senderID.transportString(),
+            "time": NSDate().transportString(),
+            "data": [
+                "text": genericMessage.data().base64String()
+            ],
+            "type": "conversation.otr-message-add"
+        ]
+        switch eventSource {
+        case .Download:
+            return ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nonce)
+        default:
+            let streamPayload = ["payload" : [payload],
+                                 "id" : NSUUID.createUUID().transportString()]
+            let event = ZMUpdateEvent.eventsArrayFromTransportData(streamPayload,
+                                                                   source: eventSource)!.first!
+            XCTAssertNotNil(event)
+            return event
+        }
+    }
 
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -22,7 +22,7 @@ import XCTest
 
 // MARK: - Sending
 
-class ZMClientMessageTests_Deletion: BaseZMMessageTests {
+class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
     
     func testThatItDeletesAMessage() {
         // given
@@ -403,21 +403,6 @@ extension ZMClientMessageTests_Deletion {
 // MARK: - Helper
 
 extension ZMClientMessageTests_Deletion {
-    
-    func createUpdateEvent(nonce: NSUUID, conversationID: NSUUID, genericMessage: ZMGenericMessage, senderID: NSUUID = .createUUID()) -> ZMUpdateEvent {
-        let payload = [
-            "id": NSUUID.createUUID().transportString(),
-            "conversation": conversationID.transportString(),
-            "from": senderID.transportString(),
-            "time": NSDate().transportString(),
-            "data": [
-                "text": genericMessage.data().base64String()
-            ],
-            "type": "conversation.otr-message-add"
-        ]
-        
-        return ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nonce)
-    }
 
     func createMessageDeletedUpdateEvent(nonce: NSUUID, conversationID: NSUUID, senderID: NSUUID = .createUUID()) -> ZMUpdateEvent {
         let genericMessage = ZMGenericMessage(deleteMessage: nonce.transportString(), nonce: NSUUID.createUUID().transportString())

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
@@ -1,0 +1,119 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import ZMTesting
+import ZMCDataModel
+
+class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
+
+    func testThatItUnarchivesAConversationWhenItWasNotCleared(){
+    
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = NSUUID.createUUID()
+        conversation.isArchived = true
+        
+        let genericMessage = ZMGenericMessage(text: "bar", nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage)
+
+        // when
+        performPretendingUiMocIsSyncMoc {
+            XCTAssertNotNil(ZMOTRMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil))
+        }
+        
+        // then
+        XCTAssertFalse(conversation.isArchived)
+    }
+    
+    func testThatItDoesNotUnarchiveASilencedConversation(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = NSUUID.createUUID()
+        conversation.isArchived = true
+        conversation.isSilenced = true
+
+        let genericMessage = ZMGenericMessage(text: "bar", nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage)
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+        }
+        
+        // then
+        XCTAssertTrue(conversation.isArchived)
+    }
+    
+    func testThatItDoesNotUnarchiveAClearedConversation_TimestampForMessageIsOlder(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = NSUUID.createUUID()
+        conversation.isArchived = true
+        uiMOC.saveOrRollback()
+
+        let lastMessage = conversation.appendMessageWithText("foo") as! ZMClientMessage
+        lastMessage.serverTimestamp = NSDate().dateByAddingTimeInterval(10)
+        conversation.lastServerTimeStamp = lastMessage.serverTimestamp!
+        conversation.clearMessageHistory()
+        
+        let genericMessage = ZMGenericMessage(text: "bar", nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage)
+        XCTAssertNotNil(event)
+        
+        XCTAssertGreaterThan(conversation.clearedTimeStamp.timeIntervalSince1970, event.timeStamp()!.timeIntervalSince1970)
+        
+        // when
+        performPretendingUiMocIsSyncMoc { 
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+        }
+        
+        // then
+        XCTAssertTrue(conversation.isArchived)
+    }
+    
+    func testThatItUnarchivesAClearedConversation_TimestampForMessageIsNewer(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = NSUUID.createUUID()
+        conversation.isArchived = true
+        uiMOC.saveOrRollback()
+
+        let lastMessage = conversation.appendMessageWithText("foo") as! ZMClientMessage
+        lastMessage.serverTimestamp = NSDate().dateByAddingTimeInterval(-10)
+        conversation.lastServerTimeStamp = lastMessage.serverTimestamp!
+        conversation.clearMessageHistory()
+
+        let genericMessage = ZMGenericMessage(text: "bar", nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage)
+        
+        XCTAssertLessThan(conversation.clearedTimeStamp.timeIntervalSince1970, event.timeStamp()!.timeIntervalSince1970)
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            ZMOTRMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+        }
+        // then
+        XCTAssertFalse(conversation.isArchived)
+    }
+
+}
+
+

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -30,6 +30,7 @@ class ZMMessageTests_Confirmation: BaseZMClientMessageTests {
     
     override func tearDown() {
         self.uiMOC.globalManagedObjectContextObserver.tearDown()
+        XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         super.tearDown()
     }
     
@@ -90,44 +91,6 @@ class ZMMessageTests_Confirmation: BaseZMClientMessageTests {
         XCTAssertEqual(conversation.messages.firstObject as? ZMClientMessage, sut.message)
         XCTAssertFalse(sut.needsConfirmation)
     }
-    
-//    func testThatThePayloadOnlyContainsTheSender(){
-//        // Future proof - in case we start sending confirmations in groups as well
-//        // given
-//        createSelfClient()
-//
-//        let user1 = ZMUser.insertNewObjectInManagedObjectContext(syncMOC)
-//        user1.remoteIdentifier = NSUUID()
-//        createClientForUser(user1, createSessionWithSelfUser: true)
-//
-//        XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
-//        
-//        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(syncMOC)
-//        conversation.remoteIdentifier = .createUUID()
-//        conversation.connection = ZMConnection.insertNewObjectInManagedObjectContext(syncMOC)
-//        conversation.connection.to = user1
-//        conversation.conversationType = .OneOnOne
-//        
-//        let message = insertMessage(conversation, fromSender: user1, moc: syncMOC)
-//        XCTAssertTrue(syncMOC.saveOrRollback())
-//        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
-//        
-//        let genericMessage = ZMGenericMessage(confirmation: message.nonce.transportString(), type: .DELIVERED, nonce: NSUUID().transportString())
-//        
-//        // when
-//        var otrMessage: ZMNewOtrMessage?
-//        syncSelfUser.selfClient()!.keysStore.encryptionContext.perform{ (sessionsDirectory) in
-//            otrMessage =  ZMClientMessage.otrMessageForGenericMessage(genericMessage, selfClient:self.syncSelfUser.selfClient()!, conversation: conversation, externalData: nil, sessionsDirectory:sessionsDirectory)
-//        }
-//        
-//        // then
-//        XCTAssertNotNil(otrMessage)
-//        XCTAssertEqual(otrMessage?.recipients.count, 1)
-//        guard let recipient = otrMessage?.recipients.first else {return XCTFail()}
-//        XCTAssertTrue(recipient.hasUser())
-//        
-//        XCTAssertEqual(recipient.user.uuid, user1.remoteIdentifier?.data())
-//    }
     
     // MARK: Receiving Confirmation GenericMessage
     
@@ -276,30 +239,6 @@ extension ZMMessageTests_Confirmation {
         XCTAssertTrue(MOC!.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
         return messageUpdateResult
-    }
-    
-    func createUpdateEvent(nonce: NSUUID, conversationID: NSUUID, genericMessage: ZMGenericMessage, senderID: NSUUID = .createUUID(), eventSource: ZMUpdateEventSource = .Download) -> ZMUpdateEvent {
-        let payload = [
-            "id": NSUUID.createUUID().transportString(),
-            "conversation": conversationID.transportString(),
-            "from": senderID.transportString(),
-            "time": NSDate().transportString(),
-            "data": [
-                "text": genericMessage.data().base64String()
-            ],
-            "type": "conversation.otr-message-add"
-        ]
-        switch eventSource {
-        case .Download:
-            return ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nonce)
-        default:
-            let streamPayload = ["payload" : [payload],
-                                 "id" : NSUUID.createUUID().transportString()]
-            let event = ZMUpdateEvent.eventsArrayFromTransportData(streamPayload,
-                                                              source: eventSource)!.first!
-            XCTAssertNotNil(event)
-            return event
-        }
     }
     
     func createMessageConfirmationUpdateEvent(nonce: NSUUID, conversationID: NSUUID, senderID: NSUUID = .createUUID()) -> ZMUpdateEvent {

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		F9A708631CAEF26C00C2F5FE /* NotificationObservers.m in Sources */ = {isa = PBXBuildFile; fileRef = F9A708621CAEF26C00C2F5FE /* NotificationObservers.m */; };
 		F9A708651CAEF9BD00C2F5FE /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F9A708641CAEF9BD00C2F5FE /* Default-568h@2x.png */; };
 		F9AB395B1CB3AED900A7254F /* BaseTestSwiftHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AB39591CB3AEB100A7254F /* BaseTestSwiftHelpers.swift */; };
+		F9B0FF321D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B0FF311D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift */; };
 		F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */ = {isa = PBXBuildFile; fileRef = F9B71F041CB264DF001DB03F /* ZMConversationList.m */; };
 		F9B71F0A1CB264DF001DB03F /* ZMConversationList+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = F9B71F051CB264DF001DB03F /* ZMConversationList+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9B71F0C1CB264DF001DB03F /* ZMConversationListDirectory.h in Headers */ = {isa = PBXBuildFile; fileRef = F9B71F071CB264DF001DB03F /* ZMConversationListDirectory.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -594,6 +595,7 @@
 		F9A708621CAEF26C00C2F5FE /* NotificationObservers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationObservers.m; sourceTree = "<group>"; };
 		F9A708641CAEF9BD00C2F5FE /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		F9AB39591CB3AEB100A7254F /* BaseTestSwiftHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTestSwiftHelpers.swift; sourceTree = "<group>"; };
+		F9B0FF311D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Unarchiving.swift"; sourceTree = "<group>"; };
 		F9B71F041CB264DF001DB03F /* ZMConversationList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMConversationList.m; sourceTree = "<group>"; };
 		F9B71F051CB264DF001DB03F /* ZMConversationList+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMConversationList+Internal.h"; sourceTree = "<group>"; };
 		F9B71F071CB264DF001DB03F /* ZMConversationListDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMConversationListDirectory.h; sourceTree = "<group>"; };
@@ -1226,6 +1228,7 @@
 				F9B71F601CB2BC85001DB03F /* ZMMessageTests.h */,
 				F9B71F611CB2BC85001DB03F /* ZMMessageTests.m */,
 				F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */,
+				F9B0FF311D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift */,
 			);
 			name = Messages;
 			path = Tests/Source/Model/Messages;
@@ -1951,6 +1954,7 @@
 				F9B71FA01CB2BF2B001DB03F /* ZMConversationListTests.m in Sources */,
 				F9B71FA21CB2BF37001DB03F /* ZMConversationMessageWindowTests.m in Sources */,
 				BF794FE61D1442B100E618C6 /* ZMClientMessageTests+Location.swift in Sources */,
+				F9B0FF321D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift in Sources */,
 				F9B71FF11CB2C4C6001DB03F /* ObjectDependencyTokenTests.swift in Sources */,
 				F9331C6A1CB3D5B700139ECC /* ZMUpdateEventTests.m in Sources */,
 				F9A708601CAEEF4700C2F5FE /* MessagingTest+EventFactory.m in Sources */,


### PR DESCRIPTION
**In this PR**

We were previously handling unarchiving in the transcoder by inspecting the event type and timestamps. For messages we should not do this, because some message events don't create a message, but only invisible side effects.