### PR TITLE
Added CircleCI integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'danger', '~>3.2'
+gem 'slather'

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,40 @@
+machine:
+  xcode:
+    version: "8.2"
+  environment:
+    # Used for compatibility with scripts made for Jenkins
+    WORKSPACE: $(pwd) 
+    JENKINS_HOME: WORKSPACE
+
+checkout:
+  post:
+    # Copy the code to a subdirectory
+    - mkdir -p "${CIRCLE_PROJECT_REPONAME}"
+    - rsync -a . "${CIRCLE_PROJECT_REPONAME}/" --exclude "${CIRCLE_PROJECT_REPONAME}"
+    # Clone scripts repo if not already cached
+    - if [ ! -d "wire-ios-scripts" ]; then git clone https://github.com/wireapp/wire-ios-scripts.git; fi
+
+dependencies:
+  override:
+    - bundle install:
+        pwd:
+          $CIRCLE_PROJECT_REPONAME
+    - ./CI/bot-setup.sh:
+        pwd:
+          wire-ios-scripts
+    - ./CI/Bots/bot-pre-build.swift:
+        pwd:
+          wire-ios-scripts
+  cache_directories:
+    - wire-ios-scripts
+
+test:
+  override:
+    - ./CI/Bots/bot-build.swift --workspace "../${CIRCLE_PROJECT_REPONAME}":
+        pwd:
+          wire-ios-scripts
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - mkdir -p $CIRCLE_TEST_REPORTS/code_coverage/
+    - cp $CIRCLE_PROJECT_REPONAME/tests.xml $CIRCLE_TEST_REPORTS/junit/
+    - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/


### PR DESCRIPTION
## Why we might want CircleCI?

It would be good to have tests running on pull requests. CircleCI looks like the most popular tool for this so why not to try it.

## What's in this PR?

Added a config that could be reused in all other repos, because it doesn't have any `wire-ios-data-model` code. The resulting config is slightly convoluted, because it re-uses exactly the same build scripts as we currently use on Jenkins.

Let's see how it all works out and maybe we can set up other repos in the same fashion.