### PR TITLE
Add ability to mark messages that have degraded a conversation

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+UserInfoMerge.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+UserInfoMerge.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension NSManagedObjectContext {
+    
+    /// Will merge all relevant user info data from another context (e.g. sync to UI, or UI to sync)
+    public func mergeUserInfo(fromUserInfo userInfo: [String: Any]) {
+        self.mergeSecurityLevelDegradationInfo(fromUserInfo: userInfo)
+    }
+}

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -113,6 +113,10 @@ public protocol ZMConversationMessage : NSObjectProtocol {
 
     /// Returns the date when a ephemeral message will be destructed or `nil` if th message is not ephemeral
     var destructionDate: Date? { get }
+    
+    /// Returns whether this is a message that caused the security level of the conversation to degrade in this session (since the 
+    /// app was restarted)
+    var causedSecurityLevelDegradation : Bool { get }
 }
 
 // MARK:- Conversation managed properties
@@ -130,6 +134,10 @@ extension ZMMessage {
 // MARK:- Conversation Message protocol implementation
 
 extension ZMMessage : ZMConversationMessage {
+    
+    public var causedSecurityLevelDegradation : Bool {
+        return false
+    }
 }
 
 extension ZMMessage {

--- a/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
+++ b/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension ZMOTRMessage {
+    
+    /// Whether the message caused security level degradation (from verified to unverified)
+    /// in this user session (i.e. since the app was started. This will be kept in memory
+    /// and not persisted). This flag can be set only from the sync context. It can be read
+    /// from any context.
+    override public var causedSecurityLevelDegradation : Bool {
+        get {
+            return self.managedObjectContext?.messagesThatCausedSecurityLevelDegradation.contains(self.objectID) ?? false
+        }
+        set {
+            guard let moc = self.managedObjectContext else { return }
+            guard moc.zm_isSyncContext else { fatal("Cannot set security level on non-sync moc") }
+            var set = moc.messagesThatCausedSecurityLevelDegradation
+            if newValue {
+                set.insert(self.objectID)
+            } else {
+                set.remove(self.objectID)
+            }
+            moc.messagesThatCausedSecurityLevelDegradation = set
+        }
+    }
+    
+}
+
+private let messagesThatCausedSecurityLevelDegradationKey = "ZM_messagesThatCausedSecurityLevelDegradation"
+
+extension NSManagedObjectContext {
+    
+    /// Non-persisted list of messages that caused security level degradation
+    fileprivate(set) var messagesThatCausedSecurityLevelDegradation : Set<NSManagedObjectID> {
+        get {
+            return self.userInfo[messagesThatCausedSecurityLevelDegradationKey] as? Set<NSManagedObjectID> ?? Set<NSManagedObjectID>()
+        }
+        set {
+            self.userInfo[messagesThatCausedSecurityLevelDegradationKey] = newValue
+        }
+    }
+    
+    /// Merge list of messages that caused security level degradation from one message to another
+    func mergeSecurityLevelDegradationInfo(fromUserInfo userInfo: [String: Any]) {
+        guard self.zm_isUserInterfaceContext else { return } // we don't merge anything to sync, sync is autoritative
+        self.messagesThatCausedSecurityLevelDegradation = userInfo[messagesThatCausedSecurityLevelDegradationKey] as? Set<NSManagedObjectID> ?? Set<NSManagedObjectID>()
+    }
+    
+}

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
@@ -1,0 +1,154 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import ZMUtilities
+import ZMCDataModel
+import ZMCLinkPreview
+
+
+class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
+    
+    func testThatAtCreationAMessageIsNotCausingDegradation_UIMoc() {
+        
+        // GIVEN
+        let convo = createConversation(moc: self.uiMOC)
+        
+        // WHEN
+        let message = convo.appendMessage(withText: "Foo")!
+        
+        // THEN
+        XCTAssertFalse(message.causedSecurityLevelDegradation)
+    }
+    
+    func testThatAtCreationAMessageIsNotCausingDegradation_SyncMoc() {
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let convo = self.createConversation(moc: self.syncMOC)
+            
+            // WHEN
+            let message = convo.appendMessage(withText: "Foo")!
+            
+            // THEN
+            XCTAssertFalse(message.causedSecurityLevelDegradation)
+        }
+    }
+    
+    func testThatItSetsMessageAsCausingDegradation_SyncMoc() {
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let convo = self.createConversation(moc: self.syncMOC)
+            let message = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+            
+            // WHEN
+            message.causedSecurityLevelDegradation = true
+            
+            // THEN
+            XCTAssertTrue(message.causedSecurityLevelDegradation)
+        }
+    }
+    
+    func testThatItResetsMessageAsCausingDegradation_SyncMoc() {
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let convo = self.createConversation(moc: self.syncMOC)
+            let message = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+            message.causedSecurityLevelDegradation = true
+            
+            // WHEN
+            message.causedSecurityLevelDegradation = false
+            
+            // THEN
+            XCTAssertFalse(message.causedSecurityLevelDegradation)
+        }
+    }
+}
+
+// MARK: - Propagation across contexes
+extension ZMOTRMessage_SecurityDegradationTests {
+    
+    func testThatMessageIsNotMarkedOnUIMOCBeforeMerge() {
+        // GIVEN
+        let convo = createConversation(moc: self.uiMOC)
+        let message = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+        self.uiMOC.saveOrRollback()
+        
+        // WHEN
+        self.syncMOC.performGroupedBlockAndWait { 
+            let syncMessage = try! self.syncMOC.existingObject(with: message.objectID) as! ZMOTRMessage
+            syncMessage.causedSecurityLevelDegradation = true
+            self.syncMOC.saveOrRollback()
+        }
+        
+        // THEN
+        XCTAssertFalse(message.causedSecurityLevelDegradation)
+    }
+    
+    func testThatMessageIsMarkedOnUIMOCAfterMerge() {
+        // GIVEN
+        let convo = createConversation(moc: self.uiMOC)
+        let message = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+        self.uiMOC.saveOrRollback()
+        var userInfo : [String: Any] = [:]
+        self.syncMOC.performGroupedBlockAndWait {
+            let syncMessage = try! self.syncMOC.existingObject(with: message.objectID) as! ZMOTRMessage
+            syncMessage.causedSecurityLevelDegradation = true
+            self.syncMOC.saveOrRollback()
+            userInfo = self.syncMOC.userInfo.asDictionary() as! [String: Any]
+        }
+        
+        // WHEN
+        self.uiMOC.mergeUserInfo(fromUserInfo: userInfo)
+        
+        // THEN
+        XCTAssertTrue(message.causedSecurityLevelDegradation)
+    }
+    
+    func testThatItPreservesMessgesMargedOnSyncMOCAfterMerge() {
+        self.syncMOC.performGroupedBlockAndWait {
+            // GIVEN
+            let convo = self.createConversation(moc: self.syncMOC)
+            let message = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+            message.causedSecurityLevelDegradation = true
+            
+            // WHEN
+            self.syncMOC.mergeUserInfo(fromUserInfo: [:])
+            
+            // THEN
+            XCTAssertTrue(message.causedSecurityLevelDegradation)
+        }
+    }
+}
+
+// MARK: - Helper
+extension ZMOTRMessage_SecurityDegradationTests {
+    
+    /// Creates a group conversation with two users
+    func createConversation(moc: NSManagedObjectContext) -> ZMConversation {
+        let user1 = ZMUser.insertNewObject(in: moc)
+        user1.remoteIdentifier = UUID.create()
+        let user2 = ZMUser.insertNewObject(in: moc)
+        user2.remoteIdentifier = UUID.create()
+        let convo = ZMConversation.insertGroupConversation(into: moc, withParticipants: [user1, user2])!
+        return convo
+    }
+    
+}

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		54363A011D7876200048FD7D /* ZMClientMessage+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */; };
 		54363A031D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54363A021D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift */; };
 		544034341D6DFE8500860F2D /* ZMAddressBookContactTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544034331D6DFE8500860F2D /* ZMAddressBookContactTests.swift */; };
+		544A46AE1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */; };
+		544E8C0F1E2F69EB00F9B8B8 /* ZMOTRMessage+SecurityDegradationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544E8C0D1E2F69E800F9B8B8 /* ZMOTRMessage+SecurityDegradationTests.swift */; };
+		544E8C111E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544E8C101E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift */; };
 		54563B761E0161730089B1D7 /* ZMMessage+Categorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */; };
 		54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */; };
 		546D3DE61CE5D0B100A6047F /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546D3DE51CE5D0B100A6047F /* MimeType.swift */; };
@@ -399,6 +402,9 @@
 		54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Encryption.swift"; sourceTree = "<group>"; };
 		54363A021D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Encryption.swift"; sourceTree = "<group>"; };
 		544034331D6DFE8500860F2D /* ZMAddressBookContactTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMAddressBookContactTests.swift; sourceTree = "<group>"; };
+		544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+SecurityDegradation.swift"; sourceTree = "<group>"; };
+		544E8C0D1E2F69E800F9B8B8 /* ZMOTRMessage+SecurityDegradationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+SecurityDegradationTests.swift"; sourceTree = "<group>"; };
+		544E8C101E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+UserInfoMerge.swift"; sourceTree = "<group>"; };
 		5454C0911E01AEF700D13C4B /* zmessaging2.25.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.25.0.xcdatamodel; sourceTree = "<group>"; };
 		54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Categorization.swift"; sourceTree = "<group>"; };
 		54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMMessageCategorizationTests.swift; sourceTree = "<group>"; };
@@ -923,6 +929,7 @@
 				F9A705CC1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h */,
 				F9A705CD1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.m */,
 				F93265201D8950F10076AAD6 /* NSManagedObjectContext+FetchRequest.swift */,
+				544E8C101E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift */,
 				F9A705D01CAEE01D00C2F5FE /* NSNotification+ManagedObjectContextSave.h */,
 				F9A705D11CAEE01D00C2F5FE /* NSNotification+ManagedObjectContextSave.m */,
 				F9A705D21CAEE01D00C2F5FE /* ZMSyncMergePolicy.h */,
@@ -1027,6 +1034,7 @@
 				54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */,
 				F9A706011CAEE01D00C2F5FE /* ZMOTRMessage.h */,
 				F9A706021CAEE01D00C2F5FE /* ZMOTRMessage.m */,
+				544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */,
 				F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
 			);
@@ -1344,6 +1352,7 @@
 				F963E9841D9D47D100098AD3 /* ZMClientMessageTests+Ephemeral.swift */,
 				F963E9921D9E9D1800098AD3 /* ZMAssetClientMessageTests+Ephemeral.swift */,
 				54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */,
+				544E8C0D1E2F69E800F9B8B8 /* ZMOTRMessage+SecurityDegradationTests.swift */,
 			);
 			name = Messages;
 			path = Tests/Source/Model/Messages;
@@ -1912,6 +1921,7 @@
 				F9A706AF1CAEE01D00C2F5FE /* ManagedObjectContextObserver.swift in Sources */,
 				BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */,
 				54EDE67E1CBBF0AB0044A17E /* ZMGenericMessageImageOwner.swift in Sources */,
+				544A46AE1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift in Sources */,
 				54563B761E0161730089B1D7 /* ZMMessage+Categorization.swift in Sources */,
 				F9A706B11CAEE01D00C2F5FE /* MessageWindowChangeToken.swift in Sources */,
 				166902411D7493EB000FE4AF /* ZMTestSession.m in Sources */,
@@ -1939,6 +1949,7 @@
 				BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */,
 				546D3DE61CE5D0B100A6047F /* MimeType.swift in Sources */,
 				F963E9761D9C002000098AD3 /* ZMGenericMessage+Assets.swift in Sources */,
+				544E8C111E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift in Sources */,
 				54CD460A1DEDA55C00BA3429 /* AddressBookEntry.swift in Sources */,
 				BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */,
 				BF2ADF631E28CF1E00E81B1E /* SharedModifiedConversationsList.swift in Sources */,
@@ -2030,6 +2041,7 @@
 				F9B71F9C1CB2BF18001DB03F /* ZMCallStateTests.swift in Sources */,
 				F9B71F951CB2BF08001DB03F /* ZMDisplayNameGeneratorTests.m in Sources */,
 				F9B71FEE1CB2C4C6001DB03F /* ManagedObjectChangesTests.swift in Sources */,
+				544E8C0F1E2F69EB00F9B8B8 /* ZMOTRMessage+SecurityDegradationTests.swift in Sources */,
 				F9B720041CB2C770001DB03F /* UserClientTests.swift in Sources */,
 				1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */,
 				F9A708521CAEEB7500C2F5FE /* ZMFetchRequestBatchTests.m in Sources */,


### PR DESCRIPTION
# Reason for this pull request
Add ability to mark messages that have degraded a conversation. This info is kept in memory, not persisted, hence it needs to be merged between contexts manually. 
The actual marking when we receive a 412 will be done in another PR (potentially in WireMessageStrategy, still have to check)

# Changes
- added generic method to merge user info from a different context
- added ability to mark a message as causing conversation degradation (but only on the sync context)