### PR TITLE
Set the user when inserting a new selfuser client

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -229,7 +229,7 @@ public class UserClient: ZMManagedObject, UserClientType {
 public extension UserClient {
 
     /// Use this method only for selfUser clients (selfClient + remote clients)
-    public static func createOrUpdateClient(_ payloadData: [String: AnyObject], context: NSManagedObjectContext) -> UserClient? {
+    public static func createOrUpdateSelfUserClient(_ payloadData: [String: AnyObject], context: NSManagedObjectContext) -> UserClient? {
         
         guard let id = payloadData["id"] as? String,
               let type = payloadData["type"] as? String
@@ -265,10 +265,12 @@ public extension UserClient {
         client.activationLocationLongitude = longitude
         client.remoteIdentifier = id
         
-        if let selfClient = ZMUser.selfUser(in: context).selfClient() {
+        let selfUser = ZMUser.selfUser(in: context)
+        if let selfClient = selfUser.selfClient() {
             if client.remoteIdentifier != selfClient.remoteIdentifier &&
                 fetchedClient == .none
             {
+                client.user = client.user ?? selfUser
                 client.fetchFingerprintOrPrekeys()
                 
                 if let selfClientActivationdate = selfClient.activationDate , client.activationDate?.compare(selfClientActivationdate) == .orderedDescending {

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -352,6 +352,7 @@ extension UserClientTests {
 }
 
 extension UserClientTests {
+    
     func testThatSelfClientIsTrusted() {
         // given & when
         let selfClient = self.createSelfClient()
@@ -452,6 +453,28 @@ extension UserClientTests {
 // MARK : fetchFingerprintOrPrekeys
 
 extension UserClientTests {
+    
+    func testThatItSetsTheUserWhenInsertingANewSelfUserClient(){
+        // given
+        _ = createSelfClient()
+        let newClientPayload : [String : AnyObject] = ["id": UUID().transportString() as AnyObject,
+                                                       "type": "permanent" as AnyObject,
+                                                       "time": Date().transportString() as AnyObject]
+        // when
+        var newClient : UserClient!
+        self.performPretendingUiMocIsSyncMoc {
+            newClient = UserClient.createOrUpdateSelfUserClient(newClientPayload, context: self.uiMOC)
+            XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
+        
+        // then
+        XCTAssertNotNil(newClient)
+        XCTAssertNotNil(newClient.user)
+        XCTAssertEqual(newClient.user, ZMUser.selfUser(in: uiMOC))
+        XCTAssertNotNil(newClient.sessionIdentifier)
+    }
+    
+    
     func testThatItDoNothingWhenHasAFingerprint() {
         // GIVEN
         let fingerprint = Data(base64Encoded: "cmVhZGluZyB0ZXN0cyBpcyBjb29s")

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.m
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.m
@@ -179,7 +179,7 @@ NSString *const ZMPersistedClientIdKey = @"PersistedClientId";
     [moc setPersistentStoreMetadata:selfClient.remoteIdentifier forKey:ZMPersistedClientIdKey];
     
     [self performPretendingUiMocIsSyncMoc:^{
-        [UserClient createOrUpdateClient:@{@"id": selfClient.remoteIdentifier, @"type": @"permanent", @"time": [[NSDate date] transportString]} context:moc];
+        [UserClient createOrUpdateSelfUserClient:@{@"id": selfClient.remoteIdentifier, @"type": @"permanent", @"time": [[NSDate date] transportString]} context:moc];
     }];
     
     [moc saveOrRollback];


### PR DESCRIPTION
In order to fetch the fingerprint for a new selfUser client, we need to have a sessionIdentifier for this client. The sessionIdentifier consists of the client remoteID and the user remoteID. This in turn means, we have to set the user before trying to fetch the fingerprints.

