### PR TITLE
Call the delegate with empty results if there are no messages to be searched

### DIFF
--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -200,6 +200,12 @@ public class TextSearchQuery: NSObject {
             self.notIndexedMessageCount = self.countForNonIndexedMessages()
             zmLog.debug("Searching for \"\(self.originalQuery)\", indexed: \(self.indexedMessageCount), not indexed: \(self.notIndexedMessageCount)")
 
+            if self.indexedMessageCount == 0 && self.notIndexedMessageCount == 0 {
+                // No need to perform a search if there are not messages.
+                zmLog.debug("Skipping search as there are no searchable messages.")
+                return self.notifyDelegate(with: [], hasMore: false)
+            }
+
             self.executeQueryForIndexedMessages { [weak self] in
                 self?.executeQueryForNonIndexedMessages()
             }
@@ -287,6 +293,7 @@ public class TextSearchQuery: NSObject {
             let queryResult = self.result?.updated(appending: uiMessages, hasMore: hasMore)
                            ?? TextQueryResult(query: self, matches: uiMessages, hasMore: hasMore)
 
+            zmLog.debug("Notifying delegate with \(uiMessages.count) new and \(queryResult.matches.count) total matches")
             self.result = queryResult
             self.delegate?.textSearchQueryDidReceive(result: queryResult)
         }

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -180,7 +180,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         // Then
         let results = search(for: "search query", in: conversation)
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first?.matches.count, 1)
+        XCTAssertEqual(results.first?.matches.count, 0)
     }
 
 

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -172,6 +172,17 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         XCTAssertEqual(second.textMessageData?.messageText, firstMessage.textMessageData?.messageText)
     }
 
+    func testThatItCallsTheDelegateWithEmptyResultsIfThereAreNoMessages() {
+        // Given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.remoteIdentifier = .create()
+
+        // Then
+        let results = search(for: "search query", in: conversation)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.matches.count, 1)
+    }
+
 
     func testThatItReturnsMatchesWhenAllMessagesAreIndexed() {
         // Given


### PR DESCRIPTION
# What's in this PR?

* When searching in a conversation without any messages that can be searched the `TextSearchQueryDelegate` was never notified.
* Fixes the failing `wire-ios-sync-engine` test `testThatItDoesNotFindAMessageDeletedRemotely`.
