### PR TITLE
Fix for crash when trying to confirm to deleted client

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -241,10 +241,10 @@ NS_ASSUME_NONNULL_END
 - (void)internalRemoveParticipant:(nonnull ZMUser *)participant sender:(nonnull ZMUser *)sender;
 
 @property (nonatomic) BOOL isSelfAnActiveMember; ///< whether the self user is an active member (as opposed to a past member)
-@property (readonly, nonatomic, nonnull) NSOrderedSet *otherActiveParticipants;
-@property (readonly, nonatomic, nonnull) NSOrderedSet *otherInactiveParticipants;
-@property (readonly, nonatomic, nonnull) NSMutableOrderedSet *mutableOtherActiveParticipants;
-@property (readonly, nonatomic, nonnull) NSMutableOrderedSet *mutableOtherInactiveParticipants;
+@property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *otherActiveParticipants;
+@property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *otherInactiveParticipants;
+@property (readonly, nonatomic, nonnull) NSMutableOrderedSet<ZMUser *> *mutableOtherActiveParticipants;
+@property (readonly, nonatomic, nonnull) NSMutableOrderedSet<ZMUser *> *mutableOtherInactiveParticipants;
 
 /// Removes user from unsyncedInactiveParticipants
 - (void)synchronizeRemovedUser:(nonnull ZMUser *)user;
@@ -253,10 +253,10 @@ NS_ASSUME_NONNULL_END
 - (void)synchronizeAddedUser:(nonnull ZMUser *)user;
 
 /// List of users which have been removed from the conversation locally but not one the backend
-@property (readonly, nonatomic, nullable) NSOrderedSet *unsyncedInactiveParticipants;
+@property (readonly, nonatomic, nullable) NSOrderedSet<ZMUser *> *unsyncedInactiveParticipants;
 
 /// List of users which have been added to the conversation locally but not one the backend
-@property (readonly, nonatomic, nullable) NSOrderedSet *unsyncedActiveParticipants;
+@property (readonly, nonatomic, nullable) NSOrderedSet<ZMUser *> *unsyncedActiveParticipants;
 
 @end
 

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -96,11 +96,11 @@ extension ZMGenericMessage {
         var recipientUsers : [ZMUser] = []
         let replyOnlyToSender = self.hasConfirmation()
         if replyOnlyToSender {
+            // Reply is only supported on 1-to-1 conversations
+            assert(conversation.conversationType == .oneOnOne)
+            
             // In case of confirmation messages, we want to send the confirmation only to the clients of the sender of the original message, not to everyone in the conversation
-            let messageID = UUID(uuidString: self.confirmation.messageId)
-            if let message = ZMMessage.fetch(withNonce: messageID, for: conversation, in: conversation.managedObjectContext) {
-                recipientUsers = [message.sender].flatMap { $0 }
-            }
+            recipientUsers = conversation.otherActiveParticipants.array as! [ZMUser]
         } else {
             recipientUsers = conversation.activeParticipants.array as! [ZMUser]
         }

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -217,6 +217,8 @@ extern NSString * const ZMMessageConfirmationKey;
 
 - (void)updateWithUpdateEvent:(ZMUpdateEvent *)updateEvent forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 
+- (void)removePendingDeliveryReceipts;
+
 - (void)updateWithTimestamp:(NSDate *)serverTimestamp senderUUID:(NSUUID *)senderUUID eventID:(ZMEventID *)eventID forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 
 /// Returns whether the data represents animated GIF

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -393,6 +393,9 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     NSUUID *messageID = [NSUUID uuidWithTransportString:deletedMessage.messageId];
     ZMMessage *message = [ZMMessage fetchMessageWithNonce:messageID forConversation:conversation inManagedObjectContext:moc];
 
+    // We need to cascade delete the pending delivery confirmation messages for the message being deleted
+    [message removePendingDeliveryReceipts];
+    
     // Only the sender of the original message can delete it
     if (![senderID isEqual:message.sender.remoteIdentifier]) {
         return;
@@ -406,6 +409,28 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
     }
 
     [message removeMessageClearingSender:YES];
+}
+
+- (void)removePendingDeliveryReceipts
+{
+    // Pending receipt can exist only in new inserted messages since it is deleted locally after it is sent to the backend
+    NSFetchRequest *requestForInsertedMessages = [ZMClientMessage sortedFetchRequestWithPredicate:[ZMClientMessage predicateForObjectsThatNeedToBeInsertedUpstream]];
+    NSArray *possibleMatches = [self.managedObjectContext executeFetchRequestOrAssert:requestForInsertedMessages];
+    
+    NSArray *confirmationReceipts = [possibleMatches filterWithBlock:^BOOL(ZMClientMessage *candidateConfirmationReceipt) {
+        if (candidateConfirmationReceipt.genericMessage.hasConfirmation &&
+            candidateConfirmationReceipt.genericMessage.confirmation.hasMessageId &&
+            [candidateConfirmationReceipt.genericMessage.confirmation.messageId isEqual:self.nonce.transportString]) {
+            return YES;
+        }
+        return NO;
+    }];
+    
+    NSAssert(confirmationReceipts.count <= 1, @"More than one confirmation receipt");
+    
+    for (ZMClientMessage *confirmationReceipt in confirmationReceipts) {
+        [self.managedObjectContext deleteObject:confirmationReceipt];
+    }
 }
 
 + (ZMMessage *)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage *)genericEditMessage inConversation:(ZMConversation *)conversation senderID:(NSUUID *)senderID inManagedObjectContext:(NSManagedObjectContext *)moc;


### PR DESCRIPTION
# Issue

## Symptoms

We detected the crash loop state on Alan's phone. Crash happens when client is trying to send the confirmation for message delivery. The transcoder is trying to create the message payload for the client but fail to fetch the receiver.

## Investigation

It seems that in conversation between A and B, B sends message to A while A if offline. Then B deletes the message. A starts the client and start receiving the notifications. One notification inserts the new message from B, so A generates the delivery pingback. Then next message in the stream asks to delete the message, so message looses sender and all the data. Then we start to send the request for uploading the delivery pingback, but we fail because the message which we are pinging back about is deleted and there is no sender info.

# Solution

Solution consists of two parts:

- For users who are in the crash loop the hotfix is delivered that removes the confirmation messages for deleted messages, if any
- For the future users, to avoid that state, when we receive the message deletion call we also delete the confirmation messages for this message