### PR TITLE
Fix potential crash when loading data saved before project rename

### DIFF
--- a/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
+++ b/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
@@ -171,3 +171,40 @@ class ShareExtensionAnalyticsPersistenceTests: BaseZMMessageTests {
     }
 
 }
+
+class ShareObjectStoreTests: ZMTBaseTest {
+    var sut: SharedObjectStore<WireDataModel.SharedObjectTestClass>!
+    
+    override func setUp() {
+        super.setUp()
+        sut = createStore()
+    }
+    
+    override func tearDown() {
+        sut.clear()
+        super.tearDown()
+    }
+    
+    func createStore() -> SharedObjectStore<WireDataModel.SharedObjectTestClass> {
+        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return SharedObjectStore(sharedContainerURL: url, fileName: "store")
+    }
+    
+    func testThatItCanDecodeClassSavedBeforeProjectRename() {
+        // Given
+        
+        // Module prefix before project rename
+        NSKeyedArchiver.setClassName("ZMCDataModel.SharedObjectTestClass", for: WireDataModel.SharedObjectTestClass.self)
+        let item = WireDataModel.SharedObjectTestClass()
+        item.flag = true
+        
+        // When
+        sut.store(item)
+        sut = createStore()
+        
+        // Then
+        let items = sut.load()
+        XCTAssertEqual(items.first?.flag, item.flag)
+    }
+    
+}


### PR DESCRIPTION
This is another place where we use `NSKeyedUnarchiver` and it could potentially cause issues similar to https://github.com/wireapp/wire-ios-sync-engine/pull/338.

We make a fix-up for class names by replacing the old module name with new one and creating class from string. To test it I had to unfortunately add a dummy class to the `WireDataModel` because it will not be resolved by `NSClassFromString` otherwise.