### PR TITLE
Add logic to receive /v3 assets

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/.xccurrentversion
+++ b/Resources/zmessaging.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>zmessaging2.21.1.xcdatamodel</string>
+	<string>zmessaging2.21.2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.21.2.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.21.2.xcdatamodel/contents
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11232" systemVersion="15G31" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.21.2">
+    <entity name="AssetClientMessage" representedClassName="ZMAssetClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="assetId" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="assetId_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preprocessedSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="preprocessedSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="progress" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="transferState" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="uploadState" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="asset" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="ClientMessage" representedClassName="ZMClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkPreviewState" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="updatedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="GenericMessageData" inverseName="message" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="Connection" representedClassName="ZMConnection" syncable="YES">
+        <attribute name="existsOnBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUpdateDateInGMT" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="message" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="connection" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connection" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Conversation" representedClassName="ZMConversation" syncable="YES">
+        <attribute name="archivedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="callStateNeedsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="clearedTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="conversationType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="draftMessageText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasUnreadUnsentMessage" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSilenced" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="messageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedUserDefinedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="securityLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="silencedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userDefinedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="voiceChannel" optional="YES" transient="YES" syncable="YES"/>
+        <relationship name="callParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeCallConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="conversationsCreated" inverseEntity="User" syncable="YES"/>
+        <relationship name="hiddenMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="hiddenInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="lastServerSyncedActiveConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="visibleInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="otherActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeConversations" inverseEntity="User" syncable="YES"/>
+        <compoundIndexes>
+            <compoundIndex>
+                <index value="internalIsArchived"/>
+                <index value="lastModifiedDate"/>
+            </compoundIndex>
+        </compoundIndexes>
+    </entity>
+    <entity name="GenericMessageData" representedClassName="ZMGenericMessageData" syncable="YES">
+        <attribute name="data" attributeType="Binary" syncable="YES"/>
+        <relationship name="asset" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AssetClientMessage" inverseName="dataSet" inverseEntity="AssetClientMessage" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClientMessage" inverseName="dataSet" inverseEntity="ClientMessage" syncable="YES"/>
+    </entity>
+    <entity name="ImageMessage" representedClassName="ZMImageMessage" parentEntity="Message" syncable="YES">
+        <attribute name="imageType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isAnimatedGIF" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumDataLoaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="originalDataProcessed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="originalSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="originalSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+    </entity>
+    <entity name="KnockMessage" representedClassName="ZMKnockMessage" parentEntity="Message" syncable="YES"/>
+    <entity name="Message" representedClassName="ZMMessage" isAbstract="YES" syncable="YES">
+        <attribute name="destructionDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isEncrypted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isExpired" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isObfuscated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPlainText" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="nonce" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="nonce_data" optional="YES" attributeType="Binary" indexed="YES" versionHashModifier="add_index1" syncable="YES"/>
+        <attribute name="senderClientID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="serverTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="confirmations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MessageConfirmation" inverseName="message" inverseEntity="MessageConfirmation" syncable="YES"/>
+        <relationship name="hiddenInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="hiddenMessages" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="missingRecipients" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="messagesMissingRecipient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Reaction" inverseName="message" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+        <relationship name="visibleInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation" syncable="YES"/>
+    </entity>
+    <entity name="MessageConfirmation" representedClassName="ZMMessageConfirmation" syncable="YES">
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Reaction" representedClassName=".Reaction" syncable="YES">
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="unicodeValue" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="reactions" inverseEntity="Message" syncable="YES"/>
+        <relationship name="users" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="reactions" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Session" representedClassName="ZMSession" syncable="YES">
+        <relationship name="selfUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="SystemMessage" representedClassName="ZMSystemMessage" parentEntity="Message" syncable="YES">
+        <attribute name="needsUpdatingUsers" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="systemMessageType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="addedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserAdded" inverseEntity="User" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="addedOrRemovedInSystemMessages" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="removedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserRemoved" inverseEntity="User" syncable="YES"/>
+        <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="systemMessages" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="TextMessage" representedClassName="ZMTextMessage" parentEntity="Message" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName="ZMUser" syncable="YES">
+        <attribute name="accentColorValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="emailAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="imageCorrelationIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="imageMediumData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="imageSmallProfileData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedEmailAddress" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="normalizedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="originalProfileImageData" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <relationship name="activeCallConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="callParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="activeConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="otherActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="user" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="to" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="conversationsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="lastServerSyncedActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Reaction" inverseName="users" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="showingUserAdded" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="addedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="showingUserRemoved" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="removedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="systemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="users" inverseEntity="SystemMessage" syncable="YES"/>
+    </entity>
+    <entity name="UserClient" representedClassName=".UserClient" syncable="YES">
+        <attribute name="activationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="activationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLatitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLongitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="apsDecryptionKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="apsVerificationKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deviceClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="fingerprint" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="markedToDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="model" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToNotifyUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToUploadSignalingKeys" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="numberOfKeysRemaining" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preKeysRangeMax" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" attributeType="String" defaultValueString="permanent" syncable="YES"/>
+        <relationship name="addedOrRemovedInSystemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="clients" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="ignoredByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="ignoredClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="messagesMissingRecipient" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="missingRecipients" inverseEntity="Message" syncable="YES"/>
+        <relationship name="missedByClient" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missingClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="missingClients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missedByClient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="clients" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="225"/>
+        <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="525"/>
+        <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
+        <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="Message" positionX="0" positionY="0" width="128" height="315"/>
+        <element name="MessageConfirmation" positionX="9" positionY="153" width="128" height="90"/>
+        <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
+        <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
+        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="TextMessage" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="540"/>
+        <element name="UserClient" positionX="9" positionY="153" width="128" height="450"/>
+    </elements>
+</model>

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -184,6 +184,8 @@ NS_ASSUME_NONNULL_END
 - (nonnull ZMClientMessage *)appendOTRMessageWithLocationData:(nonnull ZMLocationData *)locationData nonce:(nonnull NSUUID *)nonce;
 - (nonnull ZMAssetClientMessage *)appendOTRMessageWithImageData:(nonnull NSData *)imageData nonce:(nonnull NSUUID *)nonce;
 - (nonnull ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata nonce:(nonnull NSUUID *)nonce;
+- (nonnull ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata nonce:(nonnull NSUUID *)nonce version3:(BOOL)version3;
+
 
 /// Appends a new message to the conversation.
 /// @param genericMessage the generic message that should be appended

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -743,6 +743,11 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return [self appendOTRMessageWithFileMetadata:fileMetadata nonce:NSUUID.UUID];
 }
 
+- (id<ZMConversationMessage>)appendMessageWithFileMetadata:(ZMFileMetadata *)fileMetadata version3:(BOOL)version3
+{
+    return [self appendOTRMessageWithFileMetadata:fileMetadata nonce:NSUUID.UUID version3:version3];
+}
+
 - (nullable id<ZMConversationMessage>)appendMessageWithLocationData:(nonnull ZMLocationData *)locationData
 {
     return [self appendOTRMessageWithLocationData:locationData nonce:NSUUID.UUID];
@@ -1313,7 +1318,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(ZMFileMetadata *)fileMetadata nonce:(NSUUID *)nonce
 {
-    ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithFileMetadata:fileMetadata nonce:nonce managedObjectContext:self.managedObjectContext expiresAfter:self.messageDestructionTimeout];
+    return [self appendOTRMessageWithFileMetadata:fileMetadata nonce:nonce version3:NO];
+}
+
+- (nonnull ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata nonce:(nonnull NSUUID *)nonce version3:(BOOL)version3;
+{
+    ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithFileMetadata:fileMetadata nonce:nonce managedObjectContext:self.managedObjectContext expiresAfter:self.messageDestructionTimeout version3:version3];
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     message.isEncrypted = YES;
     [self sortedAppendMessage:message];

--- a/Source/Model/Message/AssetEncryption.swift
+++ b/Source/Model/Message/AssetEncryption.swift
@@ -115,8 +115,8 @@ extension FileAssetCache {
     /// original. In case of error (the digest doesn't match, or any other error), deletes the original and does not create a decrypted version.
     /// Returns whether the decryption was successful and the digest matched
     public func decryptAssetIfItMatchesDigest(_ nonce: UUID, fileName: String, encryptionKey: Data, macKey: Data, macDigest: Data) -> Bool {
-        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: false)
-        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: true)
+        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: false)
+        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: true)
         return self.cache.decryptAssetIfItMatchesDigest(plaintextCacheKey, encryptedEntryKey: encryptedCacheKey, encryptionKey: encryptionKey, macKey: macKey, macDigest: macDigest)
     }
     
@@ -124,15 +124,15 @@ extension FileAssetCache {
     /// original. In case of error (the digest doesn't match, or any other error), deletes the original and does not create a decrypted version.
     /// Returns whether the decryption was successful and the digest matched
     public func decryptFileIfItMatchesDigest(_ nonce: UUID, fileName: String, encryptionKey: Data, sha256Digest: Data) -> Bool {
-        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: false)
-        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: true)
+        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: false)
+        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: true)
         return self.cache.decryptAssetIfItMatchesDigest(plaintextCacheKey, encryptedEntryKey: encryptedCacheKey, encryptionKey: encryptionKey, sha256Digest: sha256Digest)
     }
     
     /// Encrypts a plaintext cache entry to an encrypted one, also computing the digest of the encrypted entry
     public func encryptFileAndComputeSHA256Digest(_ nonce: UUID, fileName: String) -> ZMImageAssetEncryptionKeys? {
-        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: false)
-        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, fileName: fileName, encrypted: true)
+        let plaintextCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: false)
+        let encryptedCacheKey = type(of: self).cacheKeyForAsset(nonce, suffix: fileName, encrypted: true)
         return self.cache.encryptFileAndComputeSHA256Digest(plaintextCacheKey, encryptedEntryKey: encryptedCacheKey)
     }
 }

--- a/Source/Model/Message/FileAssetCache.swift
+++ b/Source/Model/Message/FileAssetCache.swift
@@ -166,48 +166,48 @@ open class FileAssetCache : NSObject {
     
     /// Returns the asset data for a given message. This will probably cause I/O
     open func assetData(_ messageID: UUID, fileName: String, encrypted: Bool) -> Data? {
-        return self.cache.assetData(type(of: self).cacheKeyForAsset(messageID, fileName: fileName, encrypted: encrypted))
+        return self.cache.assetData(type(of: self).cacheKeyForAsset(messageID, suffix: fileName, encrypted: encrypted))
     }
     
     /// Returns the asset URL for a given message
     open func accessAssetURL(_ messageID: UUID, fileName: String) -> URL? {
-        return self.cache.assetURL(type(of: self).cacheKeyForAsset(messageID, fileName: fileName))
+        return self.cache.assetURL(type(of: self).cacheKeyForAsset(messageID, suffix: fileName))
     }
     
     /// Returns the asset URL for a given message
     open func accessRequestURL(_ messageID: UUID) -> URL? {
-        return cache.assetURL(type(of: self).cacheKeyForAsset(messageID, fileName: "", request: true))
+        return cache.assetURL(type(of: self).cacheKeyForAsset(messageID, suffix: "", request: true))
     }
     
     open func hasDataOnDisk(_ messageID: UUID, fileName: String, encrypted: Bool) -> Bool {
-        return cache.hasDataForKey(type(of: self).cacheKeyForAsset(messageID, fileName: fileName, encrypted: encrypted))
+        return cache.hasDataForKey(type(of: self).cacheKeyForAsset(messageID, suffix: fileName, encrypted: encrypted))
     }
     
     /// Sets the asset data for a given message. This will cause I/O
     open func storeAssetData(_ messageID: UUID, fileName: String, encrypted: Bool, data: Data) {
-        self.cache.storeAssetData(data, key: type(of: self).cacheKeyForAsset(messageID, fileName: fileName, encrypted: encrypted))
+        self.cache.storeAssetData(data, key: type(of: self).cacheKeyForAsset(messageID, suffix: fileName, encrypted: encrypted))
     }
     
     /// Sets the request data for a given message and returns the asset url. This will cause I/O
     open func storeRequestData(_ messageID: UUID, data: Data) -> URL? {
-        let key = type(of: self).cacheKeyForAsset(messageID, fileName: "", request: true)
+        let key = type(of: self).cacheKeyForAsset(messageID, suffix: "", request: true)
         cache.storeAssetData(data, key: key)
         return accessRequestURL(messageID)
     }
     
     /// Deletes the request data for a given message. This will cause I/O
     open func deleteRequestData(_ messageID: UUID) {
-        let key = type(of: self).cacheKeyForAsset(messageID, fileName: "", request: true)
+        let key = type(of: self).cacheKeyForAsset(messageID, suffix: "", request: true)
         cache.deleteAssetData(key)
     }
     
     /// Deletes the data for a given message. This will cause I/O
     open func deleteAssetData(_ messageID: UUID, fileName: String, encrypted: Bool) {
-        self.cache.deleteAssetData(type(of: self).cacheKeyForAsset(messageID, fileName: fileName, encrypted: encrypted))
+        self.cache.deleteAssetData(type(of: self).cacheKeyForAsset(messageID, suffix: fileName, encrypted: encrypted))
     }
     
     /// Returns the cache key for an asset
-    static func cacheKeyForAsset(_ messageID: UUID, fileName: String, encrypted: Bool = false, request: Bool = false) -> String {
+    static func cacheKeyForAsset(_ messageID: UUID, suffix: String, encrypted: Bool = false, request: Bool = false) -> String {
         precondition(!(request && encrypted))
         
         if (encrypted) {
@@ -217,7 +217,7 @@ open class FileAssetCache : NSObject {
             return "\(messageID.transportString())_request"
         }
         else {
-            return "\(messageID.transportString())_\(fileName)"
+            return "\(messageID.transportString())_\(suffix)"
         }
     }
     

--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -1,0 +1,132 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import MobileCoreServices
+
+
+extension String {
+
+    var isGIF: Bool {
+        guard let UTIString = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, self as CFString, nil)?.takeUnretainedValue() else { return false }
+        return UTIString == kUTTypeGIF
+    }
+
+}
+
+
+@objc public class V2ImageAsset: NSObject, ZMImageMessageData {
+
+    fileprivate let assetClientMessage: ZMAssetClientMessage
+    fileprivate let moc: NSManagedObjectContext
+    private let assetStorage: ZMImageAssetStorage
+
+    public init?(with message: ZMAssetClientMessage) {
+        guard message.version < 3, let storage = message.imageAssetStorage else { return nil }
+        assetClientMessage = message
+        assetStorage = storage
+        moc = message.managedObjectContext!
+    }
+
+    public var mediumData: Data? {
+        if assetStorage.mediumGenericMessage?.imageAssetData?.width > 0 {
+            return assetClientMessage.imageAssetStorage?.imageData(for: .medium, encrypted: false)
+        }
+        return nil
+    }
+
+    public var imageData: Data? {
+        return mediumData ?? assetStorage.imageData(for: .original, encrypted: false)
+    }
+
+    public var imageDataIdentifier: String? {
+        return imageDataIdentifier(for: assetStorage.mediumGenericMessage) ??
+               imageDataIdentifier(for: assetStorage.previewGenericMessage) ??
+               assetClientMessage.assetId?.uuidString ??
+               imageData.map { String(format: "orig-%p", $0 as NSData) }
+    }
+
+    public var imagePreviewDataIdentifier: String? {
+        return previewData != nil ? assetClientMessage.nonce.uuidString : nil
+    }
+
+    public var previewData: Data? {
+        if assetStorage.previewGenericMessage?.imageAssetData?.width > 0 {
+            // Image preview data
+            return assetStorage.imageData(for: .original, encrypted: false)
+        } else if let fileMessage = assetClientMessage.fileMessageData, assetClientMessage.hasDownloadedImage, !fileMessage.isImage() {
+            // File preview data
+            return imageData(for: .original) ?? imageData(for: .medium)
+        }
+
+        return nil
+    }
+
+    public var isAnimatedGIF: Bool {
+        return assetStorage.mediumGenericMessage?.imageAssetData?.mimeType.isGIF ?? false
+    }
+
+    public var imageType: String? {
+        return assetStorage.mediumGenericMessage?.imageAssetData?.mimeType ??
+               assetStorage.previewGenericMessage?.imageAssetData?.mimeType
+    }
+
+    public var originalSize: CGSize {
+        let genericMessage = assetStorage.mediumGenericMessage ?? assetStorage.previewGenericMessage
+        guard let asset = genericMessage?.imageAssetData, asset.originalWidth > 0 else { return assetStorage.preprocessedSize() }
+        return CGSize(width: Int(asset.originalWidth), height: Int(asset.originalHeight))
+    }
+
+    // MARK: - Helper
+
+    private func imageDataIdentifier(for message: ZMGenericMessage?) -> String? {
+        guard let assetData = message?.imageAssetData else { return nil }
+        return String(format: "%@-w%d-%@", assetClientMessage.nonce.transportString(), Int(assetData.width), NSNumber(value: assetClientMessage.hasDownloadedImage))
+
+    }
+
+    private func imageData(for format: ZMImageFormat) -> Data? {
+        return moc.zm_imageAssetCache.assetData(assetClientMessage.nonce, format: format, encrypted: false)
+    }
+
+    fileprivate func hasImageData(for format: ZMImageFormat) -> Bool {
+        return nil != imageData(for: format)
+    }
+
+}
+
+
+extension V2ImageAsset: AssetProxyType {
+
+    public var hasDownloadedImage: Bool {
+        guard assetClientMessage.imageMessageData != nil || assetClientMessage.fileMessageData != nil else { return false }
+        return hasImageData(for: .medium) || hasImageData(for: .original)
+    }
+
+    public var hasDownloadedFile: Bool {
+        guard assetClientMessage.fileMessageData != nil, let name = assetClientMessage.filename else { return false }
+        return moc.zm_fileAssetCache.hasDataOnDisk(assetClientMessage.nonce, fileName: name, encrypted: false)
+    }
+
+    public var fileURL: URL? {
+        guard let name = assetClientMessage.filename else { return nil }
+        return moc.zm_fileAssetCache.accessAssetURL(assetClientMessage.nonce, fileName: name)
+    }
+
+}

--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -1,0 +1,118 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import MobileCoreServices
+
+
+@objc public protocol AssetProxyType {
+    var hasDownloadedImage: Bool { get }
+    var hasDownloadedFile: Bool { get }
+
+    var fileURL: URL? { get }
+}
+
+
+@objc public class V3ImageAsset: NSObject, ZMImageMessageData {
+
+    fileprivate let assetClientMessage: ZMAssetClientMessage
+    private let assetStorage: ZMImageAssetStorage
+    fileprivate let moc: NSManagedObjectContext
+
+    fileprivate var isImage: Bool {
+        return assetClientMessage.genericAssetMessage?.v3_isImage ?? false
+    }
+
+    public init?(with message: ZMAssetClientMessage) {
+        guard message.version == 3, let storage = message.imageAssetStorage else { return nil }
+        assetClientMessage = message
+        assetStorage = storage
+        moc = message.managedObjectContext!
+    }
+
+    public var mediumData: Data? {
+        guard nil != assetClientMessage.fileMessageData, isImage else { return nil }
+        guard let cacheKey = assetClientMessage.genericAssetMessage?.v3_uploadedAssetId else { return nil }
+        return moc.zm_fileAssetCache.assetData(assetClientMessage.nonce, fileName: cacheKey, encrypted: false)
+    }
+
+    public var imageData: Data? {
+        guard nil != assetClientMessage.fileMessageData, isImage else { return nil }
+        return mediumData ?? moc.zm_fileAssetCache.assetData(assetClientMessage.nonce, fileName: "", encrypted: false)
+    }
+
+    public var imageDataIdentifier: String? {
+        if nil != assetClientMessage.fileMessageData, isImage {
+            return assetClientMessage.genericAssetMessage?.v3_uploadedAssetId
+        }
+
+        return imageData.map { String(format: "orig-%p", $0 as NSData) }
+    }
+
+    public var imagePreviewDataIdentifier: String? {
+        return previewData != nil ? assetClientMessage.genericAssetMessage?.previewAssetId : nil
+    }
+
+    public var previewData: Data? {
+        guard nil != assetClientMessage.fileMessageData, isImage, assetClientMessage.hasDownloadedImage else { return nil }
+        guard let cacheKey = assetClientMessage.genericAssetMessage?.previewAssetId else { return nil }
+        return moc.zm_fileAssetCache.assetData(assetClientMessage.nonce, fileName: cacheKey, encrypted: false)
+    }
+
+    public var isAnimatedGIF: Bool {
+        return assetClientMessage.genericAssetMessage?.assetData?.original.mimeType.isGIF ?? false
+    }
+
+    public var imageType: String? {
+        guard isImage else { return nil }
+        return assetClientMessage.genericAssetMessage?.assetData?.original.mimeType
+    }
+
+    public var originalSize: CGSize {
+        guard nil != assetClientMessage.fileMessageData, isImage else { return .zero }
+        guard let asset = assetClientMessage.genericAssetMessage?.assetData else { return .zero }
+        guard asset.original.hasImage(), asset.original.image.width > 0 else { return .zero }
+        return CGSize(width: Int(asset.original.image.width), height: Int(asset.original.image.height))
+    }
+
+}
+
+extension V3ImageAsset: AssetProxyType {
+
+    public var hasDownloadedImage: Bool {
+        return hasFile(for: assetClientMessage.genericAssetMessage?.v3_imageCacheKey)
+    }
+
+    public var hasDownloadedFile: Bool {
+        let isImageAndDownloaded = isImage && hasDownloadedImage
+        return isImageAndDownloaded || hasFile(for: assetClientMessage.genericAssetMessage?.v3_uploadedAssetId)
+    }
+
+    public var fileURL: URL? {
+        guard let key = assetClientMessage.genericAssetMessage?.v3_uploadedAssetId else { return nil }
+        return moc.zm_fileAssetCache.accessAssetURL(assetClientMessage.nonce, fileName: key)
+    }
+
+    // MARK: - Helper
+
+    private func hasFile(for key: String?) -> Bool {
+        guard let cacheKey = key else { return false }
+        return moc.zm_fileAssetCache.hasDataOnDisk(assetClientMessage.nonce, fileName: cacheKey, encrypted: false)
+    }
+}

--- a/Source/Model/Message/ZMAssetClientMessage+Download.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Download.swift
@@ -29,6 +29,12 @@ extension ZMAssetClientMessage {
     }
     
     public override func requestImageDownload() {
+        // V3
+        if let fileData = fileMessageData, fileData.isImage() {
+            return requestFileDownload()
+        }
+
+        // V2
         // objects with temp ID on the UI must just have been inserted so no need to download
         guard !self.objectID.isTemporaryID else { return }
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: type(of: self).ImageDownloadNotificationName), object: self.objectID)
@@ -38,6 +44,7 @@ extension ZMAssetClientMessage {
 extension ZMImageMessage {
     
     public override func requestImageDownload() {
+        // V2
         // objects with temp ID on the UI must just have been inserted so no need to download
         guard !self.objectID.isTemporaryID else { return }
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: ZMAssetClientMessage.ImageDownloadNotificationName), object: self.objectID)

--- a/Source/Model/Message/ZMAssetClientMessage.h
+++ b/Source/Model/Message/ZMAssetClientMessage.h
@@ -48,6 +48,8 @@ extern NSString * _Nonnull const ZMAssetClientMessageUploadedStateKey;
 
 - (ZMGenericMessage * _Nullable )genericMessageForFormat:(ZMImageFormat)format;
 
+- (CGSize)preprocessedSize;
+
 @end
 
 

--- a/Source/Model/Message/ZMAssetClientMessage.h
+++ b/Source/Model/Message/ZMAssetClientMessage.h
@@ -102,6 +102,10 @@ typedef NS_ENUM(int16_t, ZMAssetUploadState) {
 /// Whether the file was downloaded
 @property (nonatomic, readonly) BOOL hasDownloadedFile;
 
+/// The asset endpoint version used to generate this message
+/// values lower than 3 represent an enpoint version of 2
+@property (nonatomic, readonly) int16_t version;
+
 // The image metaData if if this @c ZMAssetClientMessage represents an image or @c nil otherwise
 @property (nonatomic, readonly) id <ZMImageAssetStorage> _Nullable imageAssetStorage;
 
@@ -121,6 +125,12 @@ typedef NS_ENUM(int16_t, ZMAssetUploadState) {
                                                      nonce:(nonnull NSUUID *)nonce
                                       managedObjectContext:(nonnull NSManagedObjectContext *)moc
                                               expiresAfter:(NSTimeInterval)timeout;
+
++ (nonnull instancetype)assetClientMessageWithFileMetadata:(nonnull ZMFileMetadata *)metadata
+                                                     nonce:(nonnull NSUUID *)nonce
+                                      managedObjectContext:(nonnull NSManagedObjectContext *)moc
+                                              expiresAfter:(NSTimeInterval)timeout
+                                                  version3:(BOOL)version3;
 
 /// Adds a (protobuf) data entry to the list of generic message data
 - (void)addGenericMessage:(ZMGenericMessage * _Nonnull)genericMessage;

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -324,6 +324,8 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 - (BOOL)hasDownloadedImage
 {
     if(self.imageMessageData != nil || self.fileMessageData != nil) {
+        // TODO: Check if it's v3 and then use file cache
+
         return [self.managedObjectContext.zm_imageAssetCache assetData:self.nonce format:ZMImageFormatMedium encrypted:NO] != nil // processed or downloaded
         || [self.managedObjectContext.zm_imageAssetCache assetData:self.nonce format:ZMImageFormatOriginal encrypted:NO] != nil; // original
     }
@@ -332,6 +334,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 
 - (BOOL)hasDownloadedFile
 {
+    // TODO: V3 If we receive an image as asset we might not have a filename
     return self.fileMessageData != nil && self.filename != nil &&
         [self.managedObjectContext.zm_fileAssetCache hasDataOnDisk:self.nonce fileName:self.filename encrypted:NO];
 }

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -424,7 +424,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     }
 
     // V2, we do not set the thumbnail assetId in case there is one in the protobuf, then we can access it directly for V3
-    if (message.assetData.preview.hasRemote && !message.assetData.hasUploaded && ! message.assetData.preview.remote.hasAssetId) {
+    if (message.assetData.preview.hasRemote && !message.assetData.hasUploaded) {
         if (! message.assetData.preview.remote.hasAssetId) {
             NSDictionary *eventData = [updateEvent.payload dictionaryForKey:@"data"];
             NSString *thumbnailId = [eventData stringForKey:@"id"];

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -180,6 +180,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 }
 
 - (NSURL *)fileURL {
+
     if (self.version == 3 && self.genericAssetMessage.assetData.uploaded.hasAssetId) { // V3
         NSString *cacheKeySuffix = self.genericAssetMessage.assetData.uploaded.assetId;
         return [self.managedObjectContext.zm_fileAssetCache accessAssetURL:self.nonce fileName:cacheKeySuffix];
@@ -400,13 +401,11 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     }
     
     if (message.assetData.hasUploaded) {
-        NSDictionary *eventData = [updateEvent.payload dictionaryForKey:@"data"];
-
-        // V2, we directly access the protobuf for the assetId when using V3
         BOOL isVersion_3 = message.assetData.hasUploaded && message.assetData.uploaded.hasAssetId;
-        if (isVersion_3) {
+        if (isVersion_3) { // V3, we directly access the protobuf for the assetId
             self.version = 3;
-        } else {
+        } else { // V2
+            NSDictionary *eventData = [updateEvent.payload dictionaryForKey:@"data"];
             self.assetId = [NSUUID uuidWithTransportString:[eventData stringForKey:@"id"]];
         }
 

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -130,6 +130,8 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 - (nullable id<ZMConversationMessage>)appendMessageWithImageData:(nonnull NSData *)imageData;
 /// Appends a file. see ZMFileMetaData, ZMAudioMetaData, ZMVideoMetaData.
 - (nullable id<ZMConversationMessage>)appendMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata;
+- (nullable id<ZMConversationMessage>)appendMessageWithFileMetadata:(nonnull ZMFileMetadata *)fileMetadata version3:(BOOL)version3;
+
 /// Appends a location, see @c LocationData.
 - (nullable id<ZMConversationMessage>)appendMessageWithLocationData:(nonnull ZMLocationData *)locationData;
 

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -183,7 +183,7 @@ typedef NS_ENUM(int16_t, ZMFileTransferState) {
 - (BOOL)isAudio;
 
 /// Image-message related properties
-/// if MIME type is indicating image content, only used for v3 assets
+/// if the file message represents an image (presence of image meta data in the protobuf)
 - (BOOL)isImage;
 
 @end

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -69,6 +69,28 @@ public extension ZMGenericMessage {
 
 public extension ZMGenericMessage {
 
+    var v3_isImage: Bool {
+        return assetData?.original.hasImage() == true
+    }
+
+    var v3_uploadedAssetId: String? {
+        guard assetData?.uploaded.hasAssetId() == true else { return nil }
+        return assetData?.uploaded.assetId
+    }
+
+    var previewAssetId: String? {
+        guard assetData?.preview.remote.hasAssetId() == true else { return nil }
+        return assetData?.preview.remote.assetId
+    }
+
+    var v3_imageCacheKey: String? {
+        return v3_isImage ? v3_uploadedAssetId : previewAssetId
+    }
+
+}
+
+public extension ZMGenericMessage {
+
     public static func genericMessage(external: ZMExternal, messageID: String) -> ZMGenericMessage {
         return genericMessage(pbMessage: external, messageID: messageID)
     }

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -2003,12 +2003,15 @@ extension ZMAssetClientMessageTests {
     
 }
 
-// MARK: - Asset V3
 
+// MARK: - Asset V3
 
 // MARK: Receiving
 
+
 extension ZMAssetClientMessageTests {
+
+    typealias PreviewMeta = (otr: Data, sha: Data, assetId: String, token: String)
 
     private func uploadedGenericMessage(nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .zmRandomSHA256Key(), assetId: String = UUID.create().transportString(), token: String? = UUID.create().transportString()) -> ZMGenericMessage {
 
@@ -2023,7 +2026,6 @@ extension ZMAssetClientMessageTests {
         assetBuilder.setUploaded(remoteBuilder)
         return ZMGenericMessage.genericMessage(asset: assetBuilder.build(), messageID: nonce)
     }
-
 
     func previewGenericMessage(with nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
         let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
@@ -2054,7 +2056,6 @@ extension ZMAssetClientMessageTests {
 
         // when
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
-
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
 
         // then
@@ -2062,7 +2063,19 @@ extension ZMAssetClientMessageTests {
     }
 
     func testThatItSetsVersion3WhenAMessageIsUpdatedWithAnAssetPreviewWithAssetId_V3() {
-        XCTFail()
+        // given
+        let nonce = UUID.create()
+        let sut = ZMAssetClientMessage.insertNewObject(in: uiMOC)
+        sut.nonce = nonce
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertNotNil(sut)
+
+        // when
+        let (preview, _) = previewGenericMessage(with: nonce.transportString())
+        sut.update(with: preview, updateEvent: ZMUpdateEvent())
+
+        // then
+        XCTAssertEqual(sut.version, 3)
     }
 
     func testThatItDoesNotSetVersion3WhenAMessageIsUpdatedWithAnAssetUploadedWithoutAssetId_V3() {

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -2000,3 +2000,9 @@ extension ZMAssetClientMessageTests {
     }
     
 }
+
+// MARK: - Asset V3
+
+extension ZMAssetClientMessageTests {
+
+}

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -225,6 +225,7 @@ class ZMAssetClientMessageTests : BaseZMAssetClientMessageTests {
         
         XCTAssertNil(message.imageMessageData?.mediumData)
         XCTAssertFalse(message.hasDownloadedImage)
+        XCTAssertEqual(message.version, 2)
     }
     
 }
@@ -252,6 +253,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.transferState, ZMFileTransferState.uploading)
         XCTAssertEqual(sut.filename, currentTestURL!.lastPathComponent)
         XCTAssertNotNil(sut.fileMessageData)
+        XCTAssertEqual(sut.version, 2)
     }
     
     func testThatItHasDownloadedFileWhenTheFileIsOnDisk()
@@ -2003,6 +2005,114 @@ extension ZMAssetClientMessageTests {
 
 // MARK: - Asset V3
 
+
+// MARK: Receiving
+
 extension ZMAssetClientMessageTests {
+
+    private func uploadedGenericMessage(nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .zmRandomSHA256Key(), assetId: String = UUID.create().transportString(), token: String? = UUID.create().transportString()) -> ZMGenericMessage {
+
+        let assetBuilder = ZMAsset.builder()!
+        let remoteBuilder = ZMAssetRemoteData.builder()!
+
+        _ = remoteBuilder.setOtrKey(otr)
+        _ = remoteBuilder.setSha256(sha)
+        _ = remoteBuilder.setAssetId(assetId)
+        _ = remoteBuilder.setAssetToken(token)
+
+        assetBuilder.setUploaded(remoteBuilder)
+        return ZMGenericMessage.genericMessage(asset: assetBuilder.build(), messageID: nonce)
+    }
+
+
+    func previewGenericMessage(with nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
+        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let assetBuilder = ZMAsset.builder()
+        let previewBuilder = ZMAssetPreview.builder()
+        let remoteBuilder = ZMAssetRemoteData.builder()
+
+        _ = remoteBuilder?.setOtrKey(otr)
+        _ = remoteBuilder?.setSha256(sha)
+        _ = remoteBuilder?.setAssetId(assetId)
+        _ = remoteBuilder?.setAssetToken(token)
+        _ = previewBuilder?.setSize(512)
+        _ = previewBuilder?.setMimeType("image/jpg")
+        _ = previewBuilder?.setRemote(remoteBuilder)
+        _ = assetBuilder?.setPreview(previewBuilder)
+
+        let previewMeta = (otr, sha, assetId, token)
+        return (ZMGenericMessage.genericMessage(asset: assetBuilder!.build(), messageID: nonce), previewMeta)
+    }
+
+    func testThatItSetsVersion3WhenAMessageIsUpdatedWithAnAssetUploadedWithAssetId_V3() {
+        // given
+        let nonce = UUID.create()
+        let sut = ZMAssetClientMessage.insertNewObject(in: uiMOC)
+        sut.nonce = nonce
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertNotNil(sut)
+
+        // when
+        let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
+
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+
+        // then
+        XCTAssertEqual(sut.version, 3)
+    }
+
+    func testThatItSetsVersion3WhenAMessageIsUpdatedWithAnAssetPreviewWithAssetId_V3() {
+        XCTFail()
+    }
+
+    func testThatItDoesNotSetVersion3WhenAMessageIsUpdatedWithAnAssetUploadedWithoutAssetId_V3() {
+        XCTFail()
+    }
+
+    func testThatItDoesNotSetVersion3WhenAMessageIsUpdatedWithAnAssetPreviewWithoutAssetId_V3() {
+        XCTFail()
+    }
+
+    func testThatItCreatesAnAssetMessageFromUpdateEventWithAssetId_V3() {
+        XCTFail()
+    }
+
+    func testThatItReportsDownloadedFileWhenThereIsAFileOnDisk_V3() {
+        XCTFail()
+    }
+
+    func testThatItReportsDownloadedImageWhenThereIsAFileInTheCache_V3() {
+        XCTFail()
+    }
+
+    func testThatItReportsIsImageWhenItHaseImageMetaData() {
+        XCTFail()
+    }
+
+    func testThatItReturnsTheAssetIdAsImageDataIdentifierWhenItRepresentsAnImage_V3() {
+        XCTFail()
+    }
+
+    func testThatItReturnsTheThumbnailIdWhenItHasAPreviewRemoteData_V3() {
+        XCTFail()
+    }
+
+    func testThatItReturnsTheThumbnailDataWhenItHasItOnisk_V3() {
+        XCTFail()
+    }
+
+    func testThatDoesNotHaveDownloadedImageWhenTheImageIsNotOnDisk_V3() {
+        XCTFail()
+    }
+
+    func testThatRequestingImageDownloadFiresANotification_V3() {
+        XCTFail()
+    }
+
+    func testThatItReturnsTheImageDataFromTheFileAssetCacheIfItRepresentsAnImage_V3() {
+        XCTFail()
+    }
+
+
 
 }

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		54EDE6801CBBF1860044A17E /* PINCache+ZMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EDE67F1CBBF1860044A17E /* PINCache+ZMessaging.swift */; };
 		54EDE6821CBBF6260044A17E /* AssetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EDE6811CBBF6260044A17E /* AssetCacheTests.swift */; };
 		54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */; };
+		BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4666291DCB71B0007463FF /* V3Asset.swift */; };
 		BF6F82F71CD0E5FE006E9CCB /* store24.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF6F82F61CD0E5FE006E9CCB /* store24.wiredatabase */; };
 		BF76998B1D3500F0009C378B /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; };
 		BF76998C1D3500F0009C378B /* Ono.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -37,6 +38,7 @@
 		BF85CF5F1D227A78006EDB97 /* LocationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF85CF5E1D227A78006EDB97 /* LocationData.swift */; };
 		BF949E5B1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */; };
 		BFA4D57C1CCF74600028C9E1 /* store23.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BFA4D57B1CCF74600028C9E1 /* store23.wiredatabase */; };
+		BFCD8A2D1DCB4E8A00C6FCCF /* V2Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */; };
 		BFCF31DB1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */; };
 		BFD2E7991CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */; };
@@ -390,6 +392,7 @@
 		874B5DA91CEDB9E40010474C /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		874B5DAA1CEDB9E40010474C /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
 		BF260C4E1DCA1640009C97D9 /* zmessaging2.21.2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.21.2.xcdatamodel; sourceTree = "<group>"; };
+		BF4666291DCB71B0007463FF /* V3Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V3Asset.swift; sourceTree = "<group>"; };
 		BF6F82F41CD0D992006E9CCB /* zmessaging2.5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.5.xcdatamodel; sourceTree = "<group>"; };
 		BF6F82F61CD0E5FE006E9CCB /* store24.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = store24.wiredatabase; path = Tests/Resources/store24.wiredatabase; sourceTree = SOURCE_ROOT; };
 		BF710FC81CE0B83400DC92C4 /* zmessaging2.6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.6.xcdatamodel; sourceTree = "<group>"; };
@@ -403,6 +406,7 @@
 		BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LinkPreview+ProtobufTests.swift"; sourceTree = "<group>"; };
 		BFA4D57B1CCF74600028C9E1 /* store23.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = store23.wiredatabase; path = Tests/Resources/store23.wiredatabase; sourceTree = SOURCE_ROOT; };
 		BFC387681CB7BC1E00F08415 /* zmessaging2.4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.4.xcdatamodel; sourceTree = "<group>"; };
+		BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V2Asset.swift; sourceTree = "<group>"; };
 		BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessageTests+NativePush.swift"; sourceTree = "<group>"; };
 		BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMGenericMessage+UpdateEvent.h"; sourceTree = "<group>"; };
 		BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMGenericMessage+UpdateEvent.m"; sourceTree = "<group>"; };
@@ -966,6 +970,8 @@
 				54363A021D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift */,
 				54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */,
 				F9A705F51CAEE01D00C2F5FE /* ZMAssetClientMessage.m */,
+				BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */,
+				BF4666291DCB71B0007463FF /* V3Asset.swift */,
 				F9A705F61CAEE01D00C2F5FE /* ZMClientMessage.h */,
 				F9A705F71CAEE01D00C2F5FE /* ZMClientMessage.m */,
 				54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */,
@@ -1943,6 +1949,7 @@
 				F9A706A81CAEE01D00C2F5FE /* DependentObjectsKeysForObservedObjectKeysCache.swift in Sources */,
 				F9A7069A1CAEE01D00C2F5FE /* ChangedObjectSet.swift in Sources */,
 				F9B71F2D1CB264EF001DB03F /* ZMConversation+UnreadCount.m in Sources */,
+				BFCD8A2D1DCB4E8A00C6FCCF /* V2Asset.swift in Sources */,
 				F9A706B41CAEE01D00C2F5FE /* ObjectObserverToken.swift in Sources */,
 				F9A706B31CAEE01D00C2F5FE /* ObjectDependencyToken.swift in Sources */,
 				F9A706AA1CAEE01D00C2F5FE /* KeySet.swift in Sources */,
@@ -1962,6 +1969,7 @@
 				F9A7068C1CAEE01D00C2F5FE /* ZMSearchUser.m in Sources */,
 				F9A706B71CAEE01D00C2F5FE /* UserObserverToken.swift in Sources */,
 				F9A7067F1CAEE01D00C2F5FE /* ZMImageMessage.m in Sources */,
+				BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */,
 				F9A706991CAEE01D00C2F5FE /* ZMManagedObject.m in Sources */,
 				F9C9A74A1CAE6DA00039E10C /* CallingInitialisationNotification.swift in Sources */,
 				F991CE1B1CB561B0004D8465 /* ZMAddressBookContact.m in Sources */,

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		874B5DA81CEDB9E30010474C /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		874B5DA91CEDB9E40010474C /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		874B5DAA1CEDB9E40010474C /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+		BF260C4E1DCA1640009C97D9 /* zmessaging2.21.2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.21.2.xcdatamodel; sourceTree = "<group>"; };
 		BF6F82F41CD0D992006E9CCB /* zmessaging2.5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.5.xcdatamodel; sourceTree = "<group>"; };
 		BF6F82F61CD0E5FE006E9CCB /* store24.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = store24.wiredatabase; path = Tests/Resources/store24.wiredatabase; sourceTree = SOURCE_ROOT; };
 		BF710FC81CE0B83400DC92C4 /* zmessaging2.6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.6.xcdatamodel; sourceTree = "<group>"; };
@@ -2380,6 +2381,7 @@
 		F9331C8D1CB42FCF00139ECC /* zmessaging.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				BF260C4E1DCA1640009C97D9 /* zmessaging2.21.2.xcdatamodel */,
 				F94718E91DC3525A00337892 /* zmessaging2.21.1.xcdatamodel */,
 				5419A1BF1DBA028A0029A9AB /* zmessaging2.21.0.xcdatamodel */,
 				F963E95C1D9AB80B00098AD3 /* zmessaging2.18.0.xcdatamodel */,
@@ -2398,7 +2400,7 @@
 				F9331C901CB42FCF00139ECC /* zmessaging1.28.xcdatamodel */,
 				F9331C911CB42FCF00139ECC /* zmessaging2.3.xcdatamodel */,
 			);
-			currentVersion = F94718E91DC3525A00337892 /* zmessaging2.21.1.xcdatamodel */;
+			currentVersion = BF260C4E1DCA1640009C97D9 /* zmessaging2.21.2.xcdatamodel */;
 			path = zmessaging.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/ZMCDataModel.xcodeproj/xcshareddata/xcschemes/ZMCDataModel.xcscheme
+++ b/ZMCDataModel.xcodeproj/xcshareddata/xcschemes/ZMCDataModel.xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,6 +54,13 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = ""
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -76,6 +83,13 @@
             ReferencedContainer = "container:ZMCDataModel.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
# What's in this PR?

This adds the initial logic to support receiving assets send using the `/assets/v3` endpoint, this also refactors `ZMAssetClientMessage` internally to declutter the code from constant `self.version < 3` checks.

To do so the `imageMessageData` accessor now returns different implementations of this protocol depending on the version of the underlying asset. The two new added classes, `V2Asset` and `V3Asset` manage which cache and which cache key should be used to store the asset data and where to look for the image / file data etc.

There are still a couple of missing test for the receiving part that I am working on right now.