### PR TITLE
Clear all reactions when a message is removed / edited

### DIFF
--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -66,6 +66,8 @@ extension ZMMessage {
 
     @objc public func clearAllReactions() {
         reactions.removeAll()
+        guard let moc = managedObjectContext else { return }
+        reactions.forEach(moc.deleteObject)
     }
     
 }

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -63,5 +63,9 @@ extension ZMMessage {
             }
         }
     }
+
+    @objc public func clearAllReactions() {
+        reactions.removeAll()
+    }
     
 }

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -349,6 +349,7 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
 {
     self.hiddenInConversation = self.conversation;
     self.visibleInConversation = nil;
+    [self clearAllReactions];
 
     if (clearingSender) {
         self.sender = nil;


### PR DESCRIPTION
# What's in this PR?

* If a message is edited the reactions should be reset.
* We now clear the reactions when calling `removeMessageClearingSender:` to ensure this data is removed in all cases when a message is removed (which is also the case for edits as a new message is inserted)

