### PR TITLE
Discard deleted messages from prefetch

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -303,21 +303,7 @@ NSString * const ZMMessageConfirmationKey = @"confirmations";
 {
     self.eventID = [ZMEventID latestOfEventID:self.eventID and:eventID];
     [self updateTimestamp:serverTimestamp isUpdatingExistingMessage:isUpdate];
-    
-    /**
-     * Florian, the 07.06.16
-     * In some cases, the conversation relationship assignement crashes for the reason that both object are coming from a different context.
-     * I think this is a bug on Apple's side as the sender assignement also has caused a crash for the same reason (https://rink.hockeyapp.net/manage/apps/42908/app_versions/558/crash_reasons/123911635?order=asc&sort_by=date&type=crashes#crash_data)
-     *
-     * There is no way that the user and self (the message) are in different context as we EXPLICITLY fetch(or create) it from the self.managedObjectContext
-     *
-     * And after a thourough digging in the code, the conversation ALSO can't come from a different context, as both prefetched batches and fetch creation is done on SyncMOC (same for message).
-     
-     * I try to fetch the conversation from the self context as an attempt workaround.
-     *
-     * This issue was only reported on iOS 9.3.2.
-     */
-    
+
     if (self.managedObjectContext != conversation.managedObjectContext) {
         conversation = [ZMConversation conversationWithRemoteID:conversation.remoteIdentifier createIfNeeded:NO inContext:self.managedObjectContext];
     }

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -210,6 +210,11 @@ NSString * const DeliveredKey = @"delivered";
                                                       forConversation:conversation
                                                inManagedObjectContext:moc
                                                        prefetchResult:prefetchResult];
+    
+    if (clientMessage.isZombieObject) {
+        return nil;
+    }
+    
     BOOL isNewMessage = NO;
     if (clientMessage == nil) {
         clientMessage = [messageClass insertNewObjectInManagedObjectContext:moc];


### PR DESCRIPTION
# Issue

We experienced the weird crash on multiple user accounts reported with the same crash log: the relation in the database is created between objects in different managed object contexts.

# Investigation

One of the team members had this issue permanently on the work device, so it was possible to attach with debugger to the version installed. It came out that the app was trying to establish the relation between the object that does not belong to any context (deleted one) and the existing one. Deleted one had managedObjectContext set to nil.

On closer look it came out that the object that is having managed object context nil is received from object pre-fetch cache.

# Solution

Check object before using it if it is `zombie` e.g. does not belong to any managed object context.