### PR TITLE
Rewrite ZMChangedIndexes in Swift

### DIFF
--- a/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -19,12 +19,12 @@
 import Foundation
 
 
-struct OrderedSetState<T: Hashable> {
+public struct OrderedSetState<T: Hashable> {
 
-    var array : [T]
-    var order : [T : Int]
+    public private(set) var array : [T]
+    public private(set) var order : [T : Int]
     
-    init(array: [T]) {
+    public init(array: [T]) {
         guard array.count == Set(array).count else {
             fatalError("Array contains duplicate items")
         }
@@ -37,7 +37,8 @@ struct OrderedSetState<T: Hashable> {
         self.order = order
     }
     
-    @discardableResult mutating func move(item: T, to: Int) -> Int? {
+    @discardableResult
+    public mutating func move(item: T, to: Int) -> Int? {
         guard let oldIndex = order[item] else { return nil }
         
         array.remove(at: oldIndex)
@@ -49,34 +50,34 @@ struct OrderedSetState<T: Hashable> {
     }
 }
 
-public enum MoveType {
-    case tableView, uiCollectionView
+public enum SetChangeMoveType {
+    case uiTableView, uiCollectionView
 }
 
-struct MovedIndex {
-    let from : Int
-    let to: Int
+public struct MovedIndex {
+    public let from : Int
+    public let to: Int
 }
 
 
-struct ChangedIndexes<T : Hashable> {
+public struct ChangedIndexes<T : Hashable> {
 
-    let startState : OrderedSetState<T>
-    let endState : OrderedSetState<T>
-    let updatedObjects : Set<T>
+    public let startState : OrderedSetState<T>
+    public let endState : OrderedSetState<T>
+    public let updatedObjects : Set<T>
 
-    let deletedIndexes : IndexSet
-    let insertedIndexes : IndexSet
-    let updatedIndexes : IndexSet
-    let movedIndexes : [MovedIndex]
-    let moveType : MoveType
+    public let deletedIndexes : IndexSet
+    public let insertedIndexes : IndexSet
+    public let updatedIndexes : IndexSet
+    public let movedIndexes : [MovedIndex]
+    public let moveType : SetChangeMoveType
     
     /// Calculates the inserts, deletes, moves and updates comparing two sets of ordered, distinct objects
     /// @param startState: State before the updates
     /// @param endState: State after the updates
     /// @param updatedObjects: Objects that need to be reloaded
     /// @param moveType: depending on viewController, default is uiCollectionView
-    init(start: OrderedSetState<T>, end : OrderedSetState<T>, updated: Set<T>, moveType: MoveType = .uiCollectionView) {
+    public init(start: OrderedSetState<T>, end : OrderedSetState<T>, updated: Set<T>, moveType: SetChangeMoveType = .uiCollectionView) {
         let (deletedIndexes, insertedIndexes, updatedIndexes, movedIndexes) = type(of: self).calculateChanges(start: start, end: end, updated: updated, moveType: moveType)
         
         self.startState = start
@@ -90,7 +91,7 @@ struct ChangedIndexes<T : Hashable> {
         self.moveType = moveType
     }
     
-    static func calculateChanges(start: OrderedSetState<T>, end: OrderedSetState<T>, updated: Set<T>, moveType: MoveType) -> ( deletedIndexes: IndexSet, insertedIndexes: IndexSet, updatedIndexes: IndexSet, movedIndexes: [MovedIndex])
+    static func calculateChanges(start: OrderedSetState<T>, end: OrderedSetState<T>, updated: Set<T>, moveType: SetChangeMoveType) -> ( deletedIndexes: IndexSet, insertedIndexes: IndexSet, updatedIndexes: IndexSet, movedIndexes: [MovedIndex])
     {
         var deletedIndexes = IndexSet()
         var updatedIndexes = IndexSet()
@@ -121,7 +122,7 @@ struct ChangedIndexes<T : Hashable> {
                 movedIndexes: movedIndexes)
     }
     
-    static func calculateMoves(start: OrderedSetState<T>, end: OrderedSetState<T>, afterDeletesAndInserts: [T], moveType: MoveType) -> [MovedIndex]
+    static func calculateMoves(start: OrderedSetState<T>, end: OrderedSetState<T>, afterDeletesAndInserts: [T], moveType: SetChangeMoveType) -> [MovedIndex]
     {
         var intermediateState = afterDeletesAndInserts
         var movedIndexes = [MovedIndex]()
@@ -148,7 +149,7 @@ struct ChangedIndexes<T : Hashable> {
                 }
             }
         }
-        else if moveType == .tableView {
+        else if moveType == .uiTableView {
             // Moved `from` indexes are referring to the index in the intermediate state
             // Moves must be calculated comparing the endState the immediately updated intermediate state
 
@@ -174,7 +175,7 @@ struct ChangedIndexes<T : Hashable> {
         return movedIndexes
     }
     
-    func enumerateMovedIndexes(block: (_ from: Int, _ to: Int) -> Void) {
+    public func enumerateMovedIndexes(block: (_ from: Int, _ to: Int) -> Void) {
         for pair in movedIndexes {
             block(Int(pair.from), Int(pair.to))
         }

--- a/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -1,0 +1,183 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+struct OrderedSetState<T: Hashable> {
+
+    var array : [T]
+    var order : [T : Int]
+    
+    init(array: [T]) {
+        guard array.count == Set(array).count else {
+            fatalError("Array contains duplicate items")
+        }
+        var order = [T: Int]()
+        for (idx, item) in array.enumerated() {
+            order[item] = idx
+        }
+        
+        self.array = array
+        self.order = order
+    }
+    
+    @discardableResult mutating func move(item: T, to: Int) -> Int? {
+        guard let oldIndex = order[item] else { return nil }
+        
+        array.remove(at: oldIndex)
+        array.insert(item, at: to)
+        for i in [oldIndex, to].sorted() {
+            order[array[i]] = i
+        }
+        return oldIndex
+    }
+}
+
+public enum MoveType {
+    case tableView, uiCollectionView
+}
+
+struct MovedIndex {
+    let from : Int
+    let to: Int
+}
+
+
+struct ChangedIndexes<T : Hashable> {
+
+    let startState : OrderedSetState<T>
+    let endState : OrderedSetState<T>
+    let updatedObjects : Set<T>
+
+    let deletedIndexes : IndexSet
+    let insertedIndexes : IndexSet
+    let updatedIndexes : IndexSet
+    let movedIndexes : [MovedIndex]
+    let moveType : MoveType
+    
+    /// Calculates the inserts, deletes, moves and updates comparing two sets of ordered, distinct objects
+    /// @param startState: State before the updates
+    /// @param endState: State after the updates
+    /// @param updatedObjects: Objects that need to be reloaded
+    /// @param moveType: depending on viewController, default is uiCollectionView
+    init(start: OrderedSetState<T>, end : OrderedSetState<T>, updated: Set<T>, moveType: MoveType = .uiCollectionView) {
+        let (deletedIndexes, insertedIndexes, updatedIndexes, movedIndexes) = type(of: self).calculateChanges(start: start, end: end, updated: updated, moveType: moveType)
+        
+        self.startState = start
+        self.endState = end
+        self.updatedObjects = updated
+        
+        self.deletedIndexes = deletedIndexes
+        self.insertedIndexes = insertedIndexes
+        self.updatedIndexes = updatedIndexes
+        self.movedIndexes = movedIndexes
+        self.moveType = moveType
+    }
+    
+    static func calculateChanges(start: OrderedSetState<T>, end: OrderedSetState<T>, updated: Set<T>, moveType: MoveType) -> ( deletedIndexes: IndexSet, insertedIndexes: IndexSet, updatedIndexes: IndexSet, movedIndexes: [MovedIndex])
+    {
+        var deletedIndexes = IndexSet()
+        var updatedIndexes = IndexSet()
+        var insertedObjects = end.order // when iterating through the collection we remove the items we found. This way the only items remaining will be inserted objects
+        var intermediateState = [T]()
+        
+        for (idx, item) in start.array.enumerated() {
+            if insertedObjects.removeValue(forKey: item) != nil {
+                intermediateState.append(item)
+                if updated.contains(item){
+                    updatedIndexes.insert(idx)
+                }
+            } else {
+                deletedIndexes.insert(idx)
+            }
+        }
+        
+        // sort inserted indexes in ascending order to avoid out of bounds inserts
+        let ascInsertedIndexes = insertedObjects.values.sorted()
+        
+        // Insert inserted objects and calculate changes
+        ascInsertedIndexes.forEach{intermediateState.insert(end.array[$0], at: $0)}
+        let movedIndexes = calculateMoves(start: start, end: end, afterDeletesAndInserts: intermediateState, moveType: moveType)
+        
+        return (deletedIndexes: deletedIndexes,
+                insertedIndexes: IndexSet(ascInsertedIndexes),
+                updatedIndexes: updatedIndexes,
+                movedIndexes: movedIndexes)
+    }
+    
+    static func calculateMoves(start: OrderedSetState<T>, end: OrderedSetState<T>, afterDeletesAndInserts: [T], moveType: MoveType) -> [MovedIndex]
+    {
+        var intermediateState = afterDeletesAndInserts
+        var movedIndexes = [MovedIndex]()
+        
+        if moveType == .uiCollectionView {
+            // Moved `from` indexes are referring to the index in the startState
+            // Moves must be calculated comparing the endState the immediately updated intermediate state
+
+            // If the intermediate value at the index is different from the endValue:
+            // (1) add a move from the index in the startState to the index in endState
+            // (2) search for the position of the endValue in the intermediate state, move the item to the current index
+            // (3) continue at next index
+            for idx in (0..<intermediateState.endIndex) {
+                let intermediateValue = intermediateState[idx]
+                let endValue = end.array[idx]
+                if intermediateValue != endValue {
+                    if let oldIdx = start.order[endValue] {
+                        movedIndexes.append(MovedIndex(from: oldIdx, to: idx))
+                        if let intIdx = intermediateState.index(of: endValue) {
+                            intermediateState.remove(at: intIdx)
+                            intermediateState.insert(endValue, at: idx)
+                        }
+                    }
+                }
+            }
+        }
+        else if moveType == .tableView {
+            // Moved `from` indexes are referring to the index in the intermediate state
+            // Moves must be calculated comparing the endState the immediately updated intermediate state
+
+            // If the intermediate value at the index is different from the endValue:
+            // (1) search for the position of the endValue in the intermediate state, move the item to the current index
+            // (2) add a move from the index in the intermediate state to the index in endState
+            // (3) continue at next index
+
+            for idx in (0..<intermediateState.endIndex) {
+                let intermediateValue = intermediateState[idx]
+                let endValue = end.array[idx]
+                if intermediateValue != endValue {
+                    if let intIdx = intermediateState.index(of: endValue) {
+                        intermediateState.remove(at: intIdx)
+                        intermediateState.insert(endValue, at: idx)
+                        movedIndexes.append(MovedIndex(from: intIdx, to: idx))
+                    }
+                }
+            }
+        } else {
+            fatalError("Unknown moveType \(moveType)")
+        }
+        return movedIndexes
+    }
+    
+    func enumerateMovedIndexes(block: (_ from: Int, _ to: Int) -> Void) {
+        for pair in movedIndexes {
+            block(Int(pair.from), Int(pair.to))
+        }
+    }
+}
+

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -181,7 +181,7 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         let endState = ZMCDataModel.OrderedSetState(array:["A", "F", "D", "C", "E"])
         
         // when
-        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
         
         // then
         // [A,B,C,D,E] -> [A,F,C,D,E] delete & insert
@@ -214,7 +214,7 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         let endState = ZMCDataModel.OrderedSetState(array:["A", "D", "E", "F", "C"])
         
         // when
-        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
         
         // then
         // [A,B,C,D,E] -> [A,C,D,F,E] delete & insert
@@ -260,7 +260,7 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         let endState = ZMCDataModel.OrderedSetState(array:["C", "B", "A"])
         
         // when
-        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
         
         // then
         XCTAssertEqual(sut.deletedIndexes, IndexSet())

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -253,7 +253,7 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
     }
     
     func testThatItCalculatesMovedIndexesForSwappedIndexesCorrectly_tableView() {
-        // If you move an item from 0->1 other item move implicitely as well, their moves do not need to be defined
+        // If you move an item from 0->1 the item at index 1 moves implicitly to 0, its move do not need to be defined
         
         // given
         let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C"])

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -1,0 +1,292 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import ZMCDataModel
+
+class ChangedIndexesTests : ZMBaseManagedObjectTest {
+    
+    // MARK: CollectionView
+
+    func testThatItCalculatesInsertsAndDeletesBetweenSets(){
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
+        let endState = ZMCDataModel.OrderedSetState(array:["A", "F", "E", "C", "D"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
+        
+        // then
+        XCTAssertEqual(sut.deletedIndexes, [1])
+        XCTAssertEqual(sut.insertedIndexes, [1])
+    }
+    
+    
+    func testThatItCalculatesMovesCorrectly(){
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
+        let endState = ZMCDataModel.OrderedSetState(array:["A", "F", "D", "C", "E"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
+        
+        // then
+        // [A,B,C,D,E] -> [A,F,C,D,E] delete & insert
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if callCount == 0 {
+                // D: [3->2]
+                XCTAssertEqual(from, 3)
+                XCTAssertEqual(to, 2)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 1)
+        
+        var result = ["A","B", "C", "D", "E"]
+        sut.deletedIndexes.forEach{result.remove(at: $0)}
+        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = startState.array[from]
+            result.remove(at: result.index(of: item)!)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["A", "F", "D", "C", "E"])
+    }
+    
+    
+    func testThatItCalculatesMovesCorrectly_2(){
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
+        let endState = ZMCDataModel.OrderedSetState(array:["A", "D", "E", "F", "C"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
+        
+        // then
+        // [A,B,C,D,E] -> [A,C,D,F,E] delete & insert
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if callCount == 0 {
+                // ACDFE
+                // E: [3->1] -> ADCFE
+                XCTAssertEqual(from, 3)
+                XCTAssertEqual(to, 1)
+            }
+            if callCount == 1 {
+                // ADCFE
+                // D: [4->2] -> ADECF
+                XCTAssertEqual(from, 4)
+                XCTAssertEqual(to, 2)
+            }
+            if callCount == 2 {
+                // ADECF
+                // C: [2->4] -> ADEFC
+                XCTAssertEqual(from, 2)
+                XCTAssertEqual(to, 4)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 3)
+        
+        var result = ["A","B", "C", "D", "E"]
+        sut.deletedIndexes.forEach{result.remove(at: $0)}
+        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = startState.array[from]
+            result.remove(at: result.index(of: item)!)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["A", "D", "E", "F", "C"])
+    }
+    
+    func testThatItCalculatesMovedIndexesForSwappedIndexesCorrectly() {
+        // If you move an item from 0->1 another item has to move to index 0
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C"])
+        let endState = ZMCDataModel.OrderedSetState(array:["C", "B", "A"])
+
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
+        
+        // then
+        XCTAssertEqual(sut.deletedIndexes, IndexSet())
+        XCTAssertEqual(sut.insertedIndexes, IndexSet())
+
+        // then
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if (callCount == 0) {
+                XCTAssertEqual(from, 2)
+                XCTAssertEqual(to, 0)
+            }
+            if (callCount == 1) {
+                XCTAssertEqual(from, 1)
+                XCTAssertEqual(to, 1)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 2)
+        
+        var result = ["A", "B", "C"]
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = startState.array[from]
+            result.remove(at: result.index(of: item)!)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["C", "B", "A"])
+    }
+    
+    func testThatItCalculatesUpdatesCorrectly(){
+        // Updated indexes refer to the indexes before the update
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C"])
+        let endState = ZMCDataModel.OrderedSetState(array:["C", "D", "B", "A"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(["B"]))
+        
+        // then
+        XCTAssertEqual(sut.updatedIndexes, IndexSet([1]))
+    }
+    
+    
+    
+    
+    // MARK: TableView
+    
+    func testThatItCalculatesMovesCorrectly_tableView(){
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
+        let endState = ZMCDataModel.OrderedSetState(array:["A", "F", "D", "C", "E"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        
+        // then
+        // [A,B,C,D,E] -> [A,F,C,D,E] delete & insert
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if callCount == 0 {
+                // D: [3->2]
+                XCTAssertEqual(from, 3)
+                XCTAssertEqual(to, 2)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 1)
+        
+        var result = ["A","B", "C", "D", "E"]
+        sut.deletedIndexes.forEach{result.remove(at: $0)}
+        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = result.remove(at: from)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["A", "F", "D", "C", "E"])
+    }
+    
+    
+    func testThatItCalculatesMovesCorrectly_2_tableView(){
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
+        let endState = ZMCDataModel.OrderedSetState(array:["A", "D", "E", "F", "C"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        
+        // then
+        // [A,B,C,D,E] -> [A,C,D,F,E] delete & insert
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if callCount == 0 {
+                // ACDFE
+                // E: [3->1] -> ADCFE
+                XCTAssertEqual(from, 2)
+                XCTAssertEqual(to, 1)
+            }
+            if callCount == 1 {
+                // ADCFE
+                // D: [4->2] -> ADECF
+                XCTAssertEqual(from, 4)
+                XCTAssertEqual(to, 2)
+            }
+            if callCount == 2 {
+                // ADECF
+                // C: [2->4] -> ADEFC
+                XCTAssertEqual(from, 4)
+                XCTAssertEqual(to, 3)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 3)
+        
+        var result = ["A","B", "C", "D", "E"]
+        sut.deletedIndexes.forEach{result.remove(at: $0)}
+        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = result.remove(at: from)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["A", "D", "E", "F", "C"])
+    }
+    
+    func testThatItCalculatesMovedIndexesForSwappedIndexesCorrectly_tableView() {
+        // If you move an item from 0->1 other item move implicitely as well, their moves do not need to be defined
+        
+        // given
+        let startState = ZMCDataModel.OrderedSetState(array:["A","B", "C"])
+        let endState = ZMCDataModel.OrderedSetState(array:["C", "B", "A"])
+        
+        // when
+        let sut = ZMCDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .tableView)
+        
+        // then
+        XCTAssertEqual(sut.deletedIndexes, IndexSet())
+        XCTAssertEqual(sut.insertedIndexes, IndexSet())
+        
+        // then
+        var callCount = 0
+        sut.enumerateMovedIndexes{ (from, to) in
+            if (callCount == 0) {
+                XCTAssertEqual(from, 2)
+                XCTAssertEqual(to, 0)
+            }
+            if (callCount == 1) {
+                XCTAssertEqual(from, 2)
+                XCTAssertEqual(to, 1)
+            }
+            callCount = callCount+1
+        }
+        XCTAssertEqual(callCount, 2)
+        
+        var result = ["A", "B", "C"]
+        sut.enumerateMovedIndexes { (from, to) in
+            let item = result.remove(at: from)
+            result.insert(item, at: to)
+        }
+        XCTAssertEqual(result, ["C", "B", "A"])
+    }
+
+}

--- a/ZMCDataModel.xcodeproj/project.pbxproj
+++ b/ZMCDataModel.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F93A302F1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */; };
 		F93C4C7D1E24E1B1007E9CEE /* NotificationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93C4C7C1E24E1B1007E9CEE /* NotificationDispatcher.swift */; };
 		F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93C4C7E1E24F832007E9CEE /* NotificationDispatcherTests.swift */; };
+		F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F943BC2C1E88FEC80048A768 /* ChangedIndexes.swift */; };
 		F94A208D1CB51AC90059632A /* ZMSyncMergePolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */; };
 		F94A208F1CB51AF50059632A /* ManagedObjectValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A208E1CB51AF50059632A /* ManagedObjectValidationTests.m */; };
 		F94BD2671DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */; };
@@ -347,6 +348,7 @@
 		F9DBA5251E28EE1500BE23C0 /* ConversationObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DBA5231E28EE0A00BE23C0 /* ConversationObserverTests.swift */; };
 		F9DBA5271E28EEBD00BE23C0 /* UserObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DBA5261E28EEBD00BE23C0 /* UserObserverTests.swift */; };
 		F9DBA5291E29162A00BE23C0 /* MessageObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DBA5281E29162A00BE23C0 /* MessageObserverTests.swift */; };
+		F9DD60C11E8916170019823F /* ChangedIndexesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9DD60BF1E8916000019823F /* ChangedIndexesTests.swift */; };
 		F9EC8DE11DA69982003C0022 /* ZMGenericMessage+Obfuscation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EC8DE01DA69982003C0022 /* ZMGenericMessage+Obfuscation.swift */; };
 		F9FD75731E2E6A2100B4558B /* ConversationListObserverCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9FD75721E2E6A2100B4558B /* ConversationListObserverCenter.swift */; };
 		F9FD75761E2E79BF00B4558B /* ConversationListObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9FD75741E2E79B200B4558B /* ConversationListObserverTests.swift */; };
@@ -552,6 +554,7 @@
 		F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessageTests+Confirmation.swift"; sourceTree = "<group>"; };
 		F93C4C7C1E24E1B1007E9CEE /* NotificationDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationDispatcher.swift; sourceTree = "<group>"; };
 		F93C4C7E1E24F832007E9CEE /* NotificationDispatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationDispatcherTests.swift; sourceTree = "<group>"; };
+		F943BC2C1E88FEC80048A768 /* ChangedIndexes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangedIndexes.swift; sourceTree = "<group>"; };
 		F94A208C1CB51AC90059632A /* ZMSyncMergePolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZMSyncMergePolicyTests.m; path = Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m; sourceTree = SOURCE_ROOT; };
 		F94A208E1CB51AF50059632A /* ManagedObjectValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ManagedObjectValidationTests.m; path = Tests/Source/Model/ManagedObjectValidationTests.m; sourceTree = SOURCE_ROOT; };
 		F94BD2661DB4EFF200DA0A0E /* ZMAssetClientMessageTest+Encryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessageTest+Encryption.swift"; sourceTree = "<group>"; };
@@ -817,6 +820,7 @@
 		F9DBA5231E28EE0A00BE23C0 /* ConversationObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConversationObserverTests.swift; path = ../ConversationObserverTests.swift; sourceTree = "<group>"; };
 		F9DBA5261E28EEBD00BE23C0 /* UserObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserObserverTests.swift; path = ../UserObserverTests.swift; sourceTree = "<group>"; };
 		F9DBA5281E29162A00BE23C0 /* MessageObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageObserverTests.swift; path = ../MessageObserverTests.swift; sourceTree = "<group>"; };
+		F9DD60BF1E8916000019823F /* ChangedIndexesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangedIndexesTests.swift; sourceTree = "<group>"; };
 		F9EC8DE01DA69982003C0022 /* ZMGenericMessage+Obfuscation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessage+Obfuscation.swift"; sourceTree = "<group>"; };
 		F9FD75721E2E6A2100B4558B /* ConversationListObserverCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationListObserverCenter.swift; sourceTree = "<group>"; };
 		F9FD75741E2E79B200B4558B /* ConversationListObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConversationListObserverTests.swift; path = ../ConversationListObserverTests.swift; sourceTree = "<group>"; };
@@ -1147,6 +1151,7 @@
 			children = (
 				F9A7061E1CAEE01D00C2F5FE /* ZMCalculateSetChanges.h */,
 				F9A7061F1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm */,
+				F943BC2C1E88FEC80048A768 /* ChangedIndexes.swift */,
 				F9A706201CAEE01D00C2F5FE /* ZMChangedIndexes.h */,
 				F9A706211CAEE01D00C2F5FE /* ZMChangedIndexes.mm */,
 				F9A706221CAEE01D00C2F5FE /* ZMOrderedSetState+Internal.h */,
@@ -1438,6 +1443,7 @@
 				F9B71FDE1CB2C4C6001DB03F /* ObjectObserver */,
 				F929C17A1E423B620018ADA4 /* SnapshotCenterTests.swift */,
 				F9B71FEB1CB2C4C6001DB03F /* ZMChangedIndexesTests.m */,
+				F9DD60BF1E8916000019823F /* ChangedIndexesTests.swift */,
 				F93C4C7E1E24F832007E9CEE /* NotificationDispatcherTests.swift */,
 				F920AE391E3B8445001BC14F /* SearchUserObserverCenterTests.swift */,
 			);
@@ -2038,6 +2044,7 @@
 				54363A031D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift in Sources */,
 				F9A706781CAEE01D00C2F5FE /* ZMClientMessage.m in Sources */,
 				F9A7069C1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm in Sources */,
+				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMGenericMessage+Utils.m in Sources */,
 				F9FD75781E2F9A0600B4558B /* SearchUserObserverCenter.swift in Sources */,
@@ -2118,6 +2125,7 @@
 				F9B71FA71CB2BF37001DB03F /* ZMConversationTests+UnreadCount.m in Sources */,
 				F9B71F9F1CB2BF2B001DB03F /* ZMConversationListDirectoryTests.m in Sources */,
 				F94A208F1CB51AF50059632A /* ManagedObjectValidationTests.m in Sources */,
+				F9DD60C11E8916170019823F /* ChangedIndexesTests.swift in Sources */,
 				F9A7083D1CAEEB7500C2F5FE /* ModelObjectsTests.m in Sources */,
 				F9B71F921CB2BEF4001DB03F /* BaseClientMessageTests.swift in Sources */,
 				F963E9861D9D485900098AD3 /* ZMClientMessageTests+Ephemeral.swift in Sources */,


### PR DESCRIPTION
The current ZMChangedIndexes is based on c++ and fails when comparing Swift structs (e.g. String, UUID). Therefore the rewrite in Swift.