### PR TITLE
Fix: small and large images are mixed up

### DIFF
--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -25,9 +25,9 @@ import Foundation
     public var imageFormat: ZMImageFormat {
         switch self {
         case .preview:
-            return .medium
-        case .complete:
             return .profile
+        case .complete:
+            return .medium
         }
     }
 


### PR DESCRIPTION
Mapping between ZMImageFormat and size used in other places was reversed