### PR TITLE
Allow having multiple message windows

### DIFF
--- a/Source/Model/Conversation/ZMConversationMessageWindow+Internal.h
+++ b/Source/Model/Conversation/ZMConversationMessageWindow+Internal.h
@@ -16,12 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 #import "ZMConversationMessageWindow.h"
-
-extern NSString * const ZMConversationMessageWindowScrolledNotificationName;
-
-
 
 @interface ZMConversationMessageWindow (Internal)
 

--- a/Source/Model/Conversation/ZMConversationMessageWindow.m
+++ b/Source/Model/Conversation/ZMConversationMessageWindow.m
@@ -26,20 +26,6 @@
 #import "ZMOTRMessage.h"
 #import <ZMCDataModel/ZMCDataModel-Swift.h>
 
-NSString * const ZMConversationMessageWindowScrolledNotificationName = @"ZMConversationMessageWindowScrolledNotification";
-NSString * const ZMConversationMessageWindowCreatedNotificationName = @"ZMConversationMessageWindowCreatedNotification";
-
-typedef NS_ENUM(int, ZMMessageWindowEvent) {
-    ZMMessageWindowEventAddObserver = 1,
-    ZMMessageWindowEventRemoveObserver = 2,
-    ZMMessageWindowEventConversationDidChange = 3,
-    ZMMessageWindowEventConversationMessagesDidChange = 4,
-};
-
-//static inline void ZMTraceUserInterfaceMessageWindow(ZMConversationMessageWindow *window, ZMMessageWindowEvent e);
-
-
-
 @interface ZMConversationMessageWindow ()
 
 @property (nonatomic, readonly) NSMutableOrderedSet *mutableMessages;
@@ -132,8 +118,6 @@ typedef NS_ENUM(int, ZMMessageWindowEvent) {
     self.size -= MIN(amountOfMessages, MAX(self.size, 1u) - 1u);
     if (oldSize != self.activeSize) {
         [self recalculateMessages];
-        // It seems that moveDownByMessages is never called and it has no effect anyway, so I don't need the next line for now
-        //[[NSNotificationCenter defaultCenter] postNotificationName:ZMConversationMessageWindowScrolledNotificationName object:self];
     }
     
 }

--- a/Tests/Source/Model/Conversation/ZMConversationMessageWindowTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationMessageWindowTests.m
@@ -410,25 +410,6 @@
     [mockObserverCenter verify];
 }
 
-- (void)testThatScrollingTheWindowUpDoesNotCauseAScrollingNotificationIfTheWindowDidNotChange
-{
-    // given
-    ZMConversation *conversation = [self createConversationWithMessages:10];
-    ZMConversationMessageWindow *window = [conversation conversationWindowWithSize:10];
-    
-    // expect
-    [self expectationForNotification:ZMConversationMessageWindowScrolledNotificationName object:window handler:nil];
-    
-    // when
-    [window moveUpByMessages:10];
-    
-    // then
-    [self spinMainQueueWithTimeout:0.1];
-    XCTAssertFalse([self waitForCustomExpectationsWithTimeout:0.0]);
-}
-
-
-
 @end
 
 


### PR DESCRIPTION
- Before the `MessageWindowObserverCenter` allowed only one window snapshot.
- Bug happened when we used to display two conversation views at the same time (with force touch in conversation list).
- In this case the latter window was loosing the observer since it's snapshot was removed when first window was deallocated.

Also removed some old and unused code / notifications.