### PR TITLE
Attempt at fixing crash updating deleted asset message

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -292,9 +292,6 @@ NSString * const ZMMessageIsObfuscatedKey = @"isObfuscated";
 
 - (void)updateWithTimestamp:(NSDate *)serverTimestamp senderUUID:(NSUUID *)senderUUID forConversation:(ZMConversation *)conversation isUpdatingExistingMessage:(BOOL)isUpdate;
 {
-    if (self.isZombieObject) {
-        return;
-    }
     [self updateTimestamp:serverTimestamp isUpdatingExistingMessage:isUpdate];
 
     if (self.managedObjectContext != conversation.managedObjectContext) {


### PR DESCRIPTION
Looking at crash logs, I noticed that the message that caused the crash is a temporary object, it is not faulted and has all properties set to nil. This hints to the object being inserted and deleted without an intermittent save. In addition to that, the crash only happens with AssetMessages.

After further investigation I found: When inserting an asset message, it is possible that the message is deleted when the sha265 digest does not match the expected one. In this case - when an NSManagedObject is inserted and deleted without intermittent save - it seems like the isDeleted flag on the object is not set (It's possible that isDeleted is computed from the deletedObjects property of the context which as the documentation states might not include inserted & immediately deleted objects). The managedObjectContext is also not nil until the context finally saves. Therefore isZombieObject (which checks the isDeleted flag and the managedObjectContext) returns false and we try to create a relationship between a deleted object and the sender and / or conversation.

