### PR TITLE
Move concrete reaction value into data model

### DIFF
--- a/Source/Model/Reaction/Reaction.swift
+++ b/Source/Model/Reaction/Reaction.swift
@@ -22,7 +22,6 @@ public let ZMReactionUnicodeValueKey    = "unicodeValue"
 public let ZMReactionMessageValueKey    = "message"
 public let ZMReactionUsersValueKey      = "users"
 
-
 @objc public enum TransportReaction : UInt32 {
     case none  = 0
     case heart = 1
@@ -59,7 +58,7 @@ open class Reaction : ZMManagedObject {
     
     @objc public static func transportReaction(from unicode: String) -> TransportReaction {
         switch unicode {
-        case "❤️":
+        case MessageReaction.like.unicodeValue:
             return .heart
         default:
             return .none

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -243,7 +243,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         // GIVEN
         let message = self.conversation.appendMessage(withText: "ramble on!")! as! ZMClientMessage
         message.delivered = true
-        ZMMessage.addReaction("❤️", toMessage: message)
+        ZMMessage.addReaction(.like, toMessage: message)
         XCTAssertFalse(message.usersReaction.isEmpty)
         self.conversation.managedObjectContext?.saveOrRollback()
         
@@ -256,7 +256,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         // GIVEN
         let message = self.conversation.appendMessage(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt")!))! as! ZMAssetClientMessage
         message.delivered = true
-        ZMMessage.addReaction("❤️", toMessage: message)
+        ZMMessage.addReaction(.like, toMessage: message)
         XCTAssertFalse(message.usersReaction.isEmpty)
         self.conversation.managedObjectContext?.saveOrRollback()
         

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -2075,10 +2075,10 @@ NSString * const ReactionsKey = @"reactions";
     [self.uiMOC saveOrRollback];
     XCTAssertEqual(message.deliveryState, ZMDeliveryStateSent);
 
-    //when
-    NSString *reactionUnicode = @"❤️";
+    // when
     // this is the UI facing call to add reaction
-    [ZMMessage addReaction:reactionUnicode toMessage:message];
+    
+    [ZMMessage addReaction:MessageReactionLike toMessage:message];
     [self.uiMOC saveOrRollback];
 
     //then
@@ -2086,7 +2086,7 @@ NSString * const ReactionsKey = @"reactions";
     ZMClientMessage *reactionMessage = [conversation.hiddenMessages lastObject];
     XCTAssertNotNil(reactionMessage.genericMessage);
     XCTAssertTrue(reactionMessage.genericMessage.hasReaction);
-    XCTAssertEqualObjects(reactionMessage.genericMessage.reaction.emoji, reactionUnicode);
+    XCTAssertEqualObjects(reactionMessage.genericMessage.reaction.emoji, @"❤️");
 }
 
 - (void)testThatAUnSentMessageCanNotBeLiked;
@@ -2098,10 +2098,9 @@ NSString * const ReactionsKey = @"reactions";
     [self.uiMOC saveOrRollback];
     XCTAssertEqual(message.deliveryState, ZMDeliveryStatePending);
 
-    //when
-    NSString *reactionUnicode = @"❤️";
+    // when
     // this is the UI facing call to add reaction
-    [ZMMessage addReaction:reactionUnicode toMessage:message];
+    [ZMMessage addReaction:MessageReactionLike toMessage:message];
     [self.uiMOC saveOrRollback];
 
     //then


### PR DESCRIPTION
# What's in this PR?

* This value will be used from `wire-ios-sync-engine` and it generally makes more sense to keep it in the data model instead of the UI.
