### PR TITLE
Validate emoji before inserting

### DIFF
--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -21,24 +21,40 @@ import Foundation
 
 extension ZMMessage {
     
-    public static func addReaction(unicodeValue: String?, toMessage message: ZMConversationMessage)
+    static func appendReaction(unicodeValue: String?, toMessage message: ZMConversationMessage)
     {
         guard let message = message as? ZMMessage, context = message.managedObjectContext else { return }
         guard message.deliveryState == .Sent || message.deliveryState == .Delivered else { return }
-
+        
+        let emoji = unicodeValue ?? ""
+        
         let genericMessage = ZMGenericMessage(
-            emojiString: unicodeValue,
+            emojiString: emoji,
             messageID: message.nonce.transportString(),
             nonce: NSUUID().transportString()
         )
     
         message.conversation?.appendGenericMessage(genericMessage, expires:false, hidden: true)
         message.addReaction(unicodeValue, forUser: .selfUserInContext(context))
+
+    
+    
+    }
+    
+    public static func addReaction(unicodeValue: String, toMessage message: ZMConversationMessage) {
+            
+        // confirmation that we understand the emoji
+        // the UI should never send an emoji we dont handle
+        if Reaction.transportReaction(unicodeValue) == .None{
+            fatal("We can't append this reaction \(unicodeValue), this is a programmer error.")
+        }
+        
+        appendReaction(unicodeValue, toMessage: message)
     }
     
     public static func removeReaction(onMessage message:ZMConversationMessage)
     {
-        addReaction(nil, toMessage: message)
+        appendReaction(nil, toMessage: message)
     }
     
     @objc public func addReaction(unicodeValue: String?, forUser user:ZMUser)

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -159,6 +159,12 @@ NSString * const DeliveredKey = @"delivered";
         return nil;
     }
     if (message.hasReaction) {
+        
+        // if we don't understand the reaction received, discard it
+        if ([Reaction transportReaction:message.reaction.emoji] == TransportReactionNone) {
+            return nil;
+        }
+        
         [ZMMessage addReaction:message.reaction senderID:updateEvent.senderUUID conversation:conversation inManagedObjectContext:moc];
         return nil;
     }

--- a/Source/Model/Reaction/Reaction.swift
+++ b/Source/Model/Reaction/Reaction.swift
@@ -22,6 +22,13 @@ public let ZMReactionUnicodeValueKey    = "unicodeValue"
 public let ZMReactionMessageValueKey    = "message"
 public let ZMReactionUsersValueKey      = "users"
 
+
+@objc public enum TransportReaction : UInt32 {
+    case None  = 0
+    case Heart = 1
+}
+
+
 @objc(Reaction)
 public class Reaction : ZMManagedObject {
     
@@ -50,4 +57,15 @@ public class Reaction : ZMManagedObject {
     public override static func sortKey() -> String! {
         return ZMReactionUnicodeValueKey
     }
+    
+    @objc public static func transportReaction(fromUnicode: String) -> TransportReaction {
+        switch fromUnicode {
+        case "❤️":
+            return .Heart
+        default:
+            return .None
+        }
+
+    }
+    
 }

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
@@ -1,0 +1,75 @@
+//
+//  ZMClientMessagesTests+Reaction.swift
+//  ZMCDataModel
+//
+//  Created by Florian Morel on 9/6/16.
+//  Copyright © 2016 Wire Swiss GmbH. All rights reserved.
+//
+
+import ZMTesting
+
+class ZMClientMessageTests_Reaction: BaseZMClientMessageTests {
+    
+    
+}
+
+extension ZMClientMessageTests_Reaction {
+    
+    func testThatItAppendsAReactionWhenReceivingUpdateEventWithValidReaction() {
+        
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = .createUUID()
+        conversation.conversationType = .OneOnOne
+        
+        let sender = ZMUser.insertNewObjectInManagedObjectContext(uiMOC)
+        sender.remoteIdentifier = .createUUID()
+        
+        let message = conversation.appendMessageWithText("JCVD, full split please") as! ZMMessage
+        message.sender = sender
+        
+        uiMOC.saveOrRollback()
+        
+        let genericMessage = ZMGenericMessage(emojiString: "❤️", messageID: message.nonce.transportString(), nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            ZMClientMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+        }
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+
+        
+        XCTAssertEqual(message.reactions.count, 1)
+        XCTAssertEqual(message.usersReaction.count, 1)
+    }
+    
+    func testThatItDoesNOTAppendsAReactionWhenReceivingUpdateEventWithValidReaction() {
+        
+        let conversation = ZMConversation.insertNewObjectInManagedObjectContext(uiMOC)
+        conversation.remoteIdentifier = .createUUID()
+        conversation.conversationType = .OneOnOne
+        
+        let sender = ZMUser.insertNewObjectInManagedObjectContext(uiMOC)
+        sender.remoteIdentifier = .createUUID()
+        
+        let message = conversation.appendMessageWithText("JCVD, full split please") as! ZMMessage
+        message.sender = sender
+        
+        uiMOC.saveOrRollback()
+        
+        let genericMessage = ZMGenericMessage(emojiString: "TROP BIEN", messageID: message.nonce.transportString(), nonce: NSUUID.createUUID().transportString())
+        let event = createUpdateEvent(NSUUID(), conversationID: conversation.remoteIdentifier, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
+        
+        // when
+        performPretendingUiMocIsSyncMoc {
+            ZMClientMessage.messageUpdateResultFromUpdateEvent(event, inManagedObjectContext: self.uiMOC, prefetchResult: nil)
+        }
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertTrue(waitForAllGroupsToBeEmptyWithTimeout(0.5))
+        
+        
+        XCTAssertEqual(message.reactions.count, 0)
+        XCTAssertEqual(message.usersReaction.count, 0)
+    }
+}

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -2481,7 +2481,7 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertEqual(message.deliveryState, ZMDeliveryStateSent);
 
     //when
-    NSString *reactionUnicode = @"a bit of sweetness please";
+    NSString *reactionUnicode = @"❤️";
     // this is the UI facing call to add reaction
     [ZMMessage addReaction:reactionUnicode toMessage:message];
     [self.uiMOC saveOrRollback];
@@ -2505,7 +2505,7 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertEqual(message.deliveryState, ZMDeliveryStatePending);
 
     //when
-    NSString *reactionUnicode = @"a bit of sweetness please";
+    NSString *reactionUnicode = @"❤️";
     // this is the UI facing call to add reaction
     [ZMMessage addReaction:reactionUnicode toMessage:message];
     [self.uiMOC saveOrRollback];
@@ -2531,7 +2531,7 @@ NSString * const ReactionsKey = @"reactions";
     [self.uiMOC saveOrRollback];
     
     //when
-    NSString *reactionUnicode = @"a bit of sweetness please";
+    NSString *reactionUnicode = @"❤️";
     // this is the UI facing call to add reaction
     [textMessage addReaction:reactionUnicode forUser:selfUser];
     [self.uiMOC saveOrRollback];
@@ -2562,7 +2562,7 @@ NSString * const ReactionsKey = @"reactions";
     textMessage.visibleInConversation = conversation;
     [self.uiMOC saveOrRollback];
     
-    NSString *reactionUnicode = @"a bit of sweetness please";
+    NSString *reactionUnicode = @"❤️";
     // this is the UI facing call to add reaction
     [textMessage addReaction:reactionUnicode forUser:selfUser];
     [self.uiMOC saveOrRollback];
@@ -2606,8 +2606,7 @@ NSString * const ReactionsKey = @"reactions";
     [self.uiMOC saveOrRollback];
     
     //when
-    NSString *reactionUnicode = @"a bit of sweetness please";
-    // this is the UI facing call to add reaction
+    NSString *reactionUnicode = @"❤️";
     [textMessage addReaction:reactionUnicode forUser:selfUser];
     [textMessage addReaction:reactionUnicode forUser:user1];
     [self.uiMOC saveOrRollback];

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		CE4EDC091D6D9A3D002A20AA /* Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4EDC081D6D9A3D002A20AA /* Reaction.swift */; };
 		CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */; };
 		CE58A3FF1CD3B3580037B626 /* ConversationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE58A3FE1CD3B3580037B626 /* ConversationMessage.swift */; };
+		CEB15E531D7EE5AB0048A011 /* ZMClientMessagesTests+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB15E501D7EE53A0048A011 /* ZMClientMessagesTests+Reaction.swift */; };
 		CEE525AA1CCA4C97001D06F9 /* NSString+RandomString.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE525A91CCA4C97001D06F9 /* NSString+RandomString.m */; };
 		F90E5AB31D2276FD00555CD0 /* ZMConversationTests+Timestamp.m in Sources */ = {isa = PBXBuildFile; fileRef = F90E5AB21D2276FD00555CD0 /* ZMConversationTests+Timestamp.m */; };
 		F91DF5AF1D0969BE009D81F1 /* ZMConversation+OTR.m in Sources */ = {isa = PBXBuildFile; fileRef = F91DF5AD1D0969BE009D81F1 /* ZMConversation+OTR.m */; };
@@ -389,6 +390,7 @@
 		CE4EDC081D6D9A3D002A20AA /* Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reaction.swift; path = Reaction/Reaction.swift; sourceTree = "<group>"; };
 		CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Reaction.swift"; sourceTree = "<group>"; };
 		CE58A3FE1CD3B3580037B626 /* ConversationMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationMessage.swift; sourceTree = "<group>"; };
+		CEB15E501D7EE53A0048A011 /* ZMClientMessagesTests+Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Reaction.swift"; sourceTree = "<group>"; };
 		CECE61381D7D713400BA9A32 /* zmessaging2.11.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.11.xcdatamodel; sourceTree = "<group>"; };
 		CEE525A81CCA4C97001D06F9 /* NSString+RandomString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+RandomString.h"; sourceTree = "<group>"; };
 		CEE525A91CCA4C97001D06F9 /* NSString+RandomString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+RandomString.m"; sourceTree = "<group>"; };
@@ -1231,6 +1233,7 @@
 				F9B71F611CB2BC85001DB03F /* ZMMessageTests.m */,
 				F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */,
 				F9B0FF311D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift */,
+				CEB15E501D7EE53A0048A011 /* ZMClientMessagesTests+Reaction.swift */,
 			);
 			name = Messages;
 			path = Tests/Source/Model/Messages;
@@ -1956,6 +1959,7 @@
 				F9B71FA01CB2BF2B001DB03F /* ZMConversationListTests.m in Sources */,
 				F9B71FA21CB2BF37001DB03F /* ZMConversationMessageWindowTests.m in Sources */,
 				BF794FE61D1442B100E618C6 /* ZMClientMessageTests+Location.swift in Sources */,
+				CEB15E531D7EE5AB0048A011 /* ZMClientMessagesTests+Reaction.swift in Sources */,
 				F9B0FF321D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift in Sources */,
 				F9B71FF11CB2C4C6001DB03F /* ObjectDependencyTokenTests.swift in Sources */,
 				F9331C6A1CB3D5B700139ECC /* ZMUpdateEventTests.m in Sources */,


### PR DESCRIPTION
**What's in this PR**
If this PR is merged, we had the ability of validating the incoming emoji, so that if we receive an emoji that we are not expecting, nothing is inserted.
So far, the only emoji we take into account is ❤️

**NOTE**: This PR breaks the UI facing API.