### PR TITLE
Don’t decrease security level for already added users

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1475,12 +1475,16 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
     
     if (otherUsers.count > 0) {
+        NSSet *existingUsers = self.otherActiveParticipants.set;
         [self.mutableOtherActiveParticipants addObjectsFromArray:otherUsers.allObjects];
         if(isAuthoritative) {
             [self.mutableLastServerSyncedActiveParticipants addObjectsFromArray:otherUsers.allObjects];
         }
         
-        [self decreaseSecurityLevelIfNeededAfterDiscoveringClients:[ZMConversation clientsOfUsers:otherUsers] causedByAddedUsers:otherUsers];
+        [otherUsers minusSet:existingUsers];
+        if (otherUsers.count > 0) {
+            [self decreaseSecurityLevelIfNeededAfterDiscoveringClients:[ZMConversation clientsOfUsers:otherUsers] causedByAddedUsers:otherUsers];
+        }
     }
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -1109,4 +1109,22 @@
     XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
 }
 
+- (void)testThatAddingABlockedUserThatAlreadyIsMemberOfTheConversationDoesNotDegradeTheConversation
+{
+    // This happens when we are blocking a user in a 1on1: We recieve a conversation update from the backend as a response to blocking the user, which then "readds" the user. Since the user is already part of the conversation it should not degrade the conversation.
+    
+    // given
+    ZMConversation *conversation = [self setupVerifiedConversation];
+    ZMUser *participant = [conversation.otherActiveParticipants firstObject];
+    XCTAssertNotNil(participant);
+    XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
+    [participant block];
+    
+    // when
+    [conversation addParticipant:participant];
+    
+    // then
+    XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
+}
+
 @end


### PR DESCRIPTION
When blocking a user, we receive a conversation update from the backend. We process the update and call internalAddParticipants with a user that is already part of the conversation (the blocked user). Since we degrade the conversation when users are added and previously did not check of those "added" user are already part of the conversation, the securityLevel falsely decreases.

We now check if the "added user" is already there and only if not, we degrade the conversation. 