### PR TITLE
Set status to "done" when expiring

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -199,7 +199,7 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
         return;
     }
     if (self.uploadState != ZMAssetUploadStateDone) {
-        self.uploadState = ZMAssetUploadStateUploadingFailed;
+        self.uploadState = ZMAssetUploadStateDone;
     }
     if (self.transferState == ZMFileTransferStateUploading) {
         self.transferState = ZMFileTransferStateFailedUpload;

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -269,7 +269,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         XCTAssertFalse(sut.delivered)
         XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
-        XCTAssertEqual(sut.uploadState, ZMAssetUploadState.uploadingFailed)
+        XCTAssertEqual(sut.uploadState, ZMAssetUploadState.done)
         XCTAssertTrue(sut.isExpired)
     }
     
@@ -285,7 +285,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         XCTAssertFalse(sut.delivered)
         XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
-        XCTAssertEqual(sut.uploadState, ZMAssetUploadState.uploadingFailed)
+        XCTAssertEqual(sut.uploadState, ZMAssetUploadState.done)
         XCTAssertTrue(sut.isExpired)
     }
     


### PR DESCRIPTION
If the upload status is set to "failed" for files, it will upload the "failed to upload" placeholder. When we want to expire a message, we instead should set the transfer state to failed and the upload status to "done".