### PR TITLE
Use givenName as displayName, calculate personName on demand

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -973,7 +973,7 @@ static dispatch_queue_t UIContextCreationQueue(void)
 {
     [self performBlockAndWait:^{
         self.userInfo[IsUserInterfaceContextKey] = @YES;
-        self.nameGenerator = [[DisplayNameGenerator alloc] initWithManagedObjectContext:self allUsers:nil];
+        self.nameGenerator = [[DisplayNameGenerator alloc] initWithManagedObjectContext:self];
     }];
 }
 

--- a/Source/Model/Conversation/ZMConversation+DisplayName.swift
+++ b/Source/Model/Conversation/ZMConversation+DisplayName.swift
@@ -28,7 +28,7 @@ public extension ZMConversation {
         case .connection: return connectionDisplayName()
         case .group: return groupDisplayName()
         case .oneOnOne: return oneOnOneDisplayName()
-        case .self: return managedObjectContext.map(ZMUser.selfUser)?.displayName ?? ""
+        case .self: return managedObjectContext.map(ZMUser.selfUser)?.name ?? ""
         case .invalid: return ""
         }
     }
@@ -56,7 +56,7 @@ public extension ZMConversation {
         let selfUser = managedObjectContext.map(ZMUser.selfUser)
         let activeNames: [String] = otherActiveParticipants.flatMap {
             guard let user = $0 as? ZMUser, user != selfUser && user.name?.characters.count > 0 else { return nil }
-            return user.displayName
+            return user.name
         }
 
         if activeNames.count > 0 {

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -392,7 +392,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 + (NSSet *)keyPathsForValuesAffectingDisplayName;
 {
-    return [NSSet setWithObjects:ZMConversationConversationTypeKey, @"otherActiveParticipants", @"otherActiveParticipants.name", @"connection.to.name", @"otherActiveParticipants.displayName", @"connection.to.displayName", ZMConversationUserDefinedNameKey, nil];
+    return [NSSet setWithObjects:ZMConversationConversationTypeKey, @"otherActiveParticipants", @"otherActiveParticipants.name", @"connection.to.name", ZMConversationUserDefinedNameKey, nil];
 }
 
 + (instancetype)insertGroupConversationIntoUserSession:(id<ZMManagedObjectContextProvider>)session withParticipants:(NSArray *)participants

--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -73,7 +73,7 @@ public class DisplayNameGenerator : NSObject {
     
     private func displayNames(for conversation: ZMConversation) -> [NSManagedObjectID : String] {
         let givenNames : [String] = conversation.activeParticipants.array.flatMap{
-            guard let user = $0 as? ZMUser else { return nil }
+            guard let user = $0 as? ZMUser, !user.isSelfUser else { return nil }
             let personName = self.personName(for: user)
             return personName.givenName
         }
@@ -82,7 +82,7 @@ public class DisplayNameGenerator : NSObject {
         conversation.activeParticipants.forEach{ user in
             guard let user = user as? ZMUser else { return }
             let personName = self.personName(for: user)
-            if countedGivenName.count == 1 {
+            if countedGivenName.count(for: personName.givenName) == 1 {
                 map[user.objectID] = personName.givenName
             } else {
                 map[user.objectID] = personName.fullName

--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -16,102 +16,87 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+private var zmLog = ZMSLog(tag: "DisplayNameGenerator")
+
 
 public class DisplayNameGenerator : NSObject {
     private var idToPersonNameMap : [NSManagedObjectID: PersonName] = [:]
-
-    var allUsers : Set<ZMUser>?
     unowned var managedObjectContext: NSManagedObjectContext
+    let tagger =  NSLinguisticTagger(tagSchemes: [NSLinguisticTagSchemeScript], options: 0)
     
-    public func personName(for user: ZMUser) -> PersonName? {
-        fetchAllUsersIfNeeded()
-        return idToPersonNameMap[user.objectID]
+    init(managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
+        super.init()
     }
     
-    public func displayName(for user: ZMUser) -> String? {
-        fetchAllUsersIfNeeded()
-        return idToPersonNameMap[user.objectID]?.displayName
+    // MARK : Accessors
+
+    public func personName(for user: ZMUser) -> PersonName {
+        if user.objectID.isTemporaryID {
+            try! managedObjectContext.obtainPermanentIDs(for: [user])
+        }
+        if let name = idToPersonNameMap[user.objectID], name.rawFullName == (user.name ?? "") {
+            return name
+        }
+        let newName = PersonName.person(withName: user.name ?? "", schemeTagger: nil)
+        idToPersonNameMap[user.objectID] = newName
+        return newName
+    }
+    
+    public func givenName(for user: ZMUser) -> String? {
+        return personName(for: user).givenName
     }
     
     public func initials(for user: ZMUser) -> String? {
-        fetchAllUsersIfNeeded()
-        return idToPersonNameMap[user.objectID]?.initials
+        return personName(for: user).initials
     }
     
-    init(managedObjectContext: NSManagedObjectContext, allUsers: Set<ZMUser>?) {
-        self.managedObjectContext = managedObjectContext
-        super.init()
-        self.allUsers = allUsers
-        mapUsersToNames(returnChanges: false)
+    
+    // MARK : DisplayNames on a conversation basis
+    
+    var currentDisplayNameMap : ConversationDisplayNameMap?
+    
+    /// Can be used by the UI to return the displayNames for a conversation. Note that the name does not update when a user is added or removed or their name changes. It is however updated every time a different conversation is requested.
+    /// Calculates a map for this conversation, as soon as another conversation's displayNames are requested, it discards the map
+    func displayName(for user: ZMUser, in conversation: ZMConversation) -> String {
+        if let map = currentDisplayNameMap, map.conversationObjectID == conversation.objectID, let name = map.map[user.objectID] {
+            return name
+        }
+        let newMap = displayNames(for: conversation)
+        currentDisplayNameMap = ConversationDisplayNameMap(conversationObjectID: conversation.objectID, map: newMap)
+        guard let name = newMap[user.objectID] else {
+            zmLog.warn("User is not member of this conversation")
+            return user.name
+        }
+        return name
     }
     
-    /// Creates a copy the existing generator and returns the objectIDs of users whose displayName or fullName changed
-    public func createCopy(with allUsers: Set<ZMUser>) -> (newGenerator: DisplayNameGenerator, updatedUserIDs: Set<NSManagedObjectID>) {
-        let generator = DisplayNameGenerator(managedObjectContext: managedObjectContext, allUsers: Set())
-        generator.allUsers = allUsers
-        let updatedUsers = generator.mapUsersToNames(oldIDToPersonNameMap: idToPersonNameMap, returnChanges: true)
-        return (generator, updatedUsers)
-    }
-    
-    // Use the old map to avoid the expensive calculation of personNames
-    // Return users that have a new fullName or were inserted
-    static func mapIDsToPersonName(oldMap: [NSManagedObjectID : PersonName], users: Set<ZMUser>) -> (newMap: [NSManagedObjectID : PersonName], updatedUsers: Set<NSManagedObjectID>){
-        var newIdToPersonNameMap : [NSManagedObjectID : PersonName] = [:]
-        var updatedUsers = Set<NSManagedObjectID>()
-        users.forEach{
-            let fullName = $0.name ?? ""
-            if let oldPersonName = oldMap[$0.objectID], oldPersonName.fullName == fullName  {
-                newIdToPersonNameMap[$0.objectID] = oldPersonName
+    func displayNames(for conversation: ZMConversation) -> [NSManagedObjectID : String] {
+        let givenNames : [String] = conversation.activeParticipants.array.flatMap{
+            guard let user = $0 as? ZMUser else { return nil }
+            let personName = self.personName(for: user)
+            return personName.givenName
+        }
+        let countedGivenName = NSCountedSet(array: givenNames)
+        var map = [NSManagedObjectID : String]()
+        conversation.activeParticipants.forEach{ user in
+            guard let user = user as? ZMUser else { return }
+            let personName = self.personName(for: user)
+            if countedGivenName.count == 1 {
+                map[user.objectID] = personName.givenName
             } else {
-                newIdToPersonNameMap[$0.objectID] = PersonName.person(withName: fullName)
-                updatedUsers.insert($0.objectID)
+                map[user.objectID] = personName.fullName
             }
         }
-        return (newIdToPersonNameMap, updatedUsers)
+        return map
     }
     
-    /// Update the displayNames
-    /// Return users that have a new displayName
-    func updateDisplayNames() -> Set<NSManagedObjectID> {
-        let givenNameCounts = NSCountedSet(array: idToPersonNameMap.values.flatMap{$0.givenName})
-        var updatedUsers = Set<NSManagedObjectID>()
-        idToPersonNameMap.forEach{ (key, personName) in
-            if givenNameCounts.count(for: personName.givenName) < 2 {
-                if personName.displayName != personName.givenName {
-                    personName.displayName = personName.givenName
-                    updatedUsers.insert(key)
-                }
-            } else {
-                if personName.displayName != personName.fullName {
-                    personName.displayName = personName.fullName
-                    updatedUsers.insert(key)
-                }
-            }
-        }
-        return updatedUsers
-    }
+}
+
+struct ConversationDisplayNameMap {
     
-    func fetchAllUsers(in context:NSManagedObjectContext) -> Set<ZMUser> {
-        let fetchRequest = ZMUser.sortedFetchRequest()
-        guard let allUsers = context.executeFetchRequestOrAssert(fetchRequest) as? [ZMUser] else { return Set()}
-        return Set(allUsers)
-    }
-    
-    @discardableResult func mapUsersToNames(oldIDToPersonNameMap: [NSManagedObjectID : PersonName] = [:], returnChanges: Bool) -> Set<NSManagedObjectID> {
-        guard let users = allUsers else { return Set()}
-        
-        let (idToPersonNameMap, updated1) = type(of:self).mapIDsToPersonName(oldMap: oldIDToPersonNameMap, users: users)
-        self.idToPersonNameMap = idToPersonNameMap
-        let updated2 = self.updateDisplayNames()
-        return returnChanges ? updated1.union(updated2) : Set()
-    }
-    
-    func fetchAllUsersIfNeeded() {
-        guard allUsers == nil else { return }
-        allUsers = fetchAllUsers(in:managedObjectContext)
-        mapUsersToNames(returnChanges: false)
-    }
-    
+    let conversationObjectID : NSManagedObjectID
+    let map : [NSManagedObjectID : String]
 }
 
 let DisplayNameGeneratorKey = "DisplayNameGenerator"
@@ -130,39 +115,10 @@ extension NSManagedObjectContext {
             }
         }
     }
-    
-    func updateNameGenerator(updatedUsers: Set<ZMUser>, insertedUsers: Set<ZMUser>, deletedUsers: Set<ZMUser>) -> Set<ZMUser> {
-        guard let generator = nameGenerator else { return Set()}
-        let (newGenerator, updatedUsers) = generator.updateWithChanges(updatedUsers: updatedUsers, insertedUsers: insertedUsers, deletedUsers: deletedUsers)
-        self.nameGenerator = newGenerator
-        return updatedUsers
-    }
-
 }
 
 
-extension DisplayNameGenerator {
 
-    func updateWithChanges(updatedUsers: Set<ZMUser>, insertedUsers: Set<ZMUser>, deletedUsers: Set<ZMUser>)
-        -> (newGenerator:  DisplayNameGenerator, updatedUsers: Set<ZMUser>)
-    {
-        fetchAllUsersIfNeeded()
-        
-        if (insertedUsers.count == 0 && deletedUsers.count == 0 && updatedUsers.count == 0) {
-            return (self, Set())
-        }
-        let newAllUsers = allUsers!.union(insertedUsers).subtracting(deletedUsers)
-        
-        //At this point inserted users should have temporary id's, but after the save they will have permament id's.
-        //Display name generator maps names to user id's so it needs permament id's to be able to match them on subsecquent changes.
-        try! managedObjectContext.obtainPermanentIDs(for: Array(newAllUsers))
-        
-        let (newGenerator, updatedUserIDs) = createCopy(with: newAllUsers)
-        let usersToReturn = updatedUserIDs.flatMap{(try? managedObjectContext.existingObject(with: $0)) as? ZMUser}
-        
-        return (newGenerator, Set(usersToReturn))
-    }
-    
-}
+
 
 

--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -21,8 +21,8 @@ private var zmLog = ZMSLog(tag: "DisplayNameGenerator")
 
 public class DisplayNameGenerator : NSObject {
     private var idToPersonNameMap : [NSManagedObjectID: PersonName] = [:]
-    unowned var managedObjectContext: NSManagedObjectContext
-    let tagger =  NSLinguisticTagger(tagSchemes: [NSLinguisticTagSchemeScript], options: 0)
+    unowned private var managedObjectContext: NSManagedObjectContext
+    private let tagger =  NSLinguisticTagger(tagSchemes: [NSLinguisticTagSchemeScript], options: 0)
     
     init(managedObjectContext: NSManagedObjectContext) {
         self.managedObjectContext = managedObjectContext
@@ -54,11 +54,11 @@ public class DisplayNameGenerator : NSObject {
     
     // MARK : DisplayNames on a conversation basis
     
-    var currentDisplayNameMap : ConversationDisplayNameMap?
+    private var currentDisplayNameMap : ConversationDisplayNameMap?
     
     /// Can be used by the UI to return the displayNames for a conversation. Note that the name does not update when a user is added or removed or their name changes. It is however updated every time a different conversation is requested.
     /// Calculates a map for this conversation, as soon as another conversation's displayNames are requested, it discards the map
-    func displayName(for user: ZMUser, in conversation: ZMConversation) -> String {
+    @objc public func displayName(for user: ZMUser, in conversation: ZMConversation) -> String {
         if let map = currentDisplayNameMap, map.conversationObjectID == conversation.objectID, let name = map.map[user.objectID] {
             return name
         }
@@ -71,7 +71,7 @@ public class DisplayNameGenerator : NSObject {
         return name
     }
     
-    func displayNames(for conversation: ZMConversation) -> [NSManagedObjectID : String] {
+    private func displayNames(for conversation: ZMConversation) -> [NSManagedObjectID : String] {
         let givenNames : [String] = conversation.activeParticipants.array.flatMap{
             guard let user = $0 as? ZMUser else { return nil }
             let personName = self.personName(for: user)

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -92,7 +92,7 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
             _name = name;
             _handle = handle;
             
-            PersonName *personName = [PersonName personWithName:name];
+            PersonName *personName = [PersonName personWithName:name schemeTagger:nil];
             _initials = personName.initials;
             
             _accentColorValue =  color;

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -26,6 +26,7 @@
 @class ZMConnection;
 
 extern NSString * __nonnull const SessionObjectIDKey;
+extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 @interface ZMUser (Internal)
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -38,6 +38,7 @@
 
 
 NSString *const SessionObjectIDKey = @"ZMSessionManagedObjectID";
+NSString *const ZMUserActiveConversationsKey = @"activeConversations";
 
 static NSString *const ZMPersistedClientIdKey = @"PersistedClientId";
 
@@ -52,7 +53,6 @@ static NSString *const NormalizedEmailAddressKey = @"normalizedEmailAddress";
 static NSString *const RemoteIdentifierKey = @"remoteIdentifier";
 
 static NSString *const ConversationsCreatedKey = @"conversationsCreated";
-static NSString *const ActiveConversationsKey = @"activeConversations";
 static NSString *const ActiveCallConversationsKey = @"activeCallConversations";
 static NSString *const ConnectionKey = @"connection";
 static NSString *const EmailAddressKey = @"emailAddress";
@@ -229,7 +229,7 @@ static NSString *const AnnaBotHandle = @"annathebot";
 - (NSString *)displayName;
 {
     PersonName *personName = [self.managedObjectContext.nameGenerator personNameFor:self];
-    return personName.displayName ?: @"";
+    return personName.givenName ?: @"";
 }
 
 - (NSString *)initials
@@ -368,7 +368,7 @@ static NSString *const AnnaBotHandle = @"annathebot";
         [ignoredKeys addObjectsFromArray:@[
                                            NormalizedNameKey,
                                            ConversationsCreatedKey,
-                                           ActiveConversationsKey,
+                                           ZMUserActiveConversationsKey,
                                            ActiveCallConversationsKey,
                                            ConnectionKey,
                                            ConversationsCreatedKey,

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -232,6 +232,11 @@ static NSString *const AnnaBotHandle = @"annathebot";
     return personName.givenName ?: @"";
 }
 
+- (NSString *)displayNameInConversation:(ZMConversation *)conversation;
+{
+    return [self.managedObjectContext.nameGenerator displayNameFor:self in:conversation];
+}
+
 - (NSString *)initials
 {
     PersonName *personName = [self.managedObjectContext.nameGenerator personNameFor:self];

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -29,7 +29,6 @@ extension ZMUser : ObjectInSnapshot {
     
     static public var observableKeys : Set<String> {
         return Set([#keyPath(ZMUser.name),
-                    #keyPath(ZMUser.displayName),
                     #keyPath(ZMUser.accentColorValue),
                     #keyPath(ZMUser.imageMediumData),
                     #keyPath(ZMUser.imageSmallProfileData),
@@ -82,7 +81,7 @@ extension ZMUser : ObjectInSnapshot {
     }
 
     open var nameChanged : Bool {
-        return changedKeysContain(keys: #keyPath(ZMUser.name), #keyPath(ZMUser.displayName))
+        return changedKeysContain(keys: #keyPath(ZMUser.name))
     }
     
     open var accentColorValueChanged : Bool {

--- a/Source/Notifications/SnapshotCenter.swift
+++ b/Source/Notifications/SnapshotCenter.swift
@@ -84,7 +84,6 @@ public class SnapshotCenter {
             guard let count = (object.value(forKey: $0) as? Countable)?.count, count != $1 else { return }
             changedKeys.insert($0)
         }
-        snapshots.removeValue(forKey: object.objectID)
         return changedKeys
     }
     

--- a/Source/Public/ZMBareUser.h
+++ b/Source/Public/ZMBareUser.h
@@ -28,8 +28,9 @@
 
 /// The full name
 @property (nonatomic, readonly) NSString *name;
-/// The display name will be short e.g. "John A" for connected users, but always the full name for non-connected users.
+/// The given name / first name e.g. "John" for "John Smith"
 @property (nonatomic, readonly) NSString *displayName;
+/// The initials e.g. "JS" for "John Smith"
 @property (nonatomic, readonly) NSString *initials;
 /// The "@name" handle
 @property (nonatomic, readonly) NSString *handle;

--- a/Source/Public/ZMUser.h
+++ b/Source/Public/ZMUser.h
@@ -42,6 +42,8 @@
 
 @property (nonatomic, readonly) BOOL isBot;
 
+- (NSString *)displayNameInConversation:(ZMConversation *)conversation;
+
 @end
 
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1328,9 +1328,8 @@
     [conversation.mutableOtherActiveParticipants addObject:user2];
     [conversation.mutableOtherActiveParticipants addObject:[ZMUser selfUserInContext:self.uiMOC]];
     [self.uiMOC saveOrRollback];
-    [self updateDisplayNameGeneratorWithUsers:@[user1, user2, selfUser]];
     
-    NSString *expected = @"Foo, Bar";
+    NSString *expected = @"Foo 1, Bar 2";
     
     // when
     conversation.userDefinedName = nil;
@@ -1358,11 +1357,10 @@
     [conversation.mutableOtherActiveParticipants addObject:[ZMUser selfUserInContext:self.uiMOC]];
     [self.uiMOC saveOrRollback];
     
-    NSString *expected = @"Bar, Baz";
+    NSString *expected = @"Bar 2, Baz 4";
     
     // when
     conversation.userDefinedName = nil;
-    [self updateDisplayNameGeneratorWithUsers:@[user1, user2, user3, user4, selfUser]];
     
     // then
     XCTAssertEqualObjects(conversation.displayName, expected);

--- a/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -164,7 +164,6 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
                                                         let otherUser = ZMUser.insertNewObject(in:self.uiMOC)
                                                         otherUser.name = "Foo"
                                                         conversation.mutableOtherActiveParticipants.add(otherUser)
-                                                        self.updateDisplayNameGenerator(withUsers: [otherUser])
             },
                                                      expectedChangedFields: KeySet(["nameChanged", "participantsChanged"]),
                                                      expectedChangedKeys: KeySet(["displayName", "otherActiveParticipants"])
@@ -256,94 +255,7 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
         
     }
     
-    func testThatItNotifiesTheObserverOfANameChangeBecauseAUserWasAdded()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in:self.uiMOC)
-        user1.name = "Foo A"
-        
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
-        conversation.conversationType = ZMConversationType.group
-        conversation.mutableOtherActiveParticipants.add(user1)
-        
-        self.uiMOC.saveOrRollback()
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        XCTAssertTrue(user1.displayName == "Foo")
-        
-        // when
-        self.checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                     modifier: { _ in
-                                                        let user2 = ZMUser.insertNewObject(in:self.uiMOC)
-                                                        user2.name = "Foo B"
-                                                        self.uiMOC.saveOrRollback()
-                                                        XCTAssertEqual(user1.displayName, "Foo A")
-            },
-                                                     expectedChangedField: "nameChanged",
-                                                     expectedChangedKeys: KeySet(["displayName"])
-        )
-    }
     
-    func testThatItNotifiesTheObserverOfANameChangeBecauseAUserWasAddedAndLaterItsNameChanged()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in:self.uiMOC)
-        user1.name = "Foo A"
-        
-        let user2 = ZMUser.insertNewObject(in:self.uiMOC)
-        user2.name = "Bar"
-        
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
-        conversation.conversationType = ZMConversationType.group
-        conversation.mutableOtherActiveParticipants.add(user1)
-        uiMOC.saveOrRollback()
-
-        XCTAssertEqual(user1.displayName, "Foo")
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // when
-        self.checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                     modifier: { _ in
-                                                        user2.name = "Foo B"
-                                                        uiMOC.saveOrRollback()
-                                                        XCTAssertEqual(user1.displayName, "Foo A")
-            },
-                                                     expectedChangedField: "nameChanged",
-                                                     expectedChangedKeys: KeySet(["displayName"])
-        )
-    }
-    
-    func testThatItDoesNotNotifyTheObserverOfANameChangeBecauseAUserWasRemovedAndLaterItsNameChanged()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in:self.uiMOC)
-        user1.name = "Foo A"
-        
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
-        conversation.conversationType = ZMConversationType.group
-        conversation.mutableOtherActiveParticipants.add(user1)
-        
-        self.updateDisplayNameGenerator(withUsers: [user1])
-        
-        XCTAssertTrue(user1.displayName == "Foo")
-        XCTAssertTrue(conversation.otherActiveParticipants.contains(user1))
-        
-        uiMOC.saveOrRollback()
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // when
-        self.checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                     modifier: { conversation, observer in
-                                                        conversation.mutableOtherActiveParticipants.remove(user1)
-                                                        self.uiMOC.saveOrRollback()
-                                                        observer.clearNotifications()
-                                                        user1.name = "Bar"
-                                                        self.updateDisplayNameGenerator(withUsers: [user1])
-            },
-                                                     expectedChangedField: nil,
-                                                     expectedChangedKeys: KeySet()
-        )
-    }
     
     func testThatItNotifysTheObserverOfANameChangeBecauseAUserWasAddedLaterAndHisNameChanged()
     {

--- a/Tests/Source/Model/Observer/MessageWindowObserverTests.swift
+++ b/Tests/Source/Model/Observer/MessageWindowObserverTests.swift
@@ -468,30 +468,7 @@ extension MessageWindowObserverTests {
                                             XCTAssertTrue($0.nameChanged)
         })
     }
-    
-    func testThatItNotifiesObserverWhenTheSenderNameChangesBecauseOfAnotherUserWithTheSameName() {
-        // given
-        let sender = ZMUser.insertNewObject(in:self.uiMOC)
-        sender.name = "Hans A"
-        
-        let message = ZMClientMessage.insertNewObject(in: self.uiMOC)
-        message.sender = sender
-        
-        let window = createConversationWindowWithMessages([message], uiMoc: self.uiMOC)
-        uiMOC.saveOrRollback()
 
-        updateDisplayNameGenerator(withUsers: [sender])
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        // when
-        checkThatItNotifiesAboutUserChange(in: window,
-                                           modifier: {
-                                            let newUser = ZMUser.insertNewObject(in:self.uiMOC)
-                                            newUser.name = "Hans K"},
-                                           callBack: {
-                                            XCTAssertTrue($0.nameChanged)
-        })
-    }
 
     func testThatItNotifiesObserverWhenTheSenderAccentColorChanges() {
         // given

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -148,7 +148,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         uiMOC.refresh(user, mergeChanges: true)
         XCTAssertTrue(user.isFault)
-        
+        XCTAssertEqual(user.displayName, "foo")
         let observer = UserObserver()
         let token = UserChangeInfo.add(observer: observer, for: user)
         
@@ -161,6 +161,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         mergeLastChanges()
         
         // then
+        XCTAssertEqual(user.displayName, "bar")
         XCTAssertEqual(observer.notifications.count, 1)
         if let note = observer.notifications.first {
             XCTAssertTrue(note.nameChanged)

--- a/Tests/Source/Model/Observer/SnapshotCenterTests.swift
+++ b/Tests/Source/Model/Observer/SnapshotCenterTests.swift
@@ -149,19 +149,6 @@ class SnapshotCenterTests : BaseZMMessageTests {
     
     }
     
-    func testThatItRemovesTheSnapshotAfterAccessingIt(){
-        // given
-        let conv = ZMConversation.insertNewObject(in: uiMOC)
-        sut.willMergeChanges(changes: Set([conv.objectID]))
-        
-        // when
-        XCTAssertNotNil(sut.snapshots[conv.objectID])
-        _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
-        // then
-        XCTAssertNil(sut.snapshots[conv.objectID])
-    }
-    
     func testThatReturnsChangedKeys() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)

--- a/Tests/Source/Model/Observer/UserObserverTests.swift
+++ b/Tests/Source/Model/Observer/UserObserverTests.swift
@@ -165,7 +165,6 @@ extension UserObserverTests {
         user.mediumRemoteIdentifier = UUID.create()
         user.imageMediumData = self.verySmallJPEGData()
         uiMOC.saveOrRollback()
-        updateDisplayNameGenerator(withUsers: [user])
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         // when

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -35,81 +35,16 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         uiMOC.saveOrRollback()
         
         // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2, user3, user4]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         
         // then
-        XCTAssertEqual(generator.displayName(for: user1), "Rob")
-        XCTAssertEqual(generator.displayName(for: user2), "Henry")
-        XCTAssertEqual(generator.displayName(for: user3), "Arthur")
-        XCTAssertEqual(generator.displayName(for: user4), "Kevin")
+        XCTAssertEqual(generator.givenName(for: user1), "Rob")
+        XCTAssertEqual(generator.givenName(for: user2), "Henry")
+        XCTAssertEqual(generator.givenName(for: user3), "Arthur")
+        XCTAssertEqual(generator.givenName(for: user4), "Kevin")
     }
     
-    
-    func testThatItReturnsTheFullNameForUserWithSameFirstnamesDifferentLastnameFirstLetter()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in: uiMOC)
-        user1.name = "Rob Arthur";
-        let user2 = ZMUser.insertNewObject(in: uiMOC)
-        user2.name = "Rob Benjamin";
-        let user3 = ZMUser.insertNewObject(in: uiMOC)
-        user3.name = "Rob (Christopher)";
-        let user4 = ZMUser.insertNewObject(in: uiMOC)
-        user4.name = "Rob Benjamin Henry";
-        let user5 = ZMUser.insertNewObject(in: uiMOC)
-        user5.name = "Rob Christopher Benjamin";
-        
-        // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2, user3, user4, user5]))
-        
-        // then
-        XCTAssertEqual(generator.displayName(for: user1), user1.name);
-        XCTAssertEqual(generator.displayName(for: user2), user2.name);
-        XCTAssertEqual(generator.displayName(for: user3), user3.name);
-        XCTAssertEqual(generator.displayName(for: user4), user4.name);
-        XCTAssertEqual(generator.displayName(for: user5), user5.name);
-    }
-    
-    
-    func testThatItReturnsFullNameForUserWithSameFirstnamesAndSameLastnameFirstLetter()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in: uiMOC)
-        user1.name = "Rob Arthur";
-        let user2 = ZMUser.insertNewObject(in: uiMOC)
-        user2.name = "Rob Anthony";
-        let user3 = ZMUser.insertNewObject(in: uiMOC)
-        user3.name = "Rob Benjamin";
-        
-        // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2, user3]))
-        
-        // then
-        
-        XCTAssertEqual(generator.displayName(for: user1), user1.name);
-        XCTAssertEqual(generator.displayName(for: user2), user2.name);
-        XCTAssertEqual(generator.displayName(for: user3), user3.name);
-    }
-    
-    func testThatItReturnsFullNameForUsersWithDifferentlyComposedSpecialCharacters()
-    {
-        // given
-        let user1 = ZMUser.insertNewObject(in: uiMOC)
-        user1.name = "Henry \u{00cb}lse"; // LATIN CAPITAL LETTER E WITH DIAERESIS
-        
-        let user2 = ZMUser.insertNewObject(in: uiMOC)
-        user2.name = "Henry E\u{0308}mil"; // LATIN CAPITAL LETTER E + COMBINING DIAERESIS
-        
-        // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2]))
-        
-        // then
-        XCTAssertEqual(generator.displayName(for: user1), "Henry \u{00cb}lse");
-        XCTAssertEqual(generator.displayName(for: user2), "Henry \u{00cb}mil");
-    }
-    
-    
-    func testThatItReturnsAbbreviatedNameForSameFirstnamesWithDifferentlyComposedCharacters()
+    func testThatItReturnsFirstNameForSameFirstnamesWithDifferentlyComposedCharacters()
     {
         // given
         let user1 = ZMUser.insertNewObject(in: uiMOC)
@@ -118,11 +53,11 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         user2.name = "A\u{030A}ron Hans"
         
         // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         
         // then
-        XCTAssertEqual(generator.displayName(for: user1), user1.name)
-        XCTAssertEqual(generator.displayName(for: user2), user2.name.precomposedStringWithCanonicalMapping)
+        XCTAssertEqual(generator.givenName(for: user1), "\u{00C5}ron")
+        XCTAssertEqual(generator.givenName(for: user2), "\u{00C5}ron")
     }
     
     
@@ -138,52 +73,19 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         let name2b = "A\u{030A}rif Hans";
         
         // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         
         // then
-        XCTAssertEqual(generator.displayName(for: user1), user1.name);
-        XCTAssertEqual(generator.displayName(for: user2), user2.name.precomposedStringWithCanonicalMapping);
+        XCTAssertEqual(generator.givenName(for: user1), "\u{00C5}ron");
+        XCTAssertEqual(generator.givenName(for: user2), "\u{00C5}ron");
         
         // when
         user2.name = name2b
-        let (newGenerator, updated) = generator.createCopy(with: Set([user1, user2]))
-        let expectedUpdatedSet = Set([user1.objectID, user2.objectID])
         
         // then
-        XCTAssertEqual(newGenerator.displayName(for: user1), "\u{00C5}ron")
-        XCTAssertEqual(newGenerator.displayName(for: user2), "A\u{030A}rif".precomposedStringWithCanonicalMapping)
-
-        XCTAssertEqual(updated, expectedUpdatedSet);
+        XCTAssertEqual(generator.givenName(for: user1), "\u{00C5}ron")
+        XCTAssertEqual(generator.givenName(for: user2), "A\u{030A}rif".precomposedStringWithCanonicalMapping)
     }
-
- 
-    func testThatItReturnsUpdatedDisplayNamesWhenInitializedWithCopyAddingOneName() {
-        // given
-        let user1 = ZMUser.insertNewObject(in: uiMOC)
-        user1.name = "\u{00C5}ron Meister";
-        let user2 = ZMUser.insertNewObject(in: uiMOC)
-        user2.name = "A\u{030A}ron Hans";
-        let user3 = ZMUser.insertNewObject(in: uiMOC)
-        user3.name = "A\u{030A}ron Hans";
-        
-        // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2]))
-
-        // then
-        XCTAssertEqual(generator.displayName(for: user1), user1.name);
-        XCTAssertEqual(generator.displayName(for: user2), user2.name.precomposedStringWithCanonicalMapping)
-        
-        // when
-        let (newGenerator, updated) = generator.createCopy(with: Set([user1, user2, user3]))
-        
-        // then
-        XCTAssertEqual(newGenerator.displayName(for: user1), user1.name);
-        XCTAssertEqual(newGenerator.displayName(for: user2), user2.name.precomposedStringWithCanonicalMapping);
-        XCTAssertEqual(newGenerator.displayName(for: user3), user3.name.precomposedStringWithCanonicalMapping);
-        
-        XCTAssertEqual(updated, Set([user3.objectID]));
-    }
- 
 
  
     func testThatItReturnsUpdatedDisplayNamesWhenTheInitialMapWasEmpty()
@@ -194,42 +96,35 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         let user3 = ZMUser.insertNewObject(in: uiMOC)
         let allUsers = Set([user1, user2, user3])
         
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: allUsers)
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         let emptyString = ""
-        XCTAssertEqual(generator.displayName(for: user1), emptyString);
-        XCTAssertEqual(generator.displayName(for: user2), emptyString);
-        XCTAssertEqual(generator.displayName(for: user3), emptyString);
+        XCTAssertEqual(generator.givenName(for: user1), emptyString);
+        XCTAssertEqual(generator.givenName(for: user2), emptyString);
+        XCTAssertEqual(generator.givenName(for: user3), emptyString);
         
         // when
         user1.name = "\u{00C5}ron Meister";
         user2.name = "A\u{030A}ron Hans";
         user3.name = "A\u{030A}ron WhatTheFuck";
-        let (newGenerator, updated) = generator.createCopy(with: allUsers)
         
         // then
-        XCTAssertEqual(newGenerator.displayName(for: user1), user1.name.precomposedStringWithCanonicalMapping)
-        XCTAssertEqual(newGenerator.displayName(for: user2), user2.name.precomposedStringWithCanonicalMapping)
-        XCTAssertEqual(newGenerator.displayName(for: user3), user3.name.precomposedStringWithCanonicalMapping)
-        
-        XCTAssertEqual(updated, Set(allUsers.map{$0.objectID}));
+        XCTAssertEqual(generator.givenName(for: user1), "\u{00C5}ron");
+        XCTAssertEqual(generator.givenName(for: user2), "\u{00C5}ron");
+        XCTAssertEqual(generator.givenName(for: user3), "\u{00C5}ron");
     }
     
-
- 
     func testThatItReturnsUpdatedFullNames()
     {
         // given
         let user1 = ZMUser.insertNewObject(in: uiMOC)
         user1.name = "Hans Meister";
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         
         // when
         user1.name = "Hans Master"
-        let (newGenerator, updated) = generator.createCopy(with: Set([user1]))
 
         // then
-        XCTAssertEqual(newGenerator.displayName(for: user1), "Hans");
-        XCTAssertEqual(updated, Set([user1.objectID]));
+        XCTAssertEqual(generator.givenName(for: user1), "Hans");
     }
     
 
@@ -243,11 +138,11 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         user2.name = "******";
         
         // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         
         // then
-        XCTAssertEqual(generator.displayName(for: user1), user1.name);
-        XCTAssertEqual(generator.displayName(for: user2), user2.name);
+        XCTAssertEqual(generator.givenName(for: user1), user1.name);
+        XCTAssertEqual(generator.givenName(for: user2), user2.name);
     }
  
     func testThatItReturnsInitialsForUser()
@@ -264,7 +159,7 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         user4.name = "Kevin ()";
         
         // when
-        let generator = DisplayNameGenerator(managedObjectContext: uiMOC, allUsers: Set([user1, user2, user3, user4]))
+        let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
 
         // then
         XCTAssertEqual(generator.initials(for: user1), "RA");
@@ -280,11 +175,11 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         user1.name = "Rob A";
 
         // when
-        let displayName = user1.displayName
+        let givenName = user1.displayName
         
         // then
-        XCTAssertNotNil(displayName)
-        XCTAssertEqual(displayName, "Rob")
+        XCTAssertNotNil(givenName)
+        XCTAssertEqual(givenName, "Rob")
     }
     
 }

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -94,7 +94,6 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         let user1 = ZMUser.insertNewObject(in: uiMOC)
         let user2 = ZMUser.insertNewObject(in: uiMOC)
         let user3 = ZMUser.insertNewObject(in: uiMOC)
-        let allUsers = Set([user1, user2, user3])
         
         let generator = DisplayNameGenerator(managedObjectContext: uiMOC)
         let emptyString = ""
@@ -182,4 +181,53 @@ class DisplayNameGeneratorTests : ZMBaseManagedObjectTest {
         XCTAssertEqual(givenName, "Rob")
     }
     
+}
+
+
+// MARK: Conversation based names
+
+extension DisplayNameGeneratorTests {
+    
+    func testThatItCalculatesTheDisplayNamesOnConversationBasis_Group(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        let user3 = ZMUser.insertNewObject(in: uiMOC)
+        
+        user1.name = "Hans Schmidt"
+        user2.name = "Hans Meier"
+        user3.name = "Mutti Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .group
+        conversation.mutableOtherActiveParticipants.addObjects(from: [user1, user2, user3])
+
+        // when
+        let displayName1 = user1.displayName(in: conversation)
+        let displayName2 = user2.displayName(in: conversation)
+        let displayName3 = user3.displayName(in: conversation)
+        
+        // then
+        XCTAssertEqual(displayName1, user1.name)
+        XCTAssertEqual(displayName2, user2.name)
+        XCTAssertEqual(displayName3, "Mutti")
+    }
+    
+    func testThatItCalculatesTheDisplayNamesOnConversationBasis_OneOnOne(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Hans Schmidt"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.connection = ZMConnection.insertNewObject(in: uiMOC)
+        conversation.connection?.to = user1
+        
+        // when
+        let displayName1 = user1.displayName(in: conversation)
+        
+        // then
+        XCTAssertEqual(displayName1, "Hans")
+    }
+
 }

--- a/Tests/Source/Model/User/ZMPersonNameTests.m
+++ b/Tests/Source/Model/User/ZMPersonNameTests.m
@@ -48,8 +48,8 @@
     NSString *nameWithLineBreak = @"The Name \n Break Name";
     
     // when
-    PersonName *nameWithSpaceComp = [PersonName personWithName:nameWithSpace];
-    PersonName *nameWithLineBreakComp = [PersonName personWithName:nameWithLineBreak];
+    PersonName *nameWithSpaceComp = [PersonName personWithName:nameWithSpace schemeTagger:self.tagger];
+    PersonName *nameWithLineBreakComp = [PersonName personWithName:nameWithLineBreak schemeTagger:self.tagger];
     
     //then
     NSArray *nameWithSpaceArray = @[@"Henry", @"The", @"Great", @"Emporer"];
@@ -67,8 +67,8 @@
     NSString *name2 = @"The *Starred* Name";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
     
     // then
     NSArray *nameArray1 = @[@"Henry", @"The", @"Great", @"Emporer"];
@@ -85,8 +85,8 @@
     NSString *name2 = @"The (   ) Empty Name";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
     
     // then
     NSArray *nameArray1 = @[@"Henry", @"Great", @"Emporer"];
@@ -100,7 +100,7 @@
 {
     NSString *name1 = @"Henry The Great Emporer";
     
-    PersonName *nameComp1 = [PersonName personWithName:name1];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
     
     XCTAssertEqualObjects(nameComp1.givenName, @"Henry");
 
@@ -113,8 +113,8 @@
     NSString *name2 = @"Henry ()";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
 
 
     // then
@@ -130,8 +130,8 @@
     NSString *name2 = @"**********";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
     
     
     // then
@@ -147,7 +147,7 @@
     NSString *name1 = @"\u00cbmil Super Man";
     
     // when
-    PersonName *personName1 = [PersonName personWithName:name1];
+    PersonName *personName1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
 
     // then
     XCTAssertEqualObjects(personName1.initials, @"\u00cbM");
@@ -159,7 +159,7 @@
     NSString *name2 = @"E\u0308mil";
     
     // when
-    PersonName *personName2 = [PersonName personWithName:name2];
+    PersonName *personName2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(personName2.initials, @"\u00cb");
@@ -216,7 +216,7 @@
     NSString *name1 = @"李淑蒙";              // Lǐ Shūméng - Lǐ (李) is the secondName, Shūméng (淑蒙) the firstName
 
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
 
     // then
     XCTAssertEqualObjects(nameComp1.givenName, @"李淑蒙");
@@ -228,7 +228,7 @@
     NSString *name1 = @"李淑蒙";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.initials, @"李淑");
@@ -240,7 +240,7 @@
     NSString *name3 = @"李";
     
     // when
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp3.initials, @"李");
@@ -300,9 +300,9 @@
     NSString *name3 = @"ひら がな";                // hiragana
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.givenName, @"マルテイ");
@@ -318,9 +318,9 @@
     NSString *name3 = @"ひ";                // hiragana
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.initials, @"ツル");
@@ -354,7 +354,7 @@
     NSString *name1 = @"मोहनदास करमचंद गांधी"; // Mohandas Karamchand Gandhi - Mohandas Karamchand is the secondName, Gandhi the firstName
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.givenName, @"गांधी");
@@ -424,9 +424,9 @@
     NSString *name3 = @"امه العليم السوسوه‎";               // Amat Al'Alim Alsoswa, where "امه العليم" (Amat al Alim = Slave of the all knowing) is the firstName
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
 
     // then
     XCTAssertEqualObjects(nameComp1.givenName, @"محمد");
@@ -448,9 +448,9 @@
     NSString *name3 = @"امه العليم السوسوه‎";               // Amat Al'Alim Alsoswa, where "امه العليم" (Amat al Alim = Slave of the all knowing) is the firstName
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.initials, @"ما");
@@ -468,8 +468,8 @@
     NSString *name3 = @"shumeng (李淑蒙)";    // should use the chinese name as "firstName"
     
     // when
-    PersonName *nameComp2 = [PersonName personWithName:name2];
-    PersonName *nameComp3 = [PersonName personWithName:name3];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
+    PersonName *nameComp3 = [PersonName personWithName:name3 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp2.givenName, @"李淑蒙");
@@ -484,8 +484,8 @@
     NSString *name2 = @"shumeng (李淑蒙)";
     
     // when
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
     
     // then
     XCTAssertEqualObjects(nameComp1.initials, @"李s");
@@ -498,8 +498,8 @@
     NSString *name1 = @"𠀲𫝶𫝷𫝚𫞉𫟘善屠屮 𠂎";
     NSString *name2 = @"( 𝓐𝓑 𝓑";
 
-    PersonName *nameComp1 = [PersonName personWithName:name1];
-    PersonName *nameComp2 = [PersonName personWithName:name2];
+    PersonName *nameComp1 = [PersonName personWithName:name1 schemeTagger:self.tagger];
+    PersonName *nameComp2 = [PersonName personWithName:name2 schemeTagger:self.tagger];
 
     XCTAssertNotEqual(nameComp1.components.count, 0u);
     XCTAssertNotEqual(nameComp2.components.count, 0u);
@@ -537,9 +537,9 @@
 {
     // C.f. https://wearezeta.atlassian.net/browse/MEC-656
     
-    XCTAssertEqualObjects([PersonName personWithName:@""].initials, @"");
-    XCTAssertEqualObjects([PersonName personWithName:@"A"].initials, @"A");
-    XCTAssertEqualObjects([PersonName personWithName:@"𝓐"].initials, @"𝓐");
+    XCTAssertEqualObjects([PersonName personWithName:@"" schemeTagger:self.tagger].initials, @"");
+    XCTAssertEqualObjects([PersonName personWithName:@"A" schemeTagger:self.tagger].initials, @"A");
+    XCTAssertEqualObjects([PersonName personWithName:@"𝓐" schemeTagger:self.tagger].initials, @"𝓐");
 }
 
 @end

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -2324,8 +2324,6 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     user.name = @"User Name";
     
-    [self updateDisplayNameGeneratorWithUsers:@[user]];
-    
     XCTAssertEqualObjects(user.displayName, @"User");
 }
 
@@ -2334,8 +2332,6 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     user.name = @"User Name";
     
-    [self updateDisplayNameGeneratorWithUsers:@[user]];
-
     XCTAssertEqualObjects(user.initials, @"UN");
 }
 

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.h
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.h
@@ -62,14 +62,6 @@
 
 
 
-@interface ZMBaseManagedObjectTest (DisplayNameGenerator)
-
-- (void)updateDisplayNameGeneratorWithUsers:(nonnull NSArray *)users;
-
-@end
-
-
-
 @interface ZMBaseManagedObjectTest (UserTesting)
 
 - (void)setEmailAddress:(nullable NSString *)emailAddress onUser:(nonnull ZMUser *)user;

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.m
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.m
@@ -122,16 +122,6 @@ NSString *const ZMPersistedClientIdKey = @"PersistedClientId";
 @end
 
 
-@implementation ZMBaseManagedObjectTest (DisplayNameGenerator)
-
-- (void)updateDisplayNameGeneratorWithUsers:(NSArray *)users;
-{
-    [self.uiMOC updateNameGeneratorWithUpdatedUsers:[NSSet set] insertedUsers:[NSSet setWithArray:users] deletedUsers:[NSSet set]];
-}
-
-@end
-
-
 @implementation ZMBaseManagedObjectTest (UserTesting)
 
 - (void)setEmailAddress:(NSString *)emailAddress onUser:(ZMUser *)user;


### PR DESCRIPTION
Since we only want to show first names / given names in the conversation, we don't need to calculate the displayNames on start in batch and can instead do the heavy calculations (extracting the script scheme) on demand for each user. Since PersonNames are cached, we can easily access them again later. 

I added another method for the UI to get the displayName for a user in a conversation - if we want to do that - so that we can show the full name for users who have the same given name. It creates a map on demand for this conversation. If you call this method with a different conversation than before, it discards the old map. Also the map does not update when the user changes while the conversation is in the view. This however, could make opening conversations (for the first time) slow since it needs to calculate the PersonName for every user.