### PR TITLE
Fix missing empty group conversation name

### DIFF
--- a/Source/Model/Conversation/ZMConversation+DisplayName.swift
+++ b/Source/Model/Conversation/ZMConversation+DisplayName.swift
@@ -1,0 +1,80 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+public extension ZMConversation {
+
+    static private var emptyConversationEllipsis: String {
+        return "…"
+    }
+
+    public var displayName: String {
+        switch conversationType {
+        case .connection: return connectionDisplayName()
+        case .group: return groupDisplayName()
+        case .oneOnOne: return oneOnOneDisplayName()
+        case .self: return managedObjectContext.map(ZMUser.selfUser)?.displayName ?? ""
+        case .invalid: return ""
+        }
+    }
+
+    private func connectionDisplayName() -> String {
+        precondition(conversationType == .connection)
+
+        let name: String?
+        if let connectedName = connectedUser?.name, connectedName.characters.count > 0 {
+            name = connectedName
+        } else {
+            name = userDefinedName
+        }
+
+        return name ?? ZMConversation.emptyConversationEllipsis
+    }
+
+    private func groupDisplayName() -> String {
+        precondition(conversationType == .group)
+
+        if let userDefined = userDefinedName, userDefined.characters.count > 0 {
+            return userDefined
+        }
+
+        let selfUser = managedObjectContext.map(ZMUser.selfUser)
+        let activeNames: [String] = otherActiveParticipants.flatMap {
+            guard let user = $0 as? ZMUser, user != selfUser && user.name?.characters.count > 0 else { return nil }
+            return user.displayName
+        }
+
+        if activeNames.count > 0 {
+            return activeNames.joined(separator: ", ")
+        } else {
+            return NSLocalizedString("conversation.displayname.emptygroup", comment: "")
+        }
+    }
+
+    private func oneOnOneDisplayName() -> String {
+        precondition(conversationType == .oneOnOne)
+
+        let other = otherActiveParticipants.firstObject as? ZMUser ?? connectedUser
+        if let name = other?.name, name.characters.count > 0 {
+            return name
+        } else {
+            return ZMConversation.emptyConversationEllipsis
+        }
+    }
+
+}

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -405,62 +405,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return [NSSet setWithObjects:ConversationTypeKey, ZMConversationIsSelfAnActiveMemberKey, nil];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingAttributedDisplayName;
-{
-    return [ZMConversation keyPathsForValuesAffectingDisplayName];
-}
-
-- (NSString *)displayName
-{
-    switch (self.conversationType) {
-        case ZMConversationTypeConnection:
-        {
-            NSString *name = self.connectedUser.name;
-            if (name.length == 0) {
-                name = self.userDefinedName;
-            }
-            return name ?: @"…";
-        }
-        case ZMConversationTypeGroup:
-            if (0 < self.userDefinedName.length) {
-                return self.userDefinedName;
-            }
-            else {
-                ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-                NSArray *activeNames = [self.otherActiveParticipants.array mapWithBlock:^NSString*(ZMUser *user) {
-                    if(user == selfUser || user.name.length < 1) {
-                        return nil;
-                    }
-                    return user.displayName;
-                }];
-                
-                
-                NSString *joiner = @", ";
-                NSString *activeNamesString = [activeNames componentsJoinedByString:joiner];
-                return activeNamesString;
-            }
-            
-        case ZMConversationTypeOneOnOne:
-        {
-            ZMUser *other = self.otherActiveParticipants.firstObject ?: self.connectedUser;
-            NSString *name = other.name;
-            if (0 < name.length) {
-                return name;
-            }
-            else {
-                // The user is most probably deleted
-                return @"…";
-            }
-        }
-            
-        case ZMConversationTypeSelf:
-            return [ZMUser selfUserInContext:self.managedObjectContext].displayName ?: @"";
-            
-        case ZMConversationTypeInvalid:
-            return @"";
-    }
-}
-
 + (NSSet *)keyPathsForValuesAffectingDisplayName;
 {
     return [NSSet setWithObjects:ConversationTypeKey, @"connection",

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -67,7 +67,6 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 @interface ZMConversation : ZMManagedObject
 
 @property (nonatomic, copy, nullable) NSString *userDefinedName;
-@property (nonatomic, readonly, nonnull) NSString *displayName;
 
 @property (readonly, nonatomic) ZMConversationType conversationType;
 @property (readonly, nonatomic, nonnull) NSDate *lastModifiedDate;

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1380,6 +1380,17 @@
     XCTAssertEqualObjects(conversation.displayName, @"…");
 }
 
+- (void)testThatTheDisplayNameForGroupConversationWithoutParticipantsIsTheEmptyGroupConversationName;
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    [self.uiMOC saveOrRollback];
+
+    // then
+    XCTAssertEqualObjects(conversation.displayName, @"conversation.displayname.emptygroup");
+}
+
 - (void)testThatTheDisplayNameIsTheOtherUsersNameForAConnectionRequest;
 {
     __block NSManagedObjectID *moid;

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -370,7 +370,7 @@ extension ClientMessageTests_OTR {
             self.syncMOC.saveOrRollback()
             
             let confirmationMessage = clientmessage.confirmReception()
-            print(confirmationMessage)
+
             //when
             guard let _ = confirmationMessage?.encryptedMessagePayloadData()
                 else { return XCTFail()}
@@ -393,7 +393,7 @@ extension ClientMessageTests_OTR {
             self.syncMOC.saveOrRollback()
             
             let confirmationMessage = clientmessage.confirmReception()
-            print(confirmationMessage)
+
             //when
             guard let _ = confirmationMessage?.encryptedMessagePayloadData()
                 else { return XCTFail()}

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		54EDE6821CBBF6260044A17E /* AssetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EDE6811CBBF6260044A17E /* AssetCacheTests.swift */; };
 		54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */; };
 		BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4666291DCB71B0007463FF /* V3Asset.swift */; };
+		BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */; };
 		BF76998B1D3500F0009C378B /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; };
 		BF76998C1D3500F0009C378B /* Ono.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF794FE31D143DE300E618C6 /* LocationMessage+Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF794FE21D143DE300E618C6 /* LocationMessage+Coordinate.swift */; };
@@ -432,6 +433,7 @@
 		874B5DAA1CEDB9E40010474C /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
 		BF260C4E1DCA1640009C97D9 /* zmessaging2.21.2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.21.2.xcdatamodel; sourceTree = "<group>"; };
 		BF4666291DCB71B0007463FF /* V3Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V3Asset.swift; sourceTree = "<group>"; };
+		BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+DisplayName.swift"; sourceTree = "<group>"; };
 		BF6F82F41CD0D992006E9CCB /* zmessaging2.5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.5.xcdatamodel; sourceTree = "<group>"; };
 		BF710FC81CE0B83400DC92C4 /* zmessaging2.6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.6.xcdatamodel; sourceTree = "<group>"; };
 		BF7699891D3500D6009C378B /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
@@ -966,6 +968,7 @@
 				F9B71F171CB264EF001DB03F /* ZMConversation+Trace.h */,
 				F9B71F101CB264EF001DB03F /* ZMConversation.m */,
 				F92C99291DAFBC910034AFDD /* ZMConversation+Ephemeral.swift */,
+				BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */,
 				F9B71F121CB264EF001DB03F /* ZMConversation+OTR.h */,
 				F91DF5AD1D0969BE009D81F1 /* ZMConversation+OTR.m */,
 				F9B71F151CB264EF001DB03F /* ZMConversation+Timestamps.h */,
@@ -1927,6 +1930,7 @@
 				F9B71F201CB264EF001DB03F /* NSError+ZMConversation.m in Sources */,
 				F9B71F311CB264EF001DB03F /* ZMConversationSecurityLevel.m in Sources */,
 				F91DF5AF1D0969BE009D81F1 /* ZMConversation+OTR.m in Sources */,
+				BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */,
 				546D3DE61CE5D0B100A6047F /* MimeType.swift in Sources */,
 				F963E9761D9C002000098AD3 /* ZMGenericMessage+Assets.swift in Sources */,
 				54CD460A1DEDA55C00BA3429 /* AddressBookEntry.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* The logic to use the empty group conversation placeholder [has been removed here](https://github.com/wireapp/wire-ios-data-model/commit/cad79d#diff-e67417d73be307cd0a79a4351caef75eL470).
* The `displayName` logic in `ZMConversation` has been rewritten in Swift and extracted in an extension.
* Add test for empty group conversation placeholder.