### PR TITLE
Various fixes notification center

### DIFF
--- a/Source/Notifications/SnapshotCenter.swift
+++ b/Source/Notifications/SnapshotCenter.swift
@@ -61,11 +61,12 @@ public class SnapshotCenter {
         let attributes = Array(object.entity.attributesByName.keys)
         let relationShips = object.entity.relationshipsByName
         
-        let attributesDict = attributes.mapToDictionaryWithOptionalValue{object.value(forKey: $0) as? NSObject}
+        let attributesDict = attributes.mapToDictionaryWithOptionalValue{object.primitiveValue(forKey: $0) as? NSObject}
         let relationshipsDict : [String : Int] = relationShips.mapKeysAndValues(keysMapping: {$0}, valueMapping: { (key, relationShipDescription) in
             guard relationShipDescription.isToMany else { return nil}
-            return (object.value(forKey: key) as? Countable)?.count
+            return (object.primitiveValue(forKey: key) as? Countable)?.count
         })
+        
         return Snapshot(attributes : attributesDict, toManyRelationships : relationshipsDict)
     }
     


### PR DESCRIPTION
Fix 1:
When an observer performs a save when receiving a notification from the dispatcher we can currently end up in a loop because we are clearing snapshots and all changes only after they have been propagated. Now we are copying them to a local instance and/or clear them before propagating changes.

Fix 2:
In a recent PR i changed the snapshot to use valueForKey instead of primitiveValueForKey.
That was a mistake. Apparently when you use `primitiveValueForKey` it looks up the value in the CoreData snapshot. When we use `valueForKey` it refreshes CoreData's snapshot before returning the value. This way we don't notice when an object changes during a merge. Phuh...

