### PR TITLE
Fix for ephemeral message negative timer

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -401,6 +401,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     }
     // If we receive a delete for an ephemeral message that was not originally sent by the selfUser, we need to stop the deletion timer
     if (nil != message && message.isEphemeral && ![message.sender.remoteIdentifier isEqual:selfUser.remoteIdentifier]) {
+        [message removeMessageClearingSender:YES];
         [self stopDeletionTimerForMessage:message];
     } else {
         [message removeMessageClearingSender:YES];
@@ -417,15 +418,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     NSManagedObjectID *messageID = message.objectID;
     [uiMOC performGroupedBlock:^{
         NSError *error;
-        ZMMessage *uiMessage =  [uiMOC existingObjectWithID:messageID error:&error];
+        ZMMessage *uiMessage = [uiMOC existingObjectWithID:messageID error:&error];
         if (error != nil || uiMessage == nil) {
             return;
         }
         [uiMOC.zm_messageDeletionTimer stopTimerForMessage:uiMessage];
-        
-        [uiMOC.zm_syncContext performGroupedBlock:^{
-            [message removeMessageClearingSender:YES];
-        }];
     }];
 }
 


### PR DESCRIPTION
This was happening when you have two clients that receive the ephemeral message and timer in the other client runs out faster. That client then sends out message delete event which when received by iOS client deletes the message. Because of nested perform blocks UI doesn't receive conversation change notification.