### PR TITLE
Fetch all users when first accessing displayName

### DIFF
--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -24,6 +24,7 @@ public class DisplayNameGenerator : NSObject {
     unowned var managedObjectContext: NSManagedObjectContext
     
     public func personName(for user: ZMUser) -> PersonName? {
+        fetchAllUsersIfNeeded()
         return idToPersonNameMap[user.objectID]
     }
     

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -273,4 +273,18 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         XCTAssertEqual(generator.initials(for: user4), "K");
     }
     
+    func testThatItFetchesAllUsersWhenNotFetchedYet()
+    {
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Rob A";
+
+        // when
+        let displayName = user1.displayName
+        
+        // then
+        XCTAssertNotNil(displayName)
+        XCTAssertEqual(displayName, "Rob")
+    }
+    
 }


### PR DESCRIPTION
The displayName map is created on demand - when any users displayName is accessed for the first time (or when we have inserted or updated users, but that's not happening in the share engine). This step - fetching all users and creating the displayName map - was missing due to refactoring.
