### PR TITLE
Expose doneFetching parameter

### DIFF
--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -25,6 +25,7 @@ public enum AssetFetchResult : Int {
 public protocol ZMCollection : NSObjectProtocol {
     func tearDown()
     func assets(for category: CategoryMatch) -> [ZMMessage]
+    var fetchingDone : Bool { get }
 }
 
 public protocol AssetCollectionDelegate : NSObjectProtocol {
@@ -65,7 +66,7 @@ public class AssetCollection : NSObject, ZMCollection {
         }
     }
 
-    var doneFetching : Bool {
+    public var fetchingDone : Bool {
         return doneFetchingTexts && doneFetchingAssets
     }
     
@@ -133,7 +134,7 @@ public class AssetCollection : NSObject, ZMCollection {
     }
 
     private func fetchNextIfNotTornDown(limit: Int, type: MessagesToFetch, syncConversation: ZMConversation){
-        guard !doneFetching, !tornDown else { return }
+        guard !fetchingDone, !tornDown else { return }
         guard !syncConversation.isZombieObject else {
             self.notifyDelegateFetchingIsDone(result: .failed)
             return
@@ -157,7 +158,7 @@ public class AssetCollection : NSObject, ZMCollection {
             self.setFetchingCompleteFor(type: type)
         }
         if messagesToAnalyze.count == 0 {
-            if self.doneFetching {
+            if self.fetchingDone {
                 self.notifyDelegateFetchingIsDone(result: (self.assets == nil) ? .noAssetsToFetch : .success)
             }
             return
@@ -212,7 +213,7 @@ public class AssetCollection : NSObject, ZMCollection {
             
             // Notify delegate
             self.delegate.assetCollectionDidFetch(collection: self, messages: uiAssets, hasMore: didReachLastMessage)
-            if (self.doneFetching) {
+            if (self.fetchingDone) {
                 self.notifyDelegateFetchingIsDone(result: (self.assets == nil) ? .noAssetsToFetch : .success)
             }
         }

--- a/Source/Model/Conversation/AssetCollectionBatched.swift
+++ b/Source/Model/Conversation/AssetCollectionBatched.swift
@@ -68,7 +68,7 @@ public class AssetCollectionBatched : NSObject, ZMCollection {
     }
     
     /// Returns true when there are no assets to fetch OR when all assets have been processed OR the collection has been tornDown
-    public var doneFetching : Bool {
+    public var fetchingDone : Bool {
         return tornDown || (assetMessagesDone && clientMessagesDone)
     }
     
@@ -145,7 +145,7 @@ public class AssetCollectionBatched : NSObject, ZMCollection {
             self.setFetchingCompleteFor(type: type)
         }
         if numberToAnalyze == 0 {
-            if self.doneFetching {
+            if self.fetchingDone {
                 self.notifyDelegateFetchingIsDone(result: .success)
             }
             return
@@ -195,7 +195,7 @@ public class AssetCollectionBatched : NSObject, ZMCollection {
 
             // Notify delegate
             self.delegate.assetCollectionDidFetch(collection: self, messages: uiAssets, hasMore: !didReachLastMessage)
-            if self.doneFetching {
+            if self.fetchingDone {
                 self.delegate.assetCollectionDidFinishFetching(collection: self, result: .success)
             }
         }


### PR DESCRIPTION
The UI is only updating the view once the view did load. If we have no messages in the conversation, the view might load after we are done fetching the messages which would result in an endless spinner.

To avoid that, we should check if the AssetCollection is doneFetching in the viewDidLoad and then update the internal flag of the VC and the loading elements accordingly