### PR TITLE
Update missedCallTimeStamp and isArchived inserting missedCall

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Calling.swift
+++ b/Source/Model/Conversation/ZMConversation+Calling.swift
@@ -22,6 +22,9 @@ public extension ZMConversation {
     
     public func appendMissedCallMessage(fromUser user: ZMUser, at timestamp: Date) {
         appendSystemMessage(type: .missedCall, sender: user, users: Set<ZMUser>([user]), clients: nil, timestamp: timestamp)
+        if isArchived && !isSilenced {
+            isArchived = false
+        }
     }
     
 }

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -327,6 +327,7 @@ extension ZMConversation {
         if systemMessage.shouldGenerateUnreadCount() {
             precondition(timestamp != nil, "An unread dot generating system message must have a timestamp")
             updateLastServerTimeStampIfNeeded(timestamp)
+            updateUnreadMessages(with: systemMessage)
         }
         
         return (message: systemMessage, insertionIndex: index)

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -214,8 +214,11 @@ public class NotificationDispatcher : NSObject {
         let change = Changes(changedKeys: Set(changedKeys))
 
         let objectAndChangedKeys = [object: change]
-        allChanges = allChanges.merged(with: objectAndChangedKeys) 
-        managedObjectContext.forceSaveOrRollback()
+        allChanges = allChanges.merged(with: objectAndChangedKeys)
+        // Fire notifications only if there won't be a save happening anytime soon
+        if !managedObjectContext.zm_hasChanges {
+            fireAllNotifications()
+        }
     }
     
     /// Forwards inserted and deleted conversations to the conversationList observer to update lists accordingly


### PR DESCRIPTION
With V3 calling, missedCall systemMessages are inserted locally and not like previously through an push event. Therefore, we need to make sure that the conversation is updated accordingly, which means: 
1) If the conversation is archived and not silenced, we need to unarchive the conversation.
2) We need to updated the lastUnreadMissedCallDate timestamp in order to show the missedCall conversationList indicator.

Also in this PR: A minor change to how we handle nonCoreDataChanges. We used to enforce a save in order to make sure we send out the notifications with all the other changes. Instead we now check if the uiContext hasChanges which means it will most likely be saved soon. If it does not have changes, we fire the notification immediately.