### PR TITLE
never expire confirmation messages

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -209,7 +209,7 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
 - (ZMClientMessage *)confirmReception
 {
     ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithConfirmation:self.nonce.transportString type:ZMConfirmationTypeDELIVERED nonce:[NSUUID UUID].transportString];
-    return [self.conversation appendGenericMessage:genericMessage expires:YES hidden:YES];
+    return [self.conversation appendGenericMessage:genericMessage expires:NO hidden:YES];
 }
 
 - (void)expire;

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -248,6 +248,23 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(messageChangeInfo.deliveryStateChanged)
     }
+    
+    func testThatAMessageConfirmationDoesNotExpire() {
+        
+        // given
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = .createUUID()
+        let lastModified = NSDate(timeIntervalSince1970: 1234567890)
+        conversation.lastModifiedDate = lastModified
+        
+        let message = conversation.appendMessageWithText("foo") as! ZMClientMessage
+
+        // when
+        let sut = message.confirmReception()
+        
+        // then
+        XCTAssertNil(sut.expirationDate)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
**In this PR**

We should not expire confirmation messages because they can't be resent and would create an unsent message list indicator upon fail.