### PR TITLE
Check characters.count instead of utf8.count

### DIFF
--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -136,7 +136,7 @@ extension ZMMessage {
             category.update(with: .link)
         }
         // now check in the msg text
-        let matches = linkParser.matches(in: text.messageText, range: NSRange(location: 0, length: text.messageText.utf8.count))
+        let matches = linkParser.matches(in: text.messageText, range: NSRange(location: 0, length: text.messageText.characters.count))
         if matches.count > 0 {
             category.update(with: .link)
         }

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -317,7 +317,7 @@ extension ZMMessageCategorizationTests {
     func testThatItCreatesAFetchRequestToFetchLikedText() {
         
         // GIVEN
-        let textMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage
+        let textMessage = self.conversation.appendMessage(withText: "в ночной тиши")! as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
         textMessage.serverTimestamp = Date(timeIntervalSince1970: 100)
         let knockMessage = self.conversation.appendMessage(withText: "in the still of the night")! as! ZMMessage


### PR DESCRIPTION
Fixed crash loop caused by incorrect string length calculation.