### PR TITLE
Better message expiration/resend in case of security degradation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+MessageDeletion.swift
+++ b/Source/Model/Conversation/ZMConversation+MessageDeletion.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension ZMConversation {
+
+    /// Appends a "message was delete" system message
+    public func appendDeletedForEveryoneSystemMessage(at date: Date, sender: ZMUser) {
+        _ = self.appendSystemMessage(type: .messageDeletedForEveryone,
+                                     sender: sender,
+                                     users: nil,
+                                     clients: nil,
+                                     timestamp: date)
+        
+    }
+}

--- a/Source/Model/Conversation/ZMConversation+NotifyOnUI.swift
+++ b/Source/Model/Conversation/ZMConversation+NotifyOnUI.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMConversation {
+
+    /// Sends a notification with the given name on the UI context
+    func notifyOnUI(notification: String) {
+        self.managedObjectContext?.zm_userInterface .performGroupedBlock {
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: notification), object: self)
+        }
+    }
+    
+}

--- a/Source/Model/Conversation/ZMConversation+OTR.swift
+++ b/Source/Model/Conversation/ZMConversation+OTR.swift
@@ -51,9 +51,7 @@ extension ZMConversation {
         guard self.decreaseSecurityLevelIfNeeded() else { return }
         self.appendNewAddedClientSystemMessage(added: clients, before: message)
         if let message = message {
-            if message.deliveryState != .sent && message.deliveryState != .delivered {
-                self.expireAllPendingMessages(staringFrom: message)
-            }
+            self.expireAllPendingMessages(staringFrom: message)
         }
     }
 
@@ -121,22 +119,14 @@ extension ZMConversation {
                                      clients: clients,
                                      timestamp: serverTimestamp)
     }
-
-    public func appendDeletedForEveryoneSystemMessage(at date: Date, sender: ZMUser) {
-        _ = self.appendSystemMessage(type: .messageDeletedForEveryone,
-                                     sender: sender,
-                                     users: nil,
-                                     clients: nil,
-                                     timestamp: date)
-
-    }
     
     /// Expire all pending message after the given message, including the given message
     private func expireAllPendingMessages(staringFrom startingMessage: ZMMessage) {
         self.messages.enumerateObjects(options: .reverse) { (msg, idx, stop) in
-            guard let message = msg as? ZMMessage else { return }
+            guard let message = msg as? ZMOTRMessage else { return }
             if message.deliveryState != .delivered && message.deliveryState != .sent {
                 message.expire()
+                message.causedSecurityLevelDegradation = true
             }
             if startingMessage == message {
                 stop.initialize(to: true)
@@ -147,7 +137,7 @@ extension ZMConversation {
     /// Decrease the security level if some clients are now not trusted
     /// - returns: true if the security level was decreased
     private func decreaseSecurityLevelIfNeeded() -> Bool {
-        guard !self.trusted && self.securityLevel == .secure else { return false }
+        guard !self.allUsersTrusted && self.securityLevel == .secure else { return false }
         self.securityLevel = .secureWithIgnored
         return true
     }
@@ -155,7 +145,7 @@ extension ZMConversation {
     /// Increase the security level if all clients are now trusted
     /// - returns: true if the security level was increased
     private func increaseSecurityLevelIfNeeded() -> Bool {
-        guard self.trusted && self.allParticipantsHaveClients else { return false }
+        guard self.allUsersTrusted && self.allParticipantsHaveClients else { return false }
         self.securityLevel = .secure
         return true
     }
@@ -165,7 +155,7 @@ extension ZMConversation {
 extension ZMConversation {
 
     /// Replaces the first NewClient systemMessage for the selfClient with a UsingNewDevice system message
-    func replaceNewClientMessageIfNeededWithNewDeviceMesssage() {
+    public func replaceNewClientMessageIfNeededWithNewDeviceMesssage() {
 
         let selfUser = ZMUser.selfUser(in: self.managedObjectContext!)
         guard let selfClient = selfUser.selfClient() else { return }
@@ -237,7 +227,7 @@ extension ZMConversation {
                                      timestamp: self.timestamp(after: self.messages.lastObject as? ZMMessage))
     }
     
-    fileprivate func appendSystemMessage(type: ZMSystemMessageType,
+    func appendSystemMessage(type: ZMSystemMessageType,
                                          sender: ZMUser,
                                          users: Set<ZMUser>?,
                                          clients: Set<UserClient>?,
@@ -277,14 +267,14 @@ extension ZMConversation {
         // then in this case one of them will be out of order
         return timestamp.addingTimeInterval(0.001)
     }
-
 }
 
 // MARK: - Conversation participants status
 extension ZMConversation {
     
     /// Returns true if all participants are connected to the self user and all participants are trusted
-    public var trusted : Bool {
+    public var allUsersTrusted : Bool {
+        guard self.activeParticipants.count > 0 else { return false }
         let hasOnlyTrustedUsers = (self.activeParticipants.array as! [ZMUser]).first { !$0.trusted() } == nil
         return hasOnlyTrustedUsers && !self.containsUnconnectedParticipant
     }
@@ -300,16 +290,6 @@ extension ZMConversation {
     /// If true the conversation might still be trusted / ignored
     public var hasUntrustedClients : Bool {
         return (self.activeParticipants.array as! [ZMUser]).first { $0.untrusted() } != nil
-    }
-}
-
-// MARK: - Notifications
-extension ZMConversation {
-    
-    func notifyOnUI(notification: String) {
-        self.managedObjectContext?.zm_userInterface .performGroupedBlock {
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: notification), object: self)
-        }
     }
 }
 

--- a/Source/Model/Conversation/ZMConversation+OTR.swift
+++ b/Source/Model/Conversation/ZMConversation+OTR.swift
@@ -309,7 +309,7 @@ extension ZMConversation {
     
     /// Returns true if all participants are connected to the self user and all participants are trusted
     public var allUsersTrusted : Bool {
-        guard self.activeParticipants.count > 0 else { return false }
+        guard self.otherActiveParticipants.count > 0, self.isSelfAnActiveMember else { return false }
         let hasOnlyTrustedUsers = (self.activeParticipants.array as! [ZMUser]).first { !$0.trusted() } == nil
         return hasOnlyTrustedUsers && !self.containsUnconnectedParticipant
     }

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -868,17 +868,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return [self mutableOrderedSetValueForKey:LastServerSyncedActiveParticipantsKey];
 }
 
-
-- (void)resendLastUnsentMessages
-{
-    [self.messages enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(ZMMessage *message, __unused NSUInteger idx, BOOL *stop) {
-        if (message.isExpired) {
-            [message resend];
-            *stop = YES;
-        }
-    }];
-}
-
 @end
 
 

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -130,9 +130,6 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 /// Appends a location, see @c LocationData.
 - (nullable id<ZMConversationMessage>)appendMessageWithLocationData:(nonnull ZMLocationData *)locationData;
 
-/// Resend last non sent messages
-- (void)resendLastUnsentMessages;
-
 @end
 
 @interface ZMConversation (History)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -447,7 +447,7 @@
 
 }
 
-- (void)testThatAConversationIsNotTrustedIfItHasNoParticipants
+- (void)testThatAConversationIsNotTrustedIfItHasNoOtherParticipants
 {
     // GIVEN
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -455,8 +455,27 @@
     
     // THEN
     XCTAssertFalse(conversation.allUsersTrusted);
-    
 }
+
+- (void)testThatAConversationIsNotTrustedIfNotAMemberAnymore
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    [conversation addParticipant:otherUser];
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
+    client.user = otherUser;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    [[selfUser selfClient] trustClient:client];
+    
+    // WHEN
+    [conversation removeParticipant:selfUser];
+    
+    // THEN
+    XCTAssertFalse(conversation.allUsersTrusted);
+}
+
 @end
 
 #pragma mark - Resending / cancelling messages in degraded conversation

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -20,11 +20,11 @@
 #import "ZMConversationTests.h"
 #import "ZMConversation+Transport.h"
 
-@interface ZMConversationTests (OTR)
+@interface ZMConversationSecurityTests : ZMConversationTestsBase
 
 @end
 
-@implementation ZMConversationTests (OTR)
+@implementation ZMConversationSecurityTests
 
 - (NSArray<ZMUser *> *)createUsersWithClientsOnSyncMOC
 {
@@ -460,7 +460,7 @@
 @end
 
 #pragma mark - Resending / cancelling messages in degraded conversation
-@implementation ZMConversationTests (ResendingMessages)
+@implementation ZMConversationSecurityTests (ResendingMessages)
 
 - (void)testItExpiresAllMessagesAfterTheCurrentOneWhenAMessageCausesDegradation
 {
@@ -596,7 +596,7 @@
 @end
 
 #pragma mark - Hotfix
-@implementation ZMConversationTests (HotFix)
+@implementation ZMConversationSecurityTests (HotFix)
 
 - (void)testThatItUpdatesFirstNewClientSystemMessage
 {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -457,6 +457,10 @@
     XCTAssertFalse(conversation.allUsersTrusted);
     
 }
+@end
+
+#pragma mark - Resending / cancelling messages in degraded conversation
+@implementation ZMConversationTests (ResendingMessages)
 
 - (void)testItExpiresAllMessagesAfterTheCurrentOneWhenAMessageCausesDegradation
 {
@@ -469,8 +473,6 @@
         ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
         conversation.securityLevel = ZMConversationSecurityLevelSecure;
 
-        ZMOTRMessage *message1 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
-        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
         ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
         [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
         ZMOTRMessage *message3 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
@@ -488,8 +490,6 @@
         [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message3];
         
         // THEN
-        XCTAssertFalse(message1.isExpired);
-        XCTAssertFalse(message1.causedSecurityLevelDegradation);
         XCTAssertFalse(message2.isExpired);
         XCTAssertFalse(message2.causedSecurityLevelDegradation);
         XCTAssertTrue(message3.isExpired);
@@ -503,9 +503,99 @@
     }];
 }
 
+- (void)testItResendsAllMessagesThatCausedDegradation
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // GIVEN
+        [self createSelfClient];
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.conversationType = ZMConversationTypeGroup;
+        ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
+        conversation.securityLevel = ZMConversationSecurityLevelSecure;
+        
+        ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message3 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message4 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 4" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message5 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"aabbccdd";
+        client.user = user;
+        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message3];
+        
+        // WHEN
+        [conversation resendMessagesThatCausedConversationSecurityDegradation];
+        
+        // THEN
+        XCTAssertFalse(message2.isExpired);
+        XCTAssertFalse(message2.causedSecurityLevelDegradation);
+        XCTAssertFalse(message3.isExpired);
+        XCTAssertFalse(message3.causedSecurityLevelDegradation);
+        XCTAssertEqual(message3.deliveryState, ZMDeliveryStatePending);
+        XCTAssertFalse(message4.isExpired);
+        XCTAssertFalse(message4.causedSecurityLevelDegradation);
+        XCTAssertEqual(message4.deliveryState, ZMDeliveryStatePending);
+        XCTAssertFalse(message5.isExpired);
+        XCTAssertFalse(message5.causedSecurityLevelDegradation);
+        XCTAssertEqual(message5.deliveryState, ZMDeliveryStatePending);
+        XCTAssertFalse(conversation.allUsersTrusted);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+    }];
+}
+
+- (void)testItCancelsAllMessagesThatCausedDegradation
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // GIVEN
+        [self createSelfClient];
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.conversationType = ZMConversationTypeGroup;
+        ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
+        conversation.securityLevel = ZMConversationSecurityLevelSecure;
+        
+        ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message3 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message4 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 4" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message5 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"aabbccdd";
+        client.user = user;
+        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message3];
+        
+        // WHEN
+        [conversation doNotResendMessagesThatCausedDegradation];
+        
+        // THEN
+        XCTAssertFalse(message2.isExpired);
+        XCTAssertFalse(message2.causedSecurityLevelDegradation);
+        XCTAssertTrue(message3.isExpired);
+        XCTAssertFalse(message3.causedSecurityLevelDegradation);
+        XCTAssertEqual(message3.deliveryState, ZMDeliveryStateFailedToSend);
+        XCTAssertTrue(message4.isExpired);
+        XCTAssertFalse(message4.causedSecurityLevelDegradation);
+        XCTAssertEqual(message4.deliveryState, ZMDeliveryStateFailedToSend);
+        XCTAssertTrue(message5.isExpired);
+        XCTAssertFalse(message5.causedSecurityLevelDegradation);
+        XCTAssertEqual(message5.deliveryState, ZMDeliveryStateFailedToSend);
+        XCTAssertFalse(conversation.allUsersTrusted);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+    }];
+}
+
 @end
 
-
+#pragma mark - Hotfix
 @implementation ZMConversationTests (HotFix)
 
 - (void)testThatItUpdatesFirstNewClientSystemMessage

--- a/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+OTR.m
@@ -88,7 +88,7 @@
         [selfClient trustClients:connectedUser.clients];
         
         // then
-        XCTAssertFalse(conversation.trusted);
+        XCTAssertFalse(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelNotSecure);
         
         // when
@@ -96,7 +96,7 @@
         [selfClient trustClients:unconnectedUser.clients];
         
         // then
-        XCTAssertTrue(conversation.trusted);
+        XCTAssertTrue(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
         
         ZMUser *newUnconnectedUser = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
@@ -107,14 +107,14 @@
         [conversation addParticipant:newUnconnectedUser];
         
         // then the conversation should degrade
-        XCTAssertFalse(conversation.trusted);
+        XCTAssertFalse(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
         
         // when
         [conversation removeParticipant:newUnconnectedUser];
         
         // then
-        XCTAssertTrue(conversation.trusted);
+        XCTAssertTrue(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
     }];
 }
@@ -298,21 +298,22 @@
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
 }
 
-- (void)insertUserInConversation:(ZMConversation *)conversation userIsTrusted:(BOOL)trusted
+- (ZMUser *)insertUserInConversation:(ZMConversation *)conversation userIsTrusted:(BOOL)trusted managedObjectContext:(NSManagedObjectContext *)moc
 {
     [self createSelfClient];
     [self.uiMOC refreshAllObjects];
     
-    UserClient *selfClient = [ZMUser selfUserInContext:self.uiMOC].selfClient;
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    UserClient *selfClient = [ZMUser selfUserInContext:moc].selfClient;
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:moc];
     [[conversation mutableOtherActiveParticipants] addObject:user];
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
+    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:moc];
     client.user  = user;
     if (trusted) {
         [selfClient trustClient:client];
     } else {
         [selfClient ignoreClient:client];
     }
+    return user;
 }
 
 - (void)testThatItReturns_HasUntrustedClients_YES_ifThereAreUntrustedClients
@@ -322,7 +323,7 @@
     conversation.conversationType = ZMConversationTypeGroup;
 
     // when
-    [self insertUserInConversation:conversation userIsTrusted:NO];
+    [self insertUserInConversation:conversation userIsTrusted:NO managedObjectContext:self.uiMOC];
     BOOL hasUntrustedClients = conversation.hasUntrustedClients;
     
     // then
@@ -337,7 +338,7 @@
     conversation.conversationType = ZMConversationTypeGroup;
     
     // when
-    [self insertUserInConversation:conversation userIsTrusted:YES];
+    [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.uiMOC];
     BOOL hasUntrustedClients = conversation.hasUntrustedClients;
     
     // then
@@ -444,6 +445,62 @@
     XCTAssertLessThan([previousMessage.serverTimestamp timeIntervalSince1970], [message.serverTimestamp timeIntervalSince1970]);
     XCTAssertEqualWithAccuracy([[NSDate date] timeIntervalSince1970], [message.serverTimestamp timeIntervalSince1970], 1.0);
 
+}
+
+- (void)testThatAConversationIsNotTrustedIfItHasNoParticipants
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    
+    // THEN
+    XCTAssertFalse(conversation.allUsersTrusted);
+    
+}
+
+- (void)testItExpiresAllMessagesAfterTheCurrentOneWhenAMessageCausesDegradation
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // GIVEN
+        [self createSelfClient];
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.conversationType = ZMConversationTypeGroup;
+        ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
+        conversation.securityLevel = ZMConversationSecurityLevelSecure;
+
+        ZMOTRMessage *message1 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message3 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message4 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 4" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message5 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"aabbccdd";
+        client.user = user;
+        
+        // WHEN
+        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message3];
+        
+        // THEN
+        XCTAssertFalse(message1.isExpired);
+        XCTAssertFalse(message1.causedSecurityLevelDegradation);
+        XCTAssertFalse(message2.isExpired);
+        XCTAssertFalse(message2.causedSecurityLevelDegradation);
+        XCTAssertTrue(message3.isExpired);
+        XCTAssertTrue(message3.causedSecurityLevelDegradation);
+        XCTAssertTrue(message4.isExpired);
+        XCTAssertTrue(message4.causedSecurityLevelDegradation);
+        XCTAssertTrue(message5.isExpired);
+        XCTAssertTrue(message5.causedSecurityLevelDegradation);
+        XCTAssertFalse(conversation.allUsersTrusted);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+    }];
 }
 
 @end

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Timestamp.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Timestamp.m
@@ -21,7 +21,7 @@
 #import "ZMConversation+Timestamps.h"
 #import "ZMConversation+Internal.h"
 
-@interface ZMConversationTests_Timestamp : ZMConversationTests
+@interface ZMConversationTests_Timestamp : ZMConversationTestsBase
 @end
 
 @implementation ZMConversationTests_Timestamp

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -20,11 +20,10 @@
 #import "ZMConversationTests.h"
 #import "ZMConversation+Transport.h"
 
-@interface ZMConversationTests (Transport)
-
+@interface ZMConversationTransportTests : ZMConversationTestsBase
 @end
 
-@implementation ZMConversationTests (Transport)
+@implementation ZMConversationTransportTests
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation conversationType:(ZMBackendConversationType)conversationType isArchived:(BOOL)isArchived archivedRef:(NSDate *)archivedRef isSilenced:(BOOL)isSilenced
     silencedRef: (NSDate *)silencedRef;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+UnreadCount.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+UnreadCount.m
@@ -21,12 +21,11 @@
 #import "ZMConversationTests.h"
 #import "ZMConversation+UnreadCount.h"
 
-
-@interface ZMConversationTests (UnreadCount)
+@interface ZMConversationUnreadCountTests : ZMConversationTestsBase
 @end
 
 
-@implementation ZMConversationTests (UnreadCount)
+@implementation ZMConversationUnreadCountTests
 
 
 - (ZMMessage *)insertMessageIntoConversation:(ZMConversation *)conversation sender:(ZMUser *)sender  timeSinceLastRead:(NSTimeInterval)intervalSinceLastRead
@@ -213,7 +212,7 @@
 
 
 
-@implementation ZMConversationTests (HasUnreadMissedCall)
+@implementation ZMConversationUnreadCountTests (HasUnreadMissedCall)
 
 - (void)testThatItSetsHasUnreadMissedCallToNoWhenLastReadEqualsLastServerTime
 {
@@ -304,7 +303,7 @@
 
 
 
-@implementation ZMConversationTests (HasUnreadKnock)
+@implementation ZMConversationUnreadCountTests (HasUnreadKnock)
 
 - (void)testThatItSetsHasUnreadKnockToNoWhenLastReadEqualsLastTimestamp
 {
@@ -365,7 +364,7 @@
 
 
 
-@implementation ZMConversationTests (HasUnreadUnsentMessage)
+@implementation ZMConversationUnreadCountTests (HasUnreadUnsentMessage)
 
 - (void)testThatItResetsHasUnreadUnsentMessage
 {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Validation.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Validation.m
@@ -21,7 +21,10 @@
 
 #import "ZMConversationTests.h"
 
-@implementation ZMConversationTests (Validation)
+@interface ZMConversationValidationTests : ZMConversationTestsBase
+@end
+
+@implementation ZMConversationValidationTests
 
 - (void)testThatItTrimmsTheUserDefinedNameForLeadingAndTrailingWhitespace;
 {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
@@ -21,7 +21,10 @@
 #import "ZMConversationList+Internal.h"
 
 
-@implementation ZMConversationTests (ConversationWindow)
+@interface ZMConversationGapsAndWindowTests : ZMConversationTestsBase
+@end
+
+@implementation ZMConversationGapsAndWindowTests
 
 
 - (void)testThatItInsertsANewConversation

--- a/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
@@ -20,8 +20,10 @@
 #import "ZMConversationTests.h"
 #import "ZMClientMessage.h"
 
+@interface ZMConversationMessagesTests : ZMConversationTestsBase
+@end
 
-@implementation ZMConversationTests (Messages)
+@implementation ZMConversationMessagesTests
 
 - (void)testThatWeCanInsertATextMessage;
 {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -20,8 +20,10 @@
 #import "ZMConversationTests.h"
 #import "ZMConversation+Transport.h"
 
+@interface ZMConversationParticipantsTests : ZMConversationTestsBase
+@end
 
-@implementation ZMConversationTests (Participants)
+@implementation ZMConversationParticipantsTests
 
 - (void)testThatUpdatingUsersFromTransportDataPreservesUnsyncedInactiveAndActiveParticipants
 {
@@ -1047,7 +1049,7 @@
 
 
 
-@implementation ZMConversationTests (ConnectedUser)
+@implementation ZMConversationParticipantsTests (ConnectedUser)
 
 - (void)testThatTheConnectedUserIsNilForGroupConversation
 {
@@ -1106,7 +1108,7 @@
 @end
 
 
-@implementation ZMConversationTests (Sorting)
+@implementation ZMConversationParticipantsTests (Sorting)
 
 - (void)testThatItSortsParticipantsByFullName
 {

--- a/Tests/Source/Model/Conversation/ZMConversationTests.h
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.h
@@ -23,7 +23,7 @@
 #import "ZMMessage+Internal.h"
 #import "ZMConnection+Internal.h"
 
-@interface ZMConversationTests : ModelObjectsTests
+@interface ZMConversationTestsBase : ModelObjectsTests
 
 @property(nonatomic) NSNotification *lastReceivedNotification;
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -35,7 +35,7 @@
 #import "ZMConversation+Transport.h"
 
 
-@interface ZMConversationTests ()
+@interface ZMConversationTestsBase ()
 
 @property (nonatomic) NSMutableArray *receivedNotifications;
 
@@ -50,7 +50,7 @@
 @end
 
 
-@implementation ZMConversationTests
+@implementation ZMConversationTestsBase
 
 - (void)setUp;
 {
@@ -166,7 +166,15 @@
 @end
 
 
-@implementation ZMConversationTests (General)
+
+
+@interface ZMConversationTests : ZMConversationTestsBase
+
+@end
+
+
+
+@implementation ZMConversationTests
 
 - (void)testThatItSetsTheSelfUserAsCreatorWhenCreatingAGroupConversationFromTheUI
 {

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		544E8C131E2F825700F9B8B8 /* ZMConversation+OTR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544E8C121E2F825700F9B8B8 /* ZMConversation+OTR.swift */; };
 		54563B761E0161730089B1D7 /* ZMMessage+Categorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */; };
 		54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */; };
+		545FA5D71E2FD3750054171A /* ZMConversation+MessageDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545FA5D61E2FD3750054171A /* ZMConversation+MessageDeletion.swift */; };
+		545FA5D91E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545FA5D81E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift */; };
 		546D3DE61CE5D0B100A6047F /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546D3DE51CE5D0B100A6047F /* MimeType.swift */; };
 		546D3DE91CE5D24C00A6047F /* MimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */; };
 		5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5473CC721E14245C00814C03 /* NSManagedObjectContext+Debugging.swift */; };
@@ -408,6 +410,8 @@
 		5454C0911E01AEF700D13C4B /* zmessaging2.25.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.25.0.xcdatamodel; sourceTree = "<group>"; };
 		54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Categorization.swift"; sourceTree = "<group>"; };
 		54563B791E0189750089B1D7 /* ZMMessageCategorizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMMessageCategorizationTests.swift; sourceTree = "<group>"; };
+		545FA5D61E2FD3750054171A /* ZMConversation+MessageDeletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+MessageDeletion.swift"; sourceTree = "<group>"; };
+		545FA5D81E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+NotifyOnUI.swift"; sourceTree = "<group>"; };
 		546D3DE51CE5D0B100A6047F /* MimeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MimeTypeTests.swift; sourceTree = "<group>"; };
 		5473CC721E14245C00814C03 /* NSManagedObjectContext+Debugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Debugging.swift"; sourceTree = "<group>"; };
@@ -977,6 +981,8 @@
 				F9B71F171CB264EF001DB03F /* ZMConversation+Trace.h */,
 				F9B71F101CB264EF001DB03F /* ZMConversation.m */,
 				F92C99291DAFBC910034AFDD /* ZMConversation+Ephemeral.swift */,
+				545FA5D81E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift */,
+				545FA5D61E2FD3750054171A /* ZMConversation+MessageDeletion.swift */,
 				BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */,
 				BF2ADF621E28CF1E00E81B1E /* SharedModifiedConversationsList.swift */,
 				544E8C121E2F825700F9B8B8 /* ZMConversation+OTR.swift */,
@@ -1914,6 +1920,7 @@
 			files = (
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
 				CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */,
+				545FA5D71E2FD3750054171A /* ZMConversation+MessageDeletion.swift in Sources */,
 				F9A706AF1CAEE01D00C2F5FE /* ManagedObjectContextObserver.swift in Sources */,
 				BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */,
 				54EDE67E1CBBF0AB0044A17E /* ZMGenericMessageImageOwner.swift in Sources */,
@@ -2010,6 +2017,7 @@
 				F9A7067F1CAEE01D00C2F5FE /* ZMImageMessage.m in Sources */,
 				5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */,
 				BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */,
+				545FA5D91E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift in Sources */,
 				F9A706991CAEE01D00C2F5FE /* ZMManagedObject.m in Sources */,
 				F9C9A74A1CAE6DA00039E10C /* CallingInitialisationNotification.swift in Sources */,
 				16DCB6631DDA2715002A7AC2 /* PersistentStoreRelocator.swift in Sources */,


### PR DESCRIPTION
# Reason for this pull request
The detection of which messages caused the conversation to degrade the security level was a bit hacky, and it would case a few issues (takeover displayed at every restart, resending of all expired messages even if they were expired for other reasons).
This PR make it possible to resend/cancel only those messages that caused the conversation to degrade.

# Changes
- Also fixed test subclassing (it was causing the same tests to be run many times)
- Also extracted methods not related to conversation degradation, as mentioned in https://github.com/wireapp/wire-ios-data-model/pull/135