### PR TITLE
Unarchive a conversation when appending a message

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1310,6 +1310,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     [message setExpirationDate];
     [self sortedAppendMessage:message];
+    [self unarchiveIfNeeded];
+
     return message;
 }
 
@@ -1327,6 +1329,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
     else {
         [self sortedAppendMessage:message];
+        [self unarchiveIfNeeded];
     }
     return message;
 }
@@ -1342,6 +1345,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     message.isEncrypted = YES;
     [self sortedAppendMessage:message];
+    [self unarchiveIfNeeded];
     return message;
 }
 
@@ -1445,6 +1449,13 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
     
     return index;
+}
+
+- (void)unarchiveIfNeeded
+{
+    if (self.isArchived) {
+        self.isArchived = NO;
+    }
 }
 
 - (void)deleteOlderMessages

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2337,6 +2337,48 @@
     XCTAssertTrue(conversation.isArchived);
 }
 
+- (void)testThatAppendingATextMessageInAnArchivedConversationUnarchivesIt
+{
+    [self assertThatAppendingAMessageUnarchivesAConversation:^(ZMConversation *conversation) {
+        [conversation appendMessageWithText:@"Text"];
+    }];
+}
+
+- (void)testThatAppendingAnImageMessageInAnArchivedConversationUnarchivesIt
+{
+    [self assertThatAppendingAMessageUnarchivesAConversation:^(ZMConversation *conversation) {
+        [conversation appendMessageWithImageData:self.verySmallJPEGData];
+    }];
+}
+
+- (void)testThatAppendingALocationMessageInAnArchivedConversationUnarchivesIt
+{
+    [self assertThatAppendingAMessageUnarchivesAConversation:^(ZMConversation *conversation) {
+        ZMLocationData *location = [ZMLocationData locationDataWithLatitude:42 longitude:8 name:@"Mars" zoomLevel:9000];
+        [conversation appendMessageWithLocationData:location];
+    }];
+}
+
+- (void)assertThatAppendingAMessageUnarchivesAConversation:(void (^)(ZMConversation *))insertBlock
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    selfUser.remoteIdentifier = NSUUID.createUUID;
+    ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    [conversation.mutableOtherActiveParticipants addObject:otherUser];
+    conversation.isArchived = YES;
+    XCTAssertTrue(conversation.isArchived);
+
+    // when
+    insertBlock(conversation);
+    WaitForAllGroupsToBeEmpty(0.5f);
+
+    // then
+    XCTAssertFalse(conversation.isArchived);
+}
+
 - (void)testThat_UnarchiveConversationFromEvent_unarchivesAConversationAndSetsLocallyModifications;
 {
 


### PR DESCRIPTION
# What's in this PR?

When sending a message we want to archive the conversation this message belongs to, until sending a message in an unarchived conversation was not possible or the conversation was unarchived on the caller site, but with forwarding and an upcoming share extension it makes more sense to move this logic into `wire-ios-data-model`.