### PR TITLE
CI: trying to fix spurious errors by turning off code signing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,11 +42,7 @@ test:
     - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output tests.xml:
         pwd:
           $CIRCLE_PROJECT_REPONAME
-    - slather coverage --html --input-format profdata --scheme ZMCDataModel --output-directory code_coverage --ignore ../../* ZMCDataModel.xcproj:
-        pwd:
-          $CIRCLE_PROJECT_REPONAME
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - mkdir -p $CIRCLE_TEST_REPORTS/code_coverage/
     - cp $CIRCLE_PROJECT_REPONAME/tests.xml $CIRCLE_TEST_REPORTS/junit/
-    - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -28,11 +28,17 @@ dependencies:
   cache_directories:
     - wire-ios-scripts
 
+compile:
+  override:
+    - xcodebuild -scheme ZMCDataModel clean analyze build-for-testing -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty:
+        pwd:
+          $CIRCLE_PROJECT_REPONAME
+
 test:
   override:
-    - ./CI/Bots/bot-build.swift --workspace "../${CIRCLE_PROJECT_REPONAME}":
+    - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty:
         pwd:
-          wire-ios-scripts
+          $CIRCLE_PROJECT_REPONAME
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - mkdir -p $CIRCLE_TEST_REPORTS/code_coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,7 @@ compile:
 
 test:
   override:
-    - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output $CIRCLE_PROJECT_REPONAME/tests.xml:
+    - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output tests.xml:
         pwd:
           $CIRCLE_PROJECT_REPONAME
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,9 @@ dependencies:
 
 compile:
   override:
+    - carthage bootstrap:
+        pwd:
+          $CIRCLE_PROJECT_REPONAME
     - xcodebuild -scheme ZMCDataModel clean analyze build-for-testing -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty:
         pwd:
           $CIRCLE_PROJECT_REPONAME

--- a/circle.yml
+++ b/circle.yml
@@ -42,9 +42,11 @@ test:
     - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output tests.xml:
         pwd:
           $CIRCLE_PROJECT_REPONAME
-    - coverage --html --input-format profdata --scheme ZMCDataModel --output-directory code_coverage .
+    - slather coverage --html --input-format profdata --scheme ZMCDataModel --output-directory code_coverage --ignore ../../* ZMCDataModel.xcproj:
+        pwd:
+          $CIRCLE_PROJECT_REPONAME
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - mkdir -p $CIRCLE_TEST_REPORTS/code_coverage/
     - cp $CIRCLE_PROJECT_REPONAME/tests.xml $CIRCLE_TEST_REPORTS/junit/
-    # - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/
+    - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -42,8 +42,9 @@ test:
     - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output tests.xml:
         pwd:
           $CIRCLE_PROJECT_REPONAME
+    - coverage --html --input-format profdata --scheme ZMCDataModel --output-directory code_coverage .
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - mkdir -p $CIRCLE_TEST_REPORTS/code_coverage/
     - cp $CIRCLE_PROJECT_REPONAME/tests.xml $CIRCLE_TEST_REPORTS/junit/
-    - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/
+    # - rsync -auv $CIRCLE_PROJECT_REPONAME/code-coverage/ $CIRCLE_TEST_REPORTS/code-coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,7 @@ compile:
 
 test:
   override:
-    - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty:
+    - xcodebuild -scheme ZMCDataModel test-without-building -enableCodeCoverage YES -destination platform=iOS\ Simulator,name=iPhone\ 7,OS=10.2 | xcpretty -r junit --output $CIRCLE_PROJECT_REPONAME/tests.xml:
         pwd:
           $CIRCLE_PROJECT_REPONAME
   post:


### PR DESCRIPTION
We got a tip from CircleCI that code signing might be the reason we get spurious build errors.