### PR TITLE
Track count of legacy messages

### DIFF
--- a/Source/Model/Analytics/Clusterizer+MessageCount.swift
+++ b/Source/Model/Analytics/Clusterizer+MessageCount.swift
@@ -1,0 +1,38 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+extension IntegerClusterizer {
+    static let messageCount = IntegerClusterizer(ranges: [
+        ClusterRange(0, 100),
+        ClusterRange(100, 250),
+        ClusterRange(250, 500),
+        ClusterRange(500, 1000),
+        ClusterRange(1000, 2000),
+        ClusterRange(2000, 3000),
+        ClusterRange(3000, 4000),
+        ClusterRange(4000, 5000),
+        ClusterRange(5000, 7500),
+        ClusterRange(7500, 10000),
+        ClusterRange(10000, 15000),
+        ClusterRange(15000, 20000),
+        ClusterRange(20000, 30000),
+        ClusterRange(30000, 40000),
+        ClusterRange(40000, 75000)
+    ])
+}

--- a/Source/Model/Analytics/Clusterizer+MessageCount.swift
+++ b/Source/Model/Analytics/Clusterizer+MessageCount.swift
@@ -35,4 +35,23 @@ extension IntegerClusterizer {
         ClusterRange(30000, 40000),
         ClusterRange(40000, 75000)
     ])
+
+    static let databaseSize = IntegerClusterizer(ranges: [
+        ClusterRange(0, 5),
+        ClusterRange(5, 10),
+        ClusterRange(10, 25),
+        ClusterRange(25, 50),
+        ClusterRange(50, 100),
+        ClusterRange(100, 200),
+        ClusterRange(200, 500),
+        ClusterRange(500, 1000),
+        ClusterRange(1000, 2000),
+        ClusterRange(2000, 3000),
+        ClusterRange(3000, 4000),
+        ClusterRange(4000, 5000),
+        ClusterRange(5000, 10000),
+        ClusterRange(10000, 15000),
+        ClusterRange(15000, 20000)
+        ])
+
 }

--- a/Source/Model/Analytics/Clusterizer.swift
+++ b/Source/Model/Analytics/Clusterizer.swift
@@ -1,0 +1,52 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public struct ClusterRange<T> {
+    let start, end: T
+    var stringValue: String { return "\(start)-\(end)" }
+
+    init(_ start: T, _ end: T) {
+        self.start = start
+        self.end = end
+    }
+}
+
+protocol ClusterizerType {
+    associatedtype ClusterType: Comparable
+    var ranges:  [ClusterRange<ClusterType>] { get }
+    func clusterize(_ value: ClusterType) -> String
+}
+
+extension ClusterizerType {
+    func clusterize(_ value: ClusterType) -> String {
+        guard let range = ranges.first, value >= range.start else { return String(describing: value) }
+        for range in ranges where range.start <= value && value <= range.end {
+            return range.stringValue
+        }
+
+        return "\(ranges.last!.end)+"
+    }
+}
+
+public struct IntegerClusterizer: ClusterizerType {
+    typealias ClusterType = Int
+    let ranges: [ClusterRange<ClusterType>]
+}

--- a/Source/Model/Analytics/Clusterizer.swift
+++ b/Source/Model/Analytics/Clusterizer.swift
@@ -23,7 +23,7 @@ public struct ClusterRange<T> {
     let start, end: T
     var stringValue: String { return "\(start)-\(end)" }
 
-    init(_ start: T, _ end: T) {
+    public init(_ start: T, _ end: T) {
         self.start = start
         self.end = end
     }

--- a/Source/Model/Analytics/Clusterizer.swift
+++ b/Source/Model/Analytics/Clusterizer.swift
@@ -29,14 +29,14 @@ public struct ClusterRange<T> {
     }
 }
 
-protocol ClusterizerType {
+public protocol ClusterizerType {
     associatedtype ClusterType: Comparable
     var ranges:  [ClusterRange<ClusterType>] { get }
     func clusterize(_ value: ClusterType) -> String
 }
 
 extension ClusterizerType {
-    func clusterize(_ value: ClusterType) -> String {
+    public func clusterize(_ value: ClusterType) -> String {
         guard let range = ranges.first, value >= range.start else { return String(describing: value) }
         for range in ranges where range.start <= value && value <= range.end {
             return range.stringValue
@@ -47,6 +47,10 @@ extension ClusterizerType {
 }
 
 public struct IntegerClusterizer: ClusterizerType {
-    typealias ClusterType = Int
-    let ranges: [ClusterRange<ClusterType>]
+    public typealias ClusterType = Int
+    public let ranges: [ClusterRange<ClusterType>]
+
+    public init(ranges: [ClusterRange<ClusterType>]) {
+        self.ranges = ranges
+    }
 }

--- a/Source/Model/Analytics/MessageCountTracker.swift
+++ b/Source/Model/Analytics/MessageCountTracker.swift
@@ -178,7 +178,6 @@ private let debugTrackingOverride = false
         lastTrackDate = createDate()
         countFetcher.fetchNumberOfLegacyMessages {
             let event = MessageCountEvent(messageCount: $0, databaseSize: self.databaseSize() ?? 0)
-            print(event.attributes)
             self.managedObjectContext.analytics?.tagEvent(event.name, attributes: event.attributes)
         }
     }

--- a/Source/Model/Analytics/MessageCountTracker.swift
+++ b/Source/Model/Analytics/MessageCountTracker.swift
@@ -1,0 +1,176 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+private let log = ZMSLog(tag: "MessageCountTracker")
+
+
+public struct MessageCount {
+    let unencryptedImageCount: Int
+    let plaintextMessageCount: Int
+    let clientMessageCount: Int
+    let assetClientMessageCount: Int
+}
+
+
+fileprivate struct MessageCountEvent {
+    let name = "legacy.message_count"
+    let attributes: [String: NSObject]
+
+    init(messageCount: MessageCount) {
+        attributes = [
+            "unencrypted_images": NSNumber(value: messageCount.unencryptedImageCount),
+            "unencrypted_text": NSNumber(value: messageCount.plaintextMessageCount),
+            "asset_messages": NSNumber(value: messageCount.assetClientMessageCount),
+            "client_messages": NSNumber(value: messageCount.clientMessageCount)
+        ]
+    }
+}
+
+
+public protocol CountFetcherType {
+    func fetchNumberOfLegacyMessages(_ completion: @escaping (MessageCount) -> Void)
+}
+
+
+final fileprivate class LegacyMessageCountFetcher: CountFetcherType {
+
+    private let managedObjectContext: NSManagedObjectContext
+
+    /// Creates a new instance of a `LegcayMessageCountFetcher`.
+    /// The passed `NSManagedObjectContext` needs to be the sync MOC.
+    init(managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
+    }
+
+    private func numberOfPlainTextMessages() -> Int {
+        do {
+            guard let request = ZMTextMessage.sortedFetchRequest() else { return 0 }
+            return try managedObjectContext.count(for: request)
+        } catch {
+            log.error("Unable to get count of plain text messages in database: \(error)")
+            return 0
+        }
+    }
+
+    private func numberOfUnencryptedImageMessages() -> Int {
+        do {
+            guard let request = ZMImageMessage.sortedFetchRequest() else { return 0 }
+            return try managedObjectContext.count(for: request)
+        } catch {
+            log.error("Unable to get count of unencrypted image messages in database: \(error)")
+            return 0
+        }
+    }
+
+    private func numberOfAssetClientMessages() -> Int {
+        do {
+            guard let request = ZMAssetClientMessage.sortedFetchRequest() else { return 0 }
+            return try managedObjectContext.count(for: request)
+        } catch {
+            log.error("Unable to get count of asset client messages in database: \(error)")
+            return 0
+        }
+    }
+
+    private func numberOfClientMessages() -> Int {
+        do {
+            guard let request = ZMClientMessage.sortedFetchRequest() else { return 0 }
+            return try managedObjectContext.count(for: request)
+        } catch {
+            log.error("Unable to get count of client messages in database: \(error)")
+            return 0
+        }
+    }
+
+    /// Fetches the number of legacy (unencrypted) image and text messages in the database and 
+    /// calls the completion handler with the result.
+    /// Safe to be called from any thread as it dispatches on the context passed to `init`.
+    /// The completion handler will be called on the NSManagedObjectContext queue passed to `init`.
+    fileprivate func fetchNumberOfLegacyMessages(_ completion: @escaping (MessageCount) -> Void) {
+        managedObjectContext.performGroupedBlock {
+            let messageCount = MessageCount(
+                unencryptedImageCount: self.numberOfUnencryptedImageMessages(),
+                plaintextMessageCount: self.numberOfPlainTextMessages(),
+                clientMessageCount: self.numberOfClientMessages(),
+                assetClientMessageCount: self.numberOfAssetClientMessages()
+            )
+            completion(messageCount)
+        }
+    }
+
+}
+
+
+@objc final public class LegacyMessageTracker: NSObject {
+
+    private let lastTrackDateKey = "LegacyMessageTracker.lastTrackDate"
+
+    private let managedObjectContext: NSManagedObjectContext
+    private let userDefaults: UserDefaults
+    private let createDate: () -> Date
+    private let countFetcher: CountFetcherType
+    private let dayThreshold = 14
+
+    @objc public convenience init?(managedObjectContext: NSManagedObjectContext) {
+        self.init(
+            managedObjectContext: managedObjectContext,
+            userDefaults: .standard,
+            createDate: Date.init,
+            countFetcher: LegacyMessageCountFetcher(managedObjectContext: managedObjectContext)
+        )
+    }
+
+    init?(
+        managedObjectContext: NSManagedObjectContext,
+        userDefaults: UserDefaults,
+        createDate: @escaping () -> Date,
+        countFetcher: CountFetcherType
+        ) {
+        self.managedObjectContext = managedObjectContext
+        self.countFetcher = countFetcher
+        self.userDefaults = userDefaults
+        self.createDate = createDate
+        super.init()
+    }
+
+    var lastTrackDate: Date? {
+        get {
+            return userDefaults.object(forKey: lastTrackDateKey) as? Date
+        }
+        set {
+            userDefaults.set(newValue, forKey: lastTrackDateKey)
+        }
+    }
+
+    func shouldTrack() -> Bool {
+        guard let lastDate = lastTrackDate else { return true }
+        guard let days = Calendar.current.dateComponents([.day], from: lastDate, to: createDate()).day else { return true }
+        return days >= dayThreshold
+    }
+
+    public func trackLegacyMessageCount() {
+        guard shouldTrack() else { return }
+        lastTrackDate = createDate()
+        countFetcher.fetchNumberOfLegacyMessages {
+            let event = MessageCountEvent(messageCount: $0)
+            self.managedObjectContext.analytics?.tagEvent(event.name, attributes: event.attributes)
+        }
+    }
+}
+

--- a/Source/Model/Analytics/MessageCountTracker.swift
+++ b/Source/Model/Analytics/MessageCountTracker.swift
@@ -33,11 +33,12 @@ fileprivate struct MessageCountEvent {
     let attributes: [String: NSObject]
 
     init(messageCount: MessageCount) {
+        let clusterizer = IntegerClusterizer.messageCount
         attributes = [
-            "unencrypted_images": NSNumber(value: messageCount.unencryptedImageCount),
-            "unencrypted_text": NSNumber(value: messageCount.plaintextMessageCount),
-            "asset_messages": NSNumber(value: messageCount.assetClientMessageCount),
-            "client_messages": NSNumber(value: messageCount.clientMessageCount)
+            "unencrypted_images": clusterizer.clusterize(messageCount.unencryptedImageCount) as NSObject,
+            "unencrypted_text": clusterizer.clusterize(messageCount.plaintextMessageCount) as NSObject,
+            "asset_messages": clusterizer.clusterize(messageCount.assetClientMessageCount) as NSObject,
+            "client_messages": clusterizer.clusterize(messageCount.clientMessageCount) as NSObject
         ]
     }
 }
@@ -131,7 +132,15 @@ final fileprivate class LegacyMessageCountFetcher: CountFetcherType {
         self.init(
             managedObjectContext: managedObjectContext,
             userDefaults: .standard,
-            createDate: Date.init,
+            createDate: Date.init
+        )
+    }
+
+    convenience init?(managedObjectContext: NSManagedObjectContext, userDefaults: UserDefaults, createDate: @escaping () -> Date) {
+        self.init(
+            managedObjectContext: managedObjectContext,
+            userDefaults: userDefaults,
+            createDate: createDate,
             countFetcher: LegacyMessageCountFetcher(managedObjectContext: managedObjectContext)
         )
     }
@@ -150,12 +159,8 @@ final fileprivate class LegacyMessageCountFetcher: CountFetcherType {
     }
 
     var lastTrackDate: Date? {
-        get {
-            return userDefaults.object(forKey: lastTrackDateKey) as? Date
-        }
-        set {
-            userDefaults.set(newValue, forKey: lastTrackDateKey)
-        }
+        get { return userDefaults.object(forKey: lastTrackDateKey) as? Date }
+        set { userDefaults.set(newValue, forKey: lastTrackDateKey) }
     }
 
     func shouldTrack() -> Bool {

--- a/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
+++ b/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
@@ -178,10 +178,12 @@ class MessageCountTrackerTests: BaseZMMessageTests {
         }
 
         // When
-        guard let sut = LegacyMessageTracker(managedObjectContext: syncMOC, userDefaults: defaults, createDate: Date.init ) else { return XCTFail("Unable to create SUT") }
+        guard let sut = LegacyMessageTracker(managedObjectContext: syncMOC, userDefaults: defaults, createDate: Date.init) else { return XCTFail("Unable to create SUT") }
 
-        sut.trackLegacyMessageCount()
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        performIgnoringZMLogError {
+            sut.trackLegacyMessageCount()
+            XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        }
 
         // Then
         guard let (event, attributes) = mockAnalytics.taggedEventsWithAttributes.first else { return XCTFail("No trackin data") }

--- a/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
+++ b/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
@@ -186,7 +186,7 @@ class MessageCountTrackerTests: BaseZMMessageTests {
         }
 
         // Then
-        guard let (event, attributes) = mockAnalytics.taggedEventsWithAttributes.first else { return XCTFail("No trackin data") }
+        guard let (event, attributes) = mockAnalytics.taggedEventsWithAttributes.first else { return XCTFail("No tracking data") }
         XCTAssertEqual(event, "legacy.message_count")
         XCTAssertEqual(attributes["client_messages"] as? String, "100-250")
         XCTAssertEqual(attributes["unencrypted_images"] as? String, "0-100")

--- a/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
+++ b/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
@@ -1,0 +1,138 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+@testable import WireDataModel
+
+
+private class DateCreator {
+    var nextDate: Date!
+
+    func create() -> Date {
+        return nextDate
+    }
+}
+
+
+private class MockCountFetcher: CountFetcherType {
+
+    var callCount = 0
+
+    func fetchNumberOfLegacyMessages(_ completion: @escaping (MessageCount) -> Void) {
+        callCount += 1
+    }
+}
+
+
+class MessageCountTrackerTests: BaseZMMessageTests {
+
+    fileprivate var mockFetcher: MockCountFetcher!
+
+    override func setUp() {
+        super.setUp()
+        mockFetcher = MockCountFetcher()
+    }
+
+    override func tearDown() {
+        mockFetcher = nil
+        super.tearDown()
+    }
+
+
+    func testThatItTracksTheMessageCountInitially() {
+        // Given
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let currentDate = Date()
+        let dateCreator = DateCreator()
+        dateCreator.nextDate = currentDate
+
+        guard let sut = LegacyMessageTracker(
+            managedObjectContext: syncMOC,
+            userDefaults: defaults,
+            createDate: dateCreator.create,
+            countFetcher: mockFetcher
+        ) else { return XCTFail("Unable to create SUT") }
+
+        // When
+        XCTAssertNil(sut.lastTrackDate)
+        XCTAssertTrue(sut.shouldTrack())
+        sut.trackLegacyMessageCount()
+
+        // Then
+        XCTAssertEqual(sut.lastTrackDate, currentDate)
+        XCTAssertEqual(mockFetcher.callCount, 1)
+    }
+
+    func testThatItDoesNotTrackTheMessageCountWhenItTrackedInTheLast14Days() {
+        // Given
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let currentDate = Date()
+        let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: currentDate)
+
+        let dateCreator = DateCreator()
+        dateCreator.nextDate = currentDate
+
+        guard let sut = LegacyMessageTracker(
+            managedObjectContext: syncMOC,
+            userDefaults: defaults,
+            createDate: dateCreator.create,
+            countFetcher: mockFetcher
+            ) else { return XCTFail("Unable to create SUT") }
+
+        // When
+        sut.lastTrackDate = oneWeekAgo
+        XCTAssertFalse(sut.shouldTrack())
+        sut.trackLegacyMessageCount()
+
+        // Then
+        XCTAssertEqual(sut.lastTrackDate, oneWeekAgo)
+        XCTAssertEqual(mockFetcher.callCount, 0)
+    }
+
+    func testThatItTracksTheMessageCountWhenItTrackedTheLastTimeBeforeMoreThan14Days() {
+        // Given
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let currentDate = Date()
+        let fifteenDaysAgo = Calendar.current.date(byAdding: .day, value: -15, to: currentDate)
+
+        let dateCreator = DateCreator()
+        dateCreator.nextDate = currentDate
+
+        guard let sut = LegacyMessageTracker(
+            managedObjectContext: syncMOC,
+            userDefaults: defaults,
+            createDate: dateCreator.create,
+            countFetcher: mockFetcher
+            ) else { return XCTFail("Unable to create SUT") }
+
+        // When
+        sut.lastTrackDate = fifteenDaysAgo
+        XCTAssertTrue(sut.shouldTrack())
+        sut.trackLegacyMessageCount()
+
+        // Then
+        XCTAssertEqual(sut.lastTrackDate, currentDate)
+        XCTAssertEqual(mockFetcher.callCount, 1)
+    }
+
+}
+

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		BF2ADF631E28CF1E00E81B1E /* SharedObjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */; };
 		BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4666291DCB71B0007463FF /* V3Asset.swift */; };
 		BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */; };
+		BF707C391EB8780800108D4E /* MessageCountTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C381EB8780800108D4E /* MessageCountTracker.swift */; };
+		BF707C3B1EB8879300108D4E /* MessageCountTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */; };
 		BF735CFD1E7050D5003BC61F /* ZMConversationTests+CallSystemMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */; };
 		BF735CFF1E70626F003BC61F /* store2-27-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF735CFE1E70626F003BC61F /* store2-27-0.wiredatabase */; };
 		BF76998B1D3500F0009C378B /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; };
@@ -461,6 +463,8 @@
 		BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedObjectStore.swift; sourceTree = "<group>"; };
 		BF4666291DCB71B0007463FF /* V3Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V3Asset.swift; sourceTree = "<group>"; };
 		BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+DisplayName.swift"; sourceTree = "<group>"; };
+		BF707C381EB8780800108D4E /* MessageCountTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTracker.swift; sourceTree = "<group>"; };
+		BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTrackerTests.swift; sourceTree = "<group>"; };
 		BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+CallSystemMessages.swift"; sourceTree = "<group>"; };
 		BF735CFE1E70626F003BC61F /* store2-27-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-27-0.wiredatabase"; path = "Tests/Resources/store2-27-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		BF7699891D3500D6009C378B /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
@@ -880,6 +884,7 @@
 				546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */,
 				54DE05DC1CF8711F00C35253 /* ProtobufUtilitiesTests.swift */,
 				BF949E5A1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift */,
+				BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */,
 				F92C99271DAE8D060034AFDD /* GenericMessageTests+Obfuscation.swift */,
 			);
 			path = Utils;
@@ -899,6 +904,7 @@
 			children = (
 				BF10B59E1E645A3A00E7036E /* Events */,
 				BF10B5951E64591600E7036E /* AnalyticsType.swift */,
+				BF707C381EB8780800108D4E /* MessageCountTracker.swift */,
 				BF10B5961E64591600E7036E /* NSManagedObjectContext+Analytics.swift */,
 			);
 			path = Analytics;
@@ -1962,6 +1968,7 @@
 				166902411D7493EB000FE4AF /* ZMTestSession.m in Sources */,
 				F963E9831D9C0DC400098AD3 /* ZMMessageDestructionTimer.swift in Sources */,
 				F9A706C91CAEE01D00C2F5FE /* ZMUpdateEvent+WireDataModel.m in Sources */,
+				BF707C391EB8780800108D4E /* MessageCountTracker.swift in Sources */,
 				F9A706761CAEE01D00C2F5FE /* ZMAssetClientMessage.m in Sources */,
 				CE58A3FF1CD3B3580037B626 /* ConversationMessage.swift in Sources */,
 				BF85CF5F1D227A78006EDB97 /* LocationData.swift in Sources */,
@@ -2096,6 +2103,7 @@
 				F92C99281DAE8D070034AFDD /* GenericMessageTests+Obfuscation.swift in Sources */,
 				BF949E5B1D3D17FB00587597 /* LinkPreview+ProtobufTests.swift in Sources */,
 				CEE525AA1CCA4C97001D06F9 /* NSString+RandomString.m in Sources */,
+				BF707C3B1EB8879300108D4E /* MessageCountTrackerTests.swift in Sources */,
 				F90E5AB31D2276FD00555CD0 /* ZMConversationTests+Timestamp.m in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */; };
 		BF707C391EB8780800108D4E /* MessageCountTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C381EB8780800108D4E /* MessageCountTracker.swift */; };
 		BF707C3B1EB8879300108D4E /* MessageCountTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */; };
+		BF707C3D1EB8928A00108D4E /* Clusterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C3C1EB8928A00108D4E /* Clusterizer.swift */; };
+		BF707C3F1EB892D900108D4E /* Clusterizer+MessageCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C3E1EB892D900108D4E /* Clusterizer+MessageCount.swift */; };
 		BF735CFD1E7050D5003BC61F /* ZMConversationTests+CallSystemMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */; };
 		BF735CFF1E70626F003BC61F /* store2-27-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF735CFE1E70626F003BC61F /* store2-27-0.wiredatabase */; };
 		BF76998B1D3500F0009C378B /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699891D3500D6009C378B /* Ono.framework */; };
@@ -465,6 +467,8 @@
 		BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+DisplayName.swift"; sourceTree = "<group>"; };
 		BF707C381EB8780800108D4E /* MessageCountTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTracker.swift; sourceTree = "<group>"; };
 		BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTrackerTests.swift; sourceTree = "<group>"; };
+		BF707C3C1EB8928A00108D4E /* Clusterizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Clusterizer.swift; sourceTree = "<group>"; };
+		BF707C3E1EB892D900108D4E /* Clusterizer+MessageCount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Clusterizer+MessageCount.swift"; sourceTree = "<group>"; };
 		BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+CallSystemMessages.swift"; sourceTree = "<group>"; };
 		BF735CFE1E70626F003BC61F /* store2-27-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-27-0.wiredatabase"; path = "Tests/Resources/store2-27-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		BF7699891D3500D6009C378B /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
@@ -905,6 +909,8 @@
 				BF10B59E1E645A3A00E7036E /* Events */,
 				BF10B5951E64591600E7036E /* AnalyticsType.swift */,
 				BF707C381EB8780800108D4E /* MessageCountTracker.swift */,
+				BF707C3C1EB8928A00108D4E /* Clusterizer.swift */,
+				BF707C3E1EB892D900108D4E /* Clusterizer+MessageCount.swift */,
 				BF10B5961E64591600E7036E /* NSManagedObjectContext+Analytics.swift */,
 			);
 			path = Analytics;
@@ -1956,6 +1962,7 @@
 			files = (
 				F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */,
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
+				BF707C3F1EB892D900108D4E /* Clusterizer+MessageCount.swift in Sources */,
 				CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */,
 				545FA5D71E2FD3750054171A /* ZMConversation+MessageDeletion.swift in Sources */,
 				BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */,
@@ -2013,6 +2020,7 @@
 				CE4EDC091D6D9A3D002A20AA /* Reaction.swift in Sources */,
 				F963E96F1D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.m in Sources */,
 				544E8C131E2F825700F9B8B8 /* ZMConversation+SecurityLevel.swift in Sources */,
+				BF707C3D1EB8928A00108D4E /* Clusterizer.swift in Sources */,
 				F9A7067A1CAEE01D00C2F5FE /* ZMGenericMessage+External.m in Sources */,
 				F93A30251D6EFB47005CCB1D /* ZMMessageConfirmation.swift in Sources */,
 				BFABEB8C1E647054003BE9F3 /* GenericMessageScheduleNotification.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* For analytics purposes it would be nice to know the count of pre end-to-end encryption messages in the database.
* This also moves some analytics related classes from `wire-ios-sync-engine` to `wire-ios-data-model` (see https://github.com/wireapp/wire-ios-sync-engine/pull/361).