### PR TITLE
Manually enqueue a save after inserting can not decrypt system message

### DIFF
--- a/Source/Model/Conversation/ZMConversation+OTR.m
+++ b/Source/Model/Conversation/ZMConversation+OTR.m
@@ -380,9 +380,9 @@
 
     [self appendSystemMessageOfType:type sender:sender users:nil clients:clients timestamp:serverTimestamp outInsertedAtIndex:nil];
     
-    // This message is called from inside the `EventDecoder` when a message fails to be decrypted.
+    // This method is called from inside the `EventDecoder` when a message fails to be decrypted.
     // If this was the only message being processed the event decoder will not propagate any events to the `ZMSyncStrategy`,
-    // where a save is enqueued, to ensure we save in this case we manaully enqueue a save here.
+    // where a save is enqueued. To ensure we always save in this case we also manually enqueue a save here.
     [self.managedObjectContext enqueueDelayedSave];
 }
 

--- a/Source/Model/Conversation/ZMConversation+OTR.m
+++ b/Source/Model/Conversation/ZMConversation+OTR.m
@@ -380,6 +380,10 @@
 
     [self appendSystemMessageOfType:type sender:sender users:nil clients:clients timestamp:serverTimestamp outInsertedAtIndex:nil];
     
+    // This message is called from inside the `EventDecoder` when a message fails to be decrypted.
+    // If this was the only message being processed the event decoder will not propagate any events to the `ZMSyncStrategy`,
+    // where a save is enqueued, to ensure we save in this case we manaully enqueue a save here.
+    [self.managedObjectContext enqueueDelayedSave];
 }
 
 - (void)appendDeletedForEveryoneSystemMessageWithTimestamp:(NSDate *)timestamp sender:(ZMUser *)sender


### PR DESCRIPTION
# What's in this PR?

There was a missing save after a `ZMSystemMessage` of type `ZMSystemMessageTypeDecryptionFailed` or `ZMSystemMessageTypeDecryptionFailed_RemoteIdentityChanged` has been appended to a conversation. If all update events that are processed by the `EventDecoder` can not be decrypted (which could be the case if there is only one event being processed) the consume block passed into the `EventDecoder` will not be called as there are no events to be processed. As the system message is appended from a call made inside the `EventDecoder` the context will not be saved (this is done in the completion block). There are multiple solutions to this issue, we now manually enqueue a save when inserting the can not decrypt system message, another option would have been to always call the completion with an empty array, which in turn would lead to it always being called one more time after all other events have been processed.

This PR is needed to fix failing tests in `wire-iso-sync-engine`: https://github.com/wireapp/wire-ios-sync-engine/pull/70