### PR TITLE
Do not fetch count for all not indexed messages

### DIFF
--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -302,7 +302,7 @@ public class TextSearchQuery: NSObject {
     /// Returns the count of not indexed indexed messages in the conversation. 
     /// Needs to be called from the syncMOC's Queue.
     private func countForNonIndexedMessages() -> Int {
-        guard let request = ZMMessage.sortedFetchRequest(with: predicateForNotIndexedMessages) else { return 0 }
+        guard let request = ZMClientMessage.sortedFetchRequest(with: predicateForNotIndexedMessages) else { return 0 }
         return (try? self.syncMOC.count(for: request)) ?? 0
     }
 


### PR DESCRIPTION
# What's in this PR?

* We were getting the count for all non-indexed `ZMMessage`s, instead of `ZMClientMessage`s. As we only care about client message for now we should restrict the fetch request to this entity.
* Add the last batch of test (testing large messages, link previews, images present in a conversation).