### PR TITLE
Avoid crash when setting sender on updated message

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -292,6 +292,9 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
 
 - (void)updateWithTimestamp:(NSDate *)serverTimestamp senderUUID:(NSUUID *)senderUUID forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 {
+    if (self.isZombieObject) {
+        return;
+    }
     [self updateTimestamp:serverTimestamp isUpdatingExistingMessage:isUpdate];
 
     if (self.managedObjectContext != conversation.managedObjectContext) {
@@ -299,7 +302,12 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
     }
     
     self.visibleInConversation = conversation;
-    self.sender = [ZMUser userWithRemoteID:senderUUID createIfNeeded:YES inContext:self.managedObjectContext];
+    ZMUser *sender = [ZMUser userWithRemoteID:senderUUID createIfNeeded:YES inContext:self.managedObjectContext];
+    if (sender != nil && self.managedObjectContext == sender.managedObjectContext) {
+        self.sender = sender;
+    } else {
+        ZMLogError(@"Sender %@ is nil or from a different context than message %@", sender, self);
+    }
     
     if (self.sender.isSelfUser) {
         // if the message was sent by the selfUser we don't want to send a lastRead event, since we consider this message to be already read

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -303,10 +303,10 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
     
     self.visibleInConversation = conversation;
     ZMUser *sender = [ZMUser userWithRemoteID:senderUUID createIfNeeded:YES inContext:self.managedObjectContext];
-    if (sender != nil && self.managedObjectContext == sender.managedObjectContext) {
+    if (sender != nil && !sender.isZombieObject && self.managedObjectContext == sender.managedObjectContext) {
         self.sender = sender;
     } else {
-        ZMLogError(@"Sender %@ is nil or from a different context than message %@", sender, self);
+        ZMLogError(@"Sender is nil or from a different context than message. \n Sender is zombie %@: %@ \n Message: %@", @(sender.isZombieObject), sender, self);
     }
     
     if (self.sender.isSelfUser) {


### PR DESCRIPTION
**What's happening?**

We are currently experiencing a crash in `[ZMMessage updateWithTimestamp:senderUUID:eventID:forConversation:isUpdatingExistingMessage:]` 

> Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Illegal attempt to establish a relationship 'sender' between objects in different contexts

It's impossible that the objects are really from different contexts since the sender is created  or fetched using the managedObjectContext of the message. It is very possible that the message is currently being deleted since this crash was introduced with deleting message. However, the flag isDeleted seems not to be returning `true` since we check for zombie objects in the method that calls this one and return early. 

To prevent further crashes, I added another check for zombie objects and for equality of contexts. This should prevent the crash.