### PR TITLE
Remove inactive participants

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/.xccurrentversion
+++ b/Resources/zmessaging.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>zmessaging2.18.0.xcdatamodel</string>
+	<string>zmessaging2.21.0.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.21.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.21.0.xcdatamodel/contents
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11232" systemVersion="15G1004" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.21.0">
+    <entity name="AssetClientMessage" representedClassName="ZMAssetClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="assetId" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="assetId_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preprocessedSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="preprocessedSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="progress" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="transferState" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="uploadState" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="asset" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="ClientMessage" representedClassName="ZMClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkPreviewState" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="updatedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="message" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="Connection" representedClassName="ZMConnection" syncable="YES">
+        <attribute name="existsOnBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUpdateDateInGMT" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="message" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedDataFields" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="connection" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connection" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Conversation" representedClassName="ZMConversation" syncable="YES">
+        <attribute name="archivedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="archivedEventID" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="archivedEventID_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="callStateNeedsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="clearedEventID" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="clearedEventID_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="clearedTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="conversationType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadedMessageIDs" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="downloadedMessageIDs_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="draftMessageText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasUnreadUnsentMessage" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSilenced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastEventID" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="lastEventID_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastReadEventID" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="lastReadEventID_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="messageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedDataFields" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedUserDefinedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="securityLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="silencedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userDefinedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="voiceChannel" optional="YES" transient="YES" syncable="YES"/>
+        <relationship name="callParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeCallConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="conversationsCreated" inverseEntity="User" syncable="YES"/>
+        <relationship name="hiddenMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="hiddenInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="lastServerSyncedActiveConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="visibleInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="otherActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeConversations" inverseEntity="User" syncable="YES"/>
+        <compoundIndexes>
+            <compoundIndex>
+                <index value="internalIsArchived"/>
+                <index value="lastModifiedDate"/>
+            </compoundIndex>
+        </compoundIndexes>
+    </entity>
+    <entity name="GenericMessageData" representedClassName="ZMGenericMessageData" syncable="YES">
+        <attribute name="data" attributeType="Binary" syncable="YES"/>
+        <relationship name="asset" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AssetClientMessage" inverseName="dataSet" inverseEntity="AssetClientMessage" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClientMessage" inverseName="dataSet" inverseEntity="ClientMessage" syncable="YES"/>
+    </entity>
+    <entity name="ImageMessage" representedClassName="ZMImageMessage" parentEntity="Message" syncable="YES">
+        <attribute name="imageType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isAnimatedGIF" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumDataLoaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="originalDataProcessed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="originalSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="originalSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+    </entity>
+    <entity name="KnockMessage" representedClassName="ZMKnockMessage" parentEntity="Message" syncable="YES"/>
+    <entity name="Message" representedClassName="ZMMessage" isAbstract="YES" syncable="YES">
+        <attribute name="destructionDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="eventID" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="eventID_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isExpired" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isObfuscated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPlainText" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedDataFields" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="nonce" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="nonce_data" optional="YES" attributeType="Binary" indexed="YES" versionHashModifier="add_index1" syncable="YES"/>
+        <attribute name="senderClientID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="serverTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="confirmations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MessageConfirmation" inverseName="message" inverseEntity="MessageConfirmation" syncable="YES"/>
+        <relationship name="hiddenInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="hiddenMessages" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="missingRecipients" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="messagesMissingRecipient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Reaction" inverseName="message" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+        <relationship name="visibleInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation" syncable="YES"/>
+    </entity>
+    <entity name="MessageConfirmation" representedClassName="ZMMessageConfirmation" syncable="YES">
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Reaction" representedClassName=".Reaction" syncable="YES">
+        <attribute name="modifiedDataFields" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="unicodeValue" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="reactions" inverseEntity="Message" syncable="YES"/>
+        <relationship name="users" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="reactions" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Session" representedClassName="ZMSession" syncable="YES">
+        <relationship name="selfUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="SystemMessage" representedClassName="ZMSystemMessage" parentEntity="Message" syncable="YES">
+        <attribute name="needsUpdatingUsers" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="systemMessageType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="addedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserAdded" inverseEntity="User" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="addedOrRemovedInSystemMessages" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="removedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserRemoved" inverseEntity="User" syncable="YES"/>
+        <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="systemMessages" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="TextMessage" representedClassName="ZMTextMessage" parentEntity="Message" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName="ZMUser" syncable="YES">
+        <attribute name="accentColorValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="emailAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="imageMediumData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="imageSmallProfileData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="modifiedDataFields" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedEmailAddress" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="normalizedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="originalProfileImageData" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <relationship name="activeCallConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="callParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="activeConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="otherActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="user" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="to" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="conversationsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="lastServerSyncedActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Reaction" inverseName="users" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="showingUserAdded" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="addedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="showingUserRemoved" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="removedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="systemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="users" inverseEntity="SystemMessage" syncable="YES"/>
+    </entity>
+    <entity name="UserClient" representedClassName=".UserClient" syncable="YES">
+        <attribute name="activationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="activationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLatitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLongitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="apsDecryptionKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="apsVerificationKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deviceClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="fingerprint" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="markedToDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="model" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedDataFields" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToNotifyUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToUploadSignalingKeys" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="numberOfKeysRemaining" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preKeysRangeMax" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" attributeType="String" defaultValueString="permanent" syncable="YES"/>
+        <relationship name="addedOrRemovedInSystemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="clients" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="ignoredByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="ignoredClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="messagesMissingRecipient" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="missingRecipients" inverseEntity="Message" syncable="YES"/>
+        <relationship name="missedByClient" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missingClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="missingClients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missedByClient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="clients" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="210"/>
+        <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="675"/>
+        <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
+        <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="Message" positionX="0" positionY="0" width="128" height="345"/>
+        <element name="MessageConfirmation" positionX="9" positionY="153" width="128" height="90"/>
+        <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
+        <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
+        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="TextMessage" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="540"/>
+        <element name="UserClient" positionX="9" positionY="153" width="128" height="450"/>
+    </elements>
+</model>

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -243,9 +243,7 @@ NS_ASSUME_NONNULL_END
 
 @property (nonatomic) BOOL isSelfAnActiveMember; ///< whether the self user is an active member (as opposed to a past member)
 @property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *otherActiveParticipants;
-@property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *otherInactiveParticipants;
 @property (readonly, nonatomic, nonnull) NSMutableOrderedSet<ZMUser *> *mutableOtherActiveParticipants;
-@property (readonly, nonatomic, nonnull) NSMutableOrderedSet<ZMUser *> *mutableOtherInactiveParticipants;
 
 /// Removes user from unsyncedInactiveParticipants
 - (void)synchronizeRemovedUser:(nonnull ZMUser *)user;

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -128,7 +128,6 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
             [self internalAddParticipant:user isAuthoritative:YES];
         }
         else {
-            [self.mutableOtherInactiveParticipants addObject:user];
             [self.mutableOtherActiveParticipants removeObject:user];
             [self.mutableLastServerSyncedActiveParticipants removeObject:user];
         }

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -108,7 +108,7 @@ extension ZMGenericMessage {
         if sendOnlyToOtherUser {
             var sender : ZMUser? = nil
             if self.hasConfirmation(), self.confirmation.messageId != nil {
-                if let message = ZMMessage.fetch(withNonce:UUID(uuidString:self.confirmation.messageId), for:conversation, in:conversation.managedObjectContext){
+                if let message = ZMMessage.fetch(withNonce:UUID(uuidString:self.confirmation.messageId), for:conversation, in:conversation.managedObjectContext!){
                     sender = message.sender
                 }
             }

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -37,41 +37,41 @@
 
 @protocol UserClientType;
 
-extern NSString * const ZMMessageEventIDDataKey;
-extern NSString * const ZMMessageIsEncryptedKey;
-extern NSString * const ZMMessageIsPlainTextKey;
-extern NSString * const ZMMessageIsExpiredKey;
-extern NSString * const ZMMessageMissingRecipientsKey;
-extern NSString * const ZMMessageImageTypeKey;
-extern NSString * const ZMMessageIsAnimatedGifKey;
-extern NSString * const ZMMessageMediumRemoteIdentifierDataKey;
-extern NSString * const ZMMessageMediumRemoteIdentifierKey;
-extern NSString * const ZMMessageOriginalDataProcessedKey;
-extern NSString * const ZMMessageOriginalSizeDataKey;
-extern NSString * const ZMMessageOriginalSizeKey;
-extern NSString * const ZMMessageConversationKey;
-extern NSString * const ZMMessageEventIDKey;
-extern NSString * const ZMMessageExpirationDateKey;
-extern NSString * const ZMMessageNameKey;
-extern NSString * const ZMMessageNeedsToBeUpdatedFromBackendKey;
-extern NSString * const ZMMessageNonceDataKey;
-extern NSString * const ZMMessageSenderKey;
-extern NSString * const ZMMessageSystemMessageTypeKey;
-extern NSString * const ZMMessageTextKey;
-extern NSString * const ZMMessageUserIDsKey;
-extern NSString * const ZMMessageUsersKey;
-extern NSString * const ZMMessageClientsKey;
-extern NSString * const ZMMessageHiddenInConversationKey;
-extern NSString * const ZMMessageConfirmationKey;
+extern NSString * _Nonnull const ZMMessageEventIDDataKey;
+extern NSString * _Nonnull const ZMMessageIsEncryptedKey;
+extern NSString * _Nonnull const ZMMessageIsPlainTextKey;
+extern NSString * _Nonnull const ZMMessageIsExpiredKey;
+extern NSString * _Nonnull const ZMMessageMissingRecipientsKey;
+extern NSString * _Nonnull const ZMMessageImageTypeKey;
+extern NSString * _Nonnull const ZMMessageIsAnimatedGifKey;
+extern NSString * _Nonnull const ZMMessageMediumRemoteIdentifierDataKey;
+extern NSString * _Nonnull const ZMMessageMediumRemoteIdentifierKey;
+extern NSString * _Nonnull const ZMMessageOriginalDataProcessedKey;
+extern NSString * _Nonnull const ZMMessageOriginalSizeDataKey;
+extern NSString * _Nonnull const ZMMessageOriginalSizeKey;
+extern NSString * _Nonnull const ZMMessageConversationKey;
+extern NSString * _Nonnull const ZMMessageEventIDKey;
+extern NSString * _Nonnull const ZMMessageExpirationDateKey;
+extern NSString * _Nonnull const ZMMessageNameKey;
+extern NSString * _Nonnull const ZMMessageNeedsToBeUpdatedFromBackendKey;
+extern NSString * _Nonnull const ZMMessageNonceDataKey;
+extern NSString * _Nonnull const ZMMessageSenderKey;
+extern NSString * _Nonnull const ZMMessageSystemMessageTypeKey;
+extern NSString * _Nonnull const ZMMessageTextKey;
+extern NSString * _Nonnull const ZMMessageUserIDsKey;
+extern NSString * _Nonnull const ZMMessageUsersKey;
+extern NSString * _Nonnull const ZMMessageClientsKey;
+extern NSString * _Nonnull const ZMMessageHiddenInConversationKey;
+extern NSString * _Nonnull const ZMMessageConfirmationKey;
 
 @interface ZMMessage : ZMManagedObject
 
 
 // Use these for sorting:
-+ (NSArray *)defaultSortDescriptors;
-- (NSComparisonResult)compare:(ZMMessage *)other;
-- (NSUUID *)nonceFromPostPayload:(NSDictionary *)payload;
-- (void)updateWithPostPayload:(NSDictionary *)payload updatedKeys:(__unused NSSet *)updatedKeys;
++ (NSArray * _Nonnull)defaultSortDescriptors;
+- (NSComparisonResult)compare:(ZMMessage * _Nonnull)other;
+- (NSUUID * _Nullable)nonceFromPostPayload:(NSDictionary * _Nonnull)payload;
+- (void)updateWithPostPayload:(NSDictionary * _Nonnull)payload updatedKeys:(__unused NSSet * _Nullable)updatedKeys;
 - (void)resend;
 - (BOOL)shouldGenerateUnreadCount;
 
@@ -80,24 +80,30 @@ extern NSString * const ZMMessageConfirmationKey;
 - (void)removeMessageClearingSender:(BOOL)clearingSender;
 
 /// Removes the message only for clients of the selfUser
-+ (void)removeMessageWithRemotelyHiddenMessage:(ZMMessageHide *)hiddenMessage
-                                      fromUser:(ZMUser *)user
-                        inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (void)removeMessageWithRemotelyHiddenMessage:(ZMMessageHide * _Nonnull)hiddenMessage
+                                      fromUser:(ZMUser * _Nonnull)user
+                        inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 /// Removes the message for all participants of the message's conversation
 /// Clients that don't belong to the selfUser will see a system message indicating the deletion
-+ (void)removeMessageWithRemotelyDeletedMessage:(ZMMessageDelete *)deletedMessage
-                                 inConversation:(ZMConversation *)conversation
-                                       senderID:(NSUUID *)senderID
-                         inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (void)removeMessageWithRemotelyDeletedMessage:(ZMMessageDelete * _Nonnull)deletedMessage
+                                 inConversation:(ZMConversation * _Nonnull)conversation
+                                       senderID:(NSUUID * _Nonnull)senderID
+                         inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 
-+ (void)addReaction:(ZMReaction *)reaction senderID:(NSUUID *)senderID conversation:(ZMConversation *)conversation inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (void)addReaction:(ZMReaction * _Nonnull)reaction
+           senderID:(NSUUID * _Nonnull)senderID
+       conversation:(ZMConversation * _Nonnull)conversation
+inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 /// Clears the content of a message for a ZMEditMessage
 /// Returns NO when the message was not found
 /// or if the sender of the ZMEditMessage is not the same as the sender of the original message
-+ (ZMMessage *)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage *)genericEditMessage inConversation:(ZMConversation *)conversation senderID:(NSUUID *)senderID inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (ZMMessage * _Nullable)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage * _Nonnull)genericEditMessage
+                                                 inConversation:(ZMConversation * _Nonnull)conversation
+                                                       senderID:(NSUUID * _Nonnull)senderID
+                                         inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 
 @end
@@ -106,7 +112,7 @@ extern NSString * const ZMMessageConfirmationKey;
 
 @interface ZMTextMessage : ZMMessage <ZMTextMessageData>
 
-@property (nonatomic, readonly, copy) NSString *text;
+@property (nonatomic, readonly, copy) NSString * _Nullable text;
 
 @end
 
@@ -116,14 +122,14 @@ extern NSString * const ZMMessageConfirmationKey;
 
 @property (nonatomic, readonly) BOOL mediumDataLoaded;
 @property (nonatomic, readonly) BOOL originalDataProcessed;
-@property (nonatomic, readonly) NSData *mediumData; ///< N.B.: Will go away from public header
-@property (nonatomic, readonly) NSData *imageData; ///< This will either returns the mediumData or the original image data. Usefull only for newly inserted messages.
-@property (nonatomic, readonly) NSString *imageDataIdentifier; /// This can be used as a cache key for @c -imageData
+@property (nonatomic, readonly) NSData * _Nullable mediumData; ///< N.B.: Will go away from public header
+@property (nonatomic, readonly) NSData * _Nullable imageData; ///< This will either returns the mediumData or the original image data. Usefull only for newly inserted messages.
+@property (nonatomic, readonly) NSString * _Nullable imageDataIdentifier; /// This can be used as a cache key for @c -imageData
 
-@property (nonatomic, readonly) NSData *previewData;
-@property (nonatomic, readonly) NSString *imagePreviewDataIdentifier; /// This can be used as a cache key for @c -previewData
+@property (nonatomic, readonly) NSData * _Nullable previewData;
+@property (nonatomic, readonly) NSString * _Nullable imagePreviewDataIdentifier; /// This can be used as a cache key for @c -previewData
 @property (nonatomic, readonly) BOOL isAnimatedGIF; // If it is GIF and has more than 1 frame
-@property (nonatomic, readonly) NSString *imageType; // UTI e.g. kUTTypeGIF
+@property (nonatomic, readonly) NSString * _Nullable imageType; // UTI e.g. kUTTypeGIF
 
 @property (nonatomic, readonly) CGSize originalSize;
 
@@ -140,15 +146,15 @@ extern NSString * const ZMMessageConfirmationKey;
 @interface ZMSystemMessage : ZMMessage <ZMSystemMessageData>
 
 @property (nonatomic) ZMSystemMessageType systemMessageType;
-@property (nonatomic) NSSet<ZMUser *> *users;
-@property (nonatomic) NSSet <id<UserClientType>>*clients;
-@property (nonatomic) NSSet<ZMUser *> *addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
-@property (nonatomic) NSSet<ZMUser *> *removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic) NSSet<ZMUser *> * _Nonnull users;
+@property (nonatomic) NSSet <id<UserClientType>>* _Nonnull clients;
+@property (nonatomic) NSSet<ZMUser *> * _Nonnull addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic) NSSet<ZMUser *> * _Nonnull removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic, copy) NSString * _Nullable text;
 @property (nonatomic) BOOL needsUpdatingUsers;
 
-+ (ZMSystemMessage *)fetchLatestPotentialGapSystemMessageInConversation:(ZMConversation *)conversation;
-+ (ZMSystemMessage *)fetchStartedUsingOnThisDeviceMessageForConversation:(ZMConversation *)conversation;
++ (ZMSystemMessage * _Nullable)fetchLatestPotentialGapSystemMessageInConversation:(ZMConversation * _Nonnull)conversation;
++ (ZMSystemMessage * _Nullable)fetchStartedUsingOnThisDeviceMessageForConversation:(ZMConversation * _Nonnull)conversation;
 - (void)updateNeedsUpdatingUsersIfNeeded;
 
 @end
@@ -157,18 +163,18 @@ extern NSString * const ZMMessageConfirmationKey;
 
 @interface ZMMessage ()
 
-@property (nonatomic) NSString *senderClientID;
-@property (nonatomic) ZMEventID *eventID;
-@property (nonatomic) NSUUID *nonce;
-@property (nonatomic, readonly) NSDate *destructionDate;
+@property (nonatomic) NSString * _Nullable senderClientID;
+@property (nonatomic) ZMEventID * _Nullable eventID;
+@property (nonatomic) NSUUID * _Null_unspecified nonce;
+@property (nonatomic, readonly) NSDate * _Nullable destructionDate;
 
 @property (nonatomic, readonly) BOOL isUnreadMessage;
 @property (nonatomic, readonly) BOOL isExpired;
-@property (nonatomic, readonly) NSDate *expirationDate;
+@property (nonatomic, readonly) NSDate * _Nullable expirationDate;
 @property (nonatomic, readonly) BOOL isObfuscated;
 
-@property (nonatomic) NSSet <Reaction *> *reactions;
-@property (nonatomic, readonly) NSSet<ZMMessageConfirmation*> *confirmations;
+@property (nonatomic) NSSet <Reaction *> * _Nonnull reactions;
+@property (nonatomic, readonly) NSSet<ZMMessageConfirmation*> * _Nonnull confirmations;
 
 - (void)setExpirationDate;
 - (void)removeExpirationDate;
@@ -179,55 +185,55 @@ extern NSString * const ZMMessageConfirmationKey;
 
 
 /// Inserts and returns a ZMConfirmation message into the conversation that is sent back to the sender
-- (ZMClientMessage *)confirmReception;
+- (ZMClientMessage * __nullable)confirmReception;
 
 
-+ (instancetype)fetchMessageWithNonce:(NSUUID *)nonce
-                      forConversation:(ZMConversation *)conversation
-               inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (instancetype _Nullable)fetchMessageWithNonce:(NSUUID * _Nullable)nonce
+                      forConversation:(ZMConversation * _Nonnull)conversation
+               inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
-+ (instancetype)fetchMessageWithNonce:(NSUUID *)nonce
-                      forConversation:(ZMConversation *)conversation
-               inManagedObjectContext:(NSManagedObjectContext *)moc
-                       prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult;
++ (instancetype _Nullable)fetchMessageWithNonce:(NSUUID * _Nonnull)nonce
+                      forConversation:(ZMConversation * _Nonnull)conversation
+               inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc
+                       prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult;
 
-- (NSString *)shortDebugDescription;
+- (NSString * _Nonnull)shortDebugDescription;
 
-- (void)updateWithPostPayload:(NSDictionary *)payload updatedKeys:(NSSet *)updatedKeys;
+- (void)updateWithPostPayload:(NSDictionary * _Nonnull)payload updatedKeys:(NSSet * _Nonnull)updatedKeys;
 + (BOOL)doesEventTypeGenerateMessage:(ZMUpdateEventType)type;
 
 /// Returns a predicate that matches messages that might expire if they are not sent in time
-+ (NSPredicate *)predicateForMessagesThatWillExpire;
++ (NSPredicate * _Nonnull)predicateForMessagesThatWillExpire;
 
 /// Adds the event ID of the update event to the list of downloaded event IDs in the conversation
-+ (void)addEventToDownloadedEvents:(ZMUpdateEvent *)event inConversation:(ZMConversation *)conversation;
++ (void)addEventToDownloadedEvents:(ZMUpdateEvent * _Nonnull)event inConversation:(ZMConversation * _Nonnull)conversation;
 
 + (void)setDefaultExpirationTime:(NSTimeInterval)defaultExpiration;
 + (NSTimeInterval)defaultExpirationTime;
 + (void)resetDefaultExpirationTime;
 
-+ (ZMConversation *)conversationForUpdateEvent:(ZMUpdateEvent *)event inContext:(NSManagedObjectContext *)moc prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult;
++ (ZMConversation * _Nullable)conversationForUpdateEvent:(ZMUpdateEvent * _Nonnull)event inContext:(NSManagedObjectContext * _Nonnull)moc prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult;
 
 /// Returns the message represented in this update event
 /// @param prefetchResult Contains a mapping from message nonce to message and `remoteIdentifier` to `ZMConversation`,
 /// which should be used to avoid premature fetchRequests. If the class needs messages or conversations to be prefetched
 /// and passed into this method it should conform to `ZMObjectStrategy` and return them in
 /// `-messageNoncesToPrefetchToProcessEvents:` or `-conversationRemoteIdentifiersToPrefetchToProcessEvents`
-+ (instancetype)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent
-                              inManagedObjectContext:(NSManagedObjectContext *)moc
-                                      prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult;
++ (instancetype _Nullable)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent * _Nonnull)updateEvent
+                              inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc
+                                      prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult;
 
-- (void)updateWithUpdateEvent:(ZMUpdateEvent *)updateEvent forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
+- (void)updateWithUpdateEvent:(ZMUpdateEvent * _Nonnull)updateEvent forConversation:(ZMConversation * _Nonnull)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 
 - (void)removePendingDeliveryReceipts;
 
-- (void)updateWithTimestamp:(NSDate *)serverTimestamp senderUUID:(NSUUID *)senderUUID eventID:(ZMEventID *)eventID forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
+- (void)updateWithTimestamp:(NSDate * _Nonnull)serverTimestamp senderUUID:(NSUUID * _Nonnull)senderUUID eventID:(ZMEventID * _Nullable)eventID forConversation:(ZMConversation * _Nonnull)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 
 /// Returns whether the data represents animated GIF
-+ (BOOL)isDataAnimatedGIF:(NSData *)data;
++ (BOOL)isDataAnimatedGIF:(NSData * _Nonnull)data;
 
 /// Predicate to select messages that are part of a conversation
-+ (NSPredicate *)predicateForMessageInConversation:(ZMConversation *)conversation withNonces:(NSSet <NSUUID *>*)nonces;
++ (NSPredicate * _Nonnull)predicateForMessageInConversation:(ZMConversation * _Nonnull)conversation withNonces:(NSSet <NSUUID *>*  _Nonnull)nonces;
 
 @end
 
@@ -235,29 +241,29 @@ extern NSString * const ZMMessageConfirmationKey;
 
 @interface ZMTextMessage (Internal)
 
-@property (nonatomic, copy) NSString *text;
+@property (nonatomic, copy) NSString * _Nullable text;
 
-+ (instancetype)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent
-                               decodedGenericMessage:(ZMGenericMessage *)genericMessage
-                              inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (instancetype _Nullable)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent * _Nonnull)updateEvent
+                               decodedGenericMessage:(ZMGenericMessage * _Nonnull)genericMessage
+                              inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 @end
 
 
 
-extern NSString * const ZMImageMessagePreviewNeedsToBeUploadedKey;
-extern NSString * const ZMImageMessageMediumNeedsToBeUploadedKey;
-extern NSString * const ZMMessageServerTimestampKey;
+extern NSString *  _Nonnull const ZMImageMessagePreviewNeedsToBeUploadedKey;
+extern NSString *  _Nonnull const ZMImageMessageMediumNeedsToBeUploadedKey;
+extern NSString *  _Nonnull const ZMMessageServerTimestampKey;
 
 @interface ZMImageMessage (Internal) <ZMImageOwner>
 
 @property (nonatomic) BOOL mediumDataLoaded;
 @property (nonatomic) BOOL originalDataProcessed;
-@property (nonatomic) NSUUID *mediumRemoteIdentifier;
-@property (nonatomic) NSData *mediumData;
-@property (nonatomic) NSData *previewData;
+@property (nonatomic) NSUUID * _Nullable mediumRemoteIdentifier;
+@property (nonatomic) NSData * _Nullable mediumData;
+@property (nonatomic) NSData * _Nullable  previewData;
 @property (nonatomic) CGSize originalSize;
-@property (nonatomic) NSData *originalImageData;
+@property (nonatomic) NSData * _Nullable originalImageData;
 
 
 @end
@@ -272,8 +278,8 @@ extern NSString * const ZMMessageServerTimestampKey;
 @interface ZMSystemMessage (Internal)
 
 + (BOOL)doesEventTypeGenerateSystemMessage:(ZMUpdateEventType)type;
-+ (instancetype)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent inManagedObjectContext:(NSManagedObjectContext *)moc;
-+ (NSPredicate *)predicateForSystemMessagesInsertedLocally;
++ (instancetype _Nullable)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent * _Nonnull)updateEvent inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
++ (NSPredicate * _Nonnull)predicateForSystemMessagesInsertedLocally;
 
 @end
 
@@ -296,7 +302,7 @@ extern NSString * const ZMMessageServerTimestampKey;
 
 /// When we restart, we might still have messages that had a timer, but whose timer did not fire before killing the app
 /// To delete those messages immediately use this method on startup (e.g. in the init of the ZMClientMessageTranscoder) to fetch and delete those messages
-+ (void)deleteOldEphemeralMessages:(NSManagedObjectContext *)context;
++ (void)deleteOldEphemeralMessages:(NSManagedObjectContext * _Nonnull)context;
 
 @end
 

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -34,7 +34,6 @@ extern NSString * __nonnull const SessionObjectIDKey;
 @property (nullable, nonatomic) ZMConnection *connection;
 
 @property (nonnull, nonatomic) NSOrderedSet *activeConversations;
-@property (nonnull, nonatomic) NSOrderedSet *inactiveConversations;
 
 @property (nonnull, nonatomic) NSOrderedSet *showingUserAdded;
 @property (nonnull, nonatomic) NSOrderedSet *showingUserRemoved;

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -58,7 +58,6 @@ static NSString *const ActiveCallConversationsKey = @"activeCallConversations";
 static NSString *const ConnectionKey = @"connection";
 static NSString *const EmailAddressKey = @"emailAddress";
 static NSString *const PhoneNumberKey = @"phoneNumber";
-static NSString *const InactiveConversationsKey = @"inactiveConversations";
 static NSString *const LastServerSyncedActiveConversationsKey = @"lastServerSyncedActiveConversations";
 static NSString *const LocalMediumRemoteIdentifierDataKey = @"localMediumRemoteIdentifier_data";
 static NSString *const LocalMediumRemoteIdentifierKey = @"localMediumRemoteIdentifier";
@@ -358,7 +357,6 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
 @implementation ZMUser (Internal)
 
 @dynamic activeConversations;
-@dynamic inactiveConversations;
 @dynamic normalizedName;
 @dynamic connection;
 @dynamic showingUserAdded;
@@ -387,7 +385,6 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
                                            ActiveCallConversationsKey,
                                            ConnectionKey,
                                            ConversationsCreatedKey,
-                                           InactiveConversationsKey,
                                            LastServerSyncedActiveConversationsKey,
                                            LocalMediumRemoteIdentifierDataKey,
                                            LocalSmallProfileRemoteIdentifierDataKey,

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -531,7 +531,7 @@ extension UserClient {
             if !conversation.isReadOnly {
                 let clientsInConversation = clients.filter({ (client) -> Bool in
                     guard let user = client.user else { return false }
-                    return conversation.allParticipants.contains(user)
+                    return conversation.activeParticipants.contains(user)
                 })
                 securityChangeType.changeSecurityLevel(conversation, clients: Set(clientsInConversation), causedBy: causedBy)
             }

--- a/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
@@ -60,7 +60,7 @@ open class GeneralConversationChangeInfo : ObjectChangeInfo {
     }
     
     fileprivate var keysForConversationChangeInfo : Set<String> {
-        return Set(arrayLiteral: "messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "isSilenced", "otherActiveParticipants", "isSelfAnActiveMember", "displayName", "attributedDisplayName", "relatedConnectionState", "estimatedUnreadCount", "clearedTimeStamp", "securityLevel")
+        return Set(arrayLiteral: "messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "isSilenced", "otherActiveParticipants", "isSelfAnActiveMember", "displayName", "relatedConnectionState", "estimatedUnreadCount", "clearedTimeStamp", "securityLevel")
     }
     
     fileprivate var keysForCallParticipantsChangeInfo : Set <String> {

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -68,15 +68,11 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 
 @property (nonatomic, copy, nullable) NSString *userDefinedName;
 @property (nonatomic, readonly, nonnull) NSString *displayName;
-@property (nonatomic, readonly, nonnull) NSAttributedString *attributedDisplayName; ///< Uses @c ZMIsDimmedKey for parts that should be dimmed.
 
 @property (readonly, nonatomic) ZMConversationType conversationType;
 @property (readonly, nonatomic, nonnull) NSDate *lastModifiedDate;
 @property (readonly, nonatomic, nonnull) NSOrderedSet *messages;
 @property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *activeParticipants;
-@property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *inactiveParticipants;
-// The union of inactive and active participants.
-@property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *allParticipants;
 @property (readonly, nonatomic, nonnull) ZMUser *creator;
 @property (nonatomic, readonly) BOOL isPendingConnectionConversation;
 @property (nonatomic, readonly) NSUInteger estimatedUnreadCount;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -174,9 +174,7 @@
         
         ZMUser *user3 = [ZMUser userWithRemoteID:user3UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user3);
-        
-        XCTAssertEqualObjects(conversation.otherInactiveParticipants, ([NSOrderedSet orderedSetWithObjects:user3, nil]) );
-        
+                
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);
         XCTAssertEqual(conversation.unsyncedInactiveParticipants.count, 0u);
         

--- a/Tests/Source/Model/CoreDataRelationshipsTests.m
+++ b/Tests/Source/Model/CoreDataRelationshipsTests.m
@@ -68,11 +68,9 @@
     
     [conversation1.mutableOtherActiveParticipants addObject:user1];
     [conversation1.mutableOtherActiveParticipants addObject:user3];
-    [conversation1.mutableOtherInactiveParticipants addObject:user2];
     
     [conversation2.mutableOtherActiveParticipants addObject:user2];
     [conversation2.mutableOtherActiveParticipants addObject:user3];
-    [conversation2.mutableOtherInactiveParticipants addObject:user1];
     
     // Check that the inverse have been set:
     [self.uiMOC processPendingChanges];
@@ -92,18 +90,13 @@
     
     id s1 = [NSOrderedSet orderedSetWithArray:@[user1, user3]];
     XCTAssertEqualObjects(conversation1.otherActiveParticipants, s1);
-    XCTAssertEqualObjects(conversation1.otherInactiveParticipants, [NSOrderedSet orderedSetWithObject:user2]);
     id s2 = [NSOrderedSet orderedSetWithArray:@[user2, user3]];
     XCTAssertEqualObjects(conversation2.otherActiveParticipants, s2);
-    XCTAssertEqualObjects(conversation2.otherInactiveParticipants, [NSOrderedSet orderedSetWithObject:user1]);
     
     XCTAssertEqualObjects([user1 valueForKey:@"activeConversations"], [NSOrderedSet orderedSetWithObject:conversation1]);
-    XCTAssertEqualObjects([user1 valueForKey:@"inactiveConversations"], [NSOrderedSet orderedSetWithObject:conversation2]);
     XCTAssertEqualObjects([user2 valueForKey:@"activeConversations"], [NSOrderedSet orderedSetWithObject:conversation2]);
-    XCTAssertEqualObjects([user2 valueForKey:@"inactiveConversations"], [NSOrderedSet orderedSetWithObject:conversation1]);
     id ac = [NSOrderedSet orderedSetWithArray:@[conversation1, conversation2]];
     XCTAssertEqualObjects([user3 valueForKey:@"activeConversations"], ac);
-    XCTAssertEqualObjects([user3 valueForKey:@"inactiveConversations"], [NSOrderedSet new]);
 
     __block NSError *error = nil;
     XCTAssertTrue([self.uiMOC save:&error], @"Save failed: %@", error);

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1827,7 +1827,7 @@ extension ZMAssetClientMessageTests {
             
             // when
             let sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent1, in: self.syncMOC, prefetchResult: nil).message as! ZMAssetClientMessage
-            sut.update(with: updateEvent2, for: conversation, isUpdatingExistingMessage: true)
+            sut.update(with: updateEvent2!, for: conversation, isUpdatingExistingMessage: true)
             
             // then
             XCTAssertEqual(sut.serverTimestamp, firstDate)
@@ -1863,7 +1863,7 @@ extension ZMAssetClientMessageTests {
             
             // when
             let sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent1, in: self.syncMOC, prefetchResult: nil).message as! ZMAssetClientMessage
-            sut.update(with: updateEvent2, for: conversation, isUpdatingExistingMessage: true)
+            sut.update(with: updateEvent2!, for: conversation, isUpdatingExistingMessage: true)
             
             // then
             XCTAssertEqual(sut.serverTimestamp, firstDate)

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -112,7 +112,7 @@ extension ZMMessageTests_Confirmation {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertTrue(uiMOC.saveOrRollback())
         
-        guard let confirmation = message.confirmations?.first else {
+        guard let confirmation = message.confirmations.first else {
             XCTFail()
             return
         }

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ZMImageOwner.swift"; sourceTree = "<group>"; };
 		16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMFileMetadata.swift; sourceTree = "<group>"; };
 		541298911D7D995E00A433B7 /* zmessaging2.15.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.15.0.xcdatamodel; sourceTree = "<group>"; };
+		5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.21.0.xcdatamodel; sourceTree = "<group>"; };
 		541E4F941CBD182100D82D69 /* FileAssetCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAssetCache.swift; sourceTree = "<group>"; };
 		543089B71D420165004D8AC4 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Encryption.swift"; sourceTree = "<group>"; };
@@ -2382,6 +2383,7 @@
 		F9331C8D1CB42FCF00139ECC /* zmessaging.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */,
 				F963E95C1D9AB80B00098AD3 /* zmessaging2.18.0.xcdatamodel */,
 				F97E28BC1D8AA27700A77567 /* zmessaging2.17.0.xcdatamodel */,
 				541298911D7D995E00A433B7 /* zmessaging2.15.0.xcdatamodel */,
@@ -2398,7 +2400,7 @@
 				F9331C901CB42FCF00139ECC /* zmessaging1.28.xcdatamodel */,
 				F9331C911CB42FCF00139ECC /* zmessaging2.3.xcdatamodel */,
 			);
-			currentVersion = F963E95C1D9AB80B00098AD3 /* zmessaging2.18.0.xcdatamodel */;
+			currentVersion = 5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */;
 			path = zmessaging.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;


### PR DESCRIPTION
# Reason for this pull request
Backend will remove support for list of inactive participants. It is also not used on the client at all.

# Changes
Removed stored inactive (past) participants for conversations. We kept unsynchronized inactive participants (a computed property) because we need to know which participants to ask the BE to remove.

Also add nullability annotation to `ZMMessage+Internal.h`

# Testing
This PR is missing database migration test. This is because next topic to include in the same release also require database changes and I will do them in the same model, and write one test at the end.
