### PR TITLE
Do not set assets from syncMOC

### DIFF
--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -92,8 +92,8 @@ public class AssetCollection : NSObject, ZMCollection {
             
             let categorizedMessages : [ZMMessage] = AssetCollectionBatched.categorizedMessages(for: syncConversation, matchPairs: self.matchingCategories)
             if categorizedMessages.count > 0 {
-                self.assets = AssetCollectionBatched.messageMap(messages: categorizedMessages, matchingCategories: self.matchingCategories)
-                self.notifyDelegate(newAssets: self.assets!, type: nil, didReachLastMessage: false)
+                let categorized = AssetCollectionBatched.messageMap(messages: categorizedMessages, matchingCategories: self.matchingCategories)
+                self.notifyDelegate(newAssets: categorized, type: nil, didReachLastMessage: false)
             }
             
             self.fetchNextIfNotTornDown(limit: AssetCollection.initialFetchCount, type: .asset, syncConversation: syncConversation)

--- a/Source/Model/Conversation/AssetCollectionBatched.swift
+++ b/Source/Model/Conversation/AssetCollectionBatched.swift
@@ -91,8 +91,7 @@ public class AssetCollectionBatched : NSObject, ZMCollection {
             let categorizedMessages : [ZMMessage] = AssetCollectionBatched.categorizedMessages(for: syncConversation, matchPairs: self.matchingCategories)
             if categorizedMessages.count > 0 {
                 let categorized = AssetCollectionBatched.messageMap(messages: categorizedMessages, matchingCategories: self.matchingCategories)
-                self.assets = categorized
-                self.notifyDelegate(newAssets: self.assets!, type: nil, didReachLastMessage: false)
+                self.notifyDelegate(newAssets: categorized, type: nil, didReachLastMessage: false)
             }
 
             self.categorizeNextBatch(type: .asset, allMessages: allAssetMessages)

--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -353,4 +353,20 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .success)
     }
+    
+    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects(){
+        // given
+        let messages = insertAssetMessages(count: 20)
+        messages[0..<10].forEach{_ = $0.cachedCategory}
+        uiMOC.saveOrRollback()
+        
+        // when
+        sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        let allMessages = sut.assets(for: defaultMatchPair)
+        XCTAssertEqual(allMessages.count, 20)
+        XCTAssertTrue(allMessages.reduce(true){$0 && $1.managedObjectContext!.zm_isUserInterfaceContext})
+    }
 }

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -374,6 +374,22 @@ class AssetColletionTests : ModelObjectsTests {
         
         XCTAssertEqual(delegate.result, .success)
     }
+    
+    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects(){
+        // given
+        let messages = insertAssetMessages(count: 20)
+        messages[0..<10].forEach{_ = $0.cachedCategory}
+        uiMOC.saveOrRollback()
+        
+        // when
+        sut = AssetCollection(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        let allMessages = sut.assets(for: defaultMatchPair)
+        XCTAssertEqual(allMessages.count, 20)
+        XCTAssertTrue(allMessages.reduce(true){$0 && $1.managedObjectContext!.zm_isUserInterfaceContext})
+    }
 }
- 
+
 


### PR DESCRIPTION
Pre-categorized messages were stored as sync objects instead of UI objects and then again added as UI objects. 