### PR TITLE
Store callState for V3 group calling in memory

### DIFF
--- a/Source/Model/Conversation/ZMCallState.swift
+++ b/Source/Model/Conversation/ZMCallState.swift
@@ -227,6 +227,33 @@ extension ZMConversation {
     }
 }
 
+// MARK : Group Calling V3
+// This needs to be set to display the correct conversationListIndicator
+extension ZMConversation {
+    
+    public var isIgnoringCallV3: Bool {
+        get {
+            return callState.isIgnoringCallV3
+        }
+        set {
+            if callState.isIgnoringCallV3 != newValue {
+                callState.isIgnoringCallV3 = newValue
+            }
+        }
+    }
+    
+    public var isCallDeviceActiveV3: Bool {
+        get {
+            return callState.isCallDeviceActiveV3
+        }
+        set {
+            if callState.isCallDeviceActiveV3 != newValue {
+                callState.isCallDeviceActiveV3 = newValue
+            }
+        }
+    }
+}
+
 /// MARK: VideoCalling
 extension ZMConversation {
     
@@ -416,11 +443,29 @@ open class ZMConversationCallState : NSObject {
         }
     }
     
+    open var isCallDeviceActiveV3: Bool = false {
+        didSet {
+            hasChanges = true
+            if contextType == .main {
+                hasLocalModificationsForCallDeviceActiveV3 = true
+            }
+        }
+    }
+    
     open var isIgnoringCall: Bool = false {
         didSet {
             hasChanges = true
             if self.contextType == .main {
                 hasLocalModificationsForIgnoringCall = true
+            }
+        }
+    }
+    
+    open var isIgnoringCallV3: Bool = false {
+        didSet {
+            hasChanges = true
+            if contextType == .main {
+                hasLocalModificationsForIgnoringCallV3 = true
             }
         }
     }
@@ -495,7 +540,9 @@ open class ZMConversationCallState : NSObject {
     
     fileprivate (set) open var hasChanges: Bool = false
     fileprivate (set) open var hasLocalModificationsForCallDeviceActive: Bool = false
+    fileprivate (set) open var hasLocalModificationsForCallDeviceActiveV3: Bool = false
     fileprivate (set) open var hasLocalModificationsForIgnoringCall: Bool = false
+    fileprivate (set) open var hasLocalModificationsForIgnoringCallV3: Bool = false
     fileprivate (set) open var hasLocalModificationsForActiveParticipants: Bool = false
     fileprivate (set) open var hasLocalModificationsForIsOutgoingCall: Bool = false
     fileprivate (set) open var hasLocalModificationsForTimedOut: Bool = false
@@ -552,6 +599,8 @@ open class ZMConversationCallState : NSObject {
         newState.hasLocalModificationsForIsSendingVideo = hasLocalModificationsForIsSendingVideo
         newState.hasLocalModificationsForActiveVideoCallParticipants = hasLocalModificationsForActiveVideoCallParticipants
         newState.hasLocalModificationsForReasonToLeave = hasLocalModificationsForReasonToLeave
+        newState.hasLocalModificationsForIgnoringCallV3 = hasLocalModificationsForIgnoringCallV3
+        newState.hasLocalModificationsForCallDeviceActiveV3 = hasLocalModificationsForCallDeviceActiveV3
         
         hasLocalModificationsForCallDeviceActive = false
         hasLocalModificationsForIgnoringCall = false
@@ -562,7 +611,9 @@ open class ZMConversationCallState : NSObject {
         hasLocalModificationsForIsSendingVideo = needsToSyncIsSendingVideo
         hasLocalModificationsForActiveVideoCallParticipants = false
         hasLocalModificationsForReasonToLeave = false
-        
+        hasLocalModificationsForIgnoringCallV3 = false
+        hasLocalModificationsForCallDeviceActiveV3 = false
+
         newState.hasChanges = false
         return newState
     }
@@ -598,6 +649,16 @@ open class ZMConversationCallState : NSObject {
                 if other.hasLocalModificationsForReasonToLeave {
                     reasonToLeave = other.reasonToLeave
                 }
+                // Group calling V3 start -->
+                if other.hasLocalModificationsForIgnoringCallV3 {
+                    isIgnoringCallV3 = other.isIgnoringCallV3
+                    other.hasLocalModificationsForIgnoringCallV3 = false
+                }
+                if other.hasLocalModificationsForCallDeviceActiveV3 {
+                    isCallDeviceActiveV3 = other.isCallDeviceActiveV3
+                    other.hasLocalModificationsForCallDeviceActiveV3 = false
+                }
+                // <-- Group calling V3 end
 
             case .main: // Sync -> Main
                 zmLog.debug("merge->main other:\(other)")
@@ -627,6 +688,16 @@ open class ZMConversationCallState : NSObject {
                     reasonToLeave = other.reasonToLeave
                     hasLocalModificationsForReasonToLeave = false
                 }
+                
+                // Group calling V3 start -->
+                if !hasLocalModificationsForIgnoringCallV3 {
+                    isIgnoringCallV3 = other.isIgnoringCallV3
+                }
+                if !hasLocalModificationsForCallDeviceActiveV3 {
+                    isCallDeviceActiveV3 = other.isCallDeviceActiveV3
+                }
+                // <-- Group calling V3 end
+                
                 isFlowActive = other.isFlowActive
                 isOutgoingCall = other.isOutgoingCall
                 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -735,10 +735,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     if (self.connectedUser.isPendingApprovalByOtherUser) {
         return ZMConversationListIndicatorPending;
     }
-    
-    // NOTE only works for v2 calls, but this only relevant for group calls so until v3
-    // also does group calls it can stay like this.
-    if (self.isIgnoringCall && self.callParticipants.count > 0) {
+    else if (self.callDeviceIsActive || self.isCallDeviceActiveV3) {
+        return ZMConversationListIndicatorActiveCall;
+    }
+    BOOL ignoredV2Call = (self.isIgnoringCall && self.callParticipants.count > 0);
+    BOOL ignoredV3Call = self.isIgnoringCallV3;
+    if ( ignoredV2Call || ignoredV3Call) {
         return ZMConversationListIndicatorInactiveCall;        
     }
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -3831,3 +3831,34 @@
 }
 
 @end
+
+
+@implementation ZMConversationTests (GroupCallingV3)
+
+- (void)testThatItReturnsActiveCall_isCallDeviceActiveV3
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    XCTAssertNotEqual(conversation.conversationListIndicator, ZMConversationListIndicatorActiveCall);
+
+    // when
+    conversation.isCallDeviceActiveV3 = YES;
+
+    // then
+    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorActiveCall);
+}
+
+- (void)testThatItReturnsInactiveCall_isIgnoringCallV3
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    XCTAssertNotEqual(conversation.conversationListIndicator, ZMConversationListIndicatorInactiveCall);
+
+    // when
+    conversation.isIgnoringCallV3 = YES;
+    
+    // then
+    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorInactiveCall);
+}
+
+@end

--- a/Tests/Source/Model/VoiceChannel/ZMCallStateTests.swift
+++ b/Tests/Source/Model/VoiceChannel/ZMCallStateTests.swift
@@ -863,3 +863,113 @@ extension ZMCallStateTests {
         }
     }
 }
+
+
+// V3 Group calling
+
+extension ZMCallStateTests {
+
+    func testThatItMergesIsIgnoringCallV3_Main_to_Sync(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        mainSut.isIgnoringCallV3 = true
+        syncSut.isIgnoringCallV3 = false
+        XCTAssertTrue(mainSut.hasLocalModificationsForIgnoringCallV3)
+
+        // when
+        syncSut.mergeChangesFromState(mainSut)
+        
+        // then
+        XCTAssertTrue(mainSut.isIgnoringCallV3)
+        XCTAssertTrue(syncSut.isIgnoringCallV3)
+    }
+    
+    func testThatItMergesIsCallDeviceActiveV3_Main_to_Sync(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        mainSut.isCallDeviceActiveV3 = true
+        syncSut.isCallDeviceActiveV3 = false
+        XCTAssertTrue(mainSut.hasLocalModificationsForCallDeviceActiveV3)
+
+        // when
+        syncSut.mergeChangesFromState(mainSut)
+        
+        // then
+        XCTAssertTrue(mainSut.isCallDeviceActiveV3)
+        XCTAssertTrue(syncSut.isCallDeviceActiveV3)
+    }
+    
+    func testThatItMergesIsIgnoringCallV3_Sync_to_Main(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        mainSut.isIgnoringCallV3 = false
+        syncSut.mergeChangesFromState(mainSut) // reset hasLocalModificationsForIgnoringCallV3
+        
+        syncSut.isIgnoringCallV3 = true
+        XCTAssertFalse(mainSut.hasLocalModificationsForIgnoringCallV3)
+        XCTAssertFalse(mainSut.isIgnoringCallV3)
+        XCTAssertTrue(syncSut.isIgnoringCallV3)
+
+        // when
+        mainSut.mergeChangesFromState(syncSut)
+        
+        // then
+        XCTAssertTrue(mainSut.isIgnoringCallV3)
+        XCTAssertTrue(syncSut.isIgnoringCallV3)
+    }
+    
+    func testThatItMergesIsCallDeviceActiveV3_Sync_to_Main(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        mainSut.isCallDeviceActiveV3 = false
+        syncSut.mergeChangesFromState(mainSut) // reset hasLocalModificationsForIgnoringCallV3
+
+        syncSut.isCallDeviceActiveV3 = true
+        XCTAssertFalse(mainSut.hasLocalModificationsForCallDeviceActiveV3)
+        XCTAssertFalse(mainSut.isCallDeviceActiveV3)
+        XCTAssertTrue(syncSut.isCallDeviceActiveV3)
+        
+        // when
+        mainSut.mergeChangesFromState(syncSut)
+        
+        // then
+        XCTAssertTrue(mainSut.isCallDeviceActiveV3)
+        XCTAssertTrue(syncSut.isCallDeviceActiveV3)
+    }
+    
+    func testThatItDoesNotMergeIsIgnoringCallV3_LocalModifications_Sync_to_Main(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        syncSut.isIgnoringCallV3 = true
+        mainSut.isIgnoringCallV3 = false
+        XCTAssertTrue(mainSut.hasLocalModificationsForIgnoringCallV3)
+        
+        // when
+        mainSut.mergeChangesFromState(syncSut)
+        
+        // then
+        XCTAssertFalse(mainSut.isIgnoringCallV3)
+        XCTAssertTrue(syncSut.isIgnoringCallV3)
+    }
+    
+    func testThatItDoesNotMergeIsCallDeviceActiveV3_LocalModifications_Sync_to_Main(){
+        // given
+        let mainSut = ZMConversationCallState(contextType: .main)
+        let syncSut = ZMConversationCallState(contextType: .sync)
+        syncSut.isCallDeviceActiveV3 = true
+        mainSut.isCallDeviceActiveV3 = false
+        XCTAssertTrue(mainSut.hasLocalModificationsForCallDeviceActiveV3)
+        
+        // when
+        mainSut.mergeChangesFromState(syncSut)
+        
+        // then
+        XCTAssertFalse(mainSut.isCallDeviceActiveV3)
+        XCTAssertTrue(syncSut.isCallDeviceActiveV3)
+    }
+}


### PR DESCRIPTION
This is only needed to show the correct conversationListIndicator in group calling.
Merging this PR should not have an impact on previous calling & list behaviour.
