### PR TITLE
Make sure security warning when a conversation degraded is displayed once only

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -88,6 +88,9 @@ extern NSString *const ZMConversationInternalEstimatedUnreadCountKey;
 extern NSString *const ZMConversationLastUnreadKnockDateKey;
 extern NSString *const ZMConversationLastUnreadMissedCallDateKey;
 extern NSString *const ZMConversationLastReadLocalTimestampKey;
+
+extern NSString *const SecurityLevelKey;
+
 NS_ASSUME_NONNULL_END
 
 @interface ZMConversation (Internal)

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -85,6 +85,7 @@ NSString *const ZMConversationClearTypingNotificationName = @"ZMConversationClea
 NSString *const ZMConversationIsVerifiedNotificationName = @"ZMConversationIsVerifiedNotificationName";
 NSString *const ZMConversationFailedToDecryptMessageNotificationName = @"ZMConversationFailedToDecryptMessageNotificationName";
 NSString *const ZMConversationLastReadDidChangeNotificationName = @"ZMConversationLastReadDidChangeNotification";
+NSString *const SecurityLevelKey = @"securityLevel";
 
 static NSString *const CallStateNeedsToBeUpdatedFromBackendKey = @"callStateNeedsToBeUpdatedFromBackend";
 static NSString *const ConnectedUserKey = @"connectedUser";
@@ -102,7 +103,6 @@ static NSString *const VoiceChannelStateKey = @"voiceChannelState";
 static NSString *const CallDeviceIsActiveKey = @"callDeviceIsActive";
 static NSString *const IsFlowActiveKey = @"isFlowActive";
 
-static NSString *const SecurityLevelKey = @"securityLevel";
 static NSString *const MessageDestructionTimeoutKey = @"messageDestructionTimeout";
 
 

--- a/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
@@ -27,7 +27,7 @@ public protocol ZMGeneralConversationObserver {
 extension ZMConversation : ObjectInSnapshot {
     
     public var observableKeys : [String] {
-        var keys = ["messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "activeFlowParticipants", "callParticipants", "isSilenced", "securityLevel", "otherActiveVideoCallParticipants", "displayName", "estimatedUnreadCount", "clearedTimeStamp"]
+        var keys = ["messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "activeFlowParticipants", "callParticipants", "isSilenced", SecurityLevelKey, "otherActiveVideoCallParticipants", "displayName", "estimatedUnreadCount", "clearedTimeStamp"]
         if self.conversationType == .group {
             keys.append("otherActiveParticipants")
             keys.append("isSelfAnActiveMember")
@@ -60,7 +60,7 @@ open class GeneralConversationChangeInfo : ObjectChangeInfo {
     }
     
     fileprivate var keysForConversationChangeInfo : Set<String> {
-        return Set(arrayLiteral: "messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "isSilenced", "otherActiveParticipants", "isSelfAnActiveMember", "displayName", "relatedConnectionState", "estimatedUnreadCount", "clearedTimeStamp", "securityLevel")
+        return Set(arrayLiteral: "messages", "lastModifiedDate", "isArchived", "conversationListIndicator", "voiceChannelState", "isSilenced", "otherActiveParticipants", "isSelfAnActiveMember", "displayName", "relatedConnectionState", "estimatedUnreadCount", "clearedTimeStamp", SecurityLevelKey)
     }
     
     fileprivate var keysForCallParticipantsChangeInfo : Set <String> {
@@ -228,7 +228,7 @@ class GeneralConversationObserverToken<T: NSObject> : ObjectObserverTokenContain
     }
 
     public var securityLevelChanged : Bool {
-        return changedKeysAndOldValues.keys.contains("securityLevel")
+        return changedKeysAndOldValues.keys.contains(SecurityLevelKey)
     }
 
     
@@ -265,7 +265,8 @@ extension ConversationChangeInfo {
     /// might have added a participant or renamed the conversation (causing a
     /// system message to be inserted)
     fileprivate var recentNewClientsSystemMessageWithExpiredMessages : ZMSystemMessage? {
-        if(!self.securityLevelChanged || self.conversation.securityLevel != .secureWithIgnored) {
+        let previousSecurityLevel = (self.previousValueForKey(SecurityLevelKey) as? NSNumber).flatMap { ZMConversationSecurityLevel(rawValue: $0.int16Value) }
+        if(!self.securityLevelChanged || self.conversation.securityLevel != .secureWithIgnored || previousSecurityLevel == nil) {
             return .none;
         }
         var foundSystemMessage : ZMSystemMessage? = .none

--- a/Tests/Source/Model/Observer/ObjectObserverToken/ConversationObserverTokenTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/ConversationObserverTokenTests.swift
@@ -648,7 +648,7 @@ class ConversationObserverTokenTests : ZMBaseManagedObjectTest {
                 conversation.securityLevel = .secure
             },
             expectedChangedField: "securityLevelChanged" ,
-            expectedChangedKeys: KeySet(key: "securityLevel"))
+            expectedChangedKeys: KeySet(key: SecurityLevelKey))
     }
     
     func testThatItStopsNotifyingAfterUnregisteringTheToken() {


### PR DESCRIPTION
# Reason for this pull request
When a conversation degrades from verified to not verified with a message, if the app is killed and restarted, the takeover warning of the degradation is displayed again at every restart.

# Changes
- Do not display the takeover if the conversation snapshot had no security level (e.g. there was no snapshot). It means that we just restarted the app. The message will still not be sent anyway (it is already marked as "expired") in any case.
- Remove magic string