### PR TITLE
Add option to append a message without fetching link preview

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_END
 - (nonnull ZMClientMessage *)appendClientMessageWithData:(nonnull NSData *)data;
 - (nonnull ZMClientMessage *)appendOTRKnockMessageWithNonce:(nonnull NSUUID *)nonce;
 - (nonnull ZMClientMessage *)appendOTRSessionResetMessage;
-- (nonnull ZMClientMessage *)appendOTRMessageWithText:(nonnull NSString *)text nonce:(nonnull NSUUID *)nonce;
+- (nonnull ZMClientMessage *)appendOTRMessageWithText:(nonnull NSString *)text nonce:(nonnull NSUUID *)nonce fetchLinkPreview:(BOOL)fetchPreview;
 - (nonnull ZMClientMessage *)appendOTRMessageWithLocationData:(nonnull ZMLocationData *)locationData nonce:(nonnull NSUUID *)nonce;
 - (nonnull ZMAssetClientMessage *)appendOTRMessageWithImageData:(nonnull NSData *)imageData nonce:(nonnull NSUUID *)nonce;
 - (nonnull ZMAssetClientMessage *)appendOTRMessageWithImageData:(nonnull NSData *)imageData nonce:(nonnull NSUUID *)nonce version3:(BOOL)version3;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -646,7 +646,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (id <ZMConversationMessage>)appendMessageWithText:(NSString *)text;
 {
-    return [self appendMessageWithText:text fetchLinkPreview:NO];
+    return [self appendMessageWithText:text fetchLinkPreview:YES];
 }
 
 - (nullable id <ZMConversationMessage>)appendMessageWithText:(nullable NSString *)text fetchLinkPreview:(BOOL)fetchPreview;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -646,12 +646,17 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (id <ZMConversationMessage>)appendMessageWithText:(NSString *)text;
 {
+    return [self appendMessageWithText:text fetchLinkPreview:NO];
+}
+
+- (nullable id <ZMConversationMessage>)appendMessageWithText:(nullable NSString *)text fetchLinkPreview:(BOOL)fetchPreview;
+{
     VerifyReturnNil(![text zmHasOnlyWhitespaceCharacters]);
     VerifyReturnNil(text != nil);
 
     NSUUID *nonce = NSUUID.UUID;
-    id <ZMConversationMessage> message = [self appendOTRMessageWithText:text nonce:nonce];
-    
+    id <ZMConversationMessage> message = [self appendOTRMessageWithText:text nonce:nonce fetchLinkPreview:fetchPreview];
+
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMConversationClearTypingNotificationName object:self];
     return message;
 }
@@ -1312,13 +1317,18 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return message;
 }
 
-- (ZMClientMessage *)appendOTRMessageWithText:(NSString *)text nonce:(NSUUID *)nonce
+- (ZMClientMessage *)appendOTRMessageWithText:(NSString *)text nonce:(NSUUID *)nonce fetchLinkPreview:(BOOL)fetchPreview
 {
     ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithText:text nonce:nonce.transportString expiresAfter:@(self.messageDestructionTimeout)];
     ZMClientMessage *message = [self appendClientMessageWithData:genericMessage.data];
-    message.linkPreviewState = ZMLinkPreviewStateWaitingToBeProcessed;
+    message.linkPreviewState = fetchPreview ? ZMLinkPreviewStateWaitingToBeProcessed : ZMLinkPreviewStateDone;
     message.isEncrypted = YES;
     return message;
+}
+
+- (ZMClientMessage *)appendOTRMessageWithText:(NSString *)text nonce:(NSUUID *)nonce
+{
+    return [self appendOTRMessageWithText:text nonce:nonce fetchLinkPreview:YES];
 }
 
 - (ZMAssetClientMessage *)appendOTRMessageWithImageData:(NSData *)imageData nonce:(NSUUID *)nonce

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -122,6 +122,8 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 
 /// It's safe to pass @c nil. Returns @c nil if no message was inserted.
 - (nullable id <ZMConversationMessage>)appendMessageWithText:(nullable NSString *)text;
+/// It's safe to pass @c nil. Returns @c nil if no message was inserted. Specify if a linkPreview should be fetched when available.
+- (nullable id <ZMConversationMessage>)appendMessageWithText:(nullable NSString *)text fetchLinkPreview:(BOOL)fetchPreview;
 
 /// The given URL must be a file URL. It's safe to pass @c nil. Returns @c nil if no message was inserted.
 - (nullable id<ZMConversationMessage>)appendMessageWithImageAtURL:(nonnull NSURL *)fileURL;

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -825,7 +825,7 @@
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.lastModifiedDate = [NSDate.date dateByAddingTimeInterval:-100];
-    ZMClientMessage *clientMessage = [conversation appendOTRMessageWithText:@"Test Message" nonce:[NSUUID new]];
+    ZMClientMessage *clientMessage = [conversation appendOTRMessageWithText:@"Test Message" nonce:[NSUUID new] fetchLinkPreview:YES];
     
     // then
     XCTAssertEqualObjects(conversation.lastModifiedDate, clientMessage.serverTimestamp);
@@ -846,7 +846,7 @@
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.lastModifiedDate = [NSDate.date dateByAddingTimeInterval:-100];
-    ZMClientMessage *clientMessage = [conversation appendOTRMessageWithText:@"Test Message" nonce:[NSUUID new]];
+    ZMClientMessage *clientMessage = [conversation appendOTRMessageWithText:@"Test Message" nonce:[NSUUID new] fetchLinkPreview:YES];
     
     NSDate *postingDate = clientMessage.serverTimestamp;
     // then
@@ -3398,7 +3398,7 @@
         
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.remoteIdentifier = [NSUUID createUUID];
-        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID];
+        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         
         ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
         NSData *contentData = message.data;
@@ -3530,7 +3530,7 @@
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.remoteIdentifier = [NSUUID createUUID];
         
-        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:[NSUUID createUUID]];
+        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:[NSUUID createUUID] fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
         ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:[NSUUID createUUID].transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
@@ -3566,7 +3566,7 @@
         
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.remoteIdentifier = [NSUUID createUUID];
-        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID];
+        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
         ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
@@ -3602,7 +3602,7 @@
         
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         conversation.remoteIdentifier = [NSUUID createUUID];
-        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID];
+        [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
         ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
@@ -268,7 +268,7 @@ extension ZMClientMessageTests_Ephemeral {
             conversation.mutableOtherActiveParticipants.add(self.syncUser1)
             self.syncMOC.saveOrRollback()
             
-            let textMessage = conversation.appendOTRMessage(withText: "foo", nonce: UUID.create())
+            let textMessage = conversation.appendOTRMessage(withText: "foo", nonce: UUID.create(), fetchLinkPreview: true)
             
             //when
             guard let _ = textMessage.encryptedMessagePayloadData()

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -78,7 +78,7 @@ extension ClientMessageTests_OTR {
         self.syncMOC.performGroupedBlockAndWait {
             
             //given
-            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create(), fetchLinkPreview: true)
             
             //when
             guard let payloadAndStrategy = message.encryptedMessagePayloadData() else {
@@ -102,7 +102,7 @@ extension ClientMessageTests_OTR {
             
             //given
             self.syncConversation.messageDestructionTimeout = 10
-            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create(), fetchLinkPreview: true)
             XCTAssertTrue(message.isEphemeral)
             
             //when
@@ -124,7 +124,7 @@ extension ClientMessageTests_OTR {
         self.syncMOC.performGroupedBlockAndWait {
             //given
             self.syncConversation.messageDestructionTimeout = 10
-            syncMessage = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            syncMessage = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create(), fetchLinkPreview: true)
             syncMessage.sender = self.syncUser1
             XCTAssertTrue(syncMessage.isEphemeral)
             self.syncMOC.saveOrRollback()
@@ -161,7 +161,7 @@ extension ClientMessageTests_OTR {
         self.syncMOC.performGroupedBlockAndWait {
             //given
             self.syncConversation.messageDestructionTimeout = 10
-            syncMessage = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            syncMessage = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create(), fetchLinkPreview: true)
             syncMessage.sender = self.syncUser1
             XCTAssertTrue(syncMessage.isEphemeral)
             self.syncMOC.saveOrRollback()
@@ -248,7 +248,7 @@ extension ClientMessageTests_OTR {
         
         syncMOC.performGroupedBlockAndWait {
             // given
-            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create())
+            let message = self.syncConversation.appendOTRMessage(withText: self.name!, nonce: UUID.create(), fetchLinkPreview: true)
             
             //when
             // when
@@ -289,7 +289,7 @@ extension ClientMessageTests_OTR {
             
             self.syncMOC.saveOrRollback()
                         
-            let textMessage = conversation.appendOTRMessage(withText: self.stringLargeEnoughToRequireExternal, nonce: UUID.create())
+            let textMessage = conversation.appendOTRMessage(withText: self.stringLargeEnoughToRequireExternal, nonce: UUID.create(), fetchLinkPreview: true)
             
             textMessage.sender = self.syncUser1
             textMessage.senderClientID = senderID
@@ -338,7 +338,7 @@ extension ClientMessageTests_OTR {
             
             self.syncMOC.saveOrRollback()
             
-            let textMessage = conversation.appendOTRMessage(withText: self.stringLargeEnoughToRequireExternal, nonce: UUID.create())
+            let textMessage = conversation.appendOTRMessage(withText: self.stringLargeEnoughToRequireExternal, nonce: UUID.create(), fetchLinkPreview: true)
             
             textMessage.sender = self.syncUser1
             textMessage.senderClientID = senderID

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.m
@@ -185,6 +185,13 @@
     XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateWaitingToBeProcessed);
 }
 
+- (void)testThatAAppendedClientMessageWithFlagToNotFetchPreviewSetHasLinkPreviewStateDone
+{
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMClientMessage *message = (ZMClientMessage *)[conversation appendMessageWithText:self.name fetchLinkPreview:NO];
+    XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateDone);
+}
+
 @end
 
 


### PR DESCRIPTION
# What's in this PR?

* At the moment we do not want to fetch link previews when sending messages through the iOS share extension (this might change at some point). 
* As the share extension does not fetch the previews itself this currently leads to the previews being fetched once the main app is opened, which is undesired. 
* This PR adds a parameter to specify if a link preview should be fetched when appending a text message.