### PR TITLE
Feature/refresh user

### DIFF
--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -572,6 +572,9 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     [mocObserver notifyUpdatedSearchUser:self];
 }
 
+- (void)refreshData {
+    [self.user refreshData];
+}
 
 @end
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -352,6 +352,10 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
     return clientsRequiringUserAttention;
 }
 
+- (void)refreshData {
+    self.needsToBeUpdatedFromBackend = true;
+}
+
 @end
 
 

--- a/Source/Public/ZMBareUser.h
+++ b/Source/Public/ZMBareUser.h
@@ -51,6 +51,9 @@
 /// Is @c YES if we can send a connection request to this user.
 @property (nonatomic, readonly) BOOL canBeConnected;
 
+/// Request a refresh of the user data from the backend.
+/// This is useful for non-connected user, that we will otherwise never refetch
+- (void)refreshData;
 
 /// Sends a connection request to the given user. May be a no-op, eg. if we're already connected.
 /// A ZMUserChangeNotification with the searchUser as object will be sent notifiying about the connection status change

--- a/Source/Public/ZMEditableUser.h
+++ b/Source/Public/ZMEditableUser.h
@@ -22,8 +22,6 @@
 #import <ZMUtilities/ZMAccentColor.h>
 #import "ZMUser.h"
 
-@protocol ZMUserEditingObserver;
-@protocol ZMUserEditingObserverToken;
 @class ZMEmailCredentials;
 @class ZMPhoneCredentials;
 
@@ -41,37 +39,6 @@
 - (void)deleteProfileImage;
 
 @end
-
-
-
-@protocol ZMUserEditingObserver <NSObject>
-
-/// Invoked when the password could not be set on the backend
-- (void)passwordUpdateRequestDidFail;
-
-/// Invoked when the email could not be set on the backend (duplicated?).
-/// The password might already have been set though - this is how BE is designed and there's nothing SE can do about it
-- (void)emailUpdateDidFail:(NSError *)error;
-
-/// Invoked when the email was sent to the backend
-- (void)didSentVerificationEmail;
-
-/// Invoked when requesting the phone number verification code failed
-- (void)phoneNumberVerificationCodeRequestDidFail:(NSError *)error;
-
-/// Invoken when requesting the phone number verification code succeeded
-- (void)phoneNumberVerificationCodeRequestDidSucceed;
-
-/// Invoked when the phone number code verification failed
-- (void)phoneNumberVerificationDidFail:(NSError *)error;
-
-// NOTE:
-// - to know when the email was verified (by the user), just listen for changes in email on the self user
-// - to know when the phone number was updated, just listen for changes in phone number on the self user
-
-@end
-
-
 
 
 @interface ZMCompleteRegistrationUser : NSObject <ZMEditableUser>

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1069,6 +1069,21 @@ static NSString *const ValidEmail = @"foo77@example.com";
     }];
 }
 
+- (void)testThatCallingRefreshDataMarksItAsToDownload {
+    
+    // GIVEN
+    ZMUser *user = [ZMUser selfUserInContext:self.syncMOC];
+    user.remoteIdentifier = [NSUUID UUID];
+    user.needsToBeUpdatedFromBackend = false;
+    XCTAssertFalse(user.needsToBeUpdatedFromBackend);
+    
+    // WHEN
+    [user refreshData];
+    
+    // THEN
+    XCTAssertTrue(user.needsToBeUpdatedFromBackend);
+}
+
 @end
 
 


### PR DESCRIPTION
# Reason for this pull request
The app needs to be able to request an update of a user profile when it is displaying it on the screen. This is because the app will not receive updated from the BE for users that are not connected to the signed in user, so their profile will go out of sync. This is especially relevant for handles.

# Changes
- add `refreshData` method on `ZMBareUser`
- Also remove now obsolete user profile observer (moved to `wire-ios-sync-engine`)
