### PR TITLE
Send currentState in SetSnapShot to avoid crashes

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
@@ -35,7 +35,7 @@ extension ZMConversationList {
     public var conversationList : ZMConversationList { return self.observedObject as! ZMConversationList }
     
     init(setChangeInfo: SetChangeInfo) {
-        super.init(observedObject: object,
+        super.init(observedObject: setChangeInfo.observedObject,
                    changeSet: setChangeInfo.changeSet,
                    orderedSetState: setChangeInfo.orderedSetState)
     }

--- a/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
@@ -35,7 +35,9 @@ extension ZMConversationList {
     public var conversationList : ZMConversationList { return self.observedObject as! ZMConversationList }
     
     init(setChangeInfo: SetChangeInfo) {
-        super.init(observedObject: setChangeInfo.observedObject, changeSet: setChangeInfo.changeSet)
+        super.init(observedObject: object,
+                   changeSet: setChangeInfo.changeSet,
+                   orderedSetState: setChangeInfo.orderedSetState)
     }
 }
 

--- a/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
@@ -33,6 +33,8 @@ public struct SetStateUpdate {
 @objc open class SetChangeInfo : NSObject {
     
     let changeSet : ZMChangedIndexes
+    open let orderedSetState : NSOrderedSet
+    
     open let observedObject : NSObject
     open var insertedIndexes : IndexSet { return changeSet.insertedIndexes }
     open var deletedIndexes : IndexSet { return changeSet.deletedIndexes }
@@ -42,11 +44,12 @@ public struct SetStateUpdate {
     
     convenience init(observedObject: NSObject) {
         let orderSetState = ZMOrderedSetState(orderedSet: NSOrderedSet())
-        self.init(observedObject: observedObject, changeSet: ZMChangedIndexes(start: orderSetState, end: orderSetState, updatedState: orderSetState))
+        self.init(observedObject: observedObject, changeSet: ZMChangedIndexes(start: orderSetState, end: orderSetState, updatedState: orderSetState), orderedSetState: NSOrderedSet())
     }
     
-    public init(observedObject: NSObject, changeSet: ZMChangedIndexes) {
+    public init(observedObject: NSObject, changeSet: ZMChangedIndexes, orderedSetState: NSOrderedSet) {
         self.changeSet = changeSet
+        self.orderedSetState = orderedSetState
         self.observedObject = observedObject
     }
 
@@ -93,8 +96,9 @@ public struct SetSnapshot {
             return nil
         }
         
-        let changeSet = self.calculateChangeSet(newSet.copy() as! NSOrderedSet, updatedObjects: updatedObjects)
-        let changeInfo = SetChangeInfo(observedObject: observedObject, changeSet: changeSet)
+        let newSetCopy = newSet.copy() as! NSOrderedSet
+        let changeSet = self.calculateChangeSet(newSetCopy, updatedObjects: updatedObjects)
+        let changeInfo = SetChangeInfo(observedObject: observedObject, changeSet: changeSet, orderedSetState: newSetCopy)
 
         let insertedObjects = newSet.subtracting(orderedSet: set)
         let removedObjects = set.subtracting(orderedSet: newSet)

--- a/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
@@ -26,7 +26,7 @@ import Foundation
     public var isFetchingMessages = false
     
     init(setChangeInfo: SetChangeInfo) {
-        super.init(observedObject: setChangeInfo.observedObject, changeSet: setChangeInfo.changeSet)
+        super.init(observedObject: setChangeInfo.observedObject, changeSet: setChangeInfo.changeSet, orderedSetState: setChangeInfo.orderedSetState)
     }
     convenience init(windowWithMissingMessagesChanged window: ZMConversationMessageWindow, isFetching: Bool) {
         self.init(setChangeInfo: SetChangeInfo(observedObject: window))


### PR DESCRIPTION
We have several crashes when updating the conversationList or other collections for which we calculate changes. These crashes can happen, when we send a notification for a change and the collection changes between creating the notification and processing the notification by the observer. The observer currently does not know about the state with which the notification was created, instead it gets the current state of the collection. 

To avoid future crashes, we can send the state of the collection at the time of creation along with the SetChangeInfo. The observer can then use this collection to populate its views or can compare the current state of the collection with the one in the notification and then reload the views instead of using the update.