### PR TITLE
Add filter to query for message category

### DIFF
--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -71,11 +71,21 @@ extension ZMMessage {
     /// Sorted fetch request by category. It will match a Core Data object if the intersection of the Core Data value and ANY of the passed
     /// in categories is matching that category (in other words, the Core Data value can have more bits set that a certain category and it will
     /// still match).
-    public static func fetchRequestMatching(categories: Set<MessageCategory>) -> NSFetchRequest<NSFetchRequestResult> {
-        let predicates = categories.map {
-            return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.rawValue, $0.rawValue)
+    public static func fetchRequestMatching(categories: Set<MessageCategory>, excluding: MessageCategory = .none) -> NSFetchRequest<NSFetchRequestResult> {
+        
+        let orPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: categories.map {
+                return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.rawValue, $0.rawValue)
+            }
+        )
+        
+        let finalPredicate : NSPredicate
+        if excluding != .none {
+            let excludingPredicate = NSPredicate(format: "(%K & %d) = 0", ZMMessageCachedCategoryKey, excluding.rawValue)
+            finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [orPredicate, excludingPredicate])
+        } else {
+            finalPredicate = orPredicate
         }
-        return self.sortedFetchRequest(with: NSCompoundPredicate(orPredicateWithSubpredicates: predicates))!
+        return self.sortedFetchRequest(with: finalPredicate)!
     }
     
 }

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -377,4 +377,36 @@ extension ZMMessageCategorizationTests {
         XCTAssertFalse(messages.contains(linkTextMessage))
         XCTAssertTrue(messages.contains(likedTextMessage))
     }
+    
+    func testThatItCreatesAFetchRequestToFetchTextExcludingLinksAndLiked() {
+        
+        // GIVEN
+        let textMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage
+        textMessage.cachedCategory = MessageCategory.text
+        textMessage.serverTimestamp = Date(timeIntervalSince1970: 100)
+        let knockMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage
+        knockMessage.cachedCategory = MessageCategory.knock
+        knockMessage.serverTimestamp = Date(timeIntervalSince1970: 2000)
+        let linkTextMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage
+        linkTextMessage.cachedCategory = [MessageCategory.link, MessageCategory.text]
+        linkTextMessage.serverTimestamp = Date(timeIntervalSince1970: 3000)
+        let likedTextMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage
+        likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
+        likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
+        self.conversation.managedObjectContext?.saveOrRollback()
+        
+        // WHEN
+        let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text), excluding: [MessageCategory.link, MessageCategory.liked])
+        let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
+        
+        // THEN
+        guard let messages = results as? [ZMMessage] else {
+            XCTFail("Result is \(results)")
+            return
+        }
+        XCTAssertTrue(messages.contains(textMessage))
+        XCTAssertFalse(messages.contains(knockMessage))
+        XCTAssertFalse(messages.contains(linkTextMessage))
+        XCTAssertFalse(messages.contains(likedTextMessage))
+    }
 }


### PR DESCRIPTION
# Reason for this pull request
We want to exclude certain categories when fetching messages, e.g. fetch all files but not videos
