### PR TITLE
Revert missed call message introduced in #234

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -886,8 +886,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
         // When we cancel a call we placed before it connected we already insert the missed call system message
         // locally and ignore the update event. (This whole logic can be removed once group calls are on v3).
         BOOL selfReason = [[ZMUser selfUserInContext:moc].remoteIdentifier isEqual:updateEvent.senderUUID];
-        BOOL notOurReason = ![reason isEqualToString:@"missed"] && ![reason isEqualToString:@"completed"];
-        if (notOurReason || selfReason) {
+        if (![reason isEqualToString:@"missed"] || selfReason) {
             return nil;
         }
     }


### PR DESCRIPTION

This reverts commit 109ce8622eb5b0c415bbf2b7739fff7a347ad55a and should fix the last failing SE test.