### PR TITLE
Fix/detect degrading messages

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -667,6 +667,7 @@ static dispatch_once_t clearStoreOnceToken;
         }
         [tp warnIfLongerThanInterval];
         [self refreshUnneededObjects];
+        self.zm_hasUserInfoChanges = NO;
     }
     else {
         ZMLogDebug(@"Not saving because there is no change");

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -173,6 +173,7 @@ extension ZMConversation {
                     stop.initialize(to: true)
                 }
             }
+            syncMOC.saveOrRollback()
         }
     }
     

--- a/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
+++ b/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
@@ -27,34 +27,64 @@ extension ZMOTRMessage {
     /// from any context.
     override public var causedSecurityLevelDegradation : Bool {
         get {
-            return self.managedObjectContext?.messagesThatCausedSecurityLevelDegradation.contains(self.objectID) ?? false
+            guard let conversation = self.conversation, let moc = self.managedObjectContext else { return false }
+            let messagesByConversation = moc.messagesThatCausedSecurityLevelDegradationByConversation
+            guard let messages = messagesByConversation[conversation.objectID] else { return false }
+            return messages.contains(self.objectID)
         }
         set {
-            guard let moc = self.managedObjectContext else { return }
+            guard let conversation = self.conversation, let moc = self.managedObjectContext else { return }
             guard moc.zm_isSyncContext else { fatal("Cannot set security level on non-sync moc") }
+            
+            // make sure it's persisted
             if self.objectID.isTemporaryID {
                 try! moc.obtainPermanentIDs(for: [self])
             }
-            var set = moc.messagesThatCausedSecurityLevelDegradation
-            if newValue {
-                set.insert(self.objectID)
-            } else {
-                set.remove(self.objectID)
+            if conversation.objectID.isTemporaryID {
+                try! moc.obtainPermanentIDs(for: [conversation])
             }
-            moc.messagesThatCausedSecurityLevelDegradation = set
+            
+            // set
+            var dictionary = moc.messagesThatCausedSecurityLevelDegradationByConversation
+            var messagesForConversation = dictionary[conversation.objectID] ?? Set()
+            if newValue {
+                messagesForConversation.insert(self.objectID)
+            } else {
+                messagesForConversation.remove(self.objectID)
+            }
+            if messagesForConversation.isEmpty {
+                dictionary.removeValue(forKey: conversation.objectID)
+            } else {
+                dictionary[conversation.objectID] = messagesForConversation
+            }
+            moc.messagesThatCausedSecurityLevelDegradationByConversation = dictionary
         }
     }
+}
+
+extension ZMConversation {
     
+    /// Whether the message caused security level degradation (from verified to unverified)
+    /// in this user session (i.e. since the app was started. This will be kept in memory
+    /// and not persisted). This flag can be set only from the sync context. It can be read
+    /// from any context.
+    public var didDegradeSecurityLevel : Bool {
+        get {
+            return self.managedObjectContext?.messagesThatCausedSecurityLevelDegradationByConversation.keys.contains(self.objectID) ?? false
+        }
+    }
 }
 
 private let messagesThatCausedSecurityLevelDegradationKey = "ZM_messagesThatCausedSecurityLevelDegradation"
 
+typealias SecurityDegradingMessagesByConversation = [NSManagedObjectID : Set<NSManagedObjectID>]
+
 extension NSManagedObjectContext {
     
-    /// Non-persisted list of messages that caused security level degradation
-    fileprivate(set) var messagesThatCausedSecurityLevelDegradation : Set<NSManagedObjectID> {
+    /// Non-persisted list of messages that caused security level degradation, indexed by conversation
+    fileprivate(set) var messagesThatCausedSecurityLevelDegradationByConversation : SecurityDegradingMessagesByConversation {
         get {
-            return self.userInfo[messagesThatCausedSecurityLevelDegradationKey] as? Set<NSManagedObjectID> ?? Set<NSManagedObjectID>()
+            return self.userInfo[messagesThatCausedSecurityLevelDegradationKey] as? SecurityDegradingMessagesByConversation ?? SecurityDegradingMessagesByConversation()
         }
         set {
             self.userInfo[messagesThatCausedSecurityLevelDegradationKey] = newValue
@@ -64,7 +94,7 @@ extension NSManagedObjectContext {
     /// Merge list of messages that caused security level degradation from one message to another
     func mergeSecurityLevelDegradationInfo(fromUserInfo userInfo: [String: Any]) {
         guard self.zm_isUserInterfaceContext else { return } // we don't merge anything to sync, sync is autoritative
-        self.messagesThatCausedSecurityLevelDegradation = userInfo[messagesThatCausedSecurityLevelDegradationKey] as? Set<NSManagedObjectID> ?? Set<NSManagedObjectID>()
+        let valuesToMerge = userInfo[messagesThatCausedSecurityLevelDegradationKey] as? SecurityDegradingMessagesByConversation
+        self.messagesThatCausedSecurityLevelDegradationByConversation = valuesToMerge ?? SecurityDegradingMessagesByConversation()
     }
-    
 }

--- a/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
+++ b/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
@@ -58,6 +58,7 @@ extension ZMOTRMessage {
                 dictionary[conversation.objectID] = messagesForConversation
             }
             moc.messagesThatCausedSecurityLevelDegradationByConversation = dictionary
+            moc.zm_hasUserInfoChanges = true
         }
     }
 }
@@ -70,6 +71,7 @@ extension ZMConversation {
     /// from any context.
     public var didDegradeSecurityLevel : Bool {
         get {
+            let conversationsDictionary = self.managedObjectContext?.messagesThatCausedSecurityLevelDegradationByConversation
             return self.managedObjectContext?.messagesThatCausedSecurityLevelDegradationByConversation.keys.contains(self.objectID) ?? false
         }
     }

--- a/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
@@ -270,7 +270,7 @@ extension ConversationChangeInfo {
             return .none;
         }
         var foundSystemMessage : ZMSystemMessage? = .none
-        var foundExpiredMessage = false
+        var foundDegradingMessage = false
         self.conversation.messages.enumerateObjects(options: NSEnumerationOptions.reverse) { (msg, _, stop) -> Void in
             if let systemMessage = msg as? ZMSystemMessage {
                 if systemMessage.systemMessageType == .newClient {
@@ -281,11 +281,11 @@ extension ConversationChangeInfo {
                     systemMessage.systemMessageType == .conversationIsSecure {
                         stop.pointee = true
                 }
-            } else if let sentMessage = msg as? ZMMessage , sentMessage.isExpired {
-                foundExpiredMessage = true
+            } else if let sentMessage = msg as? ZMMessage , sentMessage.causedSecurityLevelDegradation {
+                foundDegradingMessage = true
             }
         }
-        return foundExpiredMessage ? foundSystemMessage : .none
+        return foundDegradingMessage ? foundSystemMessage : .none
     }
     
     /// True if the conversation was just degraded

--- a/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationObserverToken.swift
@@ -265,10 +265,7 @@ extension ConversationChangeInfo {
     /// might have added a participant or renamed the conversation (causing a
     /// system message to be inserted)
     fileprivate var recentNewClientsSystemMessageWithExpiredMessages : ZMSystemMessage? {
-        let previousSecurityLevel = (self.previousValueForKey(SecurityLevelKey) as? NSNumber).flatMap { ZMConversationSecurityLevel(rawValue: $0.int16Value) }
-        if(!self.securityLevelChanged || self.conversation.securityLevel != .secureWithIgnored || previousSecurityLevel == nil) {
-            return .none;
-        }
+        guard self.conversation.didDegradeSecurityLevel else { return nil }
         var foundSystemMessage : ZMSystemMessage? = .none
         var foundDegradingMessage = false
         self.conversation.messages.enumerateObjects(options: NSEnumerationOptions.reverse) { (msg, _, stop) -> Void in

--- a/Source/VoiceChannel/ZMCallState.swift
+++ b/Source/VoiceChannel/ZMCallState.swift
@@ -49,6 +49,8 @@ public enum ZMCallStateReasonToLeave : UInt {
     }
 }
 
+private let userInfoHasChangesKey = "zm_userInfoHasChanges"
+
 extension NSManagedObjectContext {
     
     public var zm_callState: ZMCallState {
@@ -61,11 +63,21 @@ extension NSManagedObjectContext {
         }()
     }
     
+    /// True if the context has some changes in the user info that should cause a save
+    public var zm_hasUserInfoChanges : Bool {
+        get {
+            return (self.userInfo[userInfoHasChangesKey] as? Bool) ?? false
+        }
+        set {
+            self.userInfo[userInfoHasChangesKey] = newValue
+        }
+    }
+    
     /// Checks hasChanges and callStateHasChanges.
     ///
     /// The call state changes do not dirty the context's objects, hence need to be tracked / checked seperately.
     public var zm_hasChanges: Bool {
-        return hasChanges || callStateHasChanges
+        return hasChanges || callStateHasChanges || self.zm_hasUserInfoChanges
     }
 
     public var callStateHasChanges: Bool {

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
@@ -338,3 +338,47 @@
 
 @end
 
+
+
+@implementation ManagedObjectContextTests (UserInfoChanges)
+
+- (void)testThatItDoesNotSaveWhenThereAreNoUserInfoChanges {
+    
+    // GIVEN
+    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    
+    // WHEN
+    [self.uiMOC saveOrRollback];
+    
+    // THEN
+    XCTAssertFalse([self waitForCustomExpectationsWithTimeout:0.001]);
+}
+
+- (void)testThatItSaveWhenThereAreUserInfoChanges {
+    
+    // GIVEN
+    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    self.uiMOC.zm_hasUserInfoChanges = YES;
+    
+    // WHEN
+    [self.uiMOC saveOrRollback];
+    
+    // THEN
+    XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.1]);
+}
+
+- (void)testThatItResetsUserInfoChangesAfterASave {
+    
+    // GIVEN
+    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    self.uiMOC.zm_hasUserInfoChanges = YES;
+    
+    // WHEN
+    [self.uiMOC saveOrRollback];
+    
+    // THEN
+    XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.1]);
+    XCTAssertFalse(self.uiMOC.zm_hasUserInfoChanges);
+}
+
+@end

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -553,6 +553,13 @@
         client.user = user;
         [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message2];
         [self.syncMOC saveOrRollback];
+        
+        XCTAssertFalse(message1.isExpired);
+        XCTAssertFalse(message1.causedSecurityLevelDegradation);
+        XCTAssertTrue(message2.isExpired);
+        XCTAssertTrue(message2.causedSecurityLevelDegradation);
+        XCTAssertTrue(message3.isExpired);
+        XCTAssertTrue(message3.causedSecurityLevelDegradation);
     }];
     
     // WHEN

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
@@ -31,10 +31,12 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
         
         // WHEN
         let message = convo.appendMessage(withText: "Foo")!
+        self.uiMOC.saveOrRollback()
         
         // THEN
         XCTAssertFalse(message.causedSecurityLevelDegradation)
         XCTAssertFalse(convo.didDegradeSecurityLevel)
+        XCTAssertFalse(self.uiMOC.zm_hasChanges)
     }
     
     func testThatAtCreationAMessageIsNotCausingDegradation_SyncMoc() {
@@ -49,7 +51,6 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
             XCTAssertFalse(convo.didDegradeSecurityLevel)
-
         }
     }
     
@@ -62,10 +63,12 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // WHEN
             message.causedSecurityLevelDegradation = true
+            self.syncMOC.saveOrRollback()
             
             // THEN
             XCTAssertTrue(message.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.didDegradeSecurityLevel)
+            XCTAssertTrue(self.syncMOC.zm_hasChanges)
 
         }
     }
@@ -80,10 +83,13 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // WHEN
             message.causedSecurityLevelDegradation = false
+            self.syncMOC.saveOrRollback()
+
             
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
             XCTAssertFalse(convo.didDegradeSecurityLevel)
+            XCTAssertTrue(self.syncMOC.zm_hasChanges)
 
         }
     }
@@ -108,10 +114,12 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // and WHEN
             message2.causedSecurityLevelDegradation = false
+            self.syncMOC.saveOrRollback()
             
             // THEN
             XCTAssertFalse(message2.causedSecurityLevelDegradation)
             XCTAssertFalse(convo.didDegradeSecurityLevel)
+            XCTAssertTrue(self.syncMOC.zm_hasChanges)
             
         }
     }

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
@@ -34,6 +34,7 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
         
         // THEN
         XCTAssertFalse(message.causedSecurityLevelDegradation)
+        XCTAssertFalse(convo.didDegradeSecurityLevel)
     }
     
     func testThatAtCreationAMessageIsNotCausingDegradation_SyncMoc() {
@@ -47,10 +48,12 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
+            XCTAssertFalse(convo.didDegradeSecurityLevel)
+
         }
     }
     
-    func testThatItSetsMessageAsCausingDegradation_SyncMoc() {
+    func testThatItSetsMessageAsCausingDegradation() {
         
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
@@ -62,10 +65,12 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // THEN
             XCTAssertTrue(message.causedSecurityLevelDegradation)
+            XCTAssertTrue(convo.didDegradeSecurityLevel)
+
         }
     }
     
-    func testThatItResetsMessageAsCausingDegradation_SyncMoc() {
+    func testThatItResetsMessageAsCausingDegradation() {
         
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
@@ -78,6 +83,36 @@ class ZMOTRMessage_SecurityDegradationTests : ZMBaseManagedObjectTest {
             
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
+            XCTAssertFalse(convo.didDegradeSecurityLevel)
+
+        }
+    }
+    
+    func testThatItResetsDegradedConversationWhenRemovingAllMessages() {
+        
+        self.syncMOC.performGroupedBlockAndWait {
+            
+            // GIVEN
+            let convo = self.createConversation(moc: self.syncMOC)
+            let message1 = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+            message1.causedSecurityLevelDegradation = true
+            let message2 = convo.appendMessage(withText: "Foo")! as! ZMOTRMessage
+            message2.causedSecurityLevelDegradation = true
+            
+            // WHEN
+            message1.causedSecurityLevelDegradation = false
+            
+            // THEN
+            XCTAssertFalse(message1.causedSecurityLevelDegradation)
+            XCTAssertTrue(convo.didDegradeSecurityLevel)
+            
+            // and WHEN
+            message2.causedSecurityLevelDegradation = false
+            
+            // THEN
+            XCTAssertFalse(message2.causedSecurityLevelDegradation)
+            XCTAssertFalse(convo.didDegradeSecurityLevel)
+            
         }
     }
 }


### PR DESCRIPTION
# Reason for this pull request
The information about messages that caused degradation was stored in the user info, which is normally not saved if there is no other change. Also we want to store which conversation were degraded, not just the messages.

# Changes
- zm_userInfoHasChanges