### PR TITLE
Fix send ephemeral asset only to other user

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -26,7 +26,7 @@ import Cryptobox
 /// us that some user clients that were supposed to be there are missing (e.g.
 /// another user added a new client that we don't yet know about). The various
 /// strategies give a hint to the backend of how we want to handle missing clients.
-public enum MissingClientsStrategy {
+public enum MissingClientsStrategy : Equatable {
     
     /// Fail the request if there is any missing client
     case doNotIgnoreAnyMissingClient
@@ -36,6 +36,20 @@ public enum MissingClientsStrategy {
     /// Do not fail the request, no matter which clients are missing
     case ignoreAllMissingClients
 }
+
+public func ==(lhs: MissingClientsStrategy, rhs: MissingClientsStrategy) -> Bool {
+    switch (lhs, rhs) {
+    case (.doNotIgnoreAnyMissingClient, .doNotIgnoreAnyMissingClient):
+        return true
+    case (.ignoreAllMissingClients, .ignoreAllMissingClients):
+        return true
+    case (.ignoreAllMissingClientsNotFromUser(let leftUser), .ignoreAllMissingClientsNotFromUser(let rightUser)):
+        return leftUser == rightUser
+    default:
+        return false
+    }
+}
+
 
 extension ZMClientMessage {
     
@@ -87,35 +101,26 @@ extension ZMGenericMessage {
         return messageDataAndStrategy
     }
     
-    /// Returns a message with recipients and a strategy to handle missing clients
-    fileprivate func otrMessage(_ selfClient: UserClient,
-                            conversation: ZMConversation,
-                            externalData: Data?,
-                            sessionDirectory: EncryptionSessionsDirectory) -> (message: ZMNewOtrMessage, strategy: MissingClientsStrategy) {
+    
+    func recipientUsersforMessage(in conversation: ZMConversation, sendOnlyToOtherUser: Bool) -> [ZMUser] {
         
         var recipientUsers : [ZMUser] = []
-        let sendOnlyToOtherUser = ( self.hasConfirmation() || self.hasEphemeral() )
         if sendOnlyToOtherUser {
-            
-            // In case of confirmation messages, we want to send the confirmation only to the clients of the sender of the original message, 
-            // not to the other clients of the selfUser
-            
             var sender : ZMUser? = nil
             if self.hasConfirmation(), self.confirmation.messageId != nil {
-             
                 if let message = ZMMessage.fetch(withNonce:UUID(uuidString:self.confirmation.messageId), for:conversation, in:conversation.managedObjectContext){
                     sender = message.sender
                 }
             }
             
             if conversation.connectedUser != nil || sender != nil || conversation.otherActiveParticipants.firstObject != nil {
-                let recipient = { () -> ZMUser? in 
+                let recipient = { () -> ZMUser? in
                     if sender != nil { return sender }
                     if conversation.connectedUser != nil { return conversation.connectedUser }
                     if conversation.otherActiveParticipants.count > 0 { return conversation.otherActiveParticipants.firstObject! as? ZMUser }
                     return nil
                 }()
-    
+                
                 if let recipient = recipient {
                     recipientUsers = [recipient]
                 } else {
@@ -126,16 +131,26 @@ extension ZMGenericMessage {
         } else {
             recipientUsers = conversation.activeParticipants.array as! [ZMUser]
         }
+        return recipientUsers
+    }
+    
+    
+    /// Returns a message with recipients and a strategy to handle missing clients
+    fileprivate func otrMessage(_ selfClient: UserClient,
+                            conversation: ZMConversation,
+                            externalData: Data?,
+                            sessionDirectory: EncryptionSessionsDirectory) -> (message: ZMNewOtrMessage, strategy: MissingClientsStrategy) {
         
+        let sendOnlyToOtherUser = ( self.hasConfirmation() || self.hasEphemeral() )
+        let recipientUsers = recipientUsersforMessage(in: conversation, sendOnlyToOtherUser: sendOnlyToOtherUser)
         let recipients = self.recipientsWithEncryptedData(selfClient, recipients: recipientUsers, sessionDirectory: sessionDirectory)
 
         let nativePush = !hasConfirmation() // We do not want to send pushes for delivery receipts
         let message = ZMNewOtrMessage.message(withSender: selfClient, nativePush: nativePush, recipients: recipients, blob: externalData)
         
-        let strategy : MissingClientsStrategy =
-            sendOnlyToOtherUser ?
-                .ignoreAllMissingClientsNotFromUser(user: recipientUsers.first!)
-                : .doNotIgnoreAnyMissingClient
+        let strategy : MissingClientsStrategy = sendOnlyToOtherUser ? .ignoreAllMissingClientsNotFromUser(user: recipientUsers.first!)
+                                                                    : .doNotIgnoreAnyMissingClient
+        
         return (message: message, strategy: strategy)
     }
     

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
@@ -315,6 +315,8 @@ extension ZMAssetClientMessageTests_Encryption {
             expiresAfter: self.syncConversation.messageDestructionTimeout
         )
         self.syncConversation.mutableMessages.add(sut)
+        let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
+        sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString(), expiresAfter: NSNumber(value: sut.deletionTimeout)))
         return sut
     }
     
@@ -325,8 +327,6 @@ extension ZMAssetClientMessageTests_Encryption {
             self.setupConversation(conversation: self.syncConversation)
             self.syncConversation.messageDestructionTimeout = 10
             let sut = self.insertFileMessage()
-            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString(), expiresAfter: NSNumber(value: 10)))
             XCTAssertTrue(sut.isEphemeral)
 
             // when
@@ -343,8 +343,6 @@ extension ZMAssetClientMessageTests_Encryption {
             // given
             self.setupConversation(conversation: self.syncConversation)
             let sut = self.insertFileMessage()
-            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString()))
             XCTAssertFalse(sut.isEphemeral)
 
             // when

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
@@ -1,0 +1,360 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import ZMCDataModel
+
+class ZMAssetClientMessageTests_Encryption : BaseZMAssetClientMessageTests {
+
+    func decryptedMessageData(_ data: Data, forClient client: UserClient) -> ZMGenericMessage? {
+        let otrMessage = ZMNewOtrMessage.builder()!.merge(from: data).build()! as? ZMNewOtrMessage
+        XCTAssertNotNil(otrMessage, "Unable to generate OTR message")
+        let clientEntries = otrMessage?.recipients.flatMap { $0 }.flatMap { $0.clients }.joined()
+        
+        guard let entry = clientEntries?.first else { XCTFail("Unable to get client entry"); return nil }
+        
+        var message : ZMGenericMessage?
+        self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { (sessionsDirectory) in
+            do {
+                let decryptedData = try sessionsDirectory.decrypt(entry.text, senderClientId: client.remoteIdentifier!)
+                message = ZMGenericMessage.builder()!.merge(from: decryptedData).build()! as? ZMGenericMessage
+            } catch {
+                XCTFail("Failed to decrypt generic message: \(error)")
+            }
+        }
+        return message
+    }
+    
+    
+    func testThatItReturnsTheEncryptedPayloadDataForThePlaceholderMessage() {
+        self.syncMOC.performAndWait {
+            
+            // given
+            let nonce = UUID.create()
+            let mimeType = "text/plain"
+            let filename = "document.txt"
+            let url = self.testURLWithFilename(filename)
+            let data = self.createTestFile(url)
+            defer { self.removeTestFile(url) }
+            let fileMetadata = ZMFileMetadata(fileURL: url)
+            
+            // when
+            let sut = ZMAssetClientMessage(
+                fileMetadata: fileMetadata,
+                nonce: nonce,
+                managedObjectContext: self.syncMOC,
+                expiresAfter: 0
+            )
+            
+            self.syncConversation.mutableMessages.add(sut)
+            
+            // then
+            XCTAssertNotNil(sut)
+            XCTAssertTrue(sut.genericAssetMessage!.asset.hasOriginal())
+            
+            guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.placeholder) else { return XCTFail() }
+            guard let genericMessage = self.decryptedMessageData(encryptedData, forClient: self.user1Client1) else { return XCTFail() }
+            
+            XCTAssertNotNil(genericMessage)
+            XCTAssertTrue(genericMessage.hasAsset())
+            XCTAssertTrue(genericMessage.asset.hasOriginal())
+            
+            let original = genericMessage.asset.original!
+            XCTAssertEqual(original.name, filename)
+            XCTAssertEqual(original.mimeType, mimeType)
+            XCTAssertEqual(original.size, UInt64(data.count))
+        }
+    }
+    
+    func testThatItReturnsTheEncryptedMetaDataForTheFileDataMessage() {
+        self.syncMOC.performAndWait {
+            // given
+            let nonce = UUID.create()
+            let mimeType = "text/plain"
+            let filename = "document.txt"
+            let url = self.testURLWithFilename(filename)
+            let data = self.createTestFile(url)
+            defer { self.removeTestFile(url) }
+            let fileMetadata = ZMFileMetadata(fileURL: url)
+            
+            let sut = ZMAssetClientMessage(
+                fileMetadata: fileMetadata,
+                nonce: nonce,
+                managedObjectContext: self.syncMOC,
+                expiresAfter: 0
+            )
+            
+            self.syncConversation.mutableMessages.add(sut)
+            
+            // when
+            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString()))
+            
+            // then
+            guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
+            guard let genericMessage = self.decryptedMessageData(encryptedData, forClient: self.user1Client1) else { return XCTFail() }
+            
+            XCTAssertNotNil(genericMessage)
+            XCTAssertTrue(genericMessage.hasAsset())
+            
+            XCTAssertTrue(genericMessage.asset.hasUploaded())
+            let uploaded = genericMessage.asset.uploaded!
+            XCTAssertEqual(uploaded.otrKey, otrKey)
+            XCTAssertEqual(uploaded.sha256, sha256)
+            
+            XCTAssertTrue(genericMessage.asset.hasOriginal())
+            let original = genericMessage.asset.original!
+            XCTAssertEqual(original.name, filename)
+            XCTAssertEqual(original.mimeType, mimeType)
+            XCTAssertEqual(original.size, UInt64(data.count))
+            
+            XCTAssertFalse(original.hasVideo())
+        }
+    }
+    
+    func testThatItReturnsTheEncryptedMetaDataForAVideoDataMessage() {
+        self.syncMOC.performAndWait {
+            
+            // given
+            let nonce = UUID.create()
+            let mimeType = "video/mp4"
+            let duration : TimeInterval = 15000
+            let dimensions = CGSize(width: 1024, height: 768)
+            let name = "cats.mp4"
+            let url = self.testURLWithFilename(name)
+            let data = self.createTestFile(url)
+            let size = data.count
+            defer { self.removeTestFile(url) }
+            let videoMetadata = ZMVideoMetadata(fileURL: url, duration: duration, dimensions: dimensions)
+            let sut = ZMAssetClientMessage(
+                fileMetadata: videoMetadata,
+                nonce: nonce,
+                managedObjectContext: self.syncMOC,
+                expiresAfter: 0
+            )
+            
+            self.syncConversation.mutableMessages.add(sut)
+            
+            // when
+            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString()))
+            
+            // then
+            guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
+            guard let genericMessage = self.decryptedMessageData(encryptedData, forClient: self.syncUser1Client1) else { return XCTFail() }
+            
+            XCTAssertNotNil(genericMessage)
+            XCTAssertTrue(genericMessage.hasAsset())
+            
+            XCTAssertTrue(genericMessage.asset.hasUploaded())
+            let uploaded = genericMessage.asset.uploaded!
+            XCTAssertEqual(uploaded.otrKey, otrKey)
+            XCTAssertEqual(uploaded.sha256, sha256)
+            
+            XCTAssertTrue(genericMessage.asset.hasOriginal())
+            let original = genericMessage.asset.original!
+            XCTAssertEqual(original.name, name)
+            XCTAssertEqual(original.mimeType, mimeType)
+            XCTAssertEqual(original.size, UInt64(size))
+            
+            XCTAssertTrue(original.hasVideo())
+            let video = original.video!
+            XCTAssertEqual(video.durationInMillis, UInt64(duration * 1000))
+            XCTAssertEqual(video.width, Int32(dimensions.width))
+            XCTAssertEqual(video.height, Int32(dimensions.height))
+        }
+    }
+    
+    func testThatItItReturnsTheEncryptedGenericMessageDataIncludingThe_NotUploaded_WhenItIsPresent() {
+        self.syncMOC.performAndWait {
+            // given
+            let fileMetadata = self.addFile()
+            
+            let sut = ZMAssetClientMessage(
+                fileMetadata: fileMetadata,
+                nonce: UUID.create(),
+                managedObjectContext: self.syncMOC,
+                expiresAfter: 0
+            )
+            
+            self.syncConversation.mutableMessages.add(sut)
+            sut.delivered = true
+            
+            XCTAssertNotNil(sut.fileMessageData)
+            XCTAssertTrue(self.syncMOC.saveOrRollback())
+            
+            // when we cancel the transfer
+            sut.fileMessageData?.cancelTransfer()
+            XCTAssertEqual(sut.transferState, ZMFileTransferState.cancelledUpload)
+            
+            // then the genereted encrypted message should include the Asset.original and Asset.NotUploaded
+            guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.placeholder) else { return XCTFail() }
+            guard let genericMessage = self.decryptedMessageData(encryptedData, forClient: self.syncUser1Client1) else { return XCTFail() }
+            
+            XCTAssertTrue(genericMessage.asset.hasNotUploaded())
+            XCTAssertEqual(genericMessage.asset.notUploaded, ZMAssetNotUploaded.CANCELLED)
+            XCTAssertTrue(genericMessage.asset.hasOriginal())
+        }
+    }
+}
+
+
+// MARK: - Payload generation
+extension ZMAssetClientMessageTests_Encryption {
+    
+    func assertPayloadData(_ payload: Data!, forMessage message: ZMAssetClientMessage, format: ZMImageFormat) {
+        
+        let imageMessageStorage = message.imageAssetStorage!
+        let assetMetadata = ZMOtrAssetMetaBuilder().merge(from: payload).build()! as? ZMOtrAssetMeta
+        
+        AssertOptionalNotNil(assetMetadata) { assetMetadata in
+            XCTAssertEqual(assetMetadata.isInline(), imageMessageStorage.isInline(for:format))
+            XCTAssertEqual(assetMetadata.nativePush(), imageMessageStorage.isUsingNativePush(for: format))
+            
+            XCTAssertEqual(assetMetadata.sender.client, self.selfClient1.clientId.client)
+            
+            self.assertRecipients(assetMetadata.recipients)
+        }
+    }
+    
+    func testThatItCreatesPayloadData_Medium() {
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            //given
+            let message = self.appendImageMessage(.medium, to: self.syncConversation)
+            
+            //when
+            let payload = message.encryptedMessagePayloadForImageFormat(.medium)?.otrMessageData.data()
+            
+            //then
+            self.assertPayloadData(payload, forMessage: message, format: .medium)
+        }
+    }
+    
+    func testThatItCreatesPayloadData_Preview() {
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            //given
+            let message = self.appendImageMessage(ZMImageFormat.preview, to: self.syncConversation)
+            
+            //when
+            let payload = message.encryptedMessagePayloadForImageFormat(.preview)?.otrMessageData.data()
+            
+            //then
+            self.assertPayloadData(payload, forMessage: message, format: .preview)
+        }
+    }
+}
+
+
+// MARK: - MissingClientStrategy
+extension ZMAssetClientMessageTests_Encryption {
+
+    
+    func setupConversation(conversation: ZMConversation){
+        conversation.connection = ZMConnection.insertNewObject(in: syncMOC)
+        conversation.connection?.to = ZMUser.insertNewObject(in: syncMOC)
+        conversation.connection?.to.remoteIdentifier = UUID()
+        conversation.conversationType = .oneOnOne
+    }
+    
+    func testThatItReturnsCorrectStrategyForEphemeralMessages_ImageAssets(){
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            //given
+            self.setupConversation(conversation: self.syncConversation)
+            self.syncConversation.messageDestructionTimeout = 10
+            let message = self.appendImageMessage(ZMImageFormat.preview, to: self.syncConversation)
+            XCTAssertTrue(message.isEphemeral)
+            
+            //when
+            let strategy = message.encryptedMessagePayloadForImageFormat(.preview)?.strategy
+            
+            //then
+            let otherUser = self.syncConversation.connectedUser!
+            XCTAssertEqual(strategy, MissingClientsStrategy.ignoreAllMissingClientsNotFromUser(user: otherUser))
+        }
+    }
+
+    func testThatItReturnsCorrectStrategyForNormalMessages_ImageAssets(){
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            //given
+            self.setupConversation(conversation: self.syncConversation)
+            let message = self.appendImageMessage(ZMImageFormat.preview, to: self.syncConversation)
+            XCTAssertFalse(message.isEphemeral)
+
+            //when
+            let strategy = message.encryptedMessagePayloadForImageFormat(.preview)?.strategy
+            
+            //then            
+            XCTAssertEqual(strategy, MissingClientsStrategy.doNotIgnoreAnyMissingClient)
+        }
+    }
+    
+    func insertFileMessage() -> ZMAssetClientMessage{
+        let sut = ZMAssetClientMessage(
+            fileMetadata: addFile(),
+            nonce: UUID.create(),
+            managedObjectContext: self.syncMOC,
+            expiresAfter: self.syncConversation.messageDestructionTimeout
+        )
+        self.syncConversation.mutableMessages.add(sut)
+        return sut
+    }
+    
+    
+    func testThatItReturnsCorrectStrategyForEphemeralMessages_FileAssets(){
+        self.syncMOC.performGroupedBlockAndWait {
+            // given
+            self.setupConversation(conversation: self.syncConversation)
+            self.syncConversation.messageDestructionTimeout = 10
+            let sut = self.insertFileMessage()
+            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString(), expiresAfter: NSNumber(value: 10)))
+            XCTAssertTrue(sut.isEphemeral)
+
+            // when
+            guard let (_, strategy) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
+
+            //then
+            let otherUser = self.syncConversation.connectedUser!
+            XCTAssertEqual(strategy, MissingClientsStrategy.ignoreAllMissingClientsNotFromUser(user: otherUser))
+        }
+    }
+    
+    func testThatItReturnsCorrectStrategyForNormalMessages_FileAssets(){
+        self.syncMOC.performAndWait {
+            // given
+            self.setupConversation(conversation: self.syncConversation)
+            let sut = self.insertFileMessage()
+            let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce.transportString()))
+            XCTAssertFalse(sut.isEphemeral)
+
+            // when
+            guard let (_, strategy) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
+
+            // then
+            XCTAssertEqual(strategy, MissingClientsStrategy.doNotIgnoreAnyMissingClient)
+        }
+    }
+}
+
+
+

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		F93A302F1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */; };
 		F94A208D1CB51AC90059632A /* ZMSyncMergePolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */; };
 		F94A208F1CB51AF50059632A /* ManagedObjectValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A208E1CB51AF50059632A /* ManagedObjectValidationTests.m */; };
+		F94BD2671DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */; };
 		F963E96D1D9ADD5A00098AD3 /* ZMGenericMessage+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F963E9681D9ADD5A00098AD3 /* ZMGenericMessage+Helper.swift */; };
 		F963E96E1D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F963E9691D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F963E96F1D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F963E96A1D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.m */; };
@@ -444,6 +445,7 @@
 		F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessageTests+Confirmation.swift"; sourceTree = "<group>"; };
 		F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZMSyncMergePolicyTests.m; path = Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m; sourceTree = SOURCE_ROOT; };
 		F94A208E1CB51AF50059632A /* ManagedObjectValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ManagedObjectValidationTests.m; path = Tests/Source/Model/ManagedObjectValidationTests.m; sourceTree = SOURCE_ROOT; };
+		F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessageTest+Encryption.swift"; sourceTree = "<group>"; };
 		F963E95C1D9AB80B00098AD3 /* zmessaging2.18.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.18.0.xcdatamodel; sourceTree = "<group>"; };
 		F963E9681D9ADD5A00098AD3 /* ZMGenericMessage+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessage+Helper.swift"; sourceTree = "<group>"; };
 		F963E9691D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMGenericMessage+PropertyUtils.h"; sourceTree = "<group>"; };
@@ -1291,6 +1293,7 @@
 				F9331C501CB3BC6800139ECC /* CryptoBoxTests.swift */,
 				F9B71FFF1CB2C4FC001DB03F /* ZMGenericMessage_ExternalTests.m */,
 				F9B71F5D1CB2BC85001DB03F /* ZMAssetClientMessageTests.swift */,
+				F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */,
 				F9B71F5E1CB2BC85001DB03F /* ZMClientMessageTests.m */,
 				F9331C591CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift */,
 				F96470091D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m */,
@@ -2046,6 +2049,7 @@
 				16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */,
 				F9B71F9A1CB2BF0E001DB03F /* ZMUserTests.m in Sources */,
 				F9331C581CB3BE5300139ECC /* ZMConversationTests+OTR.m in Sources */,
+				F94BD2671DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift in Sources */,
 				F9B71FA91CB2BF37001DB03F /* ZMConversationTests.m in Sources */,
 				F9B71FF01CB2C4C6001DB03F /* MessageWindowChangeTokenTests.swift in Sources */,
 				F963E9931D9E9D1800098AD3 /* ZMAssetClientMessageTests+Ephemeral.swift in Sources */,


### PR DESCRIPTION
**In this PR**
When sending an ephemeral message we should only send it to the clients of the other user, not to the clients of the selfUser. We implemented this behaviour for text messages already, but the implementation for asset messages was missing.

I moved some tests from one file to the another. lines to review for tests start at ZMAssetClientMessageTests_Encryption: 218