### PR TITLE
Fix/session removal

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -164,6 +164,8 @@ public class UserClient: ZMManagedObject, UserClientType {
         if let sessionIdentifier = self.sessionIdentifier {
             UserClient.deleteSession(for: sessionIdentifier, managedObjectContext: managedObjectContext!)
         }
+        // reset the relationship
+        self.user = nil
         // delete the object
         managedObjectContext?.delete(self)
         

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -160,8 +160,6 @@ public class UserClient: ZMManagedObject, UserClientType {
         let user = self.user
         
         self.failedToEstablishSession = false
-        // reset the relationship
-        self.user = nil
         // reset the session
         if let sessionIdentifier = self.sessionIdentifier {
             UserClient.deleteSession(for: sessionIdentifier, managedObjectContext: managedObjectContext!)

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -230,6 +230,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
 
             // when
             otherClient2.deleteClientAndEndSession()
+            self.syncMOC.saveOrRollback()
             
             // then
             XCTAssertTrue(otherClient2.isZombieObject)

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -166,7 +166,8 @@ class UserClientTests: ZMBaseManagedObjectTest {
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
             var preKeys : [(id: UInt16, prekey: String)] = []
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
-                preKeys = try! sessionsDirectory.generatePrekeys(CountableRange<UInt16>(0..<2))            })
+                preKeys = try! sessionsDirectory.generatePrekeys(CountableRange<UInt16>(0..<2))
+            })
             
             let otherClient = UserClient.insertNewObject(in: self.syncMOC)
             otherClient.remoteIdentifier = UUID.create().transportString()
@@ -182,11 +183,15 @@ class UserClientTests: ZMBaseManagedObjectTest {
             
             XCTAssertTrue(selfClient.establishSessionWithClient(otherClient, usingPreKey:preKey.prekey))
             XCTAssertTrue(otherClient.hasSessionWithSelfClient)
+            let clientId = otherClient.sessionIdentifier!
             
             // when
             otherClient.deleteClientAndEndSession()
             
             // then
+            selfClient.keysStore.encryptionContext.perform {
+                XCTAssertFalse($0.hasSession(for: clientId))
+            }
             XCTAssertFalse(otherClient.hasSessionWithSelfClient)
             XCTAssertTrue(otherClient.isZombieObject)
         }


### PR DESCRIPTION
# Reason for this pull request
Nil-ing the client-to-user relationship before using the session identifier caused sessions not to be deleted

# Changes
- We still need to nil the relationship even if we later delete the client, otherwise the relationship might not change (due to `nullify` model rule) until we perform a save, but we might check for it before performing a save