### PR TITLE
Fix preview images not being downloaded

### DIFF
--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -149,8 +149,17 @@ extension V3Asset: AssetProxyType {
     }
 
     public func requestImageDownload() {
-        guard isImage else { return zmLog.info("Called \(#function) on a v3 asset that doesn't represent an image") }
-        requestFileDownload()
+        if isImage {
+            requestFileDownload()
+        } else if assetClientMessage.genericAssetMessage?.assetData?.hasPreview() == true {
+            guard !assetClientMessage.objectID.isTemporaryID else { return }
+            NotificationCenter.default.post(
+                name: NSNotification.Name(rawValue: ZMAssetClientMessage.ImageDownloadNotificationName),
+                object: assetClientMessage.objectID
+            )
+        } else {
+            return zmLog.info("Called \(#function) on a v3 asset that doesn't represent an image or has a preview")
+        }
     }
 
     // MARK: - Helper


### PR DESCRIPTION
# What's in this PR?

The AssetV3PreviewDownloadStrategy uses a whitelist, when extracting the `requestImageDownload` method in https://github.com/wireapp/wire-ios-data-model/pull/80 I missed to fire the notification to whitelist the preview image.