### PR TITLE
Fix missed call message

### DIFF
--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -155,6 +155,7 @@ inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 @property (nonatomic) NSTimeInterval duration; // Only filled for .performedCall
 @property (nonatomic) NSSet<id <ZMSystemMessageData>>  * _Nonnull childMessages; // Only filled for .performedCall & .missedCall
 @property (nonatomic) id <ZMSystemMessageData> _Nullable parentMessage; // Only filled for .performedCall & .missedCall
+@property (nonatomic, readonly) NSDate * _Nonnull lastChildMessageDate; // Equals the serverTimestamp, if no childMessages are present
 
 + (ZMSystemMessage * _Nullable)fetchLatestPotentialGapSystemMessageInConversation:(ZMConversation * _Nonnull)conversation;
 - (void)updateNeedsUpdatingUsersIfNeeded;

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -1038,6 +1038,17 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     return self.systemMessageType == ZMSystemMessageTypeMissedCall;
 }
 
+- (NSDate *)lastChildMessageDate
+{
+    NSDate *date = self.serverTimestamp;
+    for (ZMSystemMessage *message in self.childMessages) {
+        if ([message.serverTimestamp compare:date] == NSOrderedDescending) {
+            date = message.serverTimestamp;
+        }
+    }
+    return date;
+}
+
 
 @end
 

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -103,6 +103,9 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic) NSSet<id <ZMSystemMessageData>>  *childMessages;
 @property (nonatomic) id <ZMSystemMessageData> parentMessage;
 
+/// Equals the serverTimestamp, if no childMessages are present
+@property (nonatomic, readonly) NSDate * lastChildMessageDate;
+
 @end
 
 


### PR DESCRIPTION
Since systemMessages now have children, we need to consider the children's timestamp when updating the lastReadServerTimestamp as well as when computing the lastReadMessage.