### PR TITLE
Fix observing

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/ManagedObjectContextObserver.swift
+++ b/Source/Notifications/ObjectObserverTokens/ManagedObjectContextObserver.swift
@@ -26,6 +26,9 @@ import ZMCSystem
 private let zmLog = ZMSLog(tag: "Observer")
 
 public enum ObjectObserverType: Int {
+    
+    // The order of this enum is important, because some event create additional observer to fire (reaction fires message notification), 
+    // and therefore needs to happen before the message observer handler to propagate properly to the UI
     case Invalid = 0
     case Connection
     case Client
@@ -36,9 +39,9 @@ public enum ObjectObserverType: Int {
     case Message
     case Conversation
     case VoiceChannel
+    case Reaction
     case ConversationMessageWindow
     case ConversationList
-    case Reaction
 
     static func observerTypeForObject(object: NSObject) -> ObjectObserverType {
         

--- a/Tests/Source/Model/Observer/ObjectObserverToken/MessageObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/MessageObserverTokenTests.swift
@@ -306,6 +306,24 @@ class MessageObserverTokenTests : ZMBaseManagedObjectTest {
         )
         
     }
+    
+    func testThatItNotifiesWhenAReactionFromADifferentUserIsAddedOnTopOfSelfReaction() {
+        let message = ZMTextMessage.insertNewObjectInManagedObjectContext(uiMOC)
+        let otherUser = ZMUser.insertNewObjectInManagedObjectContext(uiMOC)
+        otherUser.name = "Hans"
+        otherUser.remoteIdentifier = .createUUID()
+        
+        let selfUser = ZMUser.selfUserInContext(self.uiMOC)
+        message.addReaction("👻", forUser: selfUser)
+        
+        // when
+        checkThatItNotifiesTheObserverOfAChange(
+            message,
+            modifier: { ($0 as? ZMTextMessage)?.addReaction("👻", forUser: otherUser) },
+            expectedChangedField: "reactionsChanged"
+        )
+    }
+
 
     
     func testThatItStopsNotifyingAfterUnregisteringTheToken() {


### PR DESCRIPTION
**What's in this PR**
The `Reaction` observer type had an index superior than the `MessageWindowObserver`, which lead the former being processed after the later. This means that the UI would be notifies of a change from the second event onward when receiving event. By reordering the reaction observer type index, we now are correctly notified when something is changing.