### PR TITLE
Delete the sender after the ephemeral message timer was stopped

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -386,8 +386,9 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
     // If we receive a delete for an ephemeral message that was not originally sent by the selfUser, we need to stop the deletion timer
     if (nil != message && message.isEphemeral && ![message.sender.remoteIdentifier isEqual:selfUser.remoteIdentifier]) {
         [self stopDeletionTimerForMessage:message];
+    } else {
+        [message removeMessageClearingSender:YES];
     }
-    [message removeMessageClearingSender:YES];
 }
 
 + (void)stopDeletionTimerForMessage:(ZMMessage *)message
@@ -404,6 +405,10 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
             return;
         }
         [uiMOC.zm_messageDeletionTimer stopTimerForMessage:uiMessage];
+        
+        [uiMOC.zm_syncContext performGroupedBlock:^{
+            [message removeMessageClearingSender:YES];
+        }];
     }];
 }
 


### PR DESCRIPTION
Since the timer is stopped asynchronously, it is still possible that we delete the sender after the timer fired. We therefore moved the deletion of the sender inside the block where the timer is cancelled and execute another block after the timer was cancelled.