### PR TITLE
Add method to recreate conversation lists when entering the foreground

### DIFF
--- a/Source/ConversationList/ZMConversationList.m
+++ b/Source/ConversationList/ZMConversationList.m
@@ -87,6 +87,11 @@
     return self.moc;
 }
 
+- (void)recreateWithAllConversations:(NSArray *)conversations
+{
+    [self createBackingList:conversations];
+}
+
 - (void)calculateKeysAffectingPredicateAndSort;
 {
     NSMutableSet *keysAffectingSorting = [NSMutableSet set];
@@ -209,6 +214,11 @@
 
 
 @implementation ZMConversationList (UserSession)
+
++ (void)refetchAllListsInUserSession:(id<ZMManagedObjectContextProvider>)session;
+{
+    [session.managedObjectContext.conversationListDirectory refetchAllListsInManagedObjectContext:session.managedObjectContext];
+}
 
 + (ZMConversationList *)conversationsIncludingArchivedInUserSession:(id<ZMManagedObjectContextProvider>)session;
 {

--- a/Source/ConversationList/ZMConversationListDirectory.h
+++ b/Source/ConversationList/ZMConversationListDirectory.h
@@ -21,6 +21,7 @@
 @import CoreData;
 @class ZMConversationList;
 @class ZMSharableConversations;
+@class NSManagedObjectContext;
 
 
 @interface ZMConversationListDirectory : NSObject
@@ -34,6 +35,10 @@
 @property (nonatomic, readonly, nonnull) ZMConversationList *clearedConversations; /// conversations with deleted messages (clearedTimestamp is set)
 
 - (nonnull NSArray *)allConversationLists;
+
+/// Refetches all conversation lists
+/// Call this when the app re-enters the foreground
+- (void)refetchAllListsInManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
 @end
 

--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -20,6 +20,7 @@
 #import "ZMConversationListDirectory.h"
 #import "ZMConversation+Internal.h"
 #import "ZMConversationList+Internal.h"
+#import <ZMCDataModel/ZMCDataModel-Swift.h>
 
 static NSString * const ConversationListDirectoryKey = @"ZMConversationListDirectory";
 
@@ -76,6 +77,15 @@ static NSString * const PendingKey = @"Pending";
     NSError *error;
     return [context executeFetchRequest:allConversationsRequest error:&error];
     NSAssert(error != nil, @"Failed to fetch");
+}
+
+- (void)refetchAllListsInManagedObjectContext:(NSManagedObjectContext *)moc
+{
+    NSArray *allConversations = [self fetchAllConversations:moc];
+    for (ZMConversationList* list in self.allConversationLists){
+        [list recreateWithAllConversations:allConversations];
+    }
+    [moc.globalManagedObjectContextObserver refreshConversationListObserverWithAllConversations:allConversations];
 }
 
 - (NSArray *)allConversationLists;

--- a/Source/Notifications/ObjectObserverTokens/ConversationListObserverToken.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationListObserverToken.swift
@@ -52,6 +52,11 @@ class InternalConversationListObserverToken: NSObject {
         super.init()
     }
     
+    func refreshState(){
+        guard let list = conversationList else { return }
+        self.state = SetSnapshot(set: list.toOrderedSet(), moveType: .uiCollectionView)
+    }
+    
     func notifyObserver(_ changedConversation: ZMConversation?, changes: ConversationChangeInfo?) {
         guard let conversationList = self.conversationList else {tearDown(); return}
         

--- a/Source/Notifications/ObjectObserverTokens/GlobalConversationObserver.swift
+++ b/Source/Notifications/ObjectObserverTokens/GlobalConversationObserver.swift
@@ -108,6 +108,14 @@ final class GlobalConversationObserver : NSObject, ObjectsDidChangeDelegate, ZMG
         }
     }
     
+    // Refresh the snapshots when the app re-enters the foreground
+    func refresh(allConversations: [ZMConversation]){
+        // Refresh the state of all existing tokens
+        internalConversationListObserverTokens.values.forEach{$0.refreshState()}
+        // Add new tokens for new conversations
+        registerTokensForConversations(allConversations)
+    }
+    
     func removeConversationList(_ conversationList: ZMConversationList) {
         self.conversationLists = self.conversationLists.filter { $0.unbox != conversationList}
     }

--- a/Source/Notifications/ObjectObserverTokens/ManagedObjectContextObserver.swift
+++ b/Source/Notifications/ObjectObserverTokens/ManagedObjectContextObserver.swift
@@ -467,6 +467,10 @@ extension ManagedObjectContextObserver {
         self.globalConversationObserver.removeConversationList(conversationList)
     }
     
+    public func refreshConversationListObserver(allConversations: [ZMConversation]){
+        self.globalConversationObserver.refresh(allConversations: allConversations)
+    }
+    
 }
 
 

--- a/Source/Public/ZMConversationList.h
+++ b/Source/Public/ZMConversationList.h
@@ -27,10 +27,18 @@
 
 - (void)resort;
 
+/// Call this when the app enters the background and reenters the foreground
+/// It recreates the backinglist and notifies the conversationlist observer center about the update
+- (void)recreateWithAllConversations:( NSArray * _Nonnull )conversations;
+
 @end
 
 
 @interface ZMConversationList (UserSession)
+
+/// Refetches all conversation lists and resets the snapshots
+/// Call this when the app re-enters the foreground
++ (void)refetchAllListsInUserSession:(nonnull id<ZMManagedObjectContextProvider>)session;
 
 + (nonnull ZMConversationList *)conversationsIncludingArchivedInUserSession:(nonnull id<ZMManagedObjectContextProvider>)session;
 + (nonnull ZMConversationList *)conversationsInUserSession:(nonnull id<ZMManagedObjectContextProvider>)session;

--- a/Tests/Source/Model/ConversationList/ZMConversationListTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListTests.m
@@ -28,6 +28,7 @@
 #import "ZMVoiceChannel+Testing.h"
 #import "ZMMessage+Internal.h"
 #import "NotificationObservers.h"
+#import "ZMConversationList.h"
 
 @interface ZMConversationListTests : ZMBaseManagedObjectTest
 @end
@@ -154,6 +155,57 @@
     XCTAssertEqual(list.count, 3u);
     NSArray *expected = @[c2, c1, c3];
     XCTAssertEqualObjects(list, expected);
+}
+
+- (void)testThatItRecreatesListsAndTokens
+{
+    // given
+    ZMConversation *c1 = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    c1.conversationType = ZMConversationTypeGroup;
+    c1.lastModifiedDate = [c1.lastModifiedDate dateByAddingTimeInterval:10];
+    
+    NSArray *list = [ZMConversation conversationsIncludingArchivedInContext:self.uiMOC];
+    ConversationListChangeObserver *obs = [[ConversationListChangeObserver alloc] initWithConversationList:(ZMConversationList *)list];
+    ZMConversation *c2;
+    
+    // when
+    // conversation is inserted while the app is in the background
+    {
+        self.uiMOC.globalManagedObjectContextObserver.propagateChanges = NO;
+        c2 = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+        c2.conversationType = ZMConversationTypeGroup;
+        c2.lastModifiedDate = [c1.lastModifiedDate dateByAddingTimeInterval:-20];
+        WaitForAllGroupsToBeEmpty(0.5);
+        
+        // then changes are not forwarded
+        NSArray *expected = @[c1];
+        XCTAssertEqualObjects(list, expected);
+        XCTAssertEqual(obs.notifications.count, 0u);
+    }
+    // and when
+    // refresh list and observer token
+    {
+        NSArray *allConversations = @[c1,c2];
+        [(ZMConversationList*)list recreateWithAllConversations:allConversations];
+        [self.uiMOC.globalManagedObjectContextObserver refreshConversationListObserverWithAllConversations:allConversations];
+        
+        // then list is updated
+        NSArray *expected = @[c1, c2];
+        XCTAssertEqualObjects(list, expected);
+    }
+    // and when
+    // forward accumulated changes
+    {
+        self.uiMOC.globalManagedObjectContextObserver.propagateChanges = YES;
+        WaitForAllGroupsToBeEmpty(0.5);
+
+        // then the updated snapshot prevents outdated list change notifications
+        XCTAssertEqual(obs.notifications.count, 0u);
+        NSArray *expected = @[c1, c2];
+        XCTAssertEqualObjects(list, expected);
+    }
+    [obs tearDown];
+
 }
 
 - (void)testThatItUpdatesWhenNewConversationsAreInserted


### PR DESCRIPTION
**In this PR**

We have the following bug: When the user is added to a new conversation while the app is in the background, the conversation does not show up in the list. The reason for this is that the list relies on the conversation observer to insert or remove conversations. The global conversation observer however does not receive notifications while in the background. 

Currently we are only resorting the list when reentering the foreground but this does not solve the case where the conversation was inserted  or deleted. Instead we should refetch all conversations and recreate the backinglists. At the same time we should make sure that the snapshots we keep of each list is recreated to avoid wrong change notifications.

This PR adds a new API for the UI `[ZMConversationList refetchAllListsInUserSession:]` which does all this: Recreating the backing list & refreshing the token snapshots.



