### PR TITLE
Fix inserted connection requests not being shown in the list

### DIFF
--- a/Source/Notifications/MessageWindowObserverCenter.swift
+++ b/Source/Notifications/MessageWindowObserverCenter.swift
@@ -256,6 +256,11 @@ class MessageWindowSnapshot : NSObject, ZMConversationObserver, ZMMessageObserve
         if let changeInfo = windowChangeInfo {
             userInfo["messageWindowChangeInfo"] = changeInfo
         }
+        guard !userInfo.isEmpty else {
+            zmLog.debug("No changes to post for window \(window)")
+            return
+        }
+        
         NotificationCenter.default.post(name: .MessageWindowDidChange, object: window, userInfo: userInfo)
         zmLog.debug(logMessage(for: messageChangeInfos, windowChangeInfo: windowChangeInfo))
     }
@@ -267,7 +272,7 @@ class MessageWindowSnapshot : NSObject, ZMConversationObserver, ZMMessageObserve
     }
     
     func logMessage(for messageChangeInfos: [MessageChangeInfo], windowChangeInfo: MessageWindowChangeInfo?) -> String {
-        var message = "Posting notification with messageChangeInfos: \n"
+        var message = "Posting notification for window \(self.conversationWindow) with messageChangeInfos: \n"
         message.append(messageChangeInfos.map{$0.customDebugDescription}.joined(separator: "\n"))
         
         guard let changeInfo = windowChangeInfo else { return message }

--- a/Source/Notifications/SnapshotCenter.swift
+++ b/Source/Notifications/SnapshotCenter.swift
@@ -61,10 +61,10 @@ public class SnapshotCenter {
         let attributes = Array(object.entity.attributesByName.keys)
         let relationShips = object.entity.relationshipsByName
         
-        let attributesDict = attributes.mapToDictionaryWithOptionalValue{object.primitiveValue(forKey: $0) as? NSObject}
+        let attributesDict = attributes.mapToDictionaryWithOptionalValue{object.value(forKey: $0) as? NSObject}
         let relationshipsDict : [String : Int] = relationShips.mapKeysAndValues(keysMapping: {$0}, valueMapping: { (key, relationShipDescription) in
             guard relationShipDescription.isToMany else { return nil}
-            return (object.primitiveValue(forKey: key) as? Countable)?.count
+            return (object.value(forKey: key) as? Countable)?.count
         })
         return Snapshot(attributes : attributesDict, toManyRelationships : relationshipsDict)
     }


### PR DESCRIPTION
+ minor other fixes

When the notificationDispatcher fires all notifications we forward the change infos to the changeInfoConsumer including the ConversationListObserverCenter. We were exiting early when the changes did not include any conversation changes. However, if there were conversations inserted in the same save, but none changed, then we would not fire the notification for the inserted conversation.

The main fix is in ConversationListObserverCenter line 80.


