### PR TITLE
Fixed missing reuse identifier for avatar image

### DIFF
--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -513,11 +513,19 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
     return nil;
 }
 
-- (NSString *)smallProfileImageCacheKey {
+- (NSString *)smallProfileImageCacheKey
+{
+    if (self.user != nil) {
+        return self.user.smallProfileImageCacheKey;
+    }
     return self.imageSmallProfileIdentifier;
 }
 
-- (NSString *)mediumProfileImageCacheKey {
+- (NSString *)mediumProfileImageCacheKey
+{
+    if (self.user != nil) {
+        return self.user.mediumProfileImageCacheKey;
+    }
     return self.imageMediumIdentifier;
 }
 

--- a/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -579,6 +579,39 @@
     XCTAssertEqualObjects(imageIdentifier, fetchedIdentifier);
 }
 
+- (void)testThatItReturnsSmallProfileImageCacheKeyFromUserIfItHasAUser
+{
+    // given
+    NSData *mockImage = [@"bar" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = [NSUUID createUUID];
+    user.imageSmallProfileData = mockImage;
+    user.previewProfileAssetIdentifier = [NSUUID createUUID].UUIDString;
+    
+    [self.uiMOC saveOrRollback];
+    
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithName:@"foo"
+                                                           handle:@"hans"
+                                                      accentColor:ZMAccentColorBrightYellow
+                                                         remoteID:user.remoteIdentifier
+                                                             user:user
+                                         syncManagedObjectContext:self.syncMOC
+                                           uiManagedObjectContext:self.uiMOC];
+    
+    NSCache *cache = [ZMSearchUser searchUserToSmallProfileImageCache];
+    [cache setObject:mockImage forKey:searchUser.remoteIdentifier];
+    
+    // when
+    NSString *smallImageCacheKey = searchUser.smallProfileImageCacheKey;
+    
+    // then
+    NSString *fetchedSmallImageCacheKey = user.smallProfileImageCacheKey;
+    
+    XCTAssertNotEqual(smallImageCacheKey.length, (unsigned long)0);
+    XCTAssertEqualObjects(smallImageCacheKey, fetchedSmallImageCacheKey);
+}
+
 - (void)testThatItStoresTheCachedSmallProfileData;
 {
     // given


### PR DESCRIPTION
- The issue happened to appear because we changed the implementation of how user images work with assets v3.
- In `ZMUser` `imageSmallProfileIdentifier` we rely on `localMediumRemoteIdentifier`, which is not set any more.
- In `ZMSearchUser` we used to rely to user's `localMediumRemoteIdentifier`.

Solution:

- In `ZMSearchUser` we should always forward the call to `smallProfileImageCacheKey` to user if it is there. Cache key is there.