### PR TITLE
Add thirty seconds and five minutes timeout values

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -21,7 +21,23 @@ public enum ZMConversationMessageDestructionTimeout : TimeInterval {
     case none = 0
     case fiveSeconds = 5
     case fifteenSeconds = 15
+    case thirtySeconds = 30
     case oneMinute = 60
+    case fiveMinutes = 300
+}
+
+public extension ZMConversationMessageDestructionTimeout {
+
+    static var all: [ZMConversationMessageDestructionTimeout] {
+        return [
+            .none,
+            .fiveSeconds,
+            .fifteenSeconds,
+            .thirtySeconds,
+            .oneMinute,
+            .fiveMinutes
+        ]
+    }
 }
 
 public extension ZMConversationMessageDestructionTimeout {
@@ -29,7 +45,7 @@ public extension ZMConversationMessageDestructionTimeout {
     public static func validTimeout(for timeout: TimeInterval) -> TimeInterval {
         return timeout.clamp(
             between: ZMConversationMessageDestructionTimeout.fiveSeconds.rawValue,
-            and: ZMConversationMessageDestructionTimeout.oneMinute.rawValue
+            and: ZMConversationMessageDestructionTimeout.fiveMinutes.rawValue
         )
     }
 }
@@ -45,7 +61,7 @@ public extension ZMConversation {
     /// Sets messageDestructionTimeout
     /// @param timeout The timeout after which an appended message should "self-destruct"
     public func updateMessageDestructionTimeout(timeout : ZMConversationMessageDestructionTimeout) {
-        guard (conversationType == .oneOnOne) else { return }
+        guard conversationType == .oneOnOne else { return }
         messageDestructionTimeout = timeout.rawValue
     }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -26,7 +26,9 @@ class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.none.rawValue, 0)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.fiveSeconds.rawValue, 5)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.fifteenSeconds.rawValue, 15)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.thirtySeconds.rawValue, 30)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.oneMinute.rawValue, 60)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.fiveMinutes.rawValue, 300)
     }
     
     func testThatItReturnsTheClosestTimeOut() {
@@ -38,10 +40,16 @@ class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 14), 14)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 15), 15)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 16), 16)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 29), 29)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 30), 30)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 31), 31)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 59), 59)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 60), 60)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 61), 60)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 1501), 60)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 61), 61)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 299), 299)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 300), 300)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 301), 300)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 1501), 300)
     }
 
 }


### PR DESCRIPTION
# What's in this PR?

* Add timeout thirty seconds and five minutes values for ephemeral messages
* Move accessor for all possible timeout values from the UI protect into `wire-ios-data-model`.