### PR TITLE
Make sure we always save on non-core data changes

### DIFF
--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -219,6 +219,8 @@ public class NotificationDispatcher : NSObject {
         // Fire notifications only if there won't be a save happening anytime soon
         if !managedObjectContext.zm_hasChanges {
             fireAllNotifications()
+        } else { // make sure we will save eventually, even if we forgot to save somehow
+            managedObjectContext.enqueueDelayedSave()
         }
     }
     


### PR DESCRIPTION
# Reason for this pull request
If there are changes to the context, but we "forget" to save, the non-core data change will never propagate