### PR TITLE
Stop deletion timer of ephemeral message on receiving delete

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -19,6 +19,8 @@
 import Foundation
 import Cryptobox
 
+private var zmLog = ZMSLog(tag: "message encryption")
+
 // MARK: - Encrypted data for recipients
 
 /// Strategy for missing clients.
@@ -124,7 +126,8 @@ extension ZMGenericMessage {
             guard let message = ZMMessage.fetch(withNonce:nonce, for:conversation, in:conversation.managedObjectContext!) else { return nil }
             guard message.destructionDate != nil else { return nil }
             guard let sender = message.sender else {
-                fatal("delete for ephemeral message need a recipient\n ConvID: \(conversation.remoteIdentifier) ConvType: \(conversation.conversationType)")
+                zmLog.error("sender of deleted ephemeral message \(self.deleted.messageId) is already cleared \n ConvID: \(conversation.remoteIdentifier) ConvType: \(conversation.conversationType.rawValue)")
+                return Set(arrayLiteral: selfUser)
             }
             return Set(arrayLiteral: sender, selfUser)
         }
@@ -134,7 +137,7 @@ extension ZMGenericMessage {
         if self.hasConfirmation() || self.hasEphemeral() {
             guard let recipients = recipientForConfirmationMessage() ?? recipientForOtherUsers() else {
                 let confirmationInfo = hasConfirmation() ? ", original message: \(self.confirmation.messageId)" : ""
-                fatal("confirmation need a recipient\n ConvID: \(conversation.remoteIdentifier) ConvType: \(conversation.conversationType), connection: \(conversation.connection)\(confirmationInfo)")
+                fatal("confirmation need a recipient\n ConvID: \(conversation.remoteIdentifier) ConvType: \(conversation.conversationType.rawValue), connection: \(conversation.connection)\(confirmationInfo)")
             }
             recipientUsers = recipients
         }

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -383,8 +383,28 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
     if (nil != message && ![senderID isEqual:selfUser.remoteIdentifier] && !message.isEphemeral) {
         [conversation appendDeletedForEveryoneSystemMessageWithTimestamp:message.serverTimestamp sender:message.sender];
     }
-
+    // If we receive a delete for an ephemeral message that was not originally sent by the selfUser, we need to stop the deletion timer
+    if (nil != message && message.isEphemeral && ![message.sender.remoteIdentifier isEqual:selfUser.remoteIdentifier]) {
+        [self stopDeletionTimerForMessage:message];
+    }
     [message removeMessageClearingSender:YES];
+}
+
++ (void)stopDeletionTimerForMessage:(ZMMessage *)message
+{
+    NSManagedObjectContext *uiMOC = message.managedObjectContext;
+    if (!uiMOC.zm_isUserInterfaceContext) {
+        uiMOC = uiMOC.zm_userInterfaceContext;
+    }
+    NSManagedObjectID *messageID = message.objectID;
+    [uiMOC performGroupedBlock:^{
+        NSError *error;
+        ZMMessage *uiMessage =  [uiMOC existingObjectWithID:messageID error:&error];
+        if (error != nil || uiMessage == nil) {
+            return;
+        }
+        [uiMOC.zm_messageDeletionTimer stopTimerForMessage:uiMessage];
+    }];
 }
 
 - (void)removePendingDeliveryReceipts

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -155,6 +155,48 @@ extension ClientMessageTests_OTR {
         }
     }
     
+    func testThatItCreatesPayloadForDeletionOfEphemeralTextMessage_Group_SenderWasDeleted() {
+        // This can happen due to a race condition where we receive a delete for an ephemeral after deleting the same message locally, but before creating the payload
+        var syncMessage: ZMClientMessage!
+        self.syncMOC.performGroupedBlockAndWait {
+            //given
+            self.syncConversation.messageDestructionTimeout = 10
+            syncMessage = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            syncMessage.sender = self.syncUser1
+            XCTAssertTrue(syncMessage.isEphemeral)
+            self.syncMOC.saveOrRollback()
+        }
+        
+        let uiMessage = self.uiMOC.object(with: syncMessage.objectID) as! ZMMessage
+        uiMessage.startDestructionIfNeeded()
+        XCTAssertNotNil(uiMessage.destructionDate)
+        self.uiMOC.zm_teardownMessageDeletionTimer()
+        self.uiMOC.saveOrRollback()
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            self.syncMOC.refresh(syncMessage, mergeChanges: true)
+            XCTAssertNotNil(syncMessage.destructionDate)
+            
+            let sut = syncMessage.deleteForEveryone()
+            
+            // when
+            syncMessage.sender = nil
+            var payload : (data: Data, strategy: MissingClientsStrategy)?
+            self.performIgnoringZMLogError {
+                 payload = sut?.encryptedMessagePayloadData()
+            }
+            
+            //then
+            guard let payloadAndStrategy = payload else { return XCTFail() }
+            switch payloadAndStrategy.strategy {
+            case .ignoreAllMissingClientsNotFromUsers(users: let users):
+                XCTAssertEqual(users, Set(arrayLiteral: self.syncSelfUser))
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
     
     func testThatItCreatesPayloadForZMLastReadMessages() {
         self.syncMOC.performGroupedBlockAndWait {


### PR DESCRIPTION
**In this PR**
What happened: When the receiver of an ephemeral message was looking at the message on two devices at the same time, it is possible that we delete a message locally and receive the delete from the second device before creating the payload for the local delete. In this case we will end up in a crash loop.

To avoid this: When receiving a delete, we stop any timers for ephemeral messages.