### PR TITLE
Set addedUsers property on system message if client of added participant

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1443,7 +1443,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         if(isAuthoritative) {
             [self.mutableLastServerSyncedActiveParticipants addObject:participant];
         }
-        [self decreaseSecurityLevelIfNeededAfterIgnoringClients:participant.clients];
+        [self decreaseSecurityLevelIfNeededAfterIgnoringClients:participant.clients addedUser:participant];
     }
 }
 

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -147,7 +147,7 @@ inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 @property (nonatomic) ZMSystemMessageType systemMessageType;
 @property (nonatomic) NSSet<ZMUser *> * _Nonnull users;
 @property (nonatomic) NSSet <id<UserClientType>>* _Nonnull clients;
-@property (nonatomic) NSSet<ZMUser *> * _Nonnull addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic) NSSet<ZMUser *> * _Nonnull addedUsers; // Only filled for ZMSystemMessageTypePotentialGap and ZMSystemMessageTypeIgnoredClient
 @property (nonatomic) NSSet<ZMUser *> * _Nonnull removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
 @property (nonatomic, copy) NSString * _Nullable text;
 @property (nonatomic) BOOL needsUpdatingUsers;

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -479,7 +479,7 @@ enum SecurityChangeType {
         case .clientTrusted:
             conversation.increaseSecurityLevelIfNeededAfterTrusting(clients: clients)
         case .clientIgnored:
-            conversation.decreaseSecurityLevelIfNeededAfterIgnoring(clients: clients)
+            conversation.decreaseSecurityLevelIfNeededAfterIgnoring(clients: clients, addedUser: nil)
         case .clientDiscovered:
             conversation.decreaseSecurityLevelIfNeededAfterDiscovering(clients: clients, causedBy: causedBy)
         }


### PR DESCRIPTION
We want to be able to distinguish wether the securityLevel of a secured conversation changes due to
a) you unverified a client
b) someone added a new client
c) a new person with unverified client was added

Currently c) is not possible. In order to distinguish case c) in the UI, we now set the addedUsers property on the SystemMessage