### PR TITLE
Collections: do not show gifs in the list

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -115,19 +115,6 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     var destructionDate: Date? { get }
 }
 
-extension ZMConversationMessage {
-    
-    /// Message category
-    public var categorization : MessageCategory {
-        guard let message = self as? ZMMessage else {
-            return .none
-        }
-        return message.category
-    }
-    
-}
-
-
 // MARK:- Conversation managed properties
 extension ZMMessage {
     

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -710,6 +710,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     
     if (nil != self.imageMessageData) {
         [self processAddedImageWithFormat:format properties:properties encryptionKeys:keys];
+        [self updateCategoryCache];
     } else if (nil != self.fileMessageData) {
         [self processAddedFilePreviewWithFormat:format properties:properties encryptionKeys:keys imageData:imageData];
     } else {

--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -258,6 +258,37 @@ public struct MessageCategory : OptionSet {
     }
 }
 
+extension MessageCategory : CustomDebugStringConvertible {
+
+    fileprivate static let descriptions: [MessageCategory : String] = [
+        .undefined : "Undefined",
+        .text : "Text",
+        .link : "Link",
+        .image : "Image",
+        .GIF : "GIF",
+        .file : "File",
+        .audio : "Audio",
+        .video : "Video",
+        .location : "Location",
+        .liked : "Liked",
+        .knock : "Knock",
+        .systemMessage : "System message",
+        .excludedFromCollection : "Excluded from collection",
+        .linkPreview : "Link preview"
+    ]
+
+    public var debugDescription: String {
+        let categories = MessageCategory.descriptions
+            .filter { (category, _) -> Bool in
+                return contains(category)
+            }.map { (_, description) -> String in
+                return description
+            }
+        let description = categories.isEmpty ? "None" : categories.joined(separator: ", ")
+        return description
+    }
+}
+
 extension MessageCategory : Hashable {
     
     public var hashValue : Int {

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -21,6 +21,14 @@ import ZMUtilities
 import ZMCDataModel
 import ZMCLinkPreview
 
+extension ZMConversationMessage {
+    var categorization : MessageCategory {
+        guard let message = self as? ZMMessage else {
+            return .none
+        }
+        return message.category
+    }
+}
 
 class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
     

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -22,7 +22,7 @@ import ZMCDataModel
 import ZMCLinkPreview
 
 extension ZMConversationMessage {
-    var categorization : MessageCategory {
+    fileprivate var categorization : MessageCategory {
         guard let message = self as? ZMMessage else {
             return .none
         }

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -118,7 +118,21 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.image, MessageCategory.excludedFromCollection])
     }
-    
+
+    func testThatItUpdatesCachedCategoryAfterSettingFullImageData() {
+        // GIVEN
+        let conversation = ZMConversation(remoteID: .create(), createIfNeeded: true, in: syncMOC)!
+        let data = self.data(forResource: "animated", extension: "gif")!
+        conversation.appendMessage(withImageData: data)
+
+        let message = conversation.messages.lastObject as! ZMAssetClientMessage
+        let testProperties = ZMIImageProperties(size: CGSize(width: 33, height: 55), length: UInt(10), mimeType: "image/gif")
+        message.imageAssetStorage!.setImageData(data, for: .medium, properties: testProperties)
+
+        // THEN
+        XCTAssertEqual(message.cachedCategory, [MessageCategory.image, MessageCategory.GIF])
+    }
+
     func testThatItCategorizesAGifImageMessage() {
         
         // GIVEN

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -127,6 +127,10 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
 
         let message = conversation.messages.lastObject as! ZMAssetClientMessage
         let testProperties = ZMIImageProperties(size: CGSize(width: 33, height: 55), length: UInt(10), mimeType: "image/gif")
+
+        XCTAssertEqual(message.cachedCategory, [MessageCategory.image])
+
+        // WHEN
         message.imageAssetStorage!.setImageData(data, for: .medium, properties: testProperties)
 
         // THEN


### PR DESCRIPTION
## What does it fix?

In the collections we shouldn't show GIFs to save download data, but it was showing up for the sender.

## What's in this PR?

Message category is cached, but was getting out of sync and didn't have the information that we can get after processing the image. In this case the image message category was not updated to reflect that it's a GIF.