### PR TITLE
Apply patches on persisted data asynchronously to avoid blocking UI

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -205,6 +205,11 @@ static BOOL storeIsReady = NO;
         [moc setupUserKeyStoreForDirectory:keyStoreURL];
         moc.undoManager = nil;
         moc.mergePolicy = [[ZMSyncMergePolicy alloc] initWithMergeType:NSMergeByPropertyObjectTrumpMergePolicyType];
+    }];
+    [moc performGroupedBlock:^{
+        // this will be done async, not to block the UI thread, but
+        // enqueued on the syncMOC anyway, so it will execute before
+        // any other block of code has a chance to use it
         [moc applyPersistedDataPatchesForCurrentVersion];
     }];
     return moc;


### PR DESCRIPTION
# Reason for this pull request
Applying patches on the main thread (or more accurately, on the sync thread but having the main thread block waiting for it) will freeze the UI if the user has a big database