### PR TITLE
Allow resume sending image asset messages

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.m
+++ b/Source/Model/Message/ZMAssetClientMessage.m
@@ -340,7 +340,12 @@ static NSString * const AssociatedTaskIdentifierDataKey = @"associatedTaskIdenti
 }
 
 - (void)resend {
-    self.uploadState = ZMAssetUploadStateUploadingPlaceholder;
+    if (self.v3_isImage) {
+        self.uploadState = ZMAssetUploadStateUploadingFullAsset;
+    }
+    else {
+        self.uploadState = ZMAssetUploadStateUploadingPlaceholder;
+    }
     self.transferState = ZMFileTransferStateUploading;
     self.progress = 0;
     [self removeNotUploaded];

--- a/Source/Model/Message/ZMMessage+Insert.swift
+++ b/Source/Model/Message/ZMMessage+Insert.swift
@@ -27,10 +27,11 @@ extension ZMMessage {
     /// and fire a notification on conversation security level change so that UI could act accordingly
     fileprivate func expireAndNotifyIfInsertingIntoDegradedConversation() {
         guard let conversation = self.conversation else { return }
-        guard let uiMoc = self.managedObjectContext, uiMoc.zm_isUserInterfaceContext else { return }
-        guard let syncMoc = uiMoc.zm_sync else { return }
+        guard let currentMoc = self.managedObjectContext else { return }
+        guard let syncMoc = currentMoc.zm_sync else { return }
+        guard let uiMoc = currentMoc.zm_userInterface else { return }
         if conversation.securityLevel == .secureWithIgnored && self.deliveryState == .pending {
-            uiMoc.saveOrRollback()
+            currentMoc.saveOrRollback()
             syncMoc.performGroupedBlock {
                 guard let message = (try? syncMoc.existingObject(with: self.objectID)) as? ZMOTRMessage else { return }
                 message.causedSecurityLevelDegradation = true

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -975,6 +975,32 @@ extension ZMAssetClientMessageTests {
         }
     }
     
+    func testThatItPreparesImageMessageForResend() {
+        self.syncMOC.performAndWait {
+            
+            // given
+            let image = self.verySmallJPEGData()
+            let nonce = UUID.create()
+
+            let sut = ZMAssetClientMessage(originalImageData: image, nonce: nonce, managedObjectContext: self.syncMOC, expiresAfter: 1000)
+            
+            self.syncConversation.mutableMessages.add(sut)
+            sut.delivered = true
+            sut.progress = 56
+            sut.transferState = .failedUpload
+            sut.uploadState = .uploadingFailed
+            
+            // when
+            sut.resend()
+            
+            // then
+            XCTAssertEqual(sut.uploadState, ZMAssetUploadState.uploadingFullAsset)
+            XCTAssertFalse(sut.delivered)
+            XCTAssertEqual(sut.transferState, ZMFileTransferState.uploading)
+            XCTAssertEqual(sut.progress, 0)
+        }
+    }
+    
     func testThatItReturnsNilAssetIdOnANewlyCreatedMessage() {
         self.syncMOC.performAndWait {
             


### PR DESCRIPTION
The issue happened due to the check of `uploadState` in `v3_isReadyToUploadUploaded` of `AssetClientMessageRequestStrategy`.

The `ZMAssetClientMessage`'s `resend` method was setting the `uploadState` to `uploadingPlaceholder`, which is not accepted as the proper state by the request strategy for images, but works correctly for file messages.

Also fixes threading for `expireAndNotifyIfInsertingIntoDegradedConversation` which can be called from main thread and from the sync thread.