### PR TITLE
Do not insert missed call system message from update event if sender is self

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Calling.swift
+++ b/Source/Model/Conversation/ZMConversation+Calling.swift
@@ -64,7 +64,7 @@ public extension ZMConversation {
         return message
     }
 
-    private func associatedMessage(before message: ZMSystemMessage, at index: UInt) -> ZMSystemMessage? {
+    public func associatedMessage(before message: ZMSystemMessage, at index: UInt) -> ZMSystemMessage? {
         guard index >= 1 else { return nil }
         guard let previous = messages[Int(index - 1)] as? ZMSystemMessage else { return nil }
         guard previous.systemMessageType == message.systemMessageType else { return nil }
@@ -75,7 +75,7 @@ public extension ZMConversation {
 }
 
 
-fileprivate extension ZMSystemMessage {
+public extension ZMSystemMessage {
 
     func addChild(_ message: ZMSystemMessage) {
         mutableSetValue(forKey: #keyPath(ZMSystemMessage.childMessages)).add(message)

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -882,7 +882,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     if (type == ZMSystemMessageTypeMissedCall)
     {
         NSString *reason = [[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"reason"];
-        if (![reason isEqualToString:@"missed"]) {
+
+        // When we cancel a call we placed before it connected we already insert the missed call system message
+        // locally and ignore the update event. (This whole logic can be removed once group calls are on v3).
+        BOOL selfReason = [[ZMUser selfUserInContext:moc].remoteIdentifier isEqual:updateEvent.senderUUID];
+        if (![reason isEqualToString:@"missed"] || selfReason) {
             return nil;
         }
     }


### PR DESCRIPTION
# What's in this PR?

* We still receive update events for group calls until they use v3. This lead to the issue that we inserted a performed call system message when placing a group call, but also inserted a missed call system message in case we hung up before anyone connected (triggered by the received update event). We do not want to insert a missed call message in this case and ignore the update event if the sender is self from now on.
* This also exposes a couple of methods needed for https://github.com/wireapp/wire-ios-message-strategy/pull/56.