### PR TITLE
Allow storing database in application support for travis / external users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'danger'
+gem 'danger', '~>3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,25 +8,34 @@ GEM
       nap
       open4 (~> 1.3)
     colored (1.2)
-    cork (0.1.0)
+    cork (0.2.0)
       colored (~> 1.2)
-    danger (2.1.1)
+    danger (3.2.1)
       claide (~> 1.0)
       claide-plugins (> 0.9.0)
       colored (~> 1.2)
       cork (~> 0.1)
-      faraday (~> 0)
+      faraday (~> 0.9)
       faraday-http-cache (~> 1.0)
       git (~> 1)
+      gitlab (~> 3.7.0)
       kramdown (~> 1.5)
       octokit (~> 4.2)
       terminal-table (~> 1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.0)
+    faraday-http-cache (1.3.1)
       faraday (~> 0.8)
     git (1.3.0)
-    kramdown (1.11.1)
+    gitlab (3.7.0)
+      httparty (~> 0.13.0)
+      terminal-table
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.3)
+    kramdown (1.12.0)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     nap (1.1.0)
     octokit (4.3.0)
@@ -35,13 +44,12 @@ GEM
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
-    terminal-table (1.6.0)
+    terminal-table (1.7.2)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger
-
-BUNDLED WITH
-   1.12.5
+  danger (~> 3.2)

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging-Internal.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging-Internal.h
@@ -22,7 +22,6 @@
 
 @interface NSManagedObjectContext (zmessaging_Internal)
 
-+ (NSURL *)applicationSupportDirectoryStoreURL;
 + (BOOL)databaseExistsInCachesDirectory;
 + (BOOL)databaseExistsInApplicationSupportDirectory;
 + (BOOL)databaseExistsAndNotReadableDueToEncryption;

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
@@ -118,6 +118,7 @@
 - (NSArray *)executeFetchRequestOrAssert:(NSFetchRequest *)request;
 
 + (NSURL *)storeURL;
++ (NSURL *)applicationSupportDirectoryStoreURL;
 
 @end
 

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -81,7 +81,6 @@ static BOOL storeIsReady = NO;
 
 + (BOOL)needsToPrepareLocalStoreInDirectory:(NSURL *)databaseDirectory;
 {
-    
     [self setDatabaseDirectoryURL:databaseDirectory];
 
     NSManagedObjectModel *mom = self.loadManagedObjectModel;
@@ -188,7 +187,6 @@ static BOOL storeIsReady = NO;
             [result configureWithPersistentStoreCoordinator:psc];
             result.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSRollbackMergePolicyType];
             SharedUserInterfaceContext = result;
-            [result continuouslyCheckForUnsavedChanges];
             (void)result.globalManagedObjectContextObserver;
         }
     });
@@ -197,7 +195,7 @@ static BOOL storeIsReady = NO;
 
 + (void)resetUserInterfaceContext
 {
-    dispatch_async(singletonContextIsolation(), ^{
+    dispatch_sync(singletonContextIsolation(), ^{
         SharedUserInterfaceContext = nil;
     });
 }
@@ -208,10 +206,12 @@ static BOOL storeIsReady = NO;
     RequireString(psc != nil, "No persistent store coordinator, call -prepareLocalStore: first.");
 
     NSManagedObjectContext *moc = [[self alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    [moc markAsSyncContext];
-    [moc configureWithPersistentStoreCoordinator:psc];
-    moc.undoManager = nil;
-    moc.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSMergeByPropertyObjectTrumpMergePolicyType];
+    [moc performBlockAndWait:^{
+        [moc markAsSyncContext];
+        [moc configureWithPersistentStoreCoordinator:psc];
+        moc.undoManager = nil;
+        moc.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSMergeByPropertyObjectTrumpMergePolicyType];
+    }];
     return moc;
 }
 
@@ -222,10 +222,12 @@ static BOOL storeIsReady = NO;
     RequireString(psc != nil, "No persistent store coordinator, call -prepareLocalStore: first.");
     
     NSManagedObjectContext *moc = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    [moc markAsSearchContext];
-    [moc configureWithPersistentStoreCoordinator:psc];
-    moc.undoManager = nil;
-    moc.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSRollbackMergePolicyType];
+    [moc performBlockAndWait:^{        
+        [moc markAsSearchContext];
+        [moc configureWithPersistentStoreCoordinator:psc];
+        moc.undoManager = nil;
+        moc.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSRollbackMergePolicyType];
+    }];
     return moc;
 }
 
@@ -1076,43 +1078,6 @@ static dispatch_once_t clearStoreOnceToken;
     NSArray *result = [self executeFetchRequest:request error:&error];
     RequireString(result != nil, "Error in fetching: %lu", (long) error.code);
     return result;
-}
-
-- (void)continuouslyCheckForUnsavedChanges;
-{
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        if (! [[NSUserDefaults standardUserDefaults] boolForKey:@"ZMCheckForUnsavedChangesOnUIContext"]) {
-            return;
-        }
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self checkForUnsavedChanges];
-        });
-    });
-}
-
-- (void)checkForUnsavedChanges;
-{
-    // When ZMCheckForUnsavedChangesOnUIContext is set to YES, this will log a warning when
-    // the UI forgets to wrap changes inside a call to -performChanges:
-    //
-    // To use this, pass
-    //     -ZMCheckForUnsavedChangesOnUIContext YES
-    // as a launch argument.
-    //
-    if ([self hasChanges]) {
-        ZMLogWarn(@"User Interface context is out of sync.");
-        ZMLogWarn(@"Context <%@: %p> has unsaved changes:", self.class, self);
-        ZMLogWarn(@"Please use -[ZMUserSession performChanges:].");
-        for (NSManagedObject *mo in self.updatedObjects) {
-            ZMLogWarn(@"    <%@: %p>: %@", mo.class, mo, [mo.changedValues.allKeys componentsJoinedByString:@", "]);
-        }
-        for (NSManagedObject *mo in self.insertedObjects) {
-            ZMLogWarn(@"    <%@: %p> (inserted)", mo.class, mo);
-        }
-        __builtin_trap();
-    }
-    [self performSelector:_cmd withObject:nil afterDelay:0.5];
 }
 
 @end

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -86,7 +86,7 @@ static BOOL storeIsReady = NO;
 
     NSManagedObjectModel *mom = self.loadManagedObjectModel;
     NSDictionary *sharedContainerMetadata = [self metadataForStoreAtURL:self.storeURL];
-    BOOL needsMigration = ![mom isConfiguration:nil compatibleWithStoreMetadata:sharedContainerMetadata];
+    BOOL needsMigration = sharedContainerMetadata != nil && ![mom isConfiguration:nil compatibleWithStoreMetadata:sharedContainerMetadata];
 
     BOOL databaseShouldBeInApplicationSupport = [self.applicationSupportDirectoryStoreURL.absoluteString hasPrefix:databaseDirectory.absoluteString];
     BOOL needsToMoveDatabase = self.databaseExistsInCachesDirectory || (!databaseShouldBeInApplicationSupport && self.databaseExistsInApplicationSupportDirectory);

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -88,7 +88,8 @@ static BOOL storeIsReady = NO;
     NSDictionary *sharedContainerMetadata = [self metadataForStoreAtURL:self.storeURL];
     BOOL needsMigration = ![mom isConfiguration:nil compatibleWithStoreMetadata:sharedContainerMetadata];
 
-    BOOL needsToMoveDatabase = self.databaseExistsInCachesDirectory || self.databaseExistsInApplicationSupportDirectory;
+    BOOL databaseShouldBeInApplicationSupport = [self.applicationSupportDirectoryStoreURL.absoluteString hasPrefix:databaseDirectory.absoluteString];
+    BOOL needsToMoveDatabase = self.databaseExistsInCachesDirectory || (!databaseShouldBeInApplicationSupport && self.databaseExistsInApplicationSupportDirectory);
     return needsMigration || needsToMoveDatabase || self.databaseExistsAndNotReadableDueToEncryption;
 }
 

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -336,7 +336,14 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
             user.needsToBeUpdatedFromBackend = YES;
             ZMConnection *connection = [ZMConnection insertNewSentConnectionToUser:user];
             connection.message = text;
-            self.user = user;
+            
+            [self.syncMOC saveOrRollback];
+            
+            [self.uiMOC performGroupedBlockAndWait:^{
+                NSError *uiObjectError = nil;
+                self.user = [self.uiMOC existingObjectWithID:user.objectID error:&uiObjectError];
+                Require(uiObjectError == nil);
+            }];
             
             // Do a delayed save and run the handler on the main queue, once it's done:
             ZMSDispatchGroup * g = [ZMSDispatchGroup groupWithLabel:@"ZMSearchUser"];

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -319,9 +319,7 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
         }
     }
     if (handler) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            handler();
-        });
+        handler();
     }
 }
 

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.h
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.h
@@ -35,6 +35,7 @@
 - (BOOL)moveDatabaseToCachesDirectory;
 - (BOOL)moveDatabaseToApplicationSupportDirectory;
 - (NSData *)invalidData;
+- (void)useApplicationSupportDirectoryAsDefault;
 - (BOOL)createdUnreadableLocalStore;
 - (void)prepareLocalStoreInSharedContainerBackingUpDatabase:(BOOL)backupCorruptedDatabase;
 - (BOOL)createExternalSupportFileForDatabaseAtURL:(NSURL *)databaseURL;

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
@@ -165,4 +165,14 @@
     }];
 }
 
+- (void)useApplicationSupportDirectoryAsDefault
+{
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSURL * const directory = [fm URLForDirectory:NSApplicationSupportDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&error];
+    Require(error == nil);
+    self.sharedContainerDirectoryURL = directory;
+    [NSManagedObjectContext setDatabaseDirectoryURL:self.sharedContainerDirectoryURL];
+}
+
 @end

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
@@ -42,6 +42,20 @@
 {
     [super setUp];
     [self cleanUp];
+    
+    NSError *error = nil;
+    for (NSString *path in [self.fm contentsOfDirectoryAtPath:self.sharedContainerDirectoryURL.path error:&error]) {
+        [self.fm removeItemAtPath:[self.sharedContainerDirectoryURL.path stringByAppendingPathComponent:path] error:&error];
+        if (error) {
+            NSLog(@"Error cleaning up %@ in %@: %@", path, self.sharedContainerDirectoryURL, error);
+            error = nil;
+        }
+    }
+    
+    if (error) {
+        NSLog(@"Error reading %@: %@", self.sharedContainerDirectoryURL, error);
+    }
+    
     [NSManagedObjectContext setUseInMemoryStore:NO];
     self.fm = [NSFileManager defaultManager];
     self.cachesDirectoryStoreURL = [NSManagedObjectContext storeURLInDirectory:NSCachesDirectory];
@@ -73,7 +87,7 @@
     if([self.fm fileExistsAtPath:testSharedContainerPath]) {
         [self.fm removeItemAtPath:testSharedContainerPath error:nil];
     }
-    
+ 
     [NSManagedObjectContext resetSharedPersistentStoreCoordinator];
 }
 

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
@@ -43,19 +43,6 @@
     [super setUp];
     [self cleanUp];
     
-    NSError *error = nil;
-    for (NSString *path in [self.fm contentsOfDirectoryAtPath:self.sharedContainerDirectoryURL.path error:&error]) {
-        [self.fm removeItemAtPath:[self.sharedContainerDirectoryURL.path stringByAppendingPathComponent:path] error:&error];
-        if (error) {
-            ZMLogError(@"Error cleaning up %@ in %@: %@", path, self.sharedContainerDirectoryURL, error);
-            error = nil;
-        }
-    }
-    
-    if (error) {
-        ZMLogError(@"Error reading %@: %@", self.sharedContainerDirectoryURL, error);
-    }
-    
     [NSManagedObjectContext setUseInMemoryStore:NO];
     self.fm = [NSFileManager defaultManager];
     self.cachesDirectoryStoreURL = [NSManagedObjectContext storeURLInDirectory:NSCachesDirectory];
@@ -89,6 +76,21 @@
     }
  
     [NSManagedObjectContext resetSharedPersistentStoreCoordinator];
+    
+    [self performIgnoringZMLogError:^{
+        NSError *error = nil;
+        for (NSString *path in [self.fm contentsOfDirectoryAtPath:self.sharedContainerDirectoryURL.path error:&error]) {
+            [self.fm removeItemAtPath:[self.sharedContainerDirectoryURL.path stringByAppendingPathComponent:path] error:&error];
+            if (error) {
+                ZMLogError(@"Error cleaning up %@ in %@: %@", path, self.sharedContainerDirectoryURL, error);
+                error = nil;
+            }
+        }
+        
+        if (error) {
+            ZMLogError(@"Error reading %@: %@", self.sharedContainerDirectoryURL, error);
+        }
+    }];
 }
 
 #pragma mark - Helper

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseBaseTest.m
@@ -47,13 +47,13 @@
     for (NSString *path in [self.fm contentsOfDirectoryAtPath:self.sharedContainerDirectoryURL.path error:&error]) {
         [self.fm removeItemAtPath:[self.sharedContainerDirectoryURL.path stringByAppendingPathComponent:path] error:&error];
         if (error) {
-            NSLog(@"Error cleaning up %@ in %@: %@", path, self.sharedContainerDirectoryURL, error);
+            ZMLogError(@"Error cleaning up %@ in %@: %@", path, self.sharedContainerDirectoryURL, error);
             error = nil;
         }
     }
     
     if (error) {
-        NSLog(@"Error reading %@: %@", self.sharedContainerDirectoryURL, error);
+        ZMLogError(@"Error reading %@: %@", self.sharedContainerDirectoryURL, error);
     }
     
     [NSManagedObjectContext setUseInMemoryStore:NO];

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseMovingTests.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseMovingTests.m
@@ -117,6 +117,45 @@
      XCTAssertTrue([self.fm fileExistsAtPath:supportURL]);
 }
 
+- (void)testThatItDoesNotMovesTheDatabaseFromTheApplicationSupportDirectoryToTheSharedDirectoryIfNotPossible
+{
+    // given
+    [self performIgnoringZMLogError:^{
+        XCTAssertTrue([self moveDatabaseToApplicationSupportDirectory]);
+        XCTAssertTrue([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
+    }];
+    
+    XCTAssertTrue([NSManagedObjectContext databaseExistsInApplicationSupportDirectory]);
+    XCTAssertFalse([NSManagedObjectContext databaseExistsInCachesDirectory]);
+    
+    for (NSString *extension in self.databaseFileExtensions) {
+        NSString *fromPath = [self.applicationSupportDirectoryStoreURL.path stringByAppendingString:extension];
+        NSString *toPath = [self.sharedContainerStoreURL.path stringByAppendingString:extension];
+        XCTAssertFalse([self.fm fileExistsAtPath:toPath]);
+        XCTAssertTrue([self.fm fileExistsAtPath:fromPath]);
+    }
+    
+    [self useApplicationSupportDirectoryAsDefault];
+
+    // when
+    [self prepareLocalStoreInSharedContainerBackingUpDatabase:NO];
+    
+    // then
+    for (NSString *extension in self.databaseFileExtensions) {
+        NSString *fromPath = [self.applicationSupportDirectoryStoreURL.path stringByAppendingString:extension];
+        NSString *toPath = [self.sharedContainerStoreURL.path stringByAppendingString:extension];
+        XCTAssertTrue([self.fm fileExistsAtPath:fromPath]);
+        XCTAssertFalse([self.fm fileExistsAtPath:toPath]);
+    }
+    
+    XCTAssertTrue([NSManagedObjectContext databaseExistsInApplicationSupportDirectory]);
+    XCTAssertFalse([NSManagedObjectContext databaseExistsInCachesDirectory]);
+    XCTAssertFalse([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
+    
+    NSString *supportURL = [self.applicationSupportDirectoryStoreURL.URLByDeletingLastPathComponent URLByAppendingPathComponent:@".store_SUPPORT"].path;
+    XCTAssertTrue([self.fm fileExistsAtPath:supportURL]);
+}
+
 - (void)testThatItMovesRemainingDatabaseFilesFromTheApplicationSupportDirectoryToTheSharedDirectory
 {
     // given

--- a/Tests/Source/ManagedObjectContext/Migrations/DatabaseMovingTests.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/DatabaseMovingTests.m
@@ -246,7 +246,7 @@
     // given
     [self performIgnoringZMLogError:^{
         XCTAssertTrue([self createdUnreadableLocalStore]);
-        XCTAssertTrue([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
+        XCTAssertFalse([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
     }];
     
     NSString *storeFile = [self.sharedContainerStoreURL.path stringByAppendingString:@""];
@@ -268,7 +268,7 @@
     // given
     [self performIgnoringZMLogError:^{
         XCTAssertTrue([self createdUnreadableLocalStore]);
-        XCTAssertTrue([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
+        XCTAssertFalse([NSManagedObjectContext needsToPrepareLocalStoreInDirectory:self.sharedContainerDirectoryURL]);
     }];
     
     NSString *storeFile = [self.sharedContainerStoreURL.path stringByAppendingString:@""];

--- a/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
+++ b/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
@@ -147,7 +147,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     XCTAssert([self.uiMOC saveOrRollback]);
@@ -155,7 +157,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     [self mergeMOC_SyncFirst];
@@ -163,7 +167,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
 }
 
 - (void)testThatItMergesReorderingOfMessagesFromSyncMOCToUiMOC
@@ -183,7 +189,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     XCTAssert([self.uiMOC saveOrRollback]);
@@ -191,7 +199,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     [self mergeMOC_SyncFirst];
@@ -199,7 +209,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
+    }];
 }
 
 
@@ -221,7 +233,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -231,8 +245,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"B", @"C", @"A"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
-
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     [self mergeMOC_SyncFirst];
@@ -240,7 +255,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"B", @"C", @"A", @"D"] failureRecorder:NewFailureRecorder()];
+    }];
 }
 
 - (void)testThatItMergesConflictingMessagesFromUiMOCToSyncMOC
@@ -251,7 +268,9 @@
     [(ZMMessage *)[self.uiConversation appendMessageWithText:@"D"] setServerTimestamp:[self nextDate]];
     [self.uiConversation.mutableMessages sortUsingDescriptors:ZMMessage.defaultSortDescriptors];
 
-    (void)self.syncConversation.mutableMessages;
+    [self.syncMOC performGroupedBlockAndWait:^{
+        (void)self.syncConversation.mutableMessages;
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // when
@@ -267,7 +286,9 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
     
     // and when
     [self.syncMOC performGroupedBlock:^{
@@ -277,15 +298,18 @@
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
-    
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
     // and when
     [self mergeMOC_SyncFirst];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
     [self checkTextInConversation:self.uiConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
-    [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self checkTextInConversation:self.syncConversation isEqual:@[@"A", @"B", @"C", @"D", @"X"] failureRecorder:NewFailureRecorder()];
+    }];
 }
 
 - (void)checkTextInConversation:(ZMConversation *)conversation isEqual:(NSArray *)texts failureRecorder:(ZMTFailureRecorder *)fr;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -27,7 +27,7 @@
 
 @implementation ZMConversationTests (OTR)
 
-- (NSArray<ZMUser *> *)createUsersWithClients
+- (NSArray<ZMUser *> *)createUsersWithClientsOnSyncMOC
 {
     self.selfUser = [ZMUser selfUserInContext:self.syncMOC];
     ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
@@ -49,7 +49,7 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray *users = [self createUsersWithClients];
+        NSArray *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
         
         // then
@@ -59,31 +59,36 @@
 
 - (void)testThatItIncreasesSecurityLevelIfAllClientsInConversationAreTrusted
 {
+    __block NSManagedObjectID *conversationObjectID = nil;
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], [[users.lastObject clients] anyObject], nil]];
-        
-        // then
-        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
+
+        [self.syncMOC saveOrRollback];
+        conversationObjectID = conversation.objectID;
     }];
+    
+    ZMConversation *uiConversation = [self.uiMOC existingObjectWithID:conversationObjectID error:nil];
+    // then
+    XCTAssertEqual(uiConversation.securityLevel, ZMConversationSecurityLevelSecure);
 }
 
 - (void)testThatItDoesNotIncreaseTheSecurityLevelIfAConversationContainsUsersWithoutAConnection
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         
         ZMUser *unconnectedUser = users.firstObject, *connectedUser = users.lastObject;
         unconnectedUser.connection.status = ZMConnectionStatusSent;
         
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         [selfClient trustClients:connectedUser.clients];
@@ -124,9 +129,9 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], nil]];
@@ -141,9 +146,9 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMUser *userWithoutClients = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
-        NSArray<ZMUser *> *users = [[self createUsersWithClients] arrayByAddingObject:userWithoutClients];
+        NSArray<ZMUser *> *users = [[self createUsersWithClientsOnSyncMOC] arrayByAddingObject:userWithoutClients];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         NSMutableSet *allClients = [NSMutableSet set];
         for(ZMUser *user in users) {
@@ -164,9 +169,9 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], [[users.lastObject clients] anyObject], nil]];
@@ -181,9 +186,9 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], [[users.lastObject clients] anyObject], nil]];
@@ -230,20 +235,25 @@
         return YES;
     }];
     
+    __block NSManagedObjectID *conversationObjectID = nil;
+    
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray<ZMUser *> *users = [self createUsersWithClients];
+        NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         
         // when
         XCTAssertNotEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], [[users.lastObject clients] anyObject], nil]];
         
-        // then
-        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
+        conversationObjectID = conversation.objectID;
+        [self.syncMOC saveOrRollback];
     }];
 
+    // then
+    ZMConversation *uiConversation = [self.uiMOC existingObjectWithID:conversationObjectID error:nil];
+    XCTAssertEqual(uiConversation.securityLevel, ZMConversationSecurityLevelSecure);
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
 }
 
@@ -252,14 +262,14 @@
     
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray <ZMUser *> *users = [self createUsersWithClients];
+        NSArray <ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
         NSSet *clients = [users.firstObject.clients setByAddingObjectsFromSet:users.lastObject.clients];
-        UserClient *selfClient = [self createSelfClient];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         [selfClient trustClients:clients];
         
         // when
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        
+        [self.syncMOC saveOrRollback];
         // then
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
         XCTAssertEqual(conversation.messages.count, 2lu);
@@ -277,8 +287,8 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
-        NSArray <ZMUser *> *users = [self createUsersWithClients];
-        UserClient *selfClient = [self createSelfClient];
+        NSArray <ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
+        UserClient *selfClient = [self createSelfClientOnMOC:self.syncMOC];
         [selfClient trustClients:users.firstObject.clients];
         
         // when

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -264,7 +264,7 @@
         
         // when
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.syncMOC withParticipants:users];
-        [self.syncMOC saveOrRollback];
+
         // then
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
         XCTAssertEqual(conversation.messages.count, 2lu);

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -59,7 +59,6 @@
 
 - (void)testThatItIncreasesSecurityLevelIfAllClientsInConversationAreTrusted
 {
-    __block NSManagedObjectID *conversationObjectID = nil;
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         NSArray<ZMUser *> *users = [self createUsersWithClientsOnSyncMOC];
@@ -69,13 +68,9 @@
         // when
         [selfClient trustClients:[NSSet setWithObjects:[[users.firstObject clients] anyObject], [[users.lastObject clients] anyObject], nil]];
 
-        [self.syncMOC saveOrRollback];
-        conversationObjectID = conversation.objectID;
+        // then
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
     }];
-    
-    ZMConversation *uiConversation = [self.uiMOC existingObjectWithID:conversationObjectID error:nil];
-    // then
-    XCTAssertEqual(uiConversation.securityLevel, ZMConversationSecurityLevelSecure);
 }
 
 - (void)testThatItDoesNotIncreaseTheSecurityLevelIfAConversationContainsUsersWithoutAConnection

--- a/Tests/Source/Model/Conversation/ZMConversationTests+UnreadCount.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+UnreadCount.m
@@ -65,10 +65,12 @@
     
     WaitForAllGroupsToBeEmpty(0.5);
     
-    // then
-    XCTAssertEqual(conv.estimatedUnreadCount, 3u);
-    XCTAssertFalse([conv.unreadTimeStamps containsObject:excludedMessage.serverTimestamp]);
-    XCTAssertEqualObjects(conv.unreadTimeStamps, expectedTimeStamps);
+    [self.syncMOC performGroupedBlockAndWait:^{
+        // then
+        XCTAssertEqual(conv.estimatedUnreadCount, 3u);
+        XCTAssertFalse([conv.unreadTimeStamps containsObject:excludedMessage.serverTimestamp]);
+        XCTAssertEqualObjects(conv.unreadTimeStamps, expectedTimeStamps);
+    }];
 }
 
 - (void)testThatItAddsNewTimeStampsToTheEndIfTheyAreNewerThanTheLastUnread
@@ -93,13 +95,14 @@
     }];
     
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(conv.estimatedUnreadCount, 1u);
     
     [self.syncMOC performGroupedBlockAndWait:^{
+        // then #1
+        XCTAssertEqual(conv.estimatedUnreadCount, 1u);
         // when
         [conv insertTimeStamp:newDate];
         
-        // then
+        // then #2
         XCTAssertEqual(conv.estimatedUnreadCount, 2u);
         XCTAssertEqualObjects(conv.unreadTimeStamps, expectedTimeStamps);
     }];
@@ -187,9 +190,9 @@
         [conv awakeFromFetch];
     }];
     WaitForAllGroupsToBeEmpty(0.5);
-    XCTAssertEqual(conv.estimatedUnreadCount, 3u);
     
     [self.syncMOC performGroupedBlockAndWait:^{
+        XCTAssertEqual(conv.estimatedUnreadCount, 3u);
         // expect
         NSOrderedSet *expectedTimeStamps = [NSOrderedSet orderedSetWithArray:@[lastMessage.serverTimestamp]];
         

--- a/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
@@ -293,9 +293,9 @@
     XCTAssertTrue([data writeToURL:fileURL options:0 error:&error]);
     XCTAssertNil(error);
     
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = NSUUID.createUUID;
-
+    
     // when
     ZMFileMetadata *fileMetadata = [[ZMFileMetadata alloc] initWithFileURL:fileURL thumbnail:nil];
     ZMAssetClientMessage *fileMessage = [conversation appendMessageWithFileMetadata:fileMetadata];
@@ -376,7 +376,7 @@
     CGSize dimensions = CGSizeMake(1900, 800);
     XCTAssertTrue([videoData writeToURL:fileURL options:0 error:&error]);
     
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = NSUUID.createUUID;
     
     // when
@@ -422,7 +422,7 @@
     NSUInteger duration = 12333;
     XCTAssertTrue([videoData writeToURL:fileURL options:0 error:&error]);
     
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = NSUUID.createUUID;
     
     // when

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -121,11 +121,10 @@
     self.clearedConversation.isArchived = YES;
 
     [self.uiMOC saveOrRollback];
-    [self.syncMOC mergeCallStateChanges:[self.uiMOC.zm_callState createCopyAndResetHasChanges]];
-    
-    
-    
+    ZMCallState *callStateFromUIMOC = [self.uiMOC.zm_callState createCopyAndResetHasChanges];
     [self.syncMOC performGroupedBlockAndWait:^{
+        [self.syncMOC mergeCallStateChanges:callStateFromUIMOC];
+
         ZMConversation *oneToOneConv = (id)[self.syncMOC objectWithID:self.oneToOneConversationWithActiveCall.objectID];
         
         oneToOneConv.activeFlowParticipants = [NSOrderedSet orderedSetWithObject:otherUser];

--- a/Tests/Source/Model/ManagedObjectValidationTests.m
+++ b/Tests/Source/Model/ManagedObjectValidationTests.m
@@ -57,21 +57,23 @@
 
 - (void)testThatValidationOnNonUIContextAlwaysPass
 {
-    ZMUser *user = [ZMUser selfUserInContext:self.syncMOC];
-    user.name = @"Ilya";
-    id value = user.name;
-    
-    id validator = [OCMockObject mockForClass:[ZMStringLengthValidator class]];
-    validator = [OCMockObject partialMockForObject:validator];
-    [[[validator reject] andForwardToRealObject] validateValue:[OCMArg anyObjectRef]
-                                           mimimumStringLength:2
-                                            maximumSringLength:64
-                                                         error:[OCMArg anyObjectRef]];
-
-    BOOL result = [user validateValue:&value forKey:@"name" error:NULL];
-    XCTAssertTrue(result);
-    [validator verify];
-    [validator stopMocking];
+    [self.syncMOC performGroupedBlockAndWait:^{        
+        ZMUser *user = [ZMUser selfUserInContext:self.syncMOC];
+        user.name = @"Ilya";
+        id value = user.name;
+        
+        id validator = [OCMockObject mockForClass:[ZMStringLengthValidator class]];
+        validator = [OCMockObject partialMockForObject:validator];
+        [[[validator reject] andForwardToRealObject] validateValue:[OCMArg anyObjectRef]
+                                               mimimumStringLength:2
+                                                maximumSringLength:64
+                                                             error:[OCMArg anyObjectRef]];
+        
+        BOOL result = [user validateValue:&value forKey:@"name" error:NULL];
+        XCTAssertTrue(result);
+        [validator verify];
+        [validator stopMocking];
+    }];
 }
 
 @end

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
@@ -25,7 +25,7 @@ class ClientMessageTests_Location: BaseZMMessageTests {
  
     func testThatItReturnsLocationMessageDataWhenPresent() {
         // given
-        let (longitude, latitude): (Float, Float) = (9.041169, 48.53775)
+        let (latitude, longitude): (Float, Float) = (48.53775, 9.041169)
         let (name, zoom) = ("Tuebingen, Deutschland", Int32(3))
         let message = ZMGenericMessage.genericMessage(
             withLocation: .location(
@@ -37,7 +37,7 @@ class ClientMessageTests_Location: BaseZMMessageTests {
         )
         
         // when
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         clientMessage.addData(message.data())
         
         // then
@@ -51,7 +51,7 @@ class ClientMessageTests_Location: BaseZMMessageTests {
     
     func testThatItDoesNotReturnLocationMessageDataWhenNotPresent() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         
         // then
         XCTAssertNil(clientMessage.locationMessageData)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -56,7 +56,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
 
     func testThatItHasImageReturnsTrueWhenLinkPreviewWillContainAnImage() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID()
         let article = Article(
             originalURLString: "www.example.com/article/original",
@@ -78,7 +78,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage() {
         
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID()
         let article = Article(
             originalURLString: "example.com/article/original",
@@ -99,7 +99,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItHasImageReturnsTrueWhenLinkPreviewWillContainAnImage_TwitterStatus() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let preview = TwitterStatus(
             originalURLString: "example.com/article/original",
@@ -123,7 +123,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage_TwitterStatus() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let preview = TwitterStatus(
             originalURLString: "example.com/article/original",
@@ -145,7 +145,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItHasImageReturnsTrueIfTheImageIsNotYetProcessedButTheOriginalIsInTheCache() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let preview = TwitterStatus(
             originalURLString: "example.com/article/original",
@@ -158,7 +158,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let genericMessage = ZMGenericMessage(text: "Text", linkPreview: preview.protocolBuffer, nonce: nonce.transportString())
         clientMessage.addData(genericMessage.data())
         clientMessage.nonce = nonce
-        syncMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: .secureRandomDataOfLength(256))
+        uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: .secureRandomDataOfLength(256))
         
         // when
         let willHaveAnImage = clientMessage.textMessageData!.hasImageData
@@ -169,7 +169,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItReturnsImageDataIdentifier_whenArticleHasImage() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let article = Article(
             originalURLString: "example.com/article/original",
@@ -195,7 +195,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     func testThatItDoesntReturnsImageDataIdentifier_whenArticleHasNoImage() {
         
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID()
         let article = Article(originalURLString: "example.com/article/original", permamentURLString: "http://www.example.com/article/1", offset: 12)
         article.title = "title"
@@ -212,7 +212,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItReturnsImageDataIdentifier_whenTwitterStatusHasImage() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let assetKey = "123"
         let twitterStatus = TwitterStatus(
@@ -237,7 +237,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
     
     func testThatItDoesntReturnsImageDataIdentifier_whenTwitterStatusHasNoImage() {
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         let preview = TwitterStatus(
             originalURLString: "example.com/tweet",
@@ -294,14 +294,14 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         setUpCaches()
         
         // given
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID.createUUID()
         
         let updated = preview.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key())
         let withID = updated.update(withAssetKey: "ID", assetToken: nil)
         clientMessage.addData(ZMGenericMessage(text: "Text", linkPreview: withID, nonce: nonce.transportString()).data())
         clientMessage.nonce = nonce
-        try! syncMOC.obtainPermanentIDsForObjects([clientMessage])
+        try! uiMOC.obtainPermanentIDsForObjects([clientMessage])
         
         // when
         

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
@@ -34,7 +34,7 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
     }
     
     func insertMessageWithLinkPreview(contentType: ContentType) -> ZMClientMessage {
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         let nonce = NSUUID()
         let article = Article(
             originalURLString: "example.com/article/original",
@@ -66,8 +66,8 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.setImageData(imageData, forFormat: .Medium, properties: properties)
         
         // then
-        XCTAssertNotNil(self.syncMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: false))
-        XCTAssertNotNil(self.syncMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: true))
+        XCTAssertNotNil(self.uiMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: false))
+        XCTAssertNotNil(self.uiMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: true))
         
         guard let linkPreview = clientMessage.genericMessage?.linkPreviews.first else { return XCTFail("did not contain linkpreview") }
         XCTAssertNotNil(linkPreview.article.image.uploaded.otrKey)
@@ -91,8 +91,8 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.setImageData(imageData, forFormat: .Medium, properties: properties)
         
         // then
-        XCTAssertNotNil(self.syncMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: false))
-        XCTAssertNotNil(self.syncMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: true))
+        XCTAssertNotNil(self.uiMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: false))
+        XCTAssertNotNil(self.uiMOC.zm_imageAssetCache.assetData(clientMessage.nonce, format: .Medium, encrypted: true))
         
         guard let linkPreview = clientMessage.genericMessage?.linkPreviews.first else { return XCTFail("did not contain linkpreview") }
         XCTAssertNotNil(linkPreview.article.image.uploaded.otrKey)
@@ -109,24 +109,24 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
     func testThatUpdatesLinkPreviewStateAndDeleteOriginalDataAfterProcessingFinishes() {
         // given
         let nonce = NSUUID()
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         clientMessage.nonce = nonce
-        self.syncMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: mediumJPEGData())
+        self.uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: mediumJPEGData())
         
         // when
         clientMessage.processingDidFinish()
         
         // then
         XCTAssertEqual(clientMessage.linkPreviewState, ZMLinkPreviewState.Processed)
-        XCTAssertNil(self.syncMOC.zm_imageAssetCache.assetData(nonce, format: .Original, encrypted: false))
+        XCTAssertNil(self.uiMOC.zm_imageAssetCache.assetData(nonce, format: .Original, encrypted: false))
     }
     
     func testThatItReturnsCorrectOriginalImageSize() {
         // given
         let nonce = NSUUID()
-        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(syncMOC)
+        let clientMessage = ZMClientMessage.insertNewObjectInManagedObjectContext(uiMOC)
         clientMessage.nonce = nonce
-        self.syncMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: mediumJPEGData())
+        self.uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .Original, encrypted: false, data: mediumJPEGData())
         
         // when
         let imageSize = clientMessage.originalImageSize()

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.m
@@ -619,7 +619,7 @@
         [self createSelfClient];
         ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
         otherUser.remoteIdentifier = NSUUID.createUUID;
-        UserClient *firstClient = [self createClientForUser:otherUser createSessionWithSelfUser:YES];
+        UserClient *firstClient = [self createClientForUser:otherUser createSessionWithSelfUser:YES onMOC:self.syncMOC];
         
         ZMUpdateEvent *messageEvent = [self encryptedExternalMessageFixtureWithBlobFromClient:firstClient];
         NSString *base64SHA = @"kKSSlbMxXEdd+7fekxB8Qr67/mpjjboBsr2wLcW7wzE=";

--- a/Tests/Source/Model/Observer/ObjectObserverToken/ConversationObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/ConversationObserverTokenTests.swift
@@ -24,7 +24,10 @@ class ConversationObserverTokenTests : ZMBaseManagedObjectTest {
     
     override func setUp() {
         super.setUp()
-        XCTAssertNotNil(self.syncMOC.globalManagedObjectContextObserver)
+        XCTAssertNotNil(self.uiMOC.globalManagedObjectContextObserver)
+        self.syncMOC.performGroupedBlockAndWait {
+            XCTAssertNotNil(self.syncMOC.globalManagedObjectContextObserver)
+        }
         NSNotificationCenter.defaultCenter().postNotificationName("ZMApplicationDidEnterEventProcessingStateNotification", object: nil)
         NSNotificationCenter.defaultCenter().postNotificationName(UIApplicationDidBecomeActiveNotification, object: nil)
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))

--- a/Tests/Source/Model/Observer/ObjectObserverToken/NewUnreadMessageObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/NewUnreadMessageObserverTokenTests.swift
@@ -67,8 +67,10 @@ class NewUnreadMessageObserverTokenTests : ZMBaseManagedObjectTest {
         self.newKnocksToken = ZMMessageNotification.addNewKnocksObserver(self.testObserver, managedObjectContext: self.uiMOC)
         
         self.syncTestObserver = UnreadMessageTestObserver()
-        self.syncNewMessageToken = ZMMessageNotification.addNewMessagesObserver(syncTestObserver, managedObjectContext: self.syncMOC)
-        self.syncNewKnocksToken = ZMMessageNotification.addNewKnocksObserver(syncTestObserver, managedObjectContext: self.syncMOC)
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncNewMessageToken = ZMMessageNotification.addNewMessagesObserver(self.syncTestObserver, managedObjectContext: self.syncMOC)
+            self.syncNewKnocksToken = ZMMessageNotification.addNewKnocksObserver(self.syncTestObserver, managedObjectContext: self.syncMOC)
+        }
         
         NSNotificationCenter.defaultCenter().postNotificationName("ZMApplicationDidEnterEventProcessingStateNotification", object: nil)
         XCTAssert(waitForAllGroupsToBeEmptyWithTimeout(0.5))
@@ -77,9 +79,10 @@ class NewUnreadMessageObserverTokenTests : ZMBaseManagedObjectTest {
     override func tearDown() {
         ZMMessageNotification.removeNewKnocksObserverForToken(self.newKnocksToken!, managedObjectContext: self.uiMOC)
         ZMMessageNotification.removeNewMessagesObserverForToken(self.newMessageToken!, managedObjectContext: self.uiMOC)
-        ZMMessageNotification.removeNewKnocksObserverForToken(self.syncNewKnocksToken!, managedObjectContext: self.syncMOC)
-        ZMMessageNotification.removeNewMessagesObserverForToken(self.syncNewMessageToken!, managedObjectContext: self.syncMOC)
-        
+        self.syncMOC.performGroupedBlockAndWait { 
+            ZMMessageNotification.removeNewKnocksObserverForToken(self.syncNewKnocksToken!, managedObjectContext: self.syncMOC)
+            ZMMessageNotification.removeNewMessagesObserverForToken(self.syncNewMessageToken!, managedObjectContext: self.syncMOC)
+        }
         self.newMessageToken = nil
         self.newKnocksToken = nil
         self.syncNewKnocksToken = nil

--- a/Tests/Source/Model/VoiceChannel/ZMCallStateTests.swift
+++ b/Tests/Source/Model/VoiceChannel/ZMCallStateTests.swift
@@ -710,7 +710,9 @@ extension ZMCallStateTests {
         let conversationA = ZMConversation.insertNewObjectInManagedObjectContext(self.uiMOC)
         let conversationB = ZMConversation.insertNewObjectInManagedObjectContext(self.uiMOC)
         self.uiMOC.saveOrRollback()
-        self.syncMOC.saveOrRollback()
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.saveOrRollback()
+        }
         
         XCTAssertFalse(mainSut.stateForConversation(conversationA).isCallDeviceActive)
         XCTAssertFalse(mainSut.stateForConversation(conversationB).isCallDeviceActive)
@@ -745,7 +747,10 @@ extension ZMCallStateTests {
         XCTAssertTrue(self.uiMOC.zm_callState.hasChanges)
 
         // when
-        let changedConversations = self.syncMOC.mergeCallStateChanges(self.uiMOC.zm_callState.createCopyAndResetHasChanges())
+        var changedConversations: Set<ZMConversation>!
+        self.syncMOC.performGroupedBlockAndWait {
+            changedConversations = self.syncMOC.mergeCallStateChanges(self.uiMOC.zm_callState.createCopyAndResetHasChanges())
+        }
         
         // then
         XCTAssertEqual(changedConversations.count, 2)
@@ -763,32 +768,40 @@ extension ZMCallStateTests {
         // when
         conversation.isIgnoringCall = true
         let callState1 = self.uiMOC.zm_callState.createCopyAndResetHasChanges()
-        self.syncMOC.mergeCallStateChanges(callState1)
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.mergeCallStateChanges(callState1)
+        }
         XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
 
         // then
-        let syncConversation = self.syncMOC.objectWithID(conversation.objectID) as? ZMConversation
-        XCTAssertNotNil(syncConversation)
-        if let syncConversation = syncConversation {
-            XCTAssertTrue(syncConversation.isIgnoringCall)
-            XCTAssertTrue(syncConversation.hasLocalModificationsForIsIgnoringCall)
-        } else {
-            XCTFail()
+        var syncConversation: ZMConversation!
+        self.syncMOC.performGroupedBlockAndWait {
+            syncConversation = self.syncMOC.objectWithID(conversation.objectID) as? ZMConversation
+            XCTAssertNotNil(syncConversation)
+            if let syncConversation = syncConversation {
+                XCTAssertTrue(syncConversation.isIgnoringCall)
+                XCTAssertTrue(syncConversation.hasLocalModificationsForIsIgnoringCall)
+            } else {
+                XCTFail()
+            }
         }
         
         // when
         conversation.isIgnoringCall = false
         let callState2 = self.uiMOC.zm_callState.createCopyAndResetHasChanges()
-        self.syncMOC.mergeCallStateChanges(callState2)
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.mergeCallStateChanges(callState2)
+        }
         XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
 
         // then
-        XCTAssertNotNil(syncConversation)
-        if let syncConversation = syncConversation {
-            XCTAssertFalse(syncConversation.isIgnoringCall)
-            XCTAssertFalse(syncConversation.hasLocalModificationsForIsIgnoringCall)
-        } else {
-            XCTFail()
+        self.syncMOC.performGroupedBlockAndWait {             
+            if let syncConversation = syncConversation {
+                XCTAssertFalse(syncConversation.isIgnoringCall)
+                XCTAssertFalse(syncConversation.hasLocalModificationsForIsIgnoringCall)
+            } else {
+                XCTFail()
+            }
         }
     }
     
@@ -803,12 +816,18 @@ extension ZMCallStateTests {
             // when
             conversation.isIgnoringCall = true
         }
-        let callState1 = self.syncMOC.zm_callState.createCopyAndResetHasChanges()
+        
+        var callState1: ZMCallState!
+        self.syncMOC.performGroupedBlockAndWait { 
+            callState1 = self.syncMOC.zm_callState.createCopyAndResetHasChanges()
+        }
         self.uiMOC.mergeCallStateChanges(callState1)
         
         // then
-        XCTAssertTrue(conversation.isIgnoringCall)
-        XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
+        self.syncMOC.performGroupedBlockAndWait {
+            XCTAssertTrue(conversation.isIgnoringCall)
+            XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
+        }
         
         let uiConversation = self.uiMOC.objectWithID(conversation.objectID) as? ZMConversation
         XCTAssertNotNil(uiConversation)
@@ -821,15 +840,18 @@ extension ZMCallStateTests {
         }
         
         // when
+        var callState2: ZMCallState!
         self.syncMOC.performGroupedBlockAndWait{
             conversation.isIgnoringCall = false
+            callState2 = self.syncMOC.zm_callState.createCopyAndResetHasChanges()
         }
-        let callState2 = self.syncMOC.zm_callState.createCopyAndResetHasChanges()
         self.uiMOC.mergeCallStateChanges(callState2)
         
         // then
-        XCTAssertFalse(conversation.isIgnoringCall)
-        XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
+        self.syncMOC.performGroupedBlockAndWait{
+            XCTAssertFalse(conversation.isIgnoringCall)
+            XCTAssertFalse(conversation.hasLocalModificationsForIsIgnoringCall)
+        }
         
         XCTAssertNotNil(uiConversation)
         if let uiConversation = uiConversation {

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.h
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.h
@@ -96,8 +96,9 @@
 @interface ZMBaseManagedObjectTest (OTR)
 
 - (UserClient *)createSelfClient;
+- (UserClient *)createSelfClientOnMOC:(NSManagedObjectContext *)moc;
 - (UserClient *)createClientForUser:(ZMUser *)user createSessionWithSelfUser:(BOOL)createSessionWithSeflUser;
-
+- (UserClient *)createClientForUser:(ZMUser *)user createSessionWithSelfUser:(BOOL)createSessionWithSeflUser onMOC:(NSManagedObjectContext *)moc;
 
 - (ZMClientMessage *)createClientTextMessage:(BOOL)encrypted;
 - (ZMClientMessage *)createClientTextMessage:(NSString *)text encrypted:(BOOL)encrypted;

--- a/Tests/Source/Model/ZMManagedObjectTests.m
+++ b/Tests/Source/Model/ZMManagedObjectTests.m
@@ -335,7 +335,7 @@
 
     // when
     __block NSSet *keysWithLocalModifications;
-    [self.syncMOC performGroupedBlockAndWaitWithReasonableTimeout:^{
+    [self.alternativeTestMOC performGroupedBlockAndWaitWithReasonableTimeout:^{
         MockEntity *fetchedEntity = [self mockEntityWithUUID:entityUUID inMoc:self.alternativeTestMOC];
         keysWithLocalModifications = fetchedEntity.keysThatHaveLocalModifications;
     }];

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		BF794FE31D143DE300E618C6 /* LocationMessage+Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF794FE21D143DE300E618C6 /* LocationMessage+Coordinate.swift */; };
 		BF794FE61D1442B100E618C6 /* ZMClientMessageTests+Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF794FE41D14425E00E618C6 /* ZMClientMessageTests+Location.swift */; };
 		BF7AFFCC1D747B5D00B2E089 /* DatabaseBaseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BF7AFFCB1D747B5D00B2E089 /* DatabaseBaseTest.m */; };
-		BF7AFFCE1D747EFD00B2E089 /* DatabaseBaseTest.h in Sources */ = {isa = PBXBuildFile; fileRef = BF7AFFCD1D747EFD00B2E089 /* DatabaseBaseTest.h */; };
 		BF85CF5F1D227A78006EDB97 /* LocationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF85CF5E1D227A78006EDB97 /* LocationData.swift */; };
 		BF949E5B1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */; };
 		BFA4D57C1CCF74600028C9E1 /* store23.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BFA4D57B1CCF74600028C9E1 /* store23.wiredatabase */; };
@@ -1900,7 +1899,6 @@
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,
 				F9331C621CB3C7D500139ECC /* DatabaseMovingTests.m in Sources */,
-				BF7AFFCE1D747EFD00B2E089 /* DatabaseBaseTest.h in Sources */,
 				F9A7085C1CAEED1B00C2F5FE /* ZMBaseManagedObjectTest.m in Sources */,
 				F9A708351CAEEB7500C2F5FE /* ManagedObjectContextTests.m in Sources */,
 				54DE05DD1CF8711F00C35253 /* ProtobufUtilitiesTests.swift in Sources */,

--- a/ZMCDataModel.xcodeproj/xcshareddata/xcschemes/ZMCDataModel.xcscheme
+++ b/ZMCDataModel.xcodeproj/xcshareddata/xcschemes/ZMCDataModel.xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,6 +48,12 @@
             ReferencedContainer = "container:ZMCDataModel.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
Relates to https://github.com/wireapp/wire-ios-sync-engine/pull/51

# Issue

On Travis there is no signing identity, and Xcode forbids using the shared container for our app during the tests, this makes tests crash. This is also the issue for external people who have no signing identity.

# Solution

Solution is to allow storing database in Application Data for simulator and builds that are non enterprise and non-appstore.

# Addition
I added the CoreData concurrency debugging flag and set it to be ON in tests.