### PR TITLE
Do not re-insert client message with uploaded link preview

### DIFF
--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -305,10 +305,8 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 + (NSPredicate *)predicateForObjectsThatNeedToBeInsertedUpstream
 {
     NSPredicate *encryptedNotSynced = [NSPredicate predicateWithFormat:@"%K == TRUE && %K == FALSE", ZMMessageIsEncryptedKey, DeliveredKey];
-    NSPredicate *linkPreviewProcessed = [NSPredicate predicateWithFormat:@"%K == %d", ZMClientMessageLinkPreviewStateKey, ZMLinkPreviewStateUploaded];
-    NSPredicate *notSynced = [NSCompoundPredicate orPredicateWithSubpredicates:@[encryptedNotSynced, linkPreviewProcessed]];
     NSPredicate *notExpired = [NSPredicate predicateWithFormat:@"%K == 0", ZMMessageIsExpiredKey];
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSynced, notExpired]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[encryptedNotSynced, notExpired]];
 }
 
 - (void)markAsSent


### PR DESCRIPTION
# What's in this PR?

* This logic is moved into a new strategy which utilises a modified object sync instead.
* This modifies the internal behaviour heavily, so I am unsure if it shouldn't be a major release.