### PR TITLE
Add callback when a failure to save is detected

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+Debugging.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+Debugging.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+private let errorOnSaveCallbackKey = "zm_errorOnSaveCallback"
+
+extension NSManagedObjectContext {
+    
+    public typealias ErrorOnSaveCallback = (NSManagedObjectContext, NSError)->()
+    
+    // Callback invoked when an error is generated during save
+    public var errorOnSaveCallback : ErrorOnSaveCallback? {
+        get {
+            return self.userInfo[errorOnSaveCallbackKey] as? ErrorOnSaveCallback
+        }
+        set {
+            self.userInfo[errorOnSaveCallbackKey] = newValue
+        }
+    }
+    
+    /// Report an error during save
+    @objc public func reportSaveError(error: NSError) {
+        if let callback = self.errorOnSaveCallback {
+            callback(self, error)
+        }
+    }
+}

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -660,6 +660,7 @@ static dispatch_once_t clearStoreOnceToken;
         ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:10 label:[NSString stringWithFormat:@"Saving context %@", self.zm_isSyncContext ? @"sync": @"ui"]];
         if (! [self save:&error]) {
             ZMLogError(@"Failed to save: %@", error);
+            [self reportSaveErrorWithError:error];
             [self rollbackWithOldMetadata:oldMetadata];
             [tp warnIfLongerThanInterval];
             return NO;

--- a/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
+++ b/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
@@ -1,0 +1,60 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+
+
+class NSManagedObjectContextDebuggingTests : ZMBaseManagedObjectTest {
+
+    func testThatItInvokesCallbackWhenFailedToSave() {
+        
+        // GIVEN
+        self.makeChangeThatWillCauseRollback()
+        let expectation = self.expectation(description: "callback invoked")
+        self.uiMOC.errorOnSaveCallback = { (moc, error) in
+            XCTAssertEqual(moc, self.uiMOC)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        
+        // WHEN
+        self.performIgnoringZMLogError {
+            self.uiMOC.saveOrRollback()
+        }
+        
+        // THEN
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+    }
+}
+
+// MARK: - Helper
+
+private let longString = (0..<50).reduce("") { (prev, next) -> String in
+    return prev + "AaAaAaAaAa"
+}
+
+extension NSManagedObjectContextDebuggingTests {
+    
+    func makeChangeThatWillCauseRollback() {
+        let user = ZMUser.selfUser(in: self.uiMOC)
+        // this user name is too long and will fail validation
+        user.name = longString
+    }
+}

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */; };
 		546D3DE61CE5D0B100A6047F /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546D3DE51CE5D0B100A6047F /* MimeType.swift */; };
 		546D3DE91CE5D24C00A6047F /* MimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */; };
+		5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5473CC721E14245C00814C03 /* NSManagedObjectContext+Debugging.swift */; };
+		5473CC751E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5473CC741E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift */; };
 		5476BA3E1DEDABCC00D047F8 /* AddressBookEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5476BA3D1DEDABCC00D047F8 /* AddressBookEntryTests.swift */; };
 		54829DAD1DE6F7BA009100D3 /* store1-24.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 54829D951DE6F782009100D3 /* store1-24.wiredatabase */; };
 		54829DAE1DE6F7BA009100D3 /* store1-25.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 54829D961DE6F782009100D3 /* store1-25.wiredatabase */; };
@@ -399,6 +401,8 @@
 		54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMMessageCategorizationTests.swift; sourceTree = "<group>"; };
 		546D3DE51CE5D0B100A6047F /* MimeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MimeTypeTests.swift; sourceTree = "<group>"; };
+		5473CC721E14245C00814C03 /* NSManagedObjectContext+Debugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Debugging.swift"; sourceTree = "<group>"; };
+		5473CC741E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSManagedObjectContextDebuggingTests.swift; sourceTree = "<group>"; };
 		5476BA3D1DEDABCC00D047F8 /* AddressBookEntryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookEntryTests.swift; sourceTree = "<group>"; };
 		54829D951DE6F782009100D3 /* store1-24.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store1-24.wiredatabase"; path = "Tests/Resources/store1-24.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		54829D961DE6F782009100D3 /* store1-25.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store1-25.wiredatabase"; path = "Tests/Resources/store1-25.wiredatabase"; sourceTree = SOURCE_ROOT; };
@@ -919,6 +923,7 @@
 				F9A705D31CAEE01D00C2F5FE /* ZMSyncMergePolicy.m */,
 				16DCB6621DDA2715002A7AC2 /* PersistentStoreRelocator.swift */,
 				54D7B83E1E12774600C1B347 /* NSPersistentStore+Metadata.swift */,
+				5473CC721E14245C00814C03 /* NSManagedObjectContext+Debugging.swift */,
 			);
 			name = ManagedObjectContext;
 			path = Source/ManagedObjectContext;
@@ -1205,6 +1210,7 @@
 				F9A708061CAEEB7400C2F5FE /* NSManagedObjectContext+TestHelpers.h */,
 				F9A708071CAEEB7400C2F5FE /* NSManagedObjectContext+TestHelpers.m */,
 				F9A708081CAEEB7400C2F5FE /* PersistentStoreCoordinatorTests.m */,
+				5473CC741E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift */,
 			);
 			name = ManagedObjectContext;
 			path = Tests/Source/ManagedObjectContext;
@@ -1984,6 +1990,7 @@
 				F9A7068C1CAEE01D00C2F5FE /* ZMSearchUser.m in Sources */,
 				F9A706B71CAEE01D00C2F5FE /* UserObserverToken.swift in Sources */,
 				F9A7067F1CAEE01D00C2F5FE /* ZMImageMessage.m in Sources */,
+				5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */,
 				BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */,
 				F9A706991CAEE01D00C2F5FE /* ZMManagedObject.m in Sources */,
 				F9C9A74A1CAE6DA00039E10C /* CallingInitialisationNotification.swift in Sources */,
@@ -2063,6 +2070,7 @@
 				F9B720051CB2C795001DB03F /* ZMGenericMessage_ExternalTests.m in Sources */,
 				F9B71FF61CB2C4C6001DB03F /* NewUnreadMessageObserverTokenTests.swift in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,
+				5473CC751E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift in Sources */,
 				F9B71FF91CB2C4C6001DB03F /* UserClientObserverTokenTests.swift in Sources */,
 				F9A7083C1CAEEB7500C2F5FE /* MockModelObjectContextFactory.m in Sources */,
 				F9331C5C1CB3BF9F00139ECC /* UserClientKeyStoreTests.swift in Sources */,


### PR DESCRIPTION
# Reason for this pull request
Adding a callback to notify when saving the managed object context fails, so that we can debug why it's happening