### PR TITLE
Compare window not conversation

### DIFF
--- a/Tests/Source/Model/Observer/MessageWindowObserverTests.swift
+++ b/Tests/Source/Model/Observer/MessageWindowObserverTests.swift
@@ -529,7 +529,28 @@ extension MessageWindowObserverTests {
                                            callBack: {
                                             XCTAssertTrue($0.imageSmallProfileDataChanged)
         })
-
+    }
+    
+    func testThatItRecreatesTheSnapshotIfTheWindowIsRecreatedForTheSameConversation(){
+        // given
+        let sender = ZMUser.insertNewObject(in:self.uiMOC)
+        sender.remoteIdentifier = UUID.create()
+        sender.smallProfileRemoteIdentifier = UUID.create()
+        
+        let message = ZMClientMessage.insertNewObject(in: self.uiMOC)
+        message.sender = sender
+        
+        let window = createConversationWindowWithMessages([message], uiMoc: self.uiMOC)
+        let newWindow = window.conversation.conversationWindow(withSize: 10)
+        uiMOC.saveOrRollback()
+        
+        // when
+        checkThatItNotifiesAboutUserChange(in: newWindow,
+                                           modifier: { message.sender!.imageSmallProfileData = self.verySmallJPEGData()},
+                                           callBack: {
+                                            XCTAssertTrue($0.imageSmallProfileDataChanged)
+        })
+    
     }
 
 }


### PR DESCRIPTION
The UI might recreate the window for the same conversation. Since we subscribe to notifications for the window object, it would not receive notifications for the new window if we don't recreate the snapshot.