### PR TITLE
Re-add isImage flag

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -980,6 +980,11 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     return [self.mimeType isAudioMimeType];
 }
 
+- (BOOL)v3_isImage
+{
+    return self.genericAssetMessage.v3_isImage;
+}
+
 - (CGSize)videoDimensions
 {
     SInt32 width = self.genericAssetMessage.assetData.original.video.width;

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -182,6 +182,9 @@ typedef NS_ENUM(int16_t, ZMFileTransferState) {
 /// if MIME type is indicating the audio content
 - (BOOL)isAudio;
 
+/// Whether the file message represents a v3 image
+- (BOOL)v3_isImage;
+
 @end
 
 #pragma mark - ZMLocationMessageData


### PR DESCRIPTION
# What's in this PR?

* Re-add isImage flag used on the UI to check if a message is a file that represents an image, this flag was removed in 972c200 but is needed on the UI.