### PR TITLE
Dispatch to correct thread

### DIFF
--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -137,6 +137,7 @@ public class AssetCollection : NSObject, ZMCollection {
         }
     }
 
+    // NB: Method is expected to be run only on sync queue.
     private func fetchNextIfNotTornDown(limit: Int, type: MessagesToFetch, syncConversation: ZMConversation){
         guard !fetchingDone, !tornDown else { return }
         guard !syncConversation.isZombieObject else {

--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -177,7 +177,7 @@ public class AssetCollection : NSObject, ZMCollection {
         
         // Categorize messages
         let newAssets = AssetCollectionBatched.messageMap(messages: messagesToAnalyze, matchingCategories: self.matchingCategories)
-        conversation.managedObjectContext?.enqueueDelayedSave()
+        syncConversation.managedObjectContext?.enqueueDelayedSave()
         
         // Notify delegate
         self.notifyDelegate(newAssets: newAssets, type: type, didReachLastMessage: didReachLastMessage)
@@ -187,7 +187,7 @@ public class AssetCollection : NSObject, ZMCollection {
             return
         }
         
-        conversation.managedObjectContext?.performGroupedBlock { [weak self] in
+        syncConversation.managedObjectContext?.performGroupedBlock { [weak self] in
             guard let `self` = self, !self.tornDown else { return }
             self.fetchNextIfNotTornDown(limit: AssetCollection.defaultFetchCount, type: type, syncConversation: syncConversation)
         }


### PR DESCRIPTION
# Issue

When running with CoreData threading sanitizer the app used to crash on opening the collection. 

# Investigation

`conversation` appears to refer to instance method that is the conversation passed in as the parameter. It is created on UI context. `syncConversation` is the one to use on the sync context.