### PR TITLE
Immediately notify after updating conversation list

### DIFF
--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -229,8 +229,7 @@ public class NotificationDispatcher : NSObject {
         let insertedObjects = (userInfo[NSInsertedObjectsKey] as? Set<NSManagedObject>)?.flatMap{$0 as? ZMConversation} ?? []
         let deletedObjects = (userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>)?.flatMap{$0 as? ZMConversation} ?? []
         conversationListObserverCenter.conversationsChanges(inserted: insertedObjects,
-                                                            deleted: deletedObjects,
-                                                            accumulated: false)
+                                                            deleted: deletedObjects)
     }
     
     /// Call this from syncStrategy AFTER merging the changes from syncMOC into uiMOC

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -51,16 +51,22 @@ import Foundation
     }
     
     @objc public func mergeLastChanges() {
-        guard let change = mergeNotifications.last else { return }
+        let changedObjects =  mergeLastChangesWithoutNotifying()
+        self.dispatcher.didMergeChanges(Set(changedObjects))
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+    }
+    @objc @discardableResult public func mergeLastChangesWithoutNotifying() -> [NSManagedObjectID] {
+        guard let change = mergeNotifications.last else { return [] }
         let changedObjects = (change.userInfo?[NSUpdatedObjectsKey] as? Set<ZMManagedObject>)?.map{$0.objectID} ?? []
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
         self.uiMOC.mergeChanges(fromContextDidSave: change)
-        self.dispatcher.didMergeChanges(Set(changedObjects))
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
         mergeNotifications = []
+        return changedObjects
     }
+
+    
 }
 
 class NotificationDispatcherTests : NotificationDispatcherTestBase {


### PR DESCRIPTION
**The Crash**
The app was crashing when logging in to an existing account. The reason as it seems was a timing issue with the conversationListObserver:
1) A new conversation was inserted, the list observer inserted it into the list
2) The conversationListObserver registered
3) The notification for the insertion and subsequent updates was sent
=> The app crashes since the notification "assumes" that the observer does not know about the conversation yet

**The solution**
Instead of updating the list immediately, we wait until the merge / save is complete and all change notifications are computed. Only then do we process inserted and deleted conversations and update the lists and immediately notify the observers.