### PR TITLE
Add delivered property to ZMSystemMessage

### DIFF
--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -150,6 +150,7 @@ inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 @property (nonatomic) NSSet<ZMUser *> * _Nonnull removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
 @property (nonatomic, copy) NSString * _Nullable text;
 @property (nonatomic) BOOL needsUpdatingUsers;
+@property (nonatomic, readonly) BOOL delivered;
 
 @property (nonatomic) NSTimeInterval duration; // Only filled for .performedCall
 @property (nonatomic) NSSet<id <ZMSystemMessageData>>  * _Nonnull childMessages; // Only filled for .performedCall & .missedCall

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -926,6 +926,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     return ZMDeliveryStateDelivered;
 }
 
+- (BOOL)delivered
+{
+    return YES;
+}
+
 - (NSDictionary<NSString *,NSArray<ZMUser *> *> *)usersReaction
 {
     return [NSDictionary dictionary];


### PR DESCRIPTION
Add `delivered` property to `ZMSystemMessage` since some predicates rely on it.