### PR TITLE
Stop updating last read when receiving like upload confirmation

### DIFF
--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -278,7 +278,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 - (void)updateWithPostPayload:(NSDictionary *)payload updatedKeys:(__unused NSSet *)updatedKeys
 {
     // we don't want to update the conversation if the message is a confirmation message
-    if (self.genericMessage.hasConfirmation) {
+    if (self.genericMessage.hasConfirmation || self.genericMessage.hasReaction) {
         return;
     }
     if (self.genericMessage.hasEdited) {


### PR DESCRIPTION
**What's in this PR**
This PR prevent the conversation lastRead to be updated when receiving like POST response.