### PR TITLE
Fix crash nil userName or nil conversation

### DIFF
--- a/Source/Model/User/DisplayNameGenerator.swift
+++ b/Source/Model/User/DisplayNameGenerator.swift
@@ -69,7 +69,7 @@ public class DisplayNameGenerator : NSObject {
         currentDisplayNameMap = ConversationDisplayNameMap(conversationObjectID: conversation.objectID, map: newMap)
         guard let name = newMap[user.objectID] else {
             zmLog.warn("User is not member of this conversation")
-            return user.name
+            return user.name ?? ""
         }
         return name
     }

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -234,6 +234,9 @@ static NSString *const AnnaBotHandle = @"annathebot";
 
 - (NSString *)displayNameInConversation:(ZMConversation *)conversation;
 {
+    if (conversation == nil) {
+        return self.displayName;
+    }
     return [self.managedObjectContext.nameGenerator displayNameFor:self in:conversation];
 }
 

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -333,4 +333,30 @@ extension DisplayNameGeneratorTests {
         XCTAssertEqual(user1.displayName(in: conversation), "Harald")
     }
 
+    func testThatItDoesNotCrashWhenTheConversationIsNil(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Hans Schmidt"
+        
+        // then
+        XCTAssertEqual(user1.displayName(in: nil), "Hans")
+    }
+    
+    func testThatItDoesNotCrashWhenTheUserIsNotInTheConversationAndItsNameIsNil(){
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        user2.name = "Uschi Meier"
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .group
+        conversation.mutableOtherActiveParticipants.addObjects(from: [user2])
+        
+        // then
+        performIgnoringZMLogError{
+            XCTAssertEqual(user1.displayName(in: conversation), "")
+        }
+    }
+    
+    
 }


### PR DESCRIPTION
The method for `displayNameInConversation` is called from an ObjC interface which does not safely check for nullability.
Also, if a user's displayName is requested in a conversation he is not a member of and his name is not set, it does now not crash anymore.