### PR TITLE
Updated collection delegates to return more abstract types

### DIFF
--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -24,7 +24,7 @@ public enum AssetFetchResult : Int {
 
 public protocol ZMCollection : NSObjectProtocol {
     func tearDown()
-    func assets(for category: CategoryMatch) -> [ZMMessage]
+    func assets(for category: CategoryMatch) -> [ZMConversationMessage]
     var fetchingDone : Bool { get }
 }
 
@@ -119,7 +119,7 @@ public class AssetCollection : NSObject, ZMCollection {
     }
     
     /// Returns all assets that have been fetched thus far
-    public func assets(for category: CategoryMatch) -> [ZMMessage] {
+    public func assets(for category: CategoryMatch) -> [ZMConversationMessage] {
         // Remove zombie objects and return remaining
         if let values = assets?[category] {
             let withoutZombie = values.filter{!$0.isZombieObject}

--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -31,7 +31,7 @@ public protocol ZMCollection : NSObjectProtocol {
 public protocol AssetCollectionDelegate : NSObjectProtocol {
     /// The AssetCollection calls this when the fetching completes
     /// To get all messages for any category defined in `including`, call `assets(for category: CategoryMatch)`
-    func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch: [ZMMessage]], hasMore: Bool)
+    func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch: [ZMConversationMessage]], hasMore: Bool)
     
     /// This method is called when all assets in the conversation have been fetched & analyzed / categorized
     func assetCollectionDidFinishFetching(collection: ZMCollection, result : AssetFetchResult)

--- a/Source/Model/Conversation/AssetCollectionBatched.swift
+++ b/Source/Model/Conversation/AssetCollectionBatched.swift
@@ -112,7 +112,7 @@ public class AssetCollectionBatched : NSObject, ZMCollection {
     }
     
     /// Returns all assets that have been fetched thus far
-    public func assets(for category: CategoryMatch) -> [ZMMessage] {
+    public func assets(for category: CategoryMatch) -> [ZMConversationMessage] {
         // Remove zombie objects and return remaining
         if let values = assets?[category] {
             let withoutZombie = values.filter{!$0.isZombieObject}

--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -111,7 +111,7 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         
         // then
         XCTAssertEqual(messages.count, 1)
-        guard let moc = messages.first?.managedObjectContext else {return XCTFail()}
+        guard let message = messages.first as? ZMMessage , let moc = message.managedObjectContext else {return XCTFail()}
         XCTAssertTrue(moc.zm_isUserInterfaceContext)
     }
     
@@ -367,7 +367,10 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true){$0 && $1.managedObjectContext!.zm_isUserInterfaceContext})
+        XCTAssertTrue(allMessages.reduce(true){ result, element in
+            guard let message = element as? ZMMessage else { return false }
+            return result && message.managedObjectContext!.zm_isUserInterfaceContext
+        })
     }
     
     func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized(){

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -112,7 +112,7 @@ class AssetColletionTests : ModelObjectsTests {
         
         // then
         XCTAssertEqual(messages.count, 1)
-        guard let moc = messages.first?.managedObjectContext else {return XCTFail()}
+        guard let message = messages.first as? ZMMessage , let moc = message.managedObjectContext else {return XCTFail()}
         XCTAssertTrue(moc.zm_isUserInterfaceContext)
     }
     
@@ -388,7 +388,10 @@ class AssetColletionTests : ModelObjectsTests {
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true){$0 && $1.managedObjectContext!.zm_isUserInterfaceContext})
+        XCTAssertTrue(allMessages.reduce(true){ result, element in
+            guard let message = element as? ZMMessage else { return false }
+            return result && message.managedObjectContext!.zm_isUserInterfaceContext
+        })
     }
     
     func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized(){

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -30,8 +30,14 @@ class MockAssetCollectionDelegate : NSObject, AssetCollectionDelegate {
         didCallDelegate = true
     }
     
-    public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMMessage]], hasMore: Bool) {
-        messagesByFilter.append(messages)
+    public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMConversationMessage]], hasMore: Bool) {
+        // For testing purposes it's easier to work with ZMMessage directly
+        var toAppend = [CategoryMatch: [ZMMessage]]()
+        for (key, value) in messages {
+            toAppend[key] = value.map { $0 as! ZMMessage }
+        }
+        messagesByFilter.append(toAppend)
+        
         didCallDelegate = true
         if !hasMore {
             finished = finished + messages.keys


### PR DESCRIPTION
## Why this is needed?

When writing tests for collections we need to be able to mock various messages and it's way easier when API works with protocols instead of `NSManagedObject` subclasses.