### PR TITLE
Use hardcoded bot handles instead of hardcoded emails

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -79,8 +79,8 @@ static NSString *const UserClientsKey = @"clients";
 static NSString *const ReactionsKey = @"reactions";
 static NSString *const AddressBookEntryKey = @"addressBookEntry";
 
-static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.com$";
-
+static NSString *const OttoBotHandle = @"ottothebot";
+static NSString *const AnnaBotHandle = @"annathebot";
 
 @interface ZMBoxedSelfUser : NSObject
 
@@ -249,20 +249,7 @@ static NSString *const UserBotEmailRegex = @"^(welcome|anna)(|\\+(.*))@wire\\.co
 
 - (BOOL)isBot
 {
-    static NSRegularExpression *botRegEx = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        NSError *regexParseError = nil;
-        botRegEx = [[NSRegularExpression alloc] initWithPattern:UserBotEmailRegex options:NSRegularExpressionCaseInsensitive error:&regexParseError];
-        assert(regexParseError == nil);
-    });
-    
-    if (self.emailAddress.length == 0) {
-        return NO;
-    }
-    NSRange matchRange = [botRegEx rangeOfFirstMatchInString:self.emailAddress options:NSMatchingAnchored range:NSMakeRange(0, self.emailAddress.length)];
-    
-    return ((matchRange.location == 0) && (matchRange.length == self.emailAddress.length));
+    return [self.handle isEqualToString:AnnaBotHandle] || [self.handle isEqualToString:OttoBotHandle];
 }
 
 - (BOOL)canBeConnected;

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1661,23 +1661,12 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    user.emailAddress = @"anna+123@wire.com";
+    user.handle = @"annathebot";
     
     // then
     XCTAssertTrue(user.isBot);
 }
 
-- (void)testThatItDetectsSimpleAnnaAsBot
-{
-    // given
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    
-    // when
-    user.emailAddress = @"anna@wire.com";
-    
-    // then
-    XCTAssertTrue(user.isBot);
-}
 
 - (void)testThatItDetectsOttoAsBot
 {
@@ -1685,7 +1674,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    user.emailAddress = @"welcome+321@wire.com";
+    user.handle = @"ottothebot";
     
     // then
     XCTAssertTrue(user.isBot);
@@ -1697,43 +1686,16 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    user.emailAddress = @"ivan@ivanovich.com";
+    user.handle = @"florence";
     
     // then
     XCTAssertFalse(user.isBot);
 }
 
-- (void)testThatItDoesNotDetectPrefixedName
+- (void)testThatItDoesNotDetectUserWithoutHandleAsBot
 {
     // given
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    
-    // when
-    user.emailAddress = @"annalisa@wire.com";
-    
-    // then
-    XCTAssertFalse(user.isBot);
-}
-
-- (void)testThatItDoesNotDetectWireUserAsBot
-{
-    // given
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    
-    // when
-    user.emailAddress = @"ivan@wire.com";
-    
-    // then
-    XCTAssertFalse(user.isBot);
-}
-
-- (void)testThatItDoesNotDetectEmptyEmailAsBot
-{
-    // given
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    
-    // when
-    user.emailAddress = @"";
     
     // then
     XCTAssertFalse(user.isBot);


### PR DESCRIPTION
# Reason for this pull request
Detection of bots (as opposed to users) was done by comparing emails. Since emails are gone, detection is now done with handles.