### PR TITLE
Use actual keys to track local modifications

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/.xccurrentversion
+++ b/Resources/zmessaging.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>zmessaging2.21.0.xcdatamodel</string>
+	<string>zmessaging2.21.1.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.21.1.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.21.1.xcdatamodel/contents
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11232" systemVersion="15G1108" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.21.1">
+    <entity name="AssetClientMessage" representedClassName="ZMAssetClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="assetId" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="assetId_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preprocessedSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="preprocessedSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="progress" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="transferState" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="uploadState" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="asset" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="ClientMessage" representedClassName="ZMClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkPreviewState" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="updatedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="message" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="Connection" representedClassName="ZMConnection" syncable="YES">
+        <attribute name="existsOnBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUpdateDateInGMT" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="message" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="connection" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connection" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Conversation" representedClassName="ZMConversation" syncable="YES">
+        <attribute name="archivedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="callStateNeedsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="clearedTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="conversationType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="draftMessageText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasUnreadUnsentMessage" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSilenced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="messageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedUserDefinedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="securityLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="silencedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userDefinedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="voiceChannel" optional="YES" transient="YES" syncable="YES"/>
+        <relationship name="callParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeCallConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="conversationsCreated" inverseEntity="User" syncable="YES"/>
+        <relationship name="hiddenMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="hiddenInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="lastServerSyncedActiveConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="visibleInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="otherActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeConversations" inverseEntity="User" syncable="YES"/>
+        <compoundIndexes>
+            <compoundIndex>
+                <index value="internalIsArchived"/>
+                <index value="lastModifiedDate"/>
+            </compoundIndex>
+        </compoundIndexes>
+    </entity>
+    <entity name="GenericMessageData" representedClassName="ZMGenericMessageData" syncable="YES">
+        <attribute name="data" attributeType="Binary" syncable="YES"/>
+        <relationship name="asset" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AssetClientMessage" inverseName="dataSet" inverseEntity="AssetClientMessage" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClientMessage" inverseName="dataSet" inverseEntity="ClientMessage" syncable="YES"/>
+    </entity>
+    <entity name="ImageMessage" representedClassName="ZMImageMessage" parentEntity="Message" syncable="YES">
+        <attribute name="imageType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isAnimatedGIF" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumDataLoaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="originalDataProcessed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="originalSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="originalSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+    </entity>
+    <entity name="KnockMessage" representedClassName="ZMKnockMessage" parentEntity="Message" syncable="YES"/>
+    <entity name="Message" representedClassName="ZMMessage" isAbstract="YES" syncable="YES">
+        <attribute name="destructionDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isExpired" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isObfuscated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPlainText" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="nonce" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="nonce_data" optional="YES" attributeType="Binary" indexed="YES" versionHashModifier="add_index1" syncable="YES"/>
+        <attribute name="senderClientID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="serverTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="confirmations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MessageConfirmation" inverseName="message" inverseEntity="MessageConfirmation" syncable="YES"/>
+        <relationship name="hiddenInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="hiddenMessages" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="missingRecipients" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="messagesMissingRecipient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Reaction" inverseName="message" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+        <relationship name="visibleInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation" syncable="YES"/>
+    </entity>
+    <entity name="MessageConfirmation" representedClassName="ZMMessageConfirmation" syncable="YES">
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Reaction" representedClassName=".Reaction" syncable="YES">
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="unicodeValue" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="reactions" inverseEntity="Message" syncable="YES"/>
+        <relationship name="users" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="reactions" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Session" representedClassName="ZMSession" syncable="YES">
+        <relationship name="selfUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="SystemMessage" representedClassName="ZMSystemMessage" parentEntity="Message" syncable="YES">
+        <attribute name="needsUpdatingUsers" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="systemMessageType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="addedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserAdded" inverseEntity="User" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="addedOrRemovedInSystemMessages" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="removedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserRemoved" inverseEntity="User" syncable="YES"/>
+        <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="systemMessages" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="TextMessage" representedClassName="ZMTextMessage" parentEntity="Message" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName="ZMUser" syncable="YES">
+        <attribute name="accentColorValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="emailAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="imageMediumData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="imageSmallProfileData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedEmailAddress" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="normalizedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="originalProfileImageData" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <relationship name="activeCallConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="callParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="activeConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="otherActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="user" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="to" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="conversationsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="lastServerSyncedActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Reaction" inverseName="users" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="showingUserAdded" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="addedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="showingUserRemoved" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="removedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="systemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="users" inverseEntity="SystemMessage" syncable="YES"/>
+    </entity>
+    <entity name="UserClient" representedClassName=".UserClient" syncable="YES">
+        <attribute name="activationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="activationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLatitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLongitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="apsDecryptionKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="apsVerificationKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deviceClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="fingerprint" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="markedToDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="model" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToNotifyUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToUploadSignalingKeys" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="numberOfKeysRemaining" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preKeysRangeMax" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" attributeType="String" defaultValueString="permanent" syncable="YES"/>
+        <relationship name="addedOrRemovedInSystemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="clients" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="ignoredByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="ignoredClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="messagesMissingRecipient" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="missingRecipients" inverseEntity="Message" syncable="YES"/>
+        <relationship name="missedByClient" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missingClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="missingClients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missedByClient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="clients" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="210"/>
+        <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="525"/>
+        <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
+        <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="Message" positionX="0" positionY="0" width="128" height="315"/>
+        <element name="MessageConfirmation" positionX="9" positionY="153" width="128" height="90"/>
+        <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
+        <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
+        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="TextMessage" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="540"/>
+        <element name="UserClient" positionX="9" positionY="153" width="128" height="450"/>
+    </elements>
+</model>

--- a/Source/ManagedObjectContext/ZMSyncMergePolicy.m
+++ b/Source/ManagedObjectContext/ZMSyncMergePolicy.m
@@ -132,12 +132,12 @@ static NSString * const MessageKeyForDebugging = @"nonce";
 - (void)finalizeMerge;
 {
     for (ZMConversation *conversation in self.objectToValueDictionaryMap.keyEnumerator) {
-        NSArray * const trackedKeys = conversation.keysTrackedForLocalModifications;
+        NSSet * const trackedKeys = conversation.keysTrackedForLocalModifications;
         NSDictionary *d = [self.objectToValueDictionaryMap objectForKey:conversation];
         [d enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSObject *value, BOOL *stop) {
             NOT_USED(stop);
             [conversation setValue:value forKey:key];
-            if ([trackedKeys indexOfObject:key] != NSNotFound) {
+            if ([trackedKeys containsObject:key]) {
                 [conversation setLocallyModifiedKeys:[NSSet setWithObject:key]];
             }
         }];

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -891,9 +891,9 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
 }
 
-- (NSArray *)keysTrackedForLocalModifications {
-    NSArray *superKeys = [super keysTrackedForLocalModifications];
-    NSMutableArray *trackedKeys = [superKeys mutableCopy];
+- (NSSet *)keysTrackedForLocalModifications {
+    NSSet *superKeys = [super keysTrackedForLocalModifications];
+    NSMutableSet *trackedKeys = [superKeys mutableCopy];
     [trackedKeys addObject:ZMConversationUnsyncedInactiveParticipantsKey];
     [trackedKeys addObject:ZMConversationUnsyncedActiveParticipantsKey];
     [trackedKeys addObject:ZMConversationCallDeviceIsActiveKey];
@@ -1766,3 +1766,5 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 }
 
 @end
+
+

--- a/Source/Model/Reaction/Reaction.swift
+++ b/Source/Model/Reaction/Reaction.swift
@@ -45,7 +45,7 @@ open class Reaction : ZMManagedObject {
     }
     
     
-    open override func keysTrackedForLocalModifications() -> [String] {
+    open override func keysTrackedForLocalModifications() -> Set<String> {
         return [ZMReactionUsersValueKey]
     }
     

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -117,7 +117,7 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
     return @"Session";
 }
 
-+ (BOOL)hasLocallyModifiedDataFields
++ (BOOL)isTrackingLocalModifications
 {
     return NO;
 }
@@ -362,13 +362,13 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
 @dynamic showingUserAdded;
 @dynamic showingUserRemoved;
 
-- (NSArray *)keysTrackedForLocalModifications
+- (NSSet *)keysTrackedForLocalModifications
 {
     if(self.isSelfUser) {
         return [super keysTrackedForLocalModifications];
     }
     else {
-        return @[];
+        return [NSSet set];
     }
 }
 

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -124,7 +124,7 @@ public class UserClient: ZMManagedObject, UserClientType {
         return "UserClient"
     }
 
-    public override func keysTrackedForLocalModifications() -> [String] {
+    public override func keysTrackedForLocalModifications() -> Set<String> {
         return [ZMUserClientMarkedToDeleteKey, ZMUserClientNumberOfKeysRemainingKey, ZMUserClientMissingKey, ZMUserClientNeedsToUpdateSignalingKeysKey]
     }
     

--- a/Source/Model/ZMManagedObject+Internal.h
+++ b/Source/Model/ZMManagedObject+Internal.h
@@ -23,7 +23,7 @@
 #import "ZMManagedObject.h"
 
 typedef void(^ObjectsEnumerationBlock)(ZMManagedObject * _Nonnull, BOOL * _Nonnull stop);
-extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedDataFieldsKey;
+extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedKeysKey;
 
 
 
@@ -32,12 +32,17 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedDataFieldsKey;
 + (nonnull NSString *)entityName; ///< subclasses must implement this
 + (nullable NSString *)sortKey; ///< subclasses must implement this or @c +defaultSortDescriptors
 + (nullable NSString *)remoteIdentifierDataKey; ///< subclasses must implement this
-+ (BOOL)hasLocallyModifiedDataFields;
 
 + (nonnull instancetype)insertNewObjectInManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
 
 /// Whether this object has all data from the backend
 @property (nonatomic) BOOL needsToBeUpdatedFromBackend;
+
+/// Returns YES if the object is tracking local modifications. If NO, it does not support modifiedKeys property
++ (BOOL)isTrackingLocalModifications;
+
+/// Keys that have been modified since the last save and not been synced and reset
+@property (nonatomic, nullable) NSSet *modifiedKeys;
 
 /// Handles conversion from and to NSUUID and NSData in CoreData
 - (nullable NSUUID *)transientUUIDForKey:(nonnull NSString *)key;
@@ -86,10 +91,6 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedDataFieldsKey;
 /// Returns the key (attributes) that have been locally modified (by the UI).
 @property (nonatomic, readonly, nonnull) NSSet *keysThatHaveLocalModifications;
 
-/// Similar to keysThatHaveLocalModifications but allows passing in a snapshot as a dictionary.
-/// Used for merging.
-- (BOOL)hasLocalModificationsForKey:(nonnull NSString *)key withModifiedFlag:(nullable NSNumber *)n;
-
 /// Removes the given @c keys from the set of keys that have been modified by the UI
 - (void)resetLocallyModifiedKeys:(nonnull NSSet *)keys;
 
@@ -101,7 +102,7 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedDataFieldsKey;
 - (BOOL)hasLocalModificationsForKey:(nonnull NSString *)key;
 
 
-- (nonnull NSArray <NSString *> *)keysTrackedForLocalModifications ZM_REQUIRES_SUPER;
+- (nonnull NSSet <NSString *> *)keysTrackedForLocalModifications ZM_REQUIRES_SUPER;
 - (void)updateKeysThatHaveLocalModifications ZM_REQUIRES_SUPER;
 
 @end

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -521,6 +521,9 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
 /// Removes keys that were previously tracked but are not tracked anymore from the modifiedKeys
 - (void)removeObsoleteKeys
 {
+    if (![self.class isTrackingLocalModifications]) {
+        return;
+    }
     if (self.modifiedKeys == nil || [self.modifiedKeys isSubsetOfSet:self.keysTrackedForLocalModifications]) {
         return;
     }

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -432,9 +432,8 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
                   "Trying to set keys that are not being tracked: %s",
                   [keys.allObjects componentsJoinedByString:@", "].UTF8String);
     
-    NSMutableSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
-    [newKeys unionSet:keys];
-    self.modifiedKeys = [newKeys copy];
+    NSSet *newKeys = [self.keysThatHaveLocalModifications setByAddingObjectsFromSet:keys];
+    self.modifiedKeys = (newKeys.count == 0) ? nil : newKeys;
 }
 
 - (BOOL)hasLocalModificationsForKeys:(NSSet *)keys;

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -512,6 +512,23 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     }
 }
 
+- (void)awakeFromFetch
+{
+    [super awakeFromFetch];
+    [self removeObsoleteKeys];
+}
+
+/// Removes keys that were previously tracked but are not tracked anymore from the modifiedKeys
+- (void)removeObsoleteKeys
+{
+    if (self.modifiedKeys == nil || [self.modifiedKeys isSubsetOfSet:self.keysTrackedForLocalModifications]) {
+        return;
+    }
+    NSMutableSet *remainingKeys = [self.modifiedKeys mutableCopy];
+    [remainingKeys intersectSet:self.keysTrackedForLocalModifications];
+    self.modifiedKeys = (remainingKeys.count == 0) ? nil : remainingKeys;
+}
+
 - (void)updateKeysThatHaveLocalModifications;
 {
     if (![self.class isTrackingLocalModifications]) {

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -27,9 +27,9 @@
 NSString * const ZMDataPropertySuffix = @"_data";
 
 static NSString * const NeedsToBeUpdatedFromBackendKey = @"needsToBeUpdatedFromBackend";
-NSString * const ZMManagedObjectLocallyModifiedDataFieldsKey = @"modifiedDataFields";
 static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
-
+NSString * const ZMManagedObjectLocallyModifiedKeysKey = @"modifiedKeys";
+static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
 
 
 @interface ZMManagedObject ()
@@ -103,21 +103,15 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
 
 - (void)setKeysThatHaveLocalModifications:(NSSet *)keys;
 {
-    if (! [[self class] hasLocallyModifiedDataFields]) {
+    if (! [[self class] isTrackingLocalModifications]) {
         return;
     }
-    
-    // The stored value is a bitfield. C.f. the -keysThatAreMissingDataFromBackend method.
-    __block int64_t bits = 0;
-    [self.keysTrackedForLocalModifications enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL *stop) {
-        NOT_USED(stop);
-        if ([keys containsObject:key]) {
-            bits |= 1ll << (int) idx;
-        }
-    }];
-    if (! [[self valueForKey:ZMManagedObjectLocallyModifiedDataFieldsKey] isEqualToValue:@(bits)]) {
-        [self setValue:@(bits) forKey:ZMManagedObjectLocallyModifiedDataFieldsKey];
+    NSMutableSet *changedTrackedKeys = [keys mutableCopy];
+    [changedTrackedKeys intersectSet:self.keysTrackedForLocalModifications];
+    if ([self.modifiedKeys isEqualToSet:changedTrackedKeys]){
+        return;
     }
+    self.modifiedKeys = (keys.count == 0) ? nil : [changedTrackedKeys copy];
 }
 
 - (NSString *)objectIDURLString
@@ -139,8 +133,9 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
 @implementation ZMManagedObject (Internal)
 
 @dynamic needsToBeUpdatedFromBackend;
+@dynamic modifiedKeys;
 
-+ (BOOL)hasLocallyModifiedDataFields;
++ (BOOL)isTrackingLocalModifications
 {
     return YES;
 }
@@ -393,8 +388,8 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
 
 + (NSPredicate *)predicateForObjectsThatNeedToBeUpdatedUpstream;
 {
-    return [NSPredicate predicateWithFormat:@"%K != 0 && %K != NULL",
-            ZMManagedObjectLocallyModifiedDataFieldsKey, ZMManagedObjectLocallyModifiedDataFieldsKey];
+    return [NSPredicate predicateWithFormat:@"%K != NULL",
+            ZMManagedObjectLocallyModifiedKeysKey];
 }
 
 + (NSPredicate *)predicateForObjectsThatNeedToBeInsertedUpstream;
@@ -405,7 +400,7 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
 - (NSSet *)ignoredKeys;
 {
     NSString * const KeysIgnoredForTrackingModifications[] = {
-        ZMManagedObjectLocallyModifiedDataFieldsKey,
+        ZMManagedObjectLocallyModifiedKeysKey,
         NeedsToBeUpdatedFromBackendKey,
         RemoteIdentifierDataKey,
     };
@@ -414,70 +409,53 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
     return ignoredKeys;
 }
 
+
 - (NSSet *)keysThatHaveLocalModifications;
 {
-    if (! [[self class] hasLocallyModifiedDataFields]) {
+    if (! [[self class] isTrackingLocalModifications]) {
         return [NSSet set];
     }
-    
-    NSNumber *n = [self valueForKey:ZMManagedObjectLocallyModifiedDataFieldsKey];
-    return [self keysThatHaveLocalModificationsForLocallyModifiedFlag:n];
-}
-
-- (BOOL)hasLocalModificationsForKey:(NSString *)key withModifiedFlag:(NSNumber *)n;
-{
-    return [[self keysThatHaveLocalModificationsForLocallyModifiedFlag:n] containsObject:key];
-}
-
-- (NSSet *)keysThatHaveLocalModificationsForLocallyModifiedFlag:(NSNumber *)n;
-{
-    // The stored value is a bitfield. We use the fact that the allKeysTrackedAsMissing
-    // keys are always sorted alphabetically.
-    NSMutableSet *keys = [NSMutableSet set];
-    int64_t const bits = [n integerValue];
-    [self.keysTrackedForLocalModifications enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL *stop) {
-        NOT_USED(stop);
-        if (bits & (1ll << (int) idx)) {
-            [keys addObject:key];
-        }
-    }];
-    return keys;
+    return self.modifiedKeys ?: [NSSet set];
 }
 
 - (void)resetLocallyModifiedKeys:(NSSet *)keys;
 {
     NSMutableSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
     [newKeys minusSet:keys];
-    [self setKeysThatHaveLocalModifications:newKeys];
+    self.modifiedKeys = (newKeys.count == 0) ? nil : [newKeys copy];
 }
 
 - (void)setLocallyModifiedKeys:(NSSet *)keys;
 {
     VerifyReturn(keys != nil);
-    RequireString([keys isSubsetOfSet:[NSSet setWithArray:self.keysTrackedForLocalModifications]],
+    RequireString([keys isSubsetOfSet:self.keysTrackedForLocalModifications],
                   "Trying to set keys that are not being tracked: %s",
                   [keys.allObjects componentsJoinedByString:@", "].UTF8String);
     
-    NSMutableSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
-    for (NSString *key in keys) {
-        [newKeys addObject:key];
-    }
-    [self setKeysThatHaveLocalModifications:newKeys];
+    NSMutableOrderedSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
+    [newKeys unionSet:keys];
+    self.modifiedKeys = [newKeys copy];
 }
 
 - (BOOL)hasLocalModificationsForKeys:(NSSet *)keys;
 {
+    if (self.modifiedKeys == nil) {
+        return NO;
+    }
     return [self.keysThatHaveLocalModifications intersectsSet:keys];
 }
 
 - (BOOL)hasLocalModificationsForKey:(NSString *)key;
 {
+    if (self.modifiedKeys == nil) {
+        return NO;
+    }
     return [self.keysThatHaveLocalModifications containsObject:key];
 }
 
-- (NSArray *)keysTrackedForLocalModifications;
+- (NSSet *)keysTrackedForLocalModifications;
 {
-    NSMutableArray *keys = [NSMutableArray array];
+    NSMutableSet *keys = [NSMutableSet set];
     NSSet *ignoredKeys = self.ignoredKeys;
     
     [self.entity.attributesByName enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSAttributeDescription *attribute, BOOL *stop) {
@@ -494,11 +472,9 @@ static NSString * const RemoteIdentifierDataKey = @"remoteIdentifier_data";
             [keys addObject:key];
         }
     }];
-    
-    return [keys sortedArrayUsingSelector:NSSelectorFromString(@"compare:")];
+    return keys;
 }
 
-static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
 
 - (NSArray *)keysForCachedValues;
 {
@@ -538,6 +514,9 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
 
 - (void)updateKeysThatHaveLocalModifications;
 {
+    if (![self.class isTrackingLocalModifications]) {
+        return;
+    }
     NSSet *oldKeys = self.keysThatHaveLocalModifications;
     NSMutableSet *newKeys = [oldKeys mutableCopy];
     [newKeys addObjectsFromArray:self.filteredChangedValues.allKeys ?: @[]];
@@ -618,7 +597,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
             if (! [filter evaluateWithObject:key]) {
                 return;
             }
-            if ([key isEqualToString:ZMManagedObjectLocallyModifiedDataFieldsKey]) {
+            if ([key isEqualToString:ZMManagedObjectLocallyModifiedKeysKey]) {
                 NSArray *keys = [self.keysThatHaveLocalModifications.allObjects sortedArrayUsingComparator:stringCompare];
                 values[key] = (keys.count == 0) ? @"0" : [keys componentsJoinedByString:@" | "];
             } else {

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -432,7 +432,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
                   "Trying to set keys that are not being tracked: %s",
                   [keys.allObjects componentsJoinedByString:@", "].UTF8String);
     
-    NSMutableOrderedSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
+    NSMutableSet *newKeys = [self.keysThatHaveLocalModifications mutableCopy];
     [newKeys unionSet:keys];
     self.modifiedKeys = [newKeys copy];
 }

--- a/Tests/Source/ManagedObjectContext/Migrations/OTRMigrationTests.m
+++ b/Tests/Source/ManagedObjectContext/Migrations/OTRMigrationTests.m
@@ -327,7 +327,7 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
     
     XCTAssertNotNil(userDictionaries);
     XCTAssertEqual(userDictionaries.count, 3lu);
-    XCTAssertEqualObjects(userDictionaries, [self userDictionaryFixture_2_45_modifiedDataFields:4]);
+    XCTAssertEqualObjects(userDictionaries, [self userDictionaryFixture_2_45]);
 }
 
 - (void)testThatItPerformsMigrationFrom_2_5_ToCurrentModelVersion {
@@ -390,7 +390,7 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
     XCTAssertNotNil(userDictionaries);
     XCTAssertEqual(userDictionaries.count, 3lu);
     
-    XCTAssertEqualObjects(userDictionaries, [self userDictionaryFixture_2_45_modifiedDataFields:0]);
+    XCTAssertEqualObjects(userDictionaries, [self userDictionaryFixture_2_45]);
 }
 
 - (void)testThatItPerformsMigrationFrom_2_6_ToCurrentModelVersion {
@@ -586,7 +586,7 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
     return @[
              @"accentColorValue",
              @"emailAddress",
-             @"modifiedDataFields",
+             @"modifiedKeys",
              @"name",
              @"normalizedEmailAddress",
              @"normalizedName"
@@ -676,7 +676,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"hello@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"awesome test user",
                  @"normalizedEmailAddress": @"hello@example.com",
                  @"normalizedName": @"awesome test user",
@@ -684,27 +683,23 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"censored@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Bruno",
                  @"normalizedEmailAddress": @"censored@example.com",
                  @"normalizedName": @"bruno"
                  },
              @{
                  @"accentColorValue": @6,
-                 @"modifiedDataFields": @0,
                  @"name": @"Florian",
                  @"normalizedName": @"florian"
                  },
              @{
                  @"accentColorValue": @4,
-                 @"modifiedDataFields": @0,
                  @"name": @"Heinzelmann",
                  @"normalizedName": @"heinzelmann"
                  },
              @{
                  @"accentColorValue": @3,
                  @"emailAddress": @"migrationtest@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"MIGRATION TEST",
                  @"normalizedEmailAddress": @"migrationtest@example.com",
                  @"normalizedName": @"migration test"
@@ -712,14 +707,12 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @3,
                  @"emailAddress": @"welcome+23@example.com",
-                 @"modifiedDataFields": @0,
                  @"name" : @"Otto the Bot",
                  @"normalizedEmailAddress": @"welcome+23@example.com",
                  @"normalizedName": @"otto the bot",
                  },
              @{
                  @"accentColorValue": @6,
-                 @"modifiedDataFields": @0,
                  @"name": @"Pierre-Joris",
                  @"normalizedName": @"pierrejoris"
                  }
@@ -732,7 +725,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue" : @(1),
                  @"emailAddress" : @"email@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Bruno",
                  @"normalizedEmailAddress" : @"email@example.com",
                  @"normalizedName" : @"bruno",
@@ -740,7 +732,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue" : @(6),
                  @"emailAddress" : @"secret@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Florian",
                  @"normalizedEmailAddress" : @"secret@example.com",
                  @"normalizedName" : @"florian",
@@ -748,7 +739,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue" : @(4),
                  @"emailAddress" : @"hidden@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Heinzelmann",
                  @"normalizedEmailAddress" : @"hidden@example.com",
                  @"normalizedName" : @"heinzelmann",
@@ -756,7 +746,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue" : @(1),
                  @"emailAddress" : @"censored@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"It is me",
                  @"normalizedEmailAddress" : @"censored@example.com",
                  @"normalizedName" : @"it is me",
@@ -764,21 +753,18 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue" : @(3),
                  @"emailAddress" : @"welcome+23@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Otto the Bot",
                  @"normalizedEmailAddress" : @"welcome+23@example.com",
                  @"normalizedName" : @"otto the bot",
                  },
              @{
                  @"accentColorValue" : @(3),
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Pierre-Joris",
                  @"normalizedName" : @"pierrejoris",
                  },
              @{
                  @"accentColorValue" : @(3),
                  @"emailAddress" : @"secret2@example.com",
-                 @"modifiedDataFields" : @(0),
                  @"name" : @"Test User",
                  @"normalizedEmailAddress" : @"secret2@example.com",
                  @"normalizedName" : @"test user",
@@ -792,7 +778,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"user1@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"user1",
                  @"normalizedEmailAddress": @"user1@example.com",
                  @"normalizedName": @"user1"
@@ -800,7 +785,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @6,
                  @"emailAddress": @"user2@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"user2",
                  @"normalizedEmailAddress": @"user2@example.com",
                  @"normalizedName": @"user2"
@@ -808,7 +792,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"user3@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"user3",
                  @"normalizedEmailAddress": @"user3@example.com",
                  @"normalizedName": @"user3",
@@ -822,21 +805,18 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"user1@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Example User 1",
                  @"normalizedEmailAddress": @"user1@example.com",
                  @"normalizedName": @"example user 1"
                  },
              @{
                  @"accentColorValue": @6,
-                 @"modifiedDataFields": @0,
                  @"name": @"Example User 2",
                  @"normalizedName": @"example user 2"
                  },
              @{
                  @"accentColorValue": @3,
                  @"emailAddress": @"user3@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Example User 3",
                  @"normalizedEmailAddress": @"user3@example.com",
                  @"normalizedName": @"example user 3",
@@ -844,27 +824,24 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              ];
 }
 
-- (NSArray <NSDictionary *>*)userDictionaryFixture_2_45_modifiedDataFields:(NSInteger)modifiedFields
+- (NSArray <NSDictionary *>*)userDictionaryFixture_2_45
 {
     return @[
              @{
                  @"accentColorValue": @4,
                  @"emailAddress": @"user1@example.com",
-                 @"modifiedDataFields": @(modifiedFields),
                  @"name": @"User 1",
                  @"normalizedEmailAddress": @"user1@example.com",
                  @"normalizedName": @"user 1"
                  },
              @{
                  @"accentColorValue": @6,
-                 @"modifiedDataFields": @0,
                  @"name": @"User 2",
                  @"normalizedName": @"user 2"
                  },
              @{
                  @"accentColorValue": @1,
                  @"emailAddress": @"user3@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"User 3",
                  @"normalizedEmailAddress": @"user3@example.com",
                  @"normalizedName": @"user 3",
@@ -877,14 +854,12 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
     return @[
              @{
                  @"accentColorValue": @3,
-                 @"modifiedDataFields": @0,
                  @"name": @"Andreas",
                  @"normalizedName": @"Andreas"
                  },
              @{
                  @"accentColorValue": @3,
                  @"emailAddress": @"574@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Chad",
                  @"normalizedEmailAddress": @"574@example.com",
                  @"normalizedName": @"Chad"
@@ -892,7 +867,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @5,
                  @"emailAddress": @"183@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Daniel",
                  @"normalizedEmailAddress": @"183@example.com",
                  @"normalizedName": @"Daniel",
@@ -905,14 +879,12 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
     return @[
              @{
                  @"accentColorValue": @3,
-                 @"modifiedDataFields": @0,
                  @"name": @"Andreas",
                  @"normalizedName": @"Andreas"
                  },
              @{
                  @"accentColorValue": @3,
                  @"emailAddress": @"574@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Chad",
                  @"normalizedEmailAddress": @"574@example.com",
                  @"normalizedName": @"Chad"
@@ -920,7 +892,6 @@ static NSString * const DataBaseFileExtensionName = @"wiredatabase";
              @{
                  @"accentColorValue": @5,
                  @"emailAddress": @"183@example.com",
-                 @"modifiedDataFields": @0,
                  @"name": @"Daniel",
                  @"normalizedEmailAddress": @"183@example.com",
                  @"normalizedName": @"Daniel",

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -186,9 +186,9 @@
 
 - (void)testThatItHasLocallyModifiedDataFields
 {
-    XCTAssertTrue([ZMConversation hasLocallyModifiedDataFields]);
+    XCTAssertTrue([ZMConversation isTrackingLocalModifications]);
     NSEntityDescription *entity = self.uiMOC.persistentStoreCoordinator.managedObjectModel.entitiesByName[ZMConversation.entityName];
-    XCTAssertNotNil(entity.attributesByName[@"modifiedDataFields"]);
+    XCTAssertNotNil(entity.attributesByName[@"modifiedKeys"]);
 }
 
 - (void)testThatWeCanSetAttributesOnConversation
@@ -220,7 +220,7 @@
 - (void)testThatSpecialKeysAreNotPartOfTheLocallyModifiedKeys
 {
     // given
-    NSArray *expected = @[
+    NSSet *expected = [NSSet setWithArray:@[
                           ZMConversationUserDefinedNameKey,
                           ZMConversationUnsyncedInactiveParticipantsKey,
                           ZMConversationUnsyncedActiveParticipantsKey,
@@ -232,13 +232,13 @@
                           ZMConversationIsIgnoringCallKey,
                           ZMConversationSilencedChangedTimeStampKey,
                           ZMConversationArchivedChangedTimeStampKey,
-                          ];
+                          ]];
     
     // when
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
 
     // then
-    AssertArraysContainsSameObjects(conversation.keysTrackedForLocalModifications, expected);
+    XCTAssertEqualObjects(conversation.keysTrackedForLocalModifications, expected);
 }
 
 - (void)testThatItAddsCallDeviceIsActiveToLocallyModifiedKeysIfHasLocalModificationsForCallDeviceIsActiveIsSet

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -65,9 +65,9 @@ NSString * const ReactionsKey = @"reactions";
 
 - (void)testThatItHasLocallyModifiedDataFields
 {
-    XCTAssertTrue([ZMImageMessage hasLocallyModifiedDataFields]);
+    XCTAssertTrue([ZMImageMessage isTrackingLocalModifications]);
     NSEntityDescription *entity = self.uiMOC.persistentStoreCoordinator.managedObjectModel.entitiesByName[ZMImageMessage.entityName];
-    XCTAssertNotNil(entity.attributesByName[@"modifiedDataFields"]);
+    XCTAssertNotNil(entity.attributesByName[@"modifiedKeys"]);
 }
 
 - (void)testThatWeCanSetAttributesOnTextMessage
@@ -376,7 +376,7 @@ NSString * const ReactionsKey = @"reactions";
 - (void)testThatSpecialKeysAreNotPartOfTheLocallyModifiedKeysForTextMessages
 {
     //given
-    NSArray *expected = @[IsExpiredKey];
+    NSSet *expected = [NSSet setWithObject:IsExpiredKey];
 
     // when
     ZMTextMessage *message = [ZMTextMessage insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -388,7 +388,7 @@ NSString * const ReactionsKey = @"reactions";
 - (void)testThatSpecialKeysAreNotPartOfTheLocallyModifiedKeysForSystemMessages
 {
     //given
-    NSArray *expected = @[IsExpiredKey];
+    NSSet *expected = [NSSet setWithObject:IsExpiredKey];
     
     // when
     ZMSystemMessage *message = [ZMSystemMessage insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -401,7 +401,7 @@ NSString * const ReactionsKey = @"reactions";
 - (void)testThatSpecialKeysAreNotPartOfTheLocallyModifiedKeysForImageMessages
 {
     // given
-    NSArray *expected = @[IsExpiredKey];
+    NSSet *expected = [NSSet setWithObject:IsExpiredKey];
     
     // when
     ZMImageMessage *message = [ZMImageMessage insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -416,8 +416,8 @@ NSString * const ReactionsKey = @"reactions";
     ZMClientMessage *message = [ZMClientMessage insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // then
-    NSArray *keysThatShouldBeTracked = @[@"dataSet", @"linkPreviewState"];
-    AssertArraysContainsSameObjects(message.keysTrackedForLocalModifications, keysThatShouldBeTracked);
+    NSSet *keysThatShouldBeTracked = [NSSet setWithArray:@[@"dataSet", @"linkPreviewState"]];
+    XCTAssertEqualObjects(message.keysTrackedForLocalModifications, keysThatShouldBeTracked);
 }
 
 - (void)testThat_doesEventGenerateMessage_returnsTrueForAllKnownTypes

--- a/Tests/Source/Model/MockDataModel/MockEntity.m
+++ b/Tests/Source/Model/MockDataModel/MockEntity.m
@@ -31,11 +31,11 @@
     return @"field";
 }
 
-+(NSString *)entityName {
++ (NSString *)entityName {
     return @"MockEntity";
 }
 
-+(NSString *)remoteIdentifierDataKey {
++ (NSString *)remoteIdentifierDataKey {
     return @"testUUID_data";
 }
 

--- a/Tests/Source/Model/MockDataModel/MockModelObjectContextFactory.m
+++ b/Tests/Source/Model/MockDataModel/MockModelObjectContextFactory.m
@@ -95,17 +95,17 @@
     [needsToBeUpdatedFromBackendAttribute setAttributeType:NSBooleanAttributeType];
     [needsToBeUpdatedFromBackendAttribute setOptional:YES];
 
-    NSAttributeDescription *modifiedDataFieldsAttribute = [[NSAttributeDescription alloc] init];
-    [modifiedDataFieldsAttribute setName:@"modifiedDataFields"];
-    [modifiedDataFieldsAttribute setAttributeType:NSInteger64AttributeType];
-    [modifiedDataFieldsAttribute setOptional:YES];
+    NSAttributeDescription *modifiedKeysAttribute = [[NSAttributeDescription alloc] init];
+    [modifiedKeysAttribute setName:@"modifiedKeys"];
+    [modifiedKeysAttribute setAttributeType:NSTransformableAttributeType];
+    [modifiedKeysAttribute setOptional:YES];
 
 
     NSEntityDescription *mockEntity2 = [[NSEntityDescription alloc] init];
     [mockEntity2 setName:@"MockEntity2"];
     [mockEntity2 setManagedObjectClassName:NSStringFromClass([MockEntity2 class])];
 
-    [mockEntity2 setProperties:@[fieldAttribute, modifiedDataFieldsAttribute, needsToBeUpdatedFromBackendAttribute, testUUIDAttribute, testUUIDDataAttribute]];
+    [mockEntity2 setProperties:@[fieldAttribute, modifiedKeysAttribute, needsToBeUpdatedFromBackendAttribute, testUUIDAttribute, testUUIDDataAttribute]];
     return mockEntity2;
 }
 
@@ -166,13 +166,13 @@
     [needsToBeUpdatedFromBackendAttribute setOptional:YES];
 
 
-    NSAttributeDescription *modifiedDataFieldsAttribute = [[NSAttributeDescription alloc] init];
-    [modifiedDataFieldsAttribute setName:@"modifiedDataFields"];
-    [modifiedDataFieldsAttribute setAttributeType:NSInteger64AttributeType];
-    [modifiedDataFieldsAttribute setOptional:YES];
+    NSAttributeDescription *modifiedKeysAttribute = [[NSAttributeDescription alloc] init];
+    [modifiedKeysAttribute setName:@"modifiedKeys"];
+    [modifiedKeysAttribute setAttributeType:NSTransformableAttributeType];
+    [modifiedKeysAttribute setOptional:YES];
 
     [mockEntity setProperties:@[fieldAttribute, field2Attribute, field3Attribute, testUUIDAttribute,
-        testUUIDDataAttribute, needsToBeUpdatedFromBackendAttribute, modifiedDataFieldsAttribute, mockEntityRelationship, remoteIdentifierAttribute, remoteIdentifierDataAttribute]];
+        testUUIDDataAttribute, needsToBeUpdatedFromBackendAttribute, modifiedKeysAttribute, mockEntityRelationship, remoteIdentifierAttribute, remoteIdentifierDataAttribute]];
     return mockEntity;
 }
 

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -78,9 +78,9 @@ static NSString *const ValidEmail = @"foo77@example.com";
 
 - (void)testThatItHasLocallyModifiedDataFields
 {
-    XCTAssertTrue([ZMUser hasLocallyModifiedDataFields]);
+    XCTAssertTrue([ZMUser isTrackingLocalModifications]);
     NSEntityDescription *entity = self.uiMOC.persistentStoreCoordinator.managedObjectModel.entitiesByName[ZMUser.entityName];
-    XCTAssertNotNil(entity.attributesByName[@"modifiedDataFields"]);
+    XCTAssertNotNil(entity.attributesByName[@"modifiedKeys"]);
 }
 
 - (void)testThatWeCanSetAttributesOnUser
@@ -908,7 +908,7 @@ static NSString *const ValidEmail = @"foo77@example.com";
     XCTAssertNotNil(user);
     
     // then
-    XCTAssertEqualObjects([NSSet setWithArray:user.keysTrackedForLocalModifications], expected);
+    XCTAssertEqualObjects(user.keysTrackedForLocalModifications, expected);
 }
 
 
@@ -1387,7 +1387,7 @@ static NSString *const ValidEmail = @"foo77@example.com";
     connection.to = user;
     connection.message = @"Some old text";
     [self.uiMOC saveOrRollback];
-    [connection setValue:@0 forKey:@"modifiedDataFields"]; // Simulate no local changes
+    [connection setValue:[NSSet set] forKey:@"modifiedKeys"]; // Simulate no local changes
     
     // when
     [user connectWithMessageText:@"Foo, bar, baz!" completionHandler:nil];
@@ -1459,7 +1459,7 @@ static NSString *const ValidEmail = @"foo77@example.com";
     connection.status = status;
     connection.message = @"Some old text";
     [self.uiMOC saveOrRollback];
-    [connection setValue:@0 forKey:@"modifiedDataFields"]; // Simulate no local changes
+    [connection setValue:[NSSet set] forKey:@"modifiedKeys"]; // Simulate no local changes
     return connection;
 }
 

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -87,7 +87,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
     }
     
     func testThatItTracksCorrectKeys() {
-        let expectedKeys = [ZMUserClientMarkedToDeleteKey, ZMUserClientNumberOfKeysRemainingKey, ZMUserClientMissingKey, ZMUserClientNeedsToUpdateSignalingKeysKey]
+        let expectedKeys = Set(arrayLiteral: ZMUserClientMarkedToDeleteKey, ZMUserClientNumberOfKeysRemainingKey, ZMUserClientMissingKey, ZMUserClientNeedsToUpdateSignalingKeysKey)
         let client = UserClient.insertNewObject(in: self.uiMOC)
 
         XCTAssertEqual(client.keysTrackedForLocalModifications() , expectedKeys)

--- a/Tests/Source/Model/ZMConnectionTests.m
+++ b/Tests/Source/Model/ZMConnectionTests.m
@@ -77,9 +77,9 @@
 
 - (void)testThatItHasLocallyModifiedDataFields
 {
-    XCTAssertTrue([ZMConnection hasLocallyModifiedDataFields]);
+    XCTAssertTrue([ZMConnection isTrackingLocalModifications]);
     NSEntityDescription *entity = self.uiMOC.persistentStoreCoordinator.managedObjectModel.entitiesByName[ZMConnection.entityName];
-    XCTAssertNotNil(entity.attributesByName[@"modifiedDataFields"]);
+    XCTAssertNotNil(entity.attributesByName[@"modifiedKeys"]);
 }
 
 - (void)testStatusFromString
@@ -984,7 +984,7 @@
     ZMConnection *connection = [ZMConnection insertNewSentConnectionToUser:user];
     
     // then
-    XCTAssertEqualObjects(connection.keysTrackedForLocalModifications, @[@"status"]);
+    XCTAssertEqualObjects(connection.keysTrackedForLocalModifications, [NSSet setWithObject:@"status"]);
 }
 
 - (NSDictionary *)validPayloadForConnectionWithStatus:(NSString *)status

--- a/Tests/Source/Model/ZMManagedObjectTests.m
+++ b/Tests/Source/Model/ZMManagedObjectTests.m
@@ -629,9 +629,19 @@
 
 - (void)testPerformanceRetrievingLocallyModifiedKeys;
 {
-    // measured with NSSet implementation: average: 0.000, relative standard deviation: 45.526%, values: [0.000716, 0.000402, 0.000347, 0.000345, 0.000232, 0.000231, 0.000230, 0.000231, 0.000232, 0.000232],
+    // measured with NSSet implementation: average: 0.000, relative standard deviation: 33.239%, values: [0.000581, 0.000390, 0.000353, 0.000351, 0.000269, 0.000238, 0.000249, 0.000239, 0.000239, 0.000237], 
+    
+    // measured with NSString implementation average: 0.000, relative standard deviation: 34.962%, values: [0.000638, 0.000414, 0.000386, 0.000380, 0.000258, 0.000259, 0.000257, 0.000258, 0.000257, 0.000257], 
     
     MockEntity *entity = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
+    entity.field = 3;
+    entity.field3 = @"barfoo";
+    [self.testMOC saveOrRollback];
+
+    NSSet *modifiedKeys = [entity keysThatHaveLocalModifications];
+    XCTAssertTrue([modifiedKeys containsObject:@"field"]);
+    XCTAssertTrue([modifiedKeys containsObject:@"field3"]);
+    
     [self.testMOC saveOrRollback];
     [self.testMOC refreshAllObjects];
     XCTAssertTrue(entity.isFault);

--- a/Tests/Source/Model/ZMManagedObjectTests.m
+++ b/Tests/Source/Model/ZMManagedObjectTests.m
@@ -630,8 +630,10 @@
 - (void)testPerformanceRetrievingLocallyModifiedKeys;
 {
     // measured with NSSet implementation: average: 0.000, relative standard deviation: 33.239%, values: [0.000581, 0.000390, 0.000353, 0.000351, 0.000269, 0.000238, 0.000249, 0.000239, 0.000239, 0.000237], 
+    // 10.000 - average: 3.526, relative standard deviation: 2.786%, values: [3.688881, 3.650577, 3.654529, 3.465883, 3.424065, 3.553015, 3.493663, 3.406812, 3.472713, 3.454525],
     
-    // measured with NSString implementation average: 0.000, relative standard deviation: 34.962%, values: [0.000638, 0.000414, 0.000386, 0.000380, 0.000258, 0.000259, 0.000257, 0.000258, 0.000257, 0.000257], 
+    // measured with NSString implementation average: 0.000, relative standard deviation: 34.962%, values: [0.000638, 0.000414, 0.000386, 0.000380, 0.000258, 0.000259, 0.000257, 0.000258, 0.000257, 0.000257],
+    // 10.000 - average: 3.845, relative standard deviation: 2.959%, values: [4.125333, 3.853140, 3.849008, 3.760596, 3.764041, 3.744273, 3.805642, 3.825166, 3.751391, 3.972608],
     
     MockEntity *entity = [MockEntity insertNewObjectInManagedObjectContext:self.testMOC];
     entity.field = 3;

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageUpdateResult.swift; sourceTree = "<group>"; };
 		F93A30231D6EFB47005CCB1D /* ZMMessageConfirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMMessageConfirmation.swift; sourceTree = "<group>"; };
 		F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessageTests+Confirmation.swift"; sourceTree = "<group>"; };
+		F94718E91DC3525A00337892 /* zmessaging2.21.1.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.21.1.xcdatamodel; sourceTree = "<group>"; };
 		F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZMSyncMergePolicyTests.m; path = Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m; sourceTree = SOURCE_ROOT; };
 		F94A208E1CB51AF50059632A /* ManagedObjectValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ManagedObjectValidationTests.m; path = Tests/Source/Model/ManagedObjectValidationTests.m; sourceTree = SOURCE_ROOT; };
 		F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessageTest+Encryption.swift"; sourceTree = "<group>"; };
@@ -2379,6 +2380,7 @@
 		F9331C8D1CB42FCF00139ECC /* zmessaging.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				F94718E91DC3525A00337892 /* zmessaging2.21.1.xcdatamodel */,
 				5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */,
 				F963E95C1D9AB80B00098AD3 /* zmessaging2.18.0.xcdatamodel */,
 				F97E28BC1D8AA27700A77567 /* zmessaging2.17.0.xcdatamodel */,
@@ -2396,7 +2398,7 @@
 				F9331C901CB42FCF00139ECC /* zmessaging1.28.xcdatamodel */,
 				F9331C911CB42FCF00139ECC /* zmessaging2.3.xcdatamodel */,
 			);
-			currentVersion = 5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */;
+			currentVersion = F94718E91DC3525A00337892 /* zmessaging2.21.1.xcdatamodel */;
 			path = zmessaging.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;


### PR DESCRIPTION
**In this PR**
We are currently tracking local modifications through a bitfield that is updated whenever we save: We loop through all the entity's attributes which are sorted alphabetically and store a 0 or 1 indicating modification. However, this leads to problems when we remove properties or exclude keys that were previously tracked. Since the removed key is then missing from the entity's attributes or included in the ignored keys, the bitfield would now be shifted and keys that were not modified were assigned the wrong value which would essentially lead to a crash when syncing.

To circumvent this, we decided to store the modified keys as strings instead, so we can assign the stored value to a specific changed key with certainty. In this case if we remove keys from the database or exclude them from the keys to be tracked we can easily remove them from the modifiedKeys as well. 

Changes made:
* Remove modifiedDataFields property and replace it by modifiedKeys which stores a Set of Strings
* When saving we add the changed field names to the modifiedKeys
* In awakeFromFetch we update modifiedKeys subtracting keys that are no longer tracked or have been removed from the entity

ToDo before merging:
- [x] needs to be tested with zmessaging 