### PR TITLE
Disable sending native pushes for delivery receipts

### DIFF
--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -52,7 +52,7 @@ open class ZMMessageConfirmation: NSManagedObject {
             let moc = conversation.managedObjectContext,
             let messageUUID = UUID(uuidString: genericMessage.confirmation.messageId),
             let message = ZMMessage.fetch(withNonce: messageUUID, for: conversation, in: moc),
-            let originalSender = message.sender , originalSender.isSelfUser
+            let originalSender = message.sender, originalSender.isSelfUser
         else { return nil }
         
         var confirmation = message.confirmations.filter{$0.user == sender}.first

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -107,7 +107,9 @@ extension ZMGenericMessage {
         }
         
         let recipients = self.recipientsWithEncryptedData(selfClient, recipients: recipientUsers, sessionDirectory: sessionDirectory)
-        let message = ZMNewOtrMessage.message(withSender: selfClient, nativePush: true, recipients: recipients, blob: externalData)
+
+        let nativePush = !hasConfirmation() // We do not want to send pushes for delivery receipts
+        let message = ZMNewOtrMessage.message(withSender: selfClient, nativePush: nativePush, recipients: recipients, blob: externalData)
         
         let strategy : MissingClientsStrategy =
             replyOnlyToSender ?

--- a/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@testable import ZMCDataModel
+
+class GenericMessageTests_NativePush: BaseZMMessageTests {
+
+    func testThatItSetsNativePushToFalseWhenSendingAConfirmationMessage() {
+        let message = ZMGenericMessage(
+            confirmation: UUID.create().transportString(),
+            type: .DELIVERED,
+            nonce: UUID.create().transportString()
+        )
+        assertThatItSetsNativePush(to: false, for: message)
+    }
+
+    func testThatItSetsNativePushToTrueWhenSendingATextMessage() {
+        let message = ZMGenericMessage(text: "Text", nonce: UUID.create().transportString())
+        assertThatItSetsNativePush(to: true, for: message)
+    }
+
+    func assertThatItSetsNativePush(to nativePush: Bool, for message: ZMGenericMessage, line: UInt = #line) {
+        createSelfClient()
+
+        syncMOC.performGroupedBlock {
+            // given
+            let user = ZMUser.insertNewObject(in: self.syncMOC)
+            user.remoteIdentifier = .create()
+            let connection = ZMConnection.insertNewObject(in: self.syncMOC)
+            connection.to = user
+
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            conversation.connection = connection
+            conversation.conversationType = .oneOnOne
+
+            // when
+            let (data, _) = message.encryptedMessagePayloadData(conversation, externalData: nil)!
+            let builder = ZMNewOtrMessage.builder()!
+            builder.merge(from: data)
+            guard let otrMessage = builder.build() else { return XCTFail("Unable to build ZMNewOTRMessage", line: line) }
+
+            // then
+            XCTAssertTrue(otrMessage.hasNativePush(), line: line)
+            XCTAssertEqual(otrMessage.nativePush(), nativePush, "Wrong value for nativePush", line: line)
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), line: line)
+    }
+    
+}
+
+

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		BF85CF5F1D227A78006EDB97 /* LocationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF85CF5E1D227A78006EDB97 /* LocationData.swift */; };
 		BF949E5B1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */; };
 		BFA4D57C1CCF74600028C9E1 /* store23.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BFA4D57B1CCF74600028C9E1 /* store23.wiredatabase */; };
+		BFCF31DB1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */; };
 		BFD2E7991CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */; };
 		BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */; };
@@ -384,6 +385,7 @@
 		BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LinkPreview+ProtobufTests.swift"; sourceTree = "<group>"; };
 		BFA4D57B1CCF74600028C9E1 /* store23.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = store23.wiredatabase; path = Tests/Resources/store23.wiredatabase; sourceTree = SOURCE_ROOT; };
 		BFC387681CB7BC1E00F08415 /* zmessaging2.4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.4.xcdatamodel; sourceTree = "<group>"; };
+		BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessageTests+NativePush.swift"; sourceTree = "<group>"; };
 		BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMGenericMessage+UpdateEvent.h"; sourceTree = "<group>"; };
 		BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMGenericMessage+UpdateEvent.m"; sourceTree = "<group>"; };
 		BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Deletion.swift"; sourceTree = "<group>"; };
@@ -1232,6 +1234,7 @@
 				F9B71F5E1CB2BC85001DB03F /* ZMClientMessageTests.m */,
 				F9331C591CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift */,
 				F96470091D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m */,
+				BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */,
 				BF794FE41D14425E00E618C6 /* ZMClientMessageTests+Location.swift */,
 				1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */,
 				BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */,
@@ -1959,6 +1962,7 @@
 				F9331C631CB3C7D500139ECC /* OTRMigrationTests.m in Sources */,
 				F9B71FA31CB2BF37001DB03F /* ZMConversationTests+gapsAndWindows.m in Sources */,
 				F9A708391CAEEB7500C2F5FE /* CoreDataRelationshipsTests.m in Sources */,
+				BFCF31DB1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift in Sources */,
 				F9B71FA41CB2BF37001DB03F /* ZMConversationTests+messages.m in Sources */,
 				F9B71FF21CB2C4C6001DB03F /* AnyClassTupleTests.swift in Sources */,
 				F9A7083A1CAEEB7500C2F5FE /* MockEntity.m in Sources */,


### PR DESCRIPTION
# What's in this PR?

Some users reported "New message" notifications without having received any new visible content inside the application. These notifications are received when we fail to pingback to the backend after receiving a `VoIP` notification, the most probable scenario is that this happens when we receive a lot of delivery receipt pushes and fail to pingback either because of bad network conditions or because we are running in the background for too long.

As there is no actual need to send native pushes for delivery receipts (as they are only visible in the UI and should not generate a local notification) we now no longer are sending them.