### PR TITLE
Update search user for v3 profile assets

### DIFF
--- a/Source/Model/User/SearchUserAsset.swift
+++ b/Source/Model/User/SearchUserAsset.swift
@@ -1,0 +1,86 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+public enum SearchUserAsset: ExpressibleByNilLiteral, Hashable {
+    case none
+    case legacyId(UUID)
+    case assetKey(String)
+
+    public init(nilLiteral: ()) {
+        self = .none
+    }
+
+    public var hashValue: Int {
+        switch self {
+        case .none: return 0
+        case .legacyId(let id): return id.hashValue
+        case .assetKey(let key): return key.hashValue
+        }
+    }
+
+    public func objcCompatibilityValue() -> SearchUserAssetObjC? {
+        return SearchUserAssetObjC(asset: self)
+    }
+}
+
+
+public func ==(lhs: SearchUserAsset, rhs: SearchUserAsset) -> Bool {
+    switch (lhs, rhs) {
+    case (.none, .none): return true
+    case (.legacyId(let leftId), .legacyId(let rightId)): return leftId == rightId
+    case (.assetKey(let leftKey), .assetKey(let rightKey)): return leftKey == rightKey
+    default: return false
+    }
+}
+
+
+@objc public class SearchUserAssetObjC: NSObject {
+    public let internalAsset: SearchUserAsset
+
+    @objc public var legacyID: UUID? {
+        get {
+            switch internalAsset {
+            case .legacyId(let id): return id
+            default: return nil
+            }
+        }
+    }
+
+    @objc public var assetKey: String? {
+        get {
+            switch internalAsset {
+            case .assetKey(let key): return key
+            default: return nil
+            }
+        }
+    }
+
+    public init(legacyId: UUID) {
+        internalAsset = .legacyId(legacyId)
+    }
+
+    public init(assetKey: String) {
+        internalAsset = .assetKey(assetKey)
+    }
+
+    fileprivate init?(asset: SearchUserAsset) {
+        if .none == asset { return nil }
+        internalAsset = asset
+    }
+}

--- a/Source/Model/User/ZMSearchUser+Internal.h
+++ b/Source/Model/User/ZMSearchUser+Internal.h
@@ -58,7 +58,8 @@ FOUNDATION_EXPORT NSString *const ZMSearchUserTotalMutualFriendsKey;
 /// C.f. +searchUserToProfileImageCache
 @property (nonatomic, readonly) BOOL isLocalOrHasCachedProfileImageData;
 
-@property (nonatomic) NSUUID *mediumAssetID;
+@property (nonatomic) NSUUID *mediumLegacyId;
+@property (nonatomic) NSString *completeAssetKey;
 
 @property (nonatomic, readwrite) NSUInteger totalCommonConnections;
 

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -398,7 +398,7 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     return searchUserToMediumImageCache;
 }
 
-+ (NSCache *)searchUserToMediumAssetIDCache;
++ (NSCache <NSUUID *, SearchUserAssetObjC* > *)searchUserToMediumAssetIDCache;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -420,7 +420,17 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
 
 - (NSUUID *)cachedMediumAssetID
 {
-    return [[ZMSearchUser searchUserToMediumAssetIDCache] objectForKey:self.remoteIdentifier];
+    return self.cachedMediumAsset.legacyID;
+}
+
+- (NSString *)cachedCompleteAssetKey
+{
+    return self.cachedMediumAsset.assetKey;
+}
+
+- (SearchUserAssetObjC *)cachedMediumAsset
+{
+    return [ZMSearchUser.searchUserToMediumAssetIDCache objectForKey:self.remoteIdentifier];
 }
 
 - (NSData *)imageSmallProfileData

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -250,7 +250,7 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
 
 - (BOOL)hasCachedMediumAssetIDOrData
 {
-    return (self.imageMediumData != nil || self.mediumAssetID != nil);
+    return (self.imageMediumData != nil || self.mediumLegacyId != nil || self.completeAssetKey != nil);
 }
 
 - (BOOL)isLocalOrHasCachedProfileImageData;
@@ -418,7 +418,7 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     return [[ZMSearchUser searchUserToMediumImageCache] objectForKey:self.remoteIdentifier];
 }
 
-- (NSUUID *)cachedMediumAssetID
+- (NSUUID *)cachedMediumLegacyId
 {
     return self.cachedMediumAsset.legacyID;
 }
@@ -465,12 +465,20 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
 }
 
 
-- (NSUUID *)mediumAssetID
+- (NSUUID *)mediumLegacyId
 {
-    if (_mediumAssetID == nil) {
-        _mediumAssetID = [self cachedMediumAssetID];
+    if (_mediumLegacyId == nil) {
+        _mediumLegacyId = [self cachedMediumLegacyId];
     }
-    return _mediumAssetID;
+    return _mediumLegacyId;
+}
+
+- (NSString *)completeAssetKey
+{
+    if (_completeAssetKey == nil) {
+        _completeAssetKey = [self cachedCompleteAssetKey];
+    }
+    return _completeAssetKey;
 }
 
 - (NSString *)imageSmallProfileIdentifier
@@ -493,8 +501,11 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     if (self.user != nil) {
         return self.user.imageMediumIdentifier;
     }
-    if (self.mediumAssetID != nil) {
-        return self.mediumAssetID.transportString;
+    if (self.completeAssetKey != nil) {
+        return self.completeAssetKey;
+    }
+    if (self.mediumLegacyId != nil) {
+        return self.mediumLegacyId.transportString;
     }
     if ([self cachedMediumProfileData] != nil) {
         return self.remoteIdentifier.transportString;

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -40,7 +40,7 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
 {
     NSData *_imageSmallProfileData;
     NSString *_imageSmallProfileIdentifier;
-    
+
     NSData *_imageMediumData;
 }
 
@@ -104,14 +104,6 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     }
 
     return self;
-}
-
-- (NSString *)smallProfileImageCacheKey {
-    return @"";
-}
-
-- (NSString *)mediumProfileImageCacheKey {
-    return @"";
 }
 
 - (instancetype)initWithName:(NSString *)name
@@ -498,6 +490,14 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
         return self.remoteIdentifier.transportString;
     }
     return nil;
+}
+
+- (NSString *)smallProfileImageCacheKey {
+    return self.imageSmallProfileIdentifier;
+}
+
+- (NSString *)mediumProfileImageCacheKey {
+    return self.imageMediumIdentifier;
 }
 
 

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -150,8 +150,6 @@ extension ZMUser {
                         completeProfileAssetIdentifier = key
                         imageMediumData = nil
                     }
-                default:
-                    break
                 }
             }
         }

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -30,6 +30,21 @@ import Foundation
             return .profile
         }
     }
+
+    init?(stringValue: String) {
+        switch stringValue {
+        case ProfileImageSize.preview.stringValue: self = .preview
+        case ProfileImageSize.complete.stringValue: self = .complete
+        default: return nil
+        }
+    }
+
+    var stringValue: String {
+        switch self {
+        case .preview: return "preview"
+        case .complete: return "complete"
+        }
+    }
     
     public static var allSizes: [ProfileImageSize] {
         return [.preview, .complete]
@@ -68,10 +83,10 @@ extension ZMUser {
             }
         } else {
             guard let imageData = data else {
-                managedObjectContext?.zm_userImageCache.removeAllUserImages(self)
+                managedObjectContext?.zm_userImageCache?.removeAllUserImages(self)
                 return
             }
-            managedObjectContext?.zm_userImageCache.setUserImage(self, imageData: imageData, size: size)
+            managedObjectContext?.zm_userImageCache?.setUserImage(self, imageData: imageData, size: size)
         }
         didChangeValue(forKey: key)
         managedObjectContext?.saveOrRollback()
@@ -82,7 +97,7 @@ extension ZMUser {
         if isSelfUser {
             return primitiveValue(forKey: size.userKeyPath) as? Data
         } else {
-            return managedObjectContext?.zm_userImageCache.userImage(self, size: size)
+            return managedObjectContext?.zm_userImageCache?.userImage(self, size: size)
         }
     }
     
@@ -123,14 +138,14 @@ extension ZMUser {
             return
         }
         for data in assets {
-            if let size = data["size"], let key = data["key"] {
+            if let size = data["size"].flatMap(ProfileImageSize.init), let key = data["key"] {
                 switch size {
-                case "preview":
+                case .preview:
                     if key != previewProfileAssetIdentifier {
                         previewProfileAssetIdentifier = key
                         imageSmallProfileData = nil
                     }
-                case "complete":
+                case .complete:
                     if key != completeProfileAssetIdentifier {
                         completeProfileAssetIdentifier = key
                         imageMediumData = nil

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -31,7 +31,7 @@ import Foundation
         }
     }
 
-    init?(stringValue: String) {
+    public init?(stringValue: String) {
         switch stringValue {
         case ProfileImageSize.preview.stringValue: self = .preview
         case ProfileImageSize.complete.stringValue: self = .complete

--- a/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -686,6 +686,7 @@
     [smallImageCache setObject:smallImage forKey:searchUser.remoteIdentifier];
     
     NSCache *mediumAssetCache = [ZMSearchUser searchUserToMediumAssetIDCache];
+    
     [mediumAssetCache setObject:mediumAssetID forKey:searchUser.remoteIdentifier];
     
     // then

--- a/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -668,11 +668,11 @@
     XCTAssertTrue(searchUser.isLocalOrHasCachedProfileImageData);
 }
 
-- (void)testThat_isLocalOrHasCachedProfileImageData_returnsYesForAUserWithCachedSmallData_MediumAssetID
+- (void)testThat_isLocalOrHasCachedProfileImageData_returnsYesForAUserWithCachedSmallData_MediumLegcayId
 {
     // given
     NSData *smallImage = [@"bar" dataUsingEncoding:NSUTF8StringEncoding];
-    NSUUID *mediumAssetID = [NSUUID UUID];
+    NSUUID *mediumLegacyId = [NSUUID UUID];
     
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"foo"
                                                            handle:@"foo"
@@ -686,9 +686,32 @@
     [smallImageCache setObject:smallImage forKey:searchUser.remoteIdentifier];
     
     NSCache *mediumAssetCache = [ZMSearchUser searchUserToMediumAssetIDCache];
+    [mediumAssetCache setObject:[[SearchUserAssetObjC alloc] initWithLegacyId:mediumLegacyId] forKey:searchUser.remoteIdentifier];
     
-    [mediumAssetCache setObject:mediumAssetID forKey:searchUser.remoteIdentifier];
-    
+    // then
+    XCTAssertTrue(searchUser.isLocalOrHasCachedProfileImageData);
+}
+
+- (void)testThat_isLocalOrHasCachedProfileImageData_returnsYesForAUserWithCachedSmallData_MediumAssetKey
+{
+    // given
+    NSData *smallImage = [@"bar" dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *assetKey = @"asset-key";
+
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"foo"
+                                                           handle:@"foo"
+                                                      accentColor:ZMAccentColorBrightYellow
+                                                         remoteID:[NSUUID createUUID]
+                                                             user:nil
+                                         syncManagedObjectContext:self.syncMOC
+                                           uiManagedObjectContext:self.uiMOC];
+
+    NSCache *smallImageCache = [ZMSearchUser searchUserToSmallProfileImageCache];
+    [smallImageCache setObject:smallImage forKey:searchUser.remoteIdentifier];
+
+    NSCache *mediumAssetCache = [ZMSearchUser searchUserToMediumAssetIDCache];
+    [mediumAssetCache setObject:[[SearchUserAssetObjC alloc] initWithAssetKey:assetKey] forKey:searchUser.remoteIdentifier];
+
     // then
     XCTAssertTrue(searchUser.isLocalOrHasCachedProfileImageData);
 }
@@ -719,10 +742,10 @@
 
 @implementation ZMSearchUserTests (MediumImage)
 
-- (void)testThatItReturnsMediumAssetIDFromCacheIfItHasNoMediumAssetID
+- (void)testThatItReturnsMediumLegacyIdFromCacheIfItHasNoMediumAssetID
 {
     // given
-    NSUUID *assetID = [NSUUID UUID];
+    NSUUID *legacyId = [NSUUID UUID];
     
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"foo"
                                                            handle:@"foo"
@@ -733,13 +756,36 @@
                                            uiManagedObjectContext:self.uiMOC];
     
     NSCache *cache = [ZMSearchUser searchUserToMediumAssetIDCache];
-    [cache setObject:assetID forKey:searchUser.remoteIdentifier];
+    [cache setObject:[[SearchUserAssetObjC alloc] initWithLegacyId:legacyId] forKey:searchUser.remoteIdentifier];
     
     // when
-    NSUUID *mediumAssetID = searchUser.mediumAssetID;
+    NSUUID *mediumAssetID = searchUser.mediumLegacyId;
     
     // then
-    XCTAssertEqual(mediumAssetID, assetID);
+    XCTAssertEqualObjects(mediumAssetID, legacyId);
+}
+
+- (void)testThatItReturnsCompleteAssetKeyFromCacheIfItHasNoMediumAssetID
+{
+    // given
+    NSString *completeAssetKey = @"asset-key";
+
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"foo"
+                                                           handle:@"foo"
+                                                      accentColor:ZMAccentColorBrightYellow
+                                                         remoteID:[NSUUID createUUID]
+                                                             user:nil
+                                         syncManagedObjectContext:self.syncMOC
+                                           uiManagedObjectContext:self.uiMOC];
+
+    NSCache *cache = [ZMSearchUser searchUserToMediumAssetIDCache];
+    [cache setObject:[[SearchUserAssetObjC alloc] initWithAssetKey:completeAssetKey] forKey:searchUser.remoteIdentifier];
+
+    // when
+    NSString *expectedKey = searchUser.completeAssetKey;
+
+    // then
+    XCTAssertEqualObjects(expectedKey, completeAssetKey);
 }
 
 - (void)testThatItReturnsMediumImageFromCacheIfItHasNoUser
@@ -888,7 +934,8 @@
     XCTAssertNotNil(dataA);
     NSString *dataIdentifierA = [searchUser imageMediumIdentifier];
     XCTAssertNotNil(dataIdentifierA);
-    [idCache setObject:[NSUUID uuidWithTransportString:dataIdentifierA] forKey:searchUser.remoteIdentifier];
+    SearchUserAssetObjC *asset = [[SearchUserAssetObjC alloc] initWithLegacyId:[NSUUID uuidWithTransportString:dataIdentifierA]];
+    [idCache setObject:asset forKey:searchUser.remoteIdentifier];
     
     // when
     [cache removeObjectForKey:searchUser.remoteIdentifier];
@@ -899,8 +946,6 @@
     AssertEqualData(dataA, dataB);
     XCTAssertEqualObjects(dataIdentifierA, dataIdentifierB);
 }
-
-
 
 
 @end

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		BF8EDC741E53182F00DA6C40 /* store2-25-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF8EDC731E53182F00DA6C40 /* store2-25-0.wiredatabase */; };
 		BF8F3A831E4B61C70079E9E7 /* TextSearchQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8F3A821E4B61C70079E9E7 /* TextSearchQuery.swift */; };
 		BF949E5B1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */; };
+		BF989D0A1E8A6A120052BF8F /* SearchUserAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF989D091E8A6A120052BF8F /* SearchUserAsset.swift */; };
 		BFABEB8C1E647054003BE9F3 /* GenericMessageScheduleNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFABEB8B1E647054003BE9F3 /* GenericMessageScheduleNotification.swift */; };
 		BFB3BA731E28D38F0032A84F /* SharedObjectStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB3BA721E28D38F0032A84F /* SharedObjectStoreTests.swift */; };
 		BFCD8A2D1DCB4E8A00C6FCCF /* V2Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */; };
@@ -470,6 +471,7 @@
 		BF8EDC731E53182F00DA6C40 /* store2-25-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-25-0.wiredatabase"; path = "Tests/Resources/store2-25-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		BF8F3A821E4B61C70079E9E7 /* TextSearchQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextSearchQuery.swift; sourceTree = "<group>"; };
 		BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LinkPreview+ProtobufTests.swift"; sourceTree = "<group>"; };
+		BF989D091E8A6A120052BF8F /* SearchUserAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchUserAsset.swift; sourceTree = "<group>"; };
 		BFABEB8B1E647054003BE9F3 /* GenericMessageScheduleNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericMessageScheduleNotification.swift; sourceTree = "<group>"; };
 		BFB3BA721E28D38F0032A84F /* SharedObjectStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedObjectStoreTests.swift; sourceTree = "<group>"; };
 		BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V2Asset.swift; sourceTree = "<group>"; };
@@ -1102,6 +1104,7 @@
 				F929C1731E41D3480018ADA4 /* PersonName.swift */,
 				F9A7060B1CAEE01D00C2F5FE /* ZMSearchUser+Internal.h */,
 				F9A7060C1CAEE01D00C2F5FE /* ZMSearchUser.m */,
+				BF989D091E8A6A120052BF8F /* SearchUserAsset.swift */,
 				F9A7060D1CAEE01D00C2F5FE /* ZMUser+Internal.h */,
 				F9A706101CAEE01D00C2F5FE /* ZMUser.m */,
 				F18998821E7AC6D900E579A2 /* ZMUser.swift */,
@@ -1964,6 +1967,7 @@
 				F9A7065C1CAEE01D00C2F5FE /* ZMConnection.m in Sources */,
 				F929C1751E41EBE20018ADA4 /* PersonName.swift in Sources */,
 				F9A706B61CAEE01D00C2F5FE /* UserClientChangeInfo.swift in Sources */,
+				BF989D0A1E8A6A120052BF8F /* SearchUserAsset.swift in Sources */,
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
 				F9A706941CAEE01D00C2F5FE /* UserClient+Protobuf.swift in Sources */,
 				BF8F3A831E4B61C70079E9E7 /* TextSearchQuery.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* Update `ZMSearchUser` to expose a `completeAssetKey` to be used for v3 assets.
* `SearchUserAsset` has been added and can be either a legacy or v3 asset.
* Unfortunately an Objective-C wrapper (`SearchUserAssetObjC `) had to be added which makes this enum accessible in the `ZMSearchUser.searchUserToMediumAssetIDCache.