### PR TITLE
Fix: missed call message for group calls that you didn't join

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -886,7 +886,8 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
         // When we cancel a call we placed before it connected we already insert the missed call system message
         // locally and ignore the update event. (This whole logic can be removed once group calls are on v3).
         BOOL selfReason = [[ZMUser selfUserInContext:moc].remoteIdentifier isEqual:updateEvent.senderUUID];
-        if (![reason isEqualToString:@"missed"] || selfReason) {
+        BOOL notOurReason = ![reason isEqualToString:@"missed"] && ![reason isEqualToString:@"completed"];
+        if (notOurReason || selfReason) {
             return nil;
         }
     }


### PR DESCRIPTION
In a v2 group call a missed call could be "completed" because it happened between other people in the chat without you joining. In this case the `reason` is `completed` and we wouldn't insert system message.