### PR TITLE
Fix array out of bounds for arabic names

### DIFF
--- a/Source/Model/User/ZMPersonName.m
+++ b/Source/Model/User/ZMPersonName.m
@@ -204,25 +204,26 @@ typedef NS_ENUM(NSUInteger, ZMPersonNameOrder) {
     if (self.components.count <2) return nil;
     
     NSUInteger startIndex;
-    NSUInteger endIndex;
+    NSUInteger length;
     
     switch (self.nameOrder) {
         case ZMPersonNameOrderGivenNameLast:
             startIndex = 0;
-            endIndex = self.components.count-2;
+            length = self.components.count-2;
             break;
             
         case ZMPersonNameOrderGivenNameFirst:
             startIndex = 1;
-            endIndex = self.components.count-1;
+            length = self.components.count-1;
             break;
             
         case ZMPersonNameOrderArabicGivenNameFirst:
             startIndex = 1;
-            endIndex = self.components.count-1;
+            length = self.components.count-1;
             if ([self.components[1] zmIsGodName]) {
                 if (self.components.count > 2) {
                     startIndex++;
+                    length--;
                 }
                 else {
                     return nil;
@@ -231,7 +232,7 @@ typedef NS_ENUM(NSUInteger, ZMPersonNameOrder) {
             break;
     }
 
-    return [self.components subarrayWithRange:NSMakeRange(startIndex, endIndex)];
+    return [self.components subarrayWithRange:NSMakeRange(startIndex, length)];
 }
 
 

--- a/Tests/Source/Model/User/ZMPersonNameTests.m
+++ b/Tests/Source/Model/User/ZMPersonNameTests.m
@@ -496,6 +496,18 @@
     XCTAssertEqualObjects(nameComp3.fullName, name3);
 }
 
+- (void)testThatArabicGodNameWithThreeComponentsAreAbbreviatedCorrectly
+{
+    // given
+    NSString *name1 = @"عبد العزيز عبد الله";
+    
+    // when
+    ZMPersonName *nameComp1 = [ZMPersonName personWithName:name1];
+    
+    // then
+    XCTAssertEqualObjects(nameComp1.abbreviatedName, @"عبد العزيز ا");
+}
+
 - (void)testThatItReturnsFirstLettersOFFirstAndLastComponentForArabicInitials
 {
     // given


### PR DESCRIPTION
## Why was it crashing
If a name contains a god name we skip it by advancing the starting index but we didn't decrease the length of the range, which results in an out of bounds error.