### PR TITLE
Add observation for username

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/UserObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserObserverToken.swift
@@ -23,7 +23,7 @@ import ZMCSystem
 extension ZMUser : ObjectInSnapshot {
     
     public var observableKeys : [String] {
-        return ["name", "displayName", "accentColorValue", "imageMediumData", "imageSmallProfileData","emailAddress", "phoneNumber", "canBeConnected", "isConnected", "isPendingApprovalByOtherUser", "isPendingApprovalBySelfUser", "clients"]
+        return ["name", "displayName", "accentColorValue", "imageMediumData", "imageSmallProfileData","emailAddress", "phoneNumber", "canBeConnected", "isConnected", "isPendingApprovalByOtherUser", "isPendingApprovalBySelfUser", "clients", "handle"]
     }
 
     public func keyPathsForValuesAffectingValueForKey(forKey key: String) -> KeySet {
@@ -69,6 +69,10 @@ extension ZMUser : ObjectInSnapshot {
 
     open var clientsChanged : Bool {
         return changedKeysAndOldValues.keys.contains("clients")
+    }
+
+    public var handleChanged : Bool {
+        return changedKeysAndOldValues.keys.contains("handle")
     }
 
 

--- a/Tests/Source/Model/Observer/ObjectObserverToken/UserObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/UserObserverTokenTests.swift
@@ -42,6 +42,7 @@ class UserObserverTokenTests : ZMBaseManagedObjectTest {
         case ProfileInfo = "profileInformationChanged"
         case ConnectionState = "connectionStateChanged"
         case TrustLevel = "trustLevelChanged"
+        case Handle = "handleChanged"
     }
 
     let userInfoChangeKeys: [UserInfoChangeKey] = [
@@ -187,6 +188,30 @@ class UserObserverTokenTests : ZMBaseManagedObjectTest {
         self.checkThatItNotifiesTheObserverOfAChange(user,
             modifier: { self.setEmailAddress(nil, on: $0) },
             expectedChangedField: .ProfileInfo)
+    }
+
+    func testThatItNotifiesTheObserverOfAnUsernameChange_fromNil()
+    {
+        // given
+        let user = ZMUser.insertNewObject(in:self.uiMOC)
+        XCTAssertNil(user.handle)
+
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(user,
+                                                     modifier: { $0.setValue("handle", forKey: "handle") },
+                                                     expectedChangedField: .Handle)
+    }
+
+    func testThatItNotifiesTheObserverOfAnUsernameChange()
+    {
+        // given
+        let user = ZMUser.insertNewObject(in:self.uiMOC)
+        user.setValue("oldHandle", forKey: "handle")
+
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(user,
+                                                     modifier: { $0.setValue("newHandle", forKey: "handle") },
+                                                     expectedChangedField: .Handle)
     }
 
     func testThatItNotifiesTheObserverOfAPhoneNumberChange()


### PR DESCRIPTION
# What's in this PR?

* There was no way of getting notified when a user's username changes, this adds the `"handle"` key to the observable keys.
* This is needed in order to dismiss the takeover screen on a secondary device when a username is set on the primary one.