### PR TITLE
Fix cannot decrypt after verifying the device

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -265,7 +265,7 @@ public extension UserClient {
             if client.remoteIdentifier != selfClient.remoteIdentifier &&
                 fetchedClient == .none
             {
-                client.markForFetchingPreKeys()
+                client.fetchFingerprintOrPrekeys()
                 
                 if let selfClientActivationdate = selfClient.activationDate , client.activationDate?.compare(selfClientActivationdate) == .orderedDescending {
                     client.needsToNotifyUser = true
@@ -304,34 +304,48 @@ public extension UserClient {
         self.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMarkedToDeleteKey))
     }
     
+    @available(*, deprecated)
     public func markForFetchingPreKeys() {
-        guard let managedObjectContext = self.managedObjectContext,
-            let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()
-            , self.fingerprint == .none
+        self.fetchFingerprintOrPrekeys()
+    }
+    
+    public func fetchFingerprintOrPrekeys() {
+        guard self.fingerprint == .none,
+            let syncMOC = self.managedObjectContext?.zm_sync
             else { return }
         
-        if selfClient.remoteIdentifier == self.remoteIdentifier {
-            guard let syncMOC = self.managedObjectContext?.zm_sync,
-                let obj = try? syncMOC.existingObject(with: selfClient.objectID),
-                let syncClient = obj as? UserClient,
-                let sessionIdentifier = syncClient.sessionIdentifier
+        let selfObjectID = self.objectID
+        
+        syncMOC.performGroupedBlock({ [unowned syncMOC] () -> Void in
+            guard let obj = try? syncMOC.existingObject(with: selfObjectID),
+                  let syncClient = obj as? UserClient,
+                  let sessionIdentifier = syncClient.sessionIdentifier,
+                  let syncSelfClient = ZMUser.selfUser(in: syncMOC).selfClient()
                 else { return }
             
-            syncMOC.performGroupedBlock({ [unowned syncMOC] () -> Void in
-                syncClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
-                    syncClient.fingerprint = sessionsDirectory.fingerprint(for: sessionIdentifier)
-                    if syncClient.fingerprint == nil {
-                        zmLog.error("Cannot fetch local fingerprint for client \(syncClient)")
-                    } else {
-                        syncMOC.saveOrRollback()
-                    }
+            if syncSelfClient == syncClient {
+                syncSelfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
+                    syncClient.fingerprint = sessionsDirectory.localFingerprint
+                    syncMOC.saveOrRollback()
                 })
-                })
-        }
-        else {
-            selfClient.missesClient(self)
-            selfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
-        }
+            }
+            else {
+                if !syncClient.hasSessionWithSelfClient {
+                    syncSelfClient.missesClient(syncClient)
+                    syncSelfClient.setLocallyModifiedKeys(Set(arrayLiteral: ZMUserClientMissingKey))
+                }
+                else {
+                    syncSelfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
+                        syncClient.fingerprint = sessionsDirectory.fingerprint(for: sessionIdentifier)
+                        if syncClient.fingerprint == nil {
+                            zmLog.error("Cannot fetch fingerprint for client \(syncClient.sessionIdentifier!)")
+                        } else {
+                            syncMOC.saveOrRollback()
+                        }
+                    })
+                }
+            }
+        })
     }
 }
 
@@ -401,8 +415,15 @@ public extension UserClient {
         guard isSelfClient(), let sessionIdentifier = client.sessionIdentifier else { return false }
         
         var didEstablishSession = false
+        
         keysStore.encryptionContext.perform { (sessionsDirectory) in
-            sessionsDirectory.delete(sessionIdentifier)
+            
+            // Session is already established?
+            guard !sessionsDirectory.hasSession(for: sessionIdentifier) else {
+                zmLog.debug("Session with \(sessionIdentifier) is already established")
+                return
+            }
+            
             do {
                 try sessionsDirectory.createClientSession(sessionIdentifier, base64PreKeyString: preKey)
                 client.fingerprint = sessionsDirectory.fingerprint(for: sessionIdentifier)


### PR DESCRIPTION
# Issue

It was detected during the testing that opening the verification screen after having a chat with the participant and verifying his device is breaking the session with this device.

After investigating the behavior it came out that when we opened the screen with user device for the first time we requested the fingerprint for it if it was not there, and by making so the device was marked by accident as missing. This kicked in the request to download the device prekey and when it was done the session was deleted and recreated. This caused the session to be broken for the sender.

# Solution

The method to fetch fingerprint was refactored because it actually had some logical errors, also we are not forcing the session deletion when receiving the devices any more.