### PR TITLE
Update local user if search result has different handle / name

### DIFF
--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -88,19 +88,21 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
         _user = user;
         _syncMOC = syncMOC;
         _uiMOC = uiMOC;
+
         if (self.user == nil) {
             _name = name;
             _handle = handle;
             
             PersonName *personName = [PersonName personWithName:name schemeTagger:nil];
             _initials = personName.initials;
-            
             _accentColorValue =  color;
             _isConnected = NO;
             _remoteIdentifier = remoteID;
+        } else {
+            [self.user updateWithSearchResultName:name handle:handle];
         }
-//        CheckString(self.remoteIdentifier != nil, "No remote ID?");
     }
+
     return self;
 }
 

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -68,6 +68,10 @@ extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 + (ZMAccentColor)accentColorFromPayloadValue:(nullable NSNumber *)payloadValue;
 
+/// @method Updates the user with a name or handle received through a search
+/// Should be called when creating a @c ZMSearchUser to ensure it's underlying user is updated.
+- (void)updateWithSearchResultName:(nullable NSString *)name handle:(nullable NSString *)handle;
+
 
 @end
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -634,6 +634,19 @@ static NSString *const AnnaBotHandle = @"annathebot";
     return predicate;
 }
 
+- (void)updateWithSearchResultName:(NSString *)name handle:(NSString *)handle;
+{
+    // We never refetch unconnected users, but when performing a search we
+    // might receive updated result and can update existing local users.
+    if (name != nil && name != self.name) {
+        self.name = name;
+    }
+
+    if (handle != nil && handle != self.handle) {
+        self.handle = handle;
+    }
+}
+
 @end
 
 

--- a/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -382,6 +382,30 @@
     XCTAssertEqual(user.connection.status, ZMConnectionStatusSent);
 }
 
+- (void)testThatALocalUserIsUpdatedWhenTheSearchUserHasAnUpdatedNameAndHandle
+{
+    // Given
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.name = @"Bruno";
+    user.handle = @"bruno";
+    XCTAssert([self.uiMOC saveOrRollback]);
+
+    // When
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"Hans"
+                                                           handle:@"hans"
+                                                      accentColor:ZMAccentColorUndefined
+                                                         remoteID:nil
+                                                             user:user
+                                         syncManagedObjectContext:self.syncMOC
+                                           uiManagedObjectContext:self.uiMOC];
+
+    NOT_USED(searchUser);
+
+    // Then
+    XCTAssertEqualObjects(user.name, @"Hans");
+    XCTAssertEqualObjects(user.handle, @"hans");
+}
+
 - (void)testThatItDoesNotConnectIfTheSearchUserHasAConnectedUser;
 {
     // We expect the search user to only have a user, if that user has a (matching)
@@ -391,6 +415,8 @@
     // given
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     user.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.name = @"Hans";
+    user.handle = @"hans";
     user.connection.status = ZMConnectionStatusAccepted;
     XCTAssert([self.uiMOC saveOrRollback]);
 


### PR DESCRIPTION
# What's in this PR?

* When searching for an unconnected user we did not update the local user (we never refetch unconnected users at the moment).
* The local user will now be updated if the search returned a different handle or name as we have stored locally.
* This is the underlying issue which was tried to be resolved in of https://github.com/wireapp/wire-ios/pull/743 and https://github.com/wireapp/wire-ios/pull/750 and also the reason these two PR's did not solve the issue.