### PR TITLE
Make encrypt function on ZMGenericMessage public

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -100,7 +100,7 @@ extension ZMGenericMessage {
     
     /// Returns the payload encrypted for each recipients in the conversation, 
     /// and the strategy to use to handle missing clients
-    func encryptedMessagePayloadData(_ conversation: ZMConversation,
+    public func encryptedMessagePayloadData(_ conversation: ZMConversation,
                                              externalData: Data?)
         -> (data: Data, strategy: MissingClientsStrategy)?
     {


### PR DESCRIPTION
### Why this change
I need to expose this method so that I can encrypt `ZMGenericMessage`'s from `wire-message-strategy` 