### PR TITLE
Upload messages regardless of the “encrypted” flag

### DIFF
--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -304,7 +304,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 
 + (NSPredicate *)predicateForObjectsThatNeedToBeInsertedUpstream
 {
-    NSPredicate *encryptedNotSynced = [NSPredicate predicateWithFormat:@"%K == TRUE && %K == FALSE", ZMMessageIsEncryptedKey, DeliveredKey];
+    NSPredicate *encryptedNotSynced = [NSPredicate predicateWithFormat:@"%K == FALSE", DeliveredKey];
     NSPredicate *notExpired = [NSPredicate predicateWithFormat:@"%K == 0", ZMMessageIsExpiredKey];
     return [NSCompoundPredicate andPredicateWithSubpredicates:@[encryptedNotSynced, notExpired]];
 }


### PR DESCRIPTION
# Reason for this pull request
Sometimes an expired message will have the flag "encrypted" set to false (unexpectedly) and not upload. The flag is not actually used anymore and will be removed in another PR, that will affect multiple frameworks.
I'm just changing the predicate here as a quick fix.