### PR TITLE
Fix/fix broken connection

### DIFF
--- a/Source/Model/Connection/ZMConnection.m
+++ b/Source/Model/Connection/ZMConnection.m
@@ -225,6 +225,9 @@ struct stringAndStatus {
         if (self.conversation != nil) {
             if (! [self.conversation.remoteIdentifier isEqual:conversationID]) {
                 ZMLogError(@"Conversation UUID in connection doesn't match previous value.");
+                ZMConversation *realConversation = [ZMConversation conversationWithRemoteID:conversationID createIfNeeded:YES inContext:self.managedObjectContext];
+                self.conversation = realConversation;
+                self.conversation.needsToBeUpdatedFromBackend = YES;
             }
         } else {
             self.conversation = [ZMConversation conversationWithRemoteID:conversationID createIfNeeded:YES inContext:self.managedObjectContext];


### PR DESCRIPTION
# Reason for this pull request
For some reasons (still to understand), the `conversation` relationship of a `connection` was pointing to a group conversation, while it should only ever point to a one-to-one conversation. This was causing all sort of issues, particularly a request loop when attempting to send a message. Even after re-fetching the conversation metadata, we could not recover.

# Changes
- Establish a relationship to the correct conversation when refetching the metadata of a connection 