### PR TITLE
Refactor common code and fix using wrong context

### DIFF
--- a/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
+++ b/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
@@ -32,6 +32,9 @@ extension ZMOTRMessage {
         set {
             guard let moc = self.managedObjectContext else { return }
             guard moc.zm_isSyncContext else { fatal("Cannot set security level on non-sync moc") }
+            if self.objectID.isTemporaryID {
+                try! moc.obtainPermanentIDs(for: [self])
+            }
             var set = moc.messagesThatCausedSecurityLevelDegradation
             if newValue {
                 set.insert(self.objectID)


### PR DESCRIPTION
# Reason for this pull request
Changing the flag `causedSecurityLevelDegradation` is supped to be done only on the sync context. The code in `resendMessagesThatCausedConversationSecurityDegradation` and `doNotResendMessagesThatCausedDegradation` was modifying it on the UI context. 

# Changes
- Also addressing the issue with duplicated code mentioned in: https://github.com/wireapp/wire-ios-data-model/pull/136
