### PR TITLE
Append filename to cachekey

### DIFF
--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -61,7 +61,7 @@ import MobileCoreServices
 
     public var mediumData: Data? {
         guard nil != assetClientMessage.fileMessageData, isImage else { return nil }
-        guard let cacheKey = assetClientMessage.genericAssetMessage?.v3_uploadedAssetId else { return nil }
+        guard let cacheKey = assetClientMessage.genericAssetMessage?.v3_fileCacheKey else { return nil }
         return moc.zm_fileAssetCache.assetData(assetClientMessage.nonce, fileName: cacheKey, encrypted: false)
     }
 
@@ -72,7 +72,7 @@ import MobileCoreServices
 
     public var imageDataIdentifier: String? {
         if nil != assetClientMessage.fileMessageData, isImage {
-            return assetClientMessage.genericAssetMessage?.v3_uploadedAssetId
+            return assetClientMessage.genericAssetMessage?.v3_fileCacheKey
         }
 
         return imageData.map { String(format: "orig-%p", $0 as NSData) }
@@ -119,17 +119,17 @@ extension V3ImageAsset: AssetProxyType {
 
     public var hasDownloadedFile: Bool {
         guard !isImage else { return false }
-        return hasFile(for: assetClientMessage.genericAssetMessage?.v3_uploadedAssetId)
+        return hasFile(for: assetClientMessage.genericAssetMessage?.v3_fileCacheKey)
     }
 
     public var fileURL: URL? {
-        guard let key = assetClientMessage.genericAssetMessage?.v3_uploadedAssetId else { return nil }
+        guard let key = assetClientMessage.genericAssetMessage?.v3_fileCacheKey else { return nil }
         return moc.zm_fileAssetCache.accessAssetURL(assetClientMessage.nonce, fileName: key)
     }
 
     public func imageData(for format: ZMImageFormat, encrypted: Bool) -> Data? {
         guard format == .medium, assetClientMessage.fileMessageData != nil, isImage else { return nil }
-        guard let key = assetClientMessage.genericAssetMessage?.v3_uploadedAssetId else { return nil }
+        guard let key = assetClientMessage.genericAssetMessage?.v3_fileCacheKey else { return nil }
         return moc.zm_fileAssetCache.assetData(assetClientMessage.nonce, fileName: key, encrypted: encrypted)
     }
 

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -73,9 +73,20 @@ public extension ZMGenericMessage {
         return assetData?.original.hasImage() == true
     }
 
-    var v3_uploadedAssetId: String? {
+    private var v3_uploadedAssetId: String? {
         guard assetData?.uploaded.hasAssetId() == true else { return nil }
         return assetData?.uploaded.assetId
+    }
+
+    var v3_fileCacheKey: String {
+        if let original = assetData?.original,
+            original.hasName(),
+            let assetId = v3_uploadedAssetId,
+            let name = original.name {
+            return assetId + "_" + name
+        }
+
+        return v3_uploadedAssetId ?? ""
     }
 
     var previewAssetId: String? {
@@ -84,7 +95,7 @@ public extension ZMGenericMessage {
     }
 
     var v3_imageCacheKey: String? {
-        return v3_isImage ? v3_uploadedAssetId : previewAssetId
+        return v3_isImage ? v3_fileCacheKey : previewAssetId
     }
 
 }

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -2228,7 +2228,7 @@ extension ZMAssetClientMessageTests {
         sut.update(with: original, updateEvent: ZMUpdateEvent())
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
 
-        guard let key = sut.genericAssetMessage?.v3_uploadedAssetId else { return XCTFail() }
+        guard let key = sut.genericAssetMessage?.v3_fileCacheKey else { return XCTFail() }
         uiMOC.zm_fileAssetCache.storeAssetData(nonce, fileName: key, encrypted: false, data: data)
 
         // then


### PR DESCRIPTION
# What's in this PR?

* There was an issue on the UI in which the video playback did not work as the url was missing the file extension. We now append the filename to the asset ID when creating the cache key which is used as url.