### PR TITLE
Categorize on insert, update on like & delete

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1309,9 +1309,10 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     [message addData:data];
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     [message setExpirationDate];
+    [message updateCategoryCache];
     [self sortedAppendMessage:message];
     [self unarchiveIfNeeded];
-
+    
     return message;
 }
 
@@ -1324,6 +1325,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithOriginalImageData:imageData nonce:nonce managedObjectContext:self.managedObjectContext expiresAfter:self.messageDestructionTimeout version3:version3];
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
+    [message updateCategoryCache];
     if(hidden) {
         message.hiddenInConversation = self;
     }
@@ -1344,6 +1346,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithFileMetadata:fileMetadata nonce:nonce managedObjectContext:self.managedObjectContext expiresAfter:self.messageDestructionTimeout version3:version3];
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     message.isEncrypted = YES;
+    [message updateCategoryCache];
     [self sortedAppendMessage:message];
     [self unarchiveIfNeeded];
     return message;

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -63,6 +63,7 @@ extension ZMMessage {
         let deletedMessage = ZMGenericMessage(deleteMessage: nonce.transportString(), nonce: NSUUID().transportString())
         let delete = conversation.append(deletedMessage, expires:false, hidden: true)
         removeClearingSender(false)
+        updateCategoryCache()
         return delete
     }
     

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -69,6 +69,7 @@ extension ZMMessage {
             let newReaction = Reaction.insertReaction(unicodeValue, users:[user], inMessage: self)
             self.mutableSetValue(forKey: "reactions").add(newReaction)
         }
+        updateCategoryCache()
     }
     
     fileprivate func removeReaction(forUser user: ZMUser)

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -370,6 +370,7 @@ NSString * const ZMMessageCachedCategoryKey = @"cachedCategory";
                                         inManagedObjectContext:moc];
     
     [localMessage addReaction:reaction.emoji forUser:user];
+    [localMessage updateCategoryCache];
 }
 
 + (void)removeMessageWithRemotelyDeletedMessage:(ZMMessageDelete *)deletedMessage inConversation:(ZMConversation *)conversation senderID:(NSUUID *)senderID inManagedObjectContext:(NSManagedObjectContext *)moc;
@@ -396,6 +397,7 @@ NSString * const ZMMessageCachedCategoryKey = @"cachedCategory";
         [self stopDeletionTimerForMessage:message];
     } else {
         [message removeMessageClearingSender:YES];
+        [message updateCategoryCache];
     }
 }
 

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -212,6 +212,7 @@ extension ZMMessageCategorizationTests {
         
         // GIVEN
         let message = self.conversation.appendMessage(withText: "ramble on!")! as! ZMMessage
+        message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: 0))
         
         // WHEN
@@ -243,6 +244,7 @@ extension ZMMessageCategorizationTests {
         
         // GIVEN
         let message = self.conversation.appendMessage(withText: "ramble on!")! as! ZMMessage
+        message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: 0))
         
         // WHEN
@@ -427,11 +429,11 @@ extension ZMMessageCategorizationTests {
         otherConversation.conversationType = .group
         otherConversation.remoteIdentifier = UUID.create()
         
-        let textMessage1 = self.conversation.appendMessage(withText: "hey jude!")! as! ZMMessage
+        let textMessage1 = self.conversation.appendMessage(withText: "hey Jean!")! as! ZMMessage
         textMessage1.cachedCategory = MessageCategory.text
         textMessage1.serverTimestamp = Date(timeIntervalSince1970: 100)
         
-        let textMessage2 = otherConversation.appendMessage(withText: "hey jude!")! as! ZMMessage
+        let textMessage2 = otherConversation.appendMessage(withText: "hey Jean!")! as! ZMMessage
         textMessage2.cachedCategory = MessageCategory.text
         textMessage2.serverTimestamp = Date(timeIntervalSince1970: 300)
         
@@ -455,11 +457,11 @@ extension ZMMessageCategorizationTests {
         otherConversation.conversationType = .group
         otherConversation.remoteIdentifier = UUID.create()
         
-        let textMessage1 = self.conversation.appendMessage(withText: "hey jude!")! as! ZMMessage
+        let textMessage1 = self.conversation.appendMessage(withText: "hey Jean!")! as! ZMMessage
         textMessage1.cachedCategory = MessageCategory.text
         textMessage1.serverTimestamp = Date(timeIntervalSince1970: 100)
         
-        let textMessage2 = otherConversation.appendMessage(withText: "hey jude!")! as! ZMMessage
+        let textMessage2 = otherConversation.appendMessage(withText: "hey Jean!")! as! ZMMessage
         textMessage2.cachedCategory = MessageCategory.text
         textMessage2.serverTimestamp = Date(timeIntervalSince1970: 300)
         
@@ -475,4 +477,78 @@ extension ZMMessageCategorizationTests {
         XCTAssertFalse(messages.contains(textMessage1))
         XCTAssertTrue(messages.contains(textMessage2))
     }
+}
+
+
+
+
+// MARK: Categorization on insert
+
+extension ZMMessageCategorizationTests {
+
+    func testThatItCategorizesAClientMessageOnInsert(){
+        
+        // when
+        let message = self.conversation.appendMessage(withText: "hey Jean!")! as! ZMMessage
+        
+        // then
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.text.rawValue))
+    }
+    
+    func testThatItCategorizesALocationMessageOnInsert(){
+        
+        // when
+        let message = self.conversation.appendMessage(with: LocationData.locationData(withLatitude: 40.42, longitude: 50.2, name: "Fooland", zoomLevel: Int32(2))) as! ZMMessage
+        
+        // then
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.location.rawValue))
+    }
+    
+    func testThatItCategorizesAKnockMessageOnInsert(){
+        
+        // when
+        let message = self.conversation.appendKnock() as! ZMMessage
+        // then
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.knock.rawValue))
+    }
+
+    func testThatItCategorizesAnImageMessageOnInsert(){
+        
+        // when
+        let message = self.conversation.appendMessage(withImageData: verySmallJPEGData()) as! ZMMessage
+        
+        // then
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.image.rawValue))
+    }
+    
+    func testThatItCategorizesAVideoMessageOnInsert(){
+        
+        // when
+        let message = self.conversation.appendMessage(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMMessage
+        
+        // then
+        let category = MessageCategory.file.union(MessageCategory.video)
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: category.rawValue))
+    }
+    
+    func testThatItCategorizesAnAudioFile() {
+        
+        // GIVEN
+        let message = self.conversation.appendMessage(with: ZMAudioMetadata(fileURL: self.fileURL(forResource: "audio", extension: "m4a"), duration: 12.2)) as! ZMMessage
+
+        
+        // THEN
+        let category = MessageCategory.file.union(MessageCategory.audio)
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: category.rawValue))
+    }
+    
+    func testThatItCategorizesAFileOnInsert() {
+        
+        // GIVEN
+        let message = self.conversation.appendMessage(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt")!)) as! ZMMessage
+        
+        // THEN
+        XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.file.rawValue))
+    }
+    
 }


### PR DESCRIPTION
Messages were not categorized on insert which would lead to weird reordering of the collection after fetching messages.
Also messages were not updated when they were liked, or deleted.