### PR TITLE
Only set the uploaded state to done when the placeholder was not yet uploaded

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -195,16 +195,19 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 
 - (void)expire {
     [super expire];
-    if (self.delivered) {
+
+    if (self.delivered || self.transferState != ZMFileTransferStateUploading) {
         return;
     }
 
     // When we expire an asset message because the conversation degraded we do not want to send
     // a `NOT UPLOADED` message. In all other cases we do want to sent a `NOT UPLOADED` message to let the
     // reveicers know we stopped uploading.
-    if (self.uploadState == ZMAssetUploadStateUploadingPlaceholder && self.transferState == ZMFileTransferStateUploading) {
+    if (self.uploadState == ZMAssetUploadStateUploadingPlaceholder) {
         self.uploadState = ZMAssetUploadStateDone;
         self.transferState = ZMFileTransferStateFailedUpload;
+    } else {
+        [self didFailToUploadFileData];
     }
 }
 

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -200,12 +200,13 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
         return;
     }
 
+    self.transferState = ZMFileTransferStateFailedUpload;
+
     // When we expire an asset message because the conversation degraded we do not want to send
     // a `NOT UPLOADED` message. In all other cases we do want to sent a `NOT UPLOADED` message to let the
     // reveicers know we stopped uploading.
     if (self.uploadState == ZMAssetUploadStateUploadingPlaceholder) {
         self.uploadState = ZMAssetUploadStateDone;
-        self.transferState = ZMFileTransferStateFailedUpload;
     } else {
         [self didFailToUploadFileData];
     }

--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -198,10 +198,12 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
     if (self.delivered) {
         return;
     }
-    if (self.uploadState != ZMAssetUploadStateDone) {
+
+    // When we expire an asset message because the conversation degraded we do not want to send
+    // a `NOT UPLOADED` message. In all other cases we do want to sent a `NOT UPLOADED` message to let the
+    // reveicers know we stopped uploading.
+    if (self.uploadState == ZMAssetUploadStateUploadingPlaceholder && self.transferState == ZMFileTransferStateUploading) {
         self.uploadState = ZMAssetUploadStateDone;
-    }
-    if (self.transferState == ZMFileTransferStateUploading) {
         self.transferState = ZMFileTransferStateFailedUpload;
     }
 }

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -272,6 +272,54 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.uploadState, ZMAssetUploadState.done)
         XCTAssertTrue(sut.isExpired)
     }
+
+    func testThatFileAssetMessageCanBeExpired_UploadingFullAsset() {
+        // given
+        let nonce = UUID.create()
+        let fileMetadata = addFile()
+        let sut = ZMAssetClientMessage(
+            fileMetadata: fileMetadata,
+            nonce: nonce,
+            managedObjectContext: uiMOC,
+            expiresAfter: 0)
+
+
+        sut.uploadState = .uploadingFullAsset
+
+        // when
+        sut.expire()
+
+        // then
+        XCTAssertNotNil(sut)
+        XCTAssertFalse(sut.delivered)
+        XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
+        XCTAssertEqual(sut.uploadState.rawValue, ZMAssetUploadState.uploadingFailed.rawValue)
+        XCTAssertTrue(sut.isExpired)
+    }
+
+    func testThatFileAssetMessageCanBeExpired_UploadingThumbnail() {
+        // given
+        let nonce = UUID.create()
+        let fileMetadata = addFile()
+        let sut = ZMAssetClientMessage(
+            fileMetadata: fileMetadata,
+            nonce: nonce,
+            managedObjectContext: uiMOC,
+            expiresAfter: 0)
+
+
+        sut.uploadState = .uploadingThumbnail
+
+        // when
+        sut.expire()
+
+        // then
+        XCTAssertNotNil(sut)
+        XCTAssertFalse(sut.delivered)
+        XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
+        XCTAssertEqual(sut.uploadState.rawValue, ZMAssetUploadState.uploadingFailed.rawValue)
+        XCTAssertTrue(sut.isExpired)
+    }
     
     func testThatImageMessageCanBeExpired() {
         


### PR DESCRIPTION
# What's in this PR?

* Only set the uploaded state to done when the placeholder was not yet uploaded
* When a conversation degrades we do not want to send a `Asset.NotUploaded` message, but in case we already sent the placeholder (which should not happen when the conversation did degrade) we want to send it.