### PR TITLE
Update displayName map when user name changes

### DIFF
--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -56,10 +56,13 @@ public class DisplayNameGenerator : NSObject {
     
     private var currentDisplayNameMap : ConversationDisplayNameMap?
     
-    /// Can be used by the UI to return the displayNames for a conversation. Note that the name does not update when a user is added or removed or their name changes. It is however updated every time a different conversation is requested.
+    /// Can be used by the UI to return the displayNames for a conversation.
     /// Calculates a map for this conversation, as soon as another conversation's displayNames are requested, it discards the map
     @objc public func displayName(for user: ZMUser, in conversation: ZMConversation) -> String {
-        if let map = currentDisplayNameMap, map.conversationObjectID == conversation.objectID, let name = map.map[user.objectID] {
+        if idToPersonNameMap[user.objectID]?.rawFullName == (user.name ?? ""),                  // the user name is still the same
+           let map = currentDisplayNameMap, map.conversationObjectID == conversation.objectID,  // the current map is of the same conversation
+           let name = map.map[user.objectID]                                                    // the current map contains the user
+        {
             return name
         }
         let newMap = displayNames(for: conversation)

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -289,5 +289,48 @@ extension DisplayNameGeneratorTests {
         XCTAssertEqual(displayName1, "Uschi")
         XCTAssertEqual(displayName2, "Uschi")
     }
+    
+    func testThatItUpdatesTheMapWhenAUsersNameChanges_UserWithSameName(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Hans Schmidt"
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        user2.name = "Uschi Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .group
+        conversation.mutableOtherActiveParticipants.addObjects(from: [user1, user2])
+        
+        XCTAssertEqual(user1.displayName(in: conversation), "Hans")
+        XCTAssertEqual(user2.displayName(in: conversation), "Uschi")
+
+        // when
+        user1.name = "Uschi Schmidt"
+
+        // then
+        XCTAssertEqual(user1.displayName(in: conversation), "Uschi Schmidt")
+        XCTAssertEqual(user2.displayName(in: conversation), "Uschi Meier")
+    }
+    
+    func testThatItUpdatesTheMapWhenAUsersNameChanges(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Hans Schmidt"
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        selfUser.name = "Uschi Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.connection = ZMConnection.insertNewObject(in: uiMOC)
+        conversation.connection?.to = user1
+        
+        XCTAssertEqual(user1.displayName(in: conversation), "Hans")
+        
+        // when
+        user1.name = "Harald Schmidt"
+        
+        // then
+        XCTAssertEqual(user1.displayName(in: conversation), "Harald")
+    }
 
 }


### PR DESCRIPTION
When we request a displayName, we check if the fullName changed in comparison to the one we stored. If so, we recreate the displayName map. 