### PR TITLE
Add crash info for crash when accessing MOC's userInfo

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -242,7 +242,18 @@ static BOOL storeIsReady = NO;
     if (value == nil) {
         return nil;
     }
-    RequireString([value isKindOfClass:class], "Value for key %s is not of class %s - userInfo contains: %s", key.UTF8String, NSStringFromClass(class).UTF8String, self.userInfo.debugDescription.UTF8String);
+    if (![value isKindOfClass:class]) {
+        if ([value isKindOfClass:NSDictionary.class]) {
+            NSMutableString *keys = [NSMutableString string];
+            for (key in ((NSDictionary*) value).allKeys) {
+                [keys appendString:[NSString stringWithFormat:@"%@, ", key]];
+            }
+            RequireString([value isKindOfClass:class], "Value for key %s is a dictionary: keys %s", key.UTF8String, keys.UTF8String);
+
+        } else {
+            RequireString([value isKindOfClass:class], "Value for key %s is not of class %s - userInfo contains: %s", key.UTF8String, NSStringFromClass(class).UTF8String, self.userInfo.debugDescription.UTF8String);
+        }
+    }
     return value;
 }
 

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -236,14 +236,24 @@ static BOOL storeIsReady = NO;
     self.persistentStoreCoordinator = psc;
 }
 
+- (id)validUserInfoValueOfClass:(Class)class forKey:(NSString *)key;
+{
+    id value = self.userInfo[key];
+    if (value == nil) {
+        return nil;
+    }
+    RequireString([value isKindOfClass:class], "Value for key %s is not of class %s - userInfo contains: %s", key.UTF8String, NSStringFromClass(class).UTF8String, self.userInfo.debugDescription.UTF8String);
+    return value;
+}
+
 - (BOOL)zm_isSyncContext;
 {
-    return [self.userInfo[IsSyncContextKey] boolValue];
+    return [[self validUserInfoValueOfClass:[NSNumber class] forKey:IsSyncContextKey] boolValue];
 }
 
 - (BOOL)zm_isUserInterfaceContext;
 {
-    return [self.userInfo[IsUserInterfaceContextKey] boolValue];
+    return [[self validUserInfoValueOfClass:[NSNumber class] forKey:IsUserInterfaceContextKey] boolValue];
 }
 
 - (BOOL)zm_isSearchContext;


### PR DESCRIPTION
We have several crashes when accessing a value in the managedObjectContext's userInfo. Instead of returning the proper value, it returns an object of a different class. I added a helper method to log what exactly is currently contained in the MOC's userInfo.
