### PR TITLE
Update ZMCommonContactsSearchDelegate protocol

### DIFF
--- a/Source/Public/ZMBareUser.h
+++ b/Source/Public/ZMBareUser.h
@@ -70,7 +70,7 @@
 
 @protocol ZMCommonContactsSearchDelegate
 
-- (void)didReceiveCommonContactsUsers:(NSOrderedSet *)users forSearchToken:(id<ZMCommonContactsSearchToken>)searchToken;
+- (void)didReceiveNumberOfTotalMutualConnections:(NSUInteger)numberOfConnections forSearchToken:(id<ZMCommonContactsSearchToken>)searchToken;
 
 @end
 

--- a/Source/Public/ZMBareUser.h
+++ b/Source/Public/ZMBareUser.h
@@ -19,10 +19,6 @@
 
 #import <ZMUtilities/ZMAccentColor.h>
 
-@protocol ZMCommonContactsSearchDelegate;
-@protocol ZMCommonContactsSearchToken
-@end
-
 /// The minimal set of properties and methods that something User-like must include
 @protocol ZMBareUser <NSObject>
 
@@ -66,13 +62,6 @@
 
 @end
 
-
-
-@protocol ZMCommonContactsSearchDelegate
-
-- (void)didReceiveNumberOfTotalMutualConnections:(NSUInteger)numberOfConnections forSearchToken:(id<ZMCommonContactsSearchToken>)searchToken;
-
-@end
 
 
 @protocol ZMBareUserConnection <NSObject>


### PR DESCRIPTION
# What's in this PR?

* We will stop using the `/search/common` endpoint and the UI only needs to know the number of common connections. This PR updates the `ZMCommonContactsSearchDelegate` protocol accordingly.