### PR TITLE
Adapt updated nullability annotations

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -124,10 +124,12 @@ extension ZMGenericMessage {
         let userEntries = recipients.flatMap { user -> ZMUserEntry? in
                 let clientsEntries = user.clients.flatMap { client -> ZMClientEntry? in
                 if client != selfClient {
+                    guard let clientRemoteIdentifier = client.remoteIdentifier else { return nil }
+                    
                     let corruptedClient = client.failedToEstablishSession
                     client.failedToEstablishSession = false
                     
-                    let hasSessionWithClient = sessionDirectory.hasSessionForID(client.remoteIdentifier)
+                    let hasSessionWithClient = sessionDirectory.hasSessionForID(clientRemoteIdentifier)
                     if !hasSessionWithClient {
                         // if the session is corrupted, will send a special payload
                         if corruptedClient {
@@ -140,7 +142,7 @@ extension ZMGenericMessage {
                         }
                     }
                     
-                    guard let encryptedData = try? sessionDirectory.encrypt(self.data(), recipientClientId: client.remoteIdentifier) else {
+                    guard let encryptedData = try? sessionDirectory.encrypt(self.data(), recipientClientId: clientRemoteIdentifier) else {
                         return nil
                     }
                     return ZMClientEntry.entry(withClient: client, data: encryptedData)

--- a/Source/Model/Message/ZMOTRMessage.h
+++ b/Source/Model/Message/ZMOTRMessage.h
@@ -29,6 +29,7 @@ extern NSString * const DeliveredKey;
 @property (nonatomic) BOOL delivered;
 @property (nonatomic) NSOrderedSet *dataSet;
 @property (nonatomic, readonly) NSSet *missingRecipients;
+@property (nonatomic, readonly) NSString *dataSetDebugInformation;
 
 - (void)missesRecipient:(UserClient *)recipient;
 - (void)missesRecipients:(NSSet<UserClient *> *)recipients;

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -22,6 +22,7 @@
 #import "ZMConversation+Internal.h"
 #import "ZMConversation+Transport.h"
 #import <ZMCDataModel/ZMCDataModel-Swift.h>
+#import "ZMGenericMessageData.h"
 
 
 @import ZMTransport;
@@ -87,6 +88,13 @@ NSString * const DeliveredKey = @"delivered";
     else {
         return [super deliveryState];
     }
+}
+
+- (NSString *)dataSetDebugInformation
+{
+    return [[self.dataSet mapWithBlock:^NSString *(ZMGenericMessageData *msg) {
+        return [NSString stringWithFormat:@"<%@>: %@", NSStringFromClass(ZMGenericMessageData.class), msg.genericMessage];
+    }].array componentsJoinedByString:@"\n"];
 }
 
 - (void)markAsSent

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -957,10 +957,6 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
 {
     [self willChangeValueForKey:key];
     
-    if (imageData == nil) {
-        [self.managedObjectContext.zm_userImageCache removeAllUserImages:self];
-        return;
-    }
     
     if (self.isSelfUser) {
         [self setPrimitiveValue:imageData forKey:key];
@@ -970,21 +966,28 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
         }
     }
     else {
+        if (nil == imageData) {
+            [self.managedObjectContext.zm_userImageCache removeAllUserImages:self];
+            return;
+        }
+        
         switch (format) {
             case ZMImageFormatMedium: {
-                [self.managedObjectContext.zm_userImageCache setLargeUserImage:self imageData:imageData]; // user image cache is thead safe
+                [self.managedObjectContext.zm_userImageCache setLargeUserImage:self imageData:imageData]; // user image cache is thread safe
                 break;
                 
             }
             case ZMImageFormatProfile: {
-                [self.managedObjectContext.zm_userImageCache setSmallUserImage:self imageData:imageData]; // user image cache is thead safe
+                [self.managedObjectContext.zm_userImageCache setSmallUserImage:self imageData:imageData]; // user image cache is thread safe
                 break;
             }
             default:
                 RequireString(NO, "Unexpected image format '%lu' set in user", (unsigned long)format);
                 break;
         }
+        
     }
+
     [self didChangeValueForKey:key];
     [self.managedObjectContext saveOrRollback];
 }

--- a/Source/Model/UserClient/UserClient+Protobuf.swift
+++ b/Source/Model/UserClient/UserClient+Protobuf.swift
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -25,7 +25,7 @@ extension UserClient {
     var hexRemoteIdentifier: UInt64 {
         let pointer = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
         defer { pointer.deallocate(capacity: 1) }
-        Scanner(string: self.remoteIdentifier).scanHexInt64(pointer)
+        Scanner(string: self.remoteIdentifier!).scanHexInt64(pointer)
         return UInt64(pointer.pointee)
     }
     

--- a/Source/VoiceChannel/ZMCallState.swift
+++ b/Source/VoiceChannel/ZMCallState.swift
@@ -265,17 +265,16 @@ extension ZMConversation {
         callState.activeVideoCallParticipants = participants.copy() as! NSOrderedSet
     }
 
-    public var otherActiveVideoCallParticipants: NSOrderedSet {
+    public var otherActiveVideoCallParticipants: Set<ZMUser> {
         get {
             if callState.isFlowActive {
-                let participants = callState.activeVideoCallParticipants.map{self.managedObjectContext?.object(with: $0 as! NSManagedObjectID)}
-                return NSOrderedSet(array: participants) 
+                return Set(callState.activeVideoCallParticipants.flatMap { self.managedObjectContext?.object(with: $0 as! NSManagedObjectID) as? ZMUser })
             }
-            return NSOrderedSet()
+            return Set()
         }
         set {
-            let objectIDs = newValue.map{($0 as!ZMUser).objectID} ?? NSOrderedSet()
-            callState.activeVideoCallParticipants = objectIDs
+            let objectIDs = newValue.map{ $0.objectID }
+            callState.activeVideoCallParticipants = NSOrderedSet(array: objectIDs)
         }
     }
 }

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -80,14 +80,14 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
             self.syncConversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [self.syncUser1, self.syncUser2, self.syncUser3])
             self.expectedRecipients = [
                 self.syncSelfUser.remoteIdentifier!.transportString(): [
-                    self.syncSelfClient2.remoteIdentifier
+                    self.syncSelfClient2.remoteIdentifier!
                 ],
                 self.syncUser1.remoteIdentifier!.transportString(): [
-                    self.syncUser1Client1.remoteIdentifier,
-                    self.syncUser1Client2.remoteIdentifier
+                    self.syncUser1Client1.remoteIdentifier!,
+                    self.syncUser1Client2.remoteIdentifier!
                 ],
                 self.syncUser2.remoteIdentifier!.transportString(): [
-                    self.syncUser2Client1.remoteIdentifier
+                    self.syncUser2Client1.remoteIdentifier!
                 ]
             ]
             
@@ -114,14 +114,14 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
         self.conversation = try! self.uiMOC.existingObject(with: self.syncConversation.objectID) as! ZMConversation
         self.expectedRecipients = [
             self.selfUser.remoteIdentifier!.transportString(): [
-                self.selfClient2.remoteIdentifier
+                self.selfClient2.remoteIdentifier!
             ],
             self.user1.remoteIdentifier!.transportString(): [
-                self.user1Client1.remoteIdentifier,
-                self.user1Client2.remoteIdentifier
+                self.user1Client1.remoteIdentifier!,
+                self.user1Client2.remoteIdentifier!
             ],
             self.user2.remoteIdentifier!.transportString(): [
-                self.user2Client1.remoteIdentifier
+                self.user2Client1.remoteIdentifier!
             ]
         ]
     }

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1311,7 +1311,7 @@ extension ZMAssetClientMessageTests {
         var message : ZMGenericMessage?
         self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { (sessionsDirectory) in
             do {
-                let decryptedData = try sessionsDirectory.decrypt(entry.text, senderClientId: client.remoteIdentifier)
+                let decryptedData = try sessionsDirectory.decrypt(entry.text, senderClientId: client.remoteIdentifier!)
                 message = ZMGenericMessage.builder()!.merge(from: decryptedData).build()! as? ZMGenericMessage
             } catch {
                 XCTFail("Failed to decrypt generic message: \(error)")

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -104,7 +104,7 @@ extension ClientMessageTests_OTR {
             self.syncConversation.remoteIdentifier = UUID()
             let message = ZMConversation.appendSelfConversation(withLastReadOf: self.syncConversation)
             
-            self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier]]
+            self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier!]]
             
             // when
             guard let payloadAndStrategy = message.encryptedMessagePayloadData() else {
@@ -130,7 +130,7 @@ extension ClientMessageTests_OTR {
             self.syncConversation.remoteIdentifier = UUID()
             let message = ZMConversation.appendSelfConversation(withClearedOf: self.syncConversation)
             
-            self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier]]
+            self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier!]]
             
             // when
             guard let payloadAndStrategy = message.encryptedMessagePayloadData() else {
@@ -207,7 +207,7 @@ extension ClientMessageTests_OTR {
                 let payloadClients = recipients.flatMap { user -> [String] in
                     return (user.clients as? [ZMClientEntry])?.map({ String(format: "%llx", $0.client.client) }) ?? []
                 }.flatMap { $0 }
-                XCTAssertEqual(payloadClients.sorted(), self.syncUser1.clients.map { $0.remoteIdentifier }.sorted())
+                XCTAssertEqual(payloadClients.sorted(), self.syncUser1.clients.map { $0.remoteIdentifier! }.sorted())
             } else {
                 XCTFail("Metadata does not contain recipients")
             }

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -153,7 +153,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
             XCTAssertTrue(otherClient.hasSessionWithSelfClient)
             
             // when
-            UserClient.deleteSession(forClientWithRemoteIdentifier:otherClient.remoteIdentifier, managedObjectContext:self.syncMOC)
+            UserClient.deleteSession(forClientWithRemoteIdentifier:otherClient.remoteIdentifier!, managedObjectContext:self.syncMOC)
             
             // then
             XCTAssertFalse(otherClient.hasSessionWithSelfClient)
@@ -259,7 +259,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
                     return }
             
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
-                try! sessionsDirectory.createClientSession(otherClient.remoteIdentifier, base64PreKeyString: preKey.prekey)
+                try! sessionsDirectory.createClientSession(otherClient.remoteIdentifier!, base64PreKeyString: preKey.prekey)
             })
             
             XCTAssertNil(otherClient.fingerprint)


### PR DESCRIPTION
# What's in this PR?

* `UserClient.remoteIdentifier` is now an Optional
* Fix a bug where self user images could not be deleted
* Add debug information property to `ZMOTRMessage`