### PR TITLE
Show fullName for user with selfUser’s name in groups, given name in 1on1

### DIFF
--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -73,7 +73,7 @@ public class DisplayNameGenerator : NSObject {
     
     private func displayNames(for conversation: ZMConversation) -> [NSManagedObjectID : String] {
         let givenNames : [String] = conversation.activeParticipants.array.flatMap{
-            guard let user = $0 as? ZMUser, !user.isSelfUser else { return nil }
+            guard let user = $0 as? ZMUser else { return nil }
             let personName = self.personName(for: user)
             return personName.givenName
         }
@@ -82,7 +82,10 @@ public class DisplayNameGenerator : NSObject {
         conversation.activeParticipants.forEach{ user in
             guard let user = user as? ZMUser else { return }
             let personName = self.personName(for: user)
-            if countedGivenName.count(for: personName.givenName) == 1 || user.isSelfUser {
+            if countedGivenName.count(for: personName.givenName) == 1
+                || conversation.conversationType == .oneOnOne
+                || user.isSelfUser
+            {
                 map[user.objectID] = personName.givenName
             } else {
                 map[user.objectID] = personName.fullName

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -247,7 +247,47 @@ extension DisplayNameGeneratorTests {
         
         // then
         XCTAssertEqual(displayName, "Uschi")
+    }
     
+    func testThatAUserWithTheSameNameAsTheSelfUserShowsFullName_Group(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Uschi Schmidt"
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        selfUser.name = "Uschi Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .group
+        conversation.mutableOtherActiveParticipants.addObjects(from: [user1])
+        
+        // when
+        let displayName1 = user1.displayName(in: conversation)
+        let displayName2 = selfUser.displayName(in: conversation)
+
+        // then
+        XCTAssertEqual(displayName1, "Uschi Schmidt")
+        XCTAssertEqual(displayName2, "Uschi")
+    }
+    
+    func testThatAUserWithTheSameNameAsTheSelfUserShowsFirstName_OneOnOne(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Uschi Schmidt"
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        selfUser.name = "Uschi Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.connection = ZMConnection.insertNewObject(in: uiMOC)
+        conversation.connection?.to = user1
+        
+        // when
+        let displayName1 = user1.displayName(in: conversation)
+        let displayName2 = selfUser.displayName(in: conversation)
+        
+        // then
+        XCTAssertEqual(displayName1, "Uschi")
+        XCTAssertEqual(displayName2, "Uschi")
     }
 
 }


### PR DESCRIPTION
Change of design:
If a user has the same name as the selfUser his/her displayName should be:
in groups: fullName
in 1on1: givenName

The selfUser's name should always be the firstName
