### PR TITLE
Fix incoming C3 call with C3 flag turned off

### DIFF
--- a/Source/VoiceChannel/VoiceChannelRouter.swift
+++ b/Source/VoiceChannel/VoiceChannelRouter.swift
@@ -25,11 +25,15 @@ public class VoiceChannelRouter : NSObject, VoiceChannel {
     }
     
     public var currentVoiceChannel : VoiceChannel {
-        if v2.state != .noActiveUsers || v2.conversation?.conversationType != .oneOnOne || !VoiceChannelRouter.isCallingV3Enabled {
+        if v2.state != .noActiveUsers || v2.conversation?.conversationType != .oneOnOne {
             return v2
-        } else {
+        }
+        
+        if v3.state != .noActiveUsers {
             return v3
         }
+        
+        return VoiceChannelRouter.isCallingV3Enabled ? v3 : v2
     }
     
     public var conversation: ZMConversation? {

--- a/Source/VoiceChannel/WireCallCenterMock.swift
+++ b/Source/VoiceChannel/WireCallCenterMock.swift
@@ -20,6 +20,8 @@ import Foundation
 
 public class WireCallCenterMock : WireCallCenter {
     
+    public var callState : CallState = .none
+    
     public required init(userId: UUID, clientId: String, registerObservers: Bool) {
         super.init(userId: userId, clientId: clientId, registerObservers: false)
     }
@@ -45,7 +47,7 @@ public class WireCallCenterMock : WireCallCenter {
     }
     
     public override func callState(conversationId: UUID) -> CallState {
-        return .none
+        return callState
     }
     
     public override func toogleVideo(conversationID: UUID, active: Bool) {

--- a/Tests/Source/Model/VoiceChannel/VoiceChannelRouterTests.swift
+++ b/Tests/Source/Model/VoiceChannel/VoiceChannelRouterTests.swift
@@ -1,0 +1,100 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+
+@testable import ZMCDataModel
+
+class VoiceChannelRouterTests : ZMBaseManagedObjectTest {
+    
+    var wireCallCenterMock : WireCallCenterMock? = nil
+    var conversation : ZMConversation?
+
+    override func setUp() {
+        super.setUp()
+        
+        let selfUser = ZMUser.selfUser(in: syncMOC)
+        selfUser.remoteIdentifier = UUID.create()
+        
+        let selfClient = createSelfClient()
+        
+        conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+        conversation?.remoteIdentifier = UUID.create()
+        
+        wireCallCenterMock = WireCallCenterMock(userId: selfUser.remoteIdentifier!, clientId: selfClient.remoteIdentifier!, registerObservers: false)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        VoiceChannelRouter.isCallingV3Enabled = false
+        wireCallCenterMock = nil
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_idle_callingV3Disabled() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_idle_callingV3Enabled() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        VoiceChannelRouter.isCallingV3Enabled = true
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
+    }
+    
+    func testCurrenVoiceChannel_group_idle_callingV3Enabled() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .group
+        VoiceChannelRouter.isCallingV3Enabled = true
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_incomingV2Call_callingV3Enabled() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        conversation?.callDeviceIsActive = true
+        VoiceChannelRouter.isCallingV3Enabled = true
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v2)
+    }
+    
+    func testCurrenVoiceChannel_oneToOne_incomingV3Call_callingV3Disabled() {
+        // given
+        let sut = VoiceChannelRouter(conversation: conversation!)
+        conversation?.conversationType = .oneOnOne
+        wireCallCenterMock?.callState = .incoming(video: false)
+        
+        // then
+        XCTAssertTrue(sut.currentVoiceChannel === sut.v3)
+    }
+    
+}

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		166A8BF71E01650300F5EEEA /* WireCallCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF61E01650300F5EEEA /* WireCallCenterMock.swift */; };
 		166A8BFB1E02EAAF00F5EEEA /* avs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 166A8BFA1E02EAAF00F5EEEA /* avs.framework */; };
 		166A8BFC1E02EB2300F5EEEA /* avs.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 166A8BFA1E02EAAF00F5EEEA /* avs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		166A8BFE1E08201B00F5EEEA /* VoiceChannelRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BFD1E08201B00F5EEEA /* VoiceChannelRouterTests.swift */; };
 		16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */; };
 		16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */; };
 		16DCB6631DDA2715002A7AC2 /* PersistentStoreRelocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DCB6621DDA2715002A7AC2 /* PersistentStoreRelocator.swift */; };
@@ -392,6 +393,7 @@
 		1669023F1D7493EB000FE4AF /* ZMTestSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTestSession.m; sourceTree = "<group>"; };
 		166A8BF61E01650300F5EEEA /* WireCallCenterMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterMock.swift; sourceTree = "<group>"; };
 		166A8BFA1E02EAAF00F5EEEA /* avs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = avs.framework; path = Carthage/Build/iOS/avs.framework; sourceTree = "<group>"; };
+		166A8BFD1E08201B00F5EEEA /* VoiceChannelRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoiceChannelRouterTests.swift; sourceTree = "<group>"; };
 		16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ZMImageOwner.swift"; sourceTree = "<group>"; };
 		16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMFileMetadata.swift; sourceTree = "<group>"; };
 		16DCB6621DDA2715002A7AC2 /* PersistentStoreRelocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStoreRelocator.swift; sourceTree = "<group>"; };
@@ -1351,6 +1353,7 @@
 			children = (
 				F9B71F6C1CB2BC85001DB03F /* CallingInitalisationNotificationTests.swift */,
 				F9B71F6D1CB2BC85001DB03F /* ZMCallStateTests.swift */,
+				166A8BFD1E08201B00F5EEEA /* VoiceChannelRouterTests.swift */,
 			);
 			name = VoiceChannel;
 			path = Tests/Source/Model/VoiceChannel;
@@ -2083,6 +2086,7 @@
 				F9B71F9A1CB2BF0E001DB03F /* ZMUserTests.m in Sources */,
 				F9331C581CB3BE5300139ECC /* ZMConversationTests+OTR.m in Sources */,
 				F94BD2671DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift in Sources */,
+				166A8BFE1E08201B00F5EEEA /* VoiceChannelRouterTests.swift in Sources */,
 				162FAC671DDB732300FAB30B /* PersistentStoreRelocatorTests.swift in Sources */,
 				F9B71FA91CB2BF37001DB03F /* ZMConversationTests.m in Sources */,
 				F9B71FF01CB2C4C6001DB03F /* MessageWindowChangeTokenTests.swift in Sources */,


### PR DESCRIPTION
It wasn't possible to answer att incoming C3 call with the C3 flag turned off.