### PR TITLE
Fix test failure after last PR

### DIFF
--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -296,7 +296,7 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         XCTAssertEqual(receivedMessages.count, 0)
         
         XCTAssertTrue(delegate.didCallDelegate)
-        XCTAssertEqual(delegate.result, .success)
+        XCTAssertEqual(delegate.result, .noAssetsToFetch)
     }
     
     func testThatItFetchesImagesAndTextMessages(){


### PR DESCRIPTION
In #131 the behaviour for fetching images was changed slightly and there was one failing test. On closer inspection the new result makes more sense.