### PR TITLE
Fix profile picture race condition

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -529,13 +529,14 @@ static NSString *const AddressBookEntryKey = @"addressBookEntry";
         self.accentColorValue = [ZMUser accentColorFromPayloadValue:accentId];
     }
     
+    BOOL hasLocalModificationsForLegacyImages = [self hasLocalModificationsForKeys:[NSSet setWithArray:@[ImageMediumDataKey, ImageSmallProfileDataKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey]]];
     NSArray *picture = [transportData optionalArrayForKey:@"picture"];
-    if ((picture != nil || authoritative) && ![self hasLocalModificationsForKeys:[NSSet setWithArray:@[ImageMediumDataKey, ImageSmallProfileDataKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey]]]) {
+    if ((picture != nil || authoritative) && !hasLocalModificationsForLegacyImages) {
         [self updateImageWithTransportData:picture];
     }
     
     NSArray *assets = [transportData optionalArrayForKey:@"assets"];
-    [self updateAssetDataWith:assets hasLegacyImages:(picture.count > 0) authoritative:authoritative];
+    [self updateAssetDataWith:assets hasLegacyImages:(picture.count > 0 || hasLocalModificationsForLegacyImages) authoritative:authoritative];
     
     // We intentionally ignore the preview data.
     //

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -554,7 +554,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
         [user setLocallyModifiedKeys:[NSSet setWithObject:locallyModifiedKey]];
         
         // when
-        [user updateWithTransportData:payload authoritative:NO];
+        [user updateWithTransportData:payload authoritative:YES];
         
         // then
         XCTAssertNotNil(user.imageSmallProfileData);


### PR DESCRIPTION
The V2 profile picture upload could be interrupted if the self user was
fetched before it was completed. We were missing a check for local
modifications.

This bug only seems to happen on the SE without a state machine.