### PR TITLE
Fix crash delivery notifications

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
@@ -41,7 +41,7 @@
 /// Creates persistent store coordinator and migrates store if needed
 /// @param sync defines if the method should execute sycnhronously or not (ususally it makes sence to execute it
 ///         synchronously when @c +needsToPrepareLocalStore is YES)
-/// @param backupCorruptedDatabase: if true, will copy a corrupted database to another folder for later investigation
+/// @param backupCorruptedDatabase if true, will copy a corrupted database to another folder for later investigation
 /// @param completionHandler callback to be executed on completion (nullable)
 + (void)prepareLocalStoreSync:(BOOL)sync
                   inDirectory:(NSURL *)directory

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -208,9 +208,9 @@ NS_ASSUME_NONNULL_END
 - (nonnull ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata nonce:(nonnull NSUUID *)nonce;
 
 /// Appends a new message to the conversation.
-/// @param genericMessage: the generic message that should be appended
-/// @param expires: wether the message should expire or tried to be send infinitively
-/// @param hidden: wether the message should be hidden in the conversation or not
+/// @param genericMessage the generic message that should be appended
+/// @param expires wether the message should expire or tried to be send infinitively
+/// @param hidden wether the message should be hidden in the conversation or not
 - (nonnull ZMClientMessage *)appendGenericMessage:(nonnull ZMGenericMessage *)genericMessage expires:(BOOL)expires hidden:(BOOL)hidden;
 
 - (void)appendNewConversationSystemMessageIfNeeded;

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -99,8 +99,9 @@ extension ZMGenericMessage {
             // Reply is only supported on 1-to-1 conversations
             assert(conversation.conversationType == .oneOnOne)
             
-            // In case of confirmation messages, we want to send the confirmation only to the clients of the sender of the original message, not to everyone in the conversation
-            recipientUsers = conversation.otherActiveParticipants.array as! [ZMUser]
+            // In case of confirmation messages, we want to send the confirmation only to the clients of the sender of the original message, 
+            // not to the other clients of the selfUser
+            recipientUsers = [conversation.connectedUser!]
         } else {
             recipientUsers = conversation.activeParticipants.array as! [ZMUser]
         }


### PR DESCRIPTION
**In this PR**

In a previous fix, we changed the recipients for delivery messages. However, instead of otherActiveParticipants (which returns nil for 1on1 conversations) we should use connectedUser which is the other user in a 1on1.