### PR TITLE
Move methods into versioned asset containers and delete unused code

### DIFF
--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -97,7 +97,12 @@ extension String {
     public var originalSize: CGSize {
         let genericMessage = assetStorage.mediumGenericMessage ?? assetStorage.previewGenericMessage
         guard let asset = genericMessage?.imageAssetData, asset.originalWidth > 0 else { return assetStorage.preprocessedSize() }
-        return CGSize(width: Int(asset.originalWidth), height: Int(asset.originalHeight))
+        let size = CGSize(width: Int(asset.originalWidth), height: Int(asset.originalHeight))
+        if size != .zero {
+            return size
+        }
+
+        return assetClientMessage.preprocessedSize
     }
 
     // MARK: - Helper
@@ -146,6 +151,11 @@ extension V2ImageAsset: AssetProxyType {
         }
 
         return moc.zm_imageAssetCache.assetData(assetClientMessage.nonce, format: format, encrypted: encrypted)
+    }
+
+    public func requestFileDownload() {
+        guard assetClientMessage.fileMessageData != nil else { return }
+        assetClientMessage.transferState = hasDownloadedFile ? .downloaded : .downloading
     }
 
 }

--- a/Source/Model/Message/ZMAssetClientMessage.h
+++ b/Source/Model/Message/ZMAssetClientMessage.h
@@ -80,6 +80,9 @@ typedef NS_ENUM(int16_t, ZMAssetUploadState) {
 /// Whether the asset was delivered to the Backend
 @property (nonatomic) BOOL delivered;
 
+
+@property (nonatomic, readonly) CGSize preprocessedSize;
+
 /// MIME type of the file being transfered (implied from file extension)
 @property (nonatomic, readonly) NSString * _Nullable mimeType;
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
@@ -119,7 +119,7 @@
     // then
     XCTAssertNotNil(message);
     XCTAssertNotNil(message.nonce);
-    XCTAssertTrue(CGSizeEqualToSize(message.originalSize, CGSizeMake(1900, 1500)));
+    XCTAssertTrue(CGSizeEqualToSize(message.imageMessageData.originalSize, CGSizeMake(1900, 1500)));
     XCTAssertEqual(message.conversation, conversation);
     XCTAssertTrue([conversation.messages containsObject:message]);
     XCTAssertNotNil(message.nonce);
@@ -142,7 +142,7 @@
     // then
     XCTAssertNotNil(message);
     XCTAssertNotNil(message.nonce);
-    AssertEqualSizes(message.originalSize, CGSizeMake(1900, 1500));
+    AssertEqualSizes(message.imageMessageData.originalSize, CGSizeMake(1900, 1500));
     XCTAssertEqual(message.conversation, conversation);
     XCTAssertTrue([conversation.messages containsObject:message]);
     XCTAssertNotNil(message.nonce);
@@ -204,7 +204,7 @@
     // then
     XCTAssertNotNil(message);
     XCTAssertNotNil(message.nonce);
-    XCTAssertTrue(CGSizeEqualToSize(message.originalSize, CGSizeMake(1900, 1500)));
+    XCTAssertTrue(CGSizeEqualToSize(message.imageMessageData.originalSize, CGSizeMake(1900, 1500)));
     XCTAssertEqual(message.conversation, conversation);
     XCTAssertTrue([conversation.messages containsObject:message]);
     XCTAssertNotNil(message.nonce);


### PR DESCRIPTION
# What's in this PR?

* `ZMAssetClientMessage` itself does no longer conform to `ZMImageMessageData` as it returns the `imageMessageData` of its underlying versioned asset container, thus a lot of methods have been removed.
* Move more methods into the versioned asset container classes.