### PR TITLE
Fix for profile picture no being set after registration

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -532,7 +532,7 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
     }
     
     NSArray *picture = [transportData optionalArrayForKey:@"picture"];
-    if ((picture != nil || authoritative) && ![self hasLocalModificationsForKeys:[NSSet setWithArray:@[ImageMediumDataKey, ImageSmallProfileDataKey]]]) {
+    if ((picture != nil || authoritative) && ![self hasLocalModificationsForKeys:[NSSet setWithArray:@[ImageMediumDataKey, ImageSmallProfileDataKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey]]]) {
         [self updateImageWithTransportData:picture];
     }
     


### PR DESCRIPTION
This PR fixes a race condition between the self user requests. It was possible
that the response handling for fetching the self user could interfer with
uploading your profile picture.

https://wearezeta.atlassian.net/browse/ZIOS-7798