### PR TITLE
Fix crash due to "reaction" key on messages not being ignored

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -677,7 +677,8 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
                              ZMMessageRemovedUsersKey,
                              ZMMessageNeedsUpdatingUsersKey,
                              ZMMessageSenderClientIDKey,
-                             ZMMessageConfirmationKey
+                             ZMMessageConfirmationKey,
+                             ZMMessageReactionKey
                              ];
         ignoredKeys = [keys setByAddingObjectsFromArray:newKeys];
     });
@@ -936,12 +937,6 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     message.isEncrypted = NO;
     message.isPlainText = YES;
     return message;
-}
-
-- (NSSet *)ignoredKeys;
-{
-    NSSet *ignoredKeys = [super ignoredKeys];
-    return [ignoredKeys setByAddingObject:ZMMessageReactionKey];
 }
 
 - (ZMDeliveryState)deliveryState

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -2621,4 +2621,18 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertEqual(usersThatReacted.count, 2lu);
 }
 
+- (void)testThatReactionKeyIsIgnored
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+    conversation.lastReadEventID = self.createEventID;
+    
+    // when
+    ZMMessage *message = [conversation appendMessageWithText:self.name];
+    
+    // then
+    XCTAssertTrue([message.ignoredKeys containsObject:@"reactions"]);
+}
+
 @end


### PR DESCRIPTION
# Reason for this pull request
The `reactions` key on `ZMMessage` was not marked as ignored, causing sync engine to try to upload it

# Changes
Ignore the `reactions` key (it was ignored only in `ZMSystemMessage`, it should have been ignored in the `ZMMessage` superclass instead)

# Known issues
Removing a key from the list of keys to synchronize (in this case, adding it to the ignore list) will cause the bitfield holding the list of keys that need to be synchronized upstream to go out of sync, potentially causing one other random key to be marked as needing to upload instead. This is undesired and might cause erratic behaviour for that one message, but it is better than the crash loop that we have if we without this PR.