### PR TITLE
Reloading message window when coming to foreground

### DIFF
--- a/Source/Notifications/MessageWindowObserverCenter.swift
+++ b/Source/Notifications/MessageWindowObserverCenter.swift
@@ -219,7 +219,7 @@ class MessageWindowSnapshot : NSObject, ZMConversationObserver, ZMMessageObserve
     func updateMessageChangeInfos(window: ZMConversationMessageWindow) {
         messageChangeInfos.forEach{
             guard let user = $0.message.sender, let userChange = userChanges.removeValue(forKey:user.objectID) else { return }
-            $0.changeInfos["userChanges"] = userChange
+            $0.changeInfos[MessageChangeInfo.UserChangeInfoKey] = userChange
         }
         
         guard userChanges.count > 0, let messages = window.messages.array as? [ZMMessage] else { return }
@@ -230,7 +230,7 @@ class MessageWindowSnapshot : NSObject, ZMConversationObserver, ZMMessageObserve
                 guard userIDs.contains(objectID) else { return }
                 
                 let changeInfo = MessageChangeInfo(object: message)
-                changeInfo.changeInfos["userChanges"] = change
+                changeInfo.changeInfos[MessageChangeInfo.UserChangeInfoKey] = change
                 messageChangeInfos.append(changeInfo)
             }
         }
@@ -247,10 +247,10 @@ class MessageWindowSnapshot : NSObject, ZMConversationObserver, ZMMessageObserve
         
         var userInfo = [String : Any]()
         if messageChangeInfos.count > 0 {
-            userInfo["messageChangeInfos"] = messageChangeInfos
+            userInfo[MessageWindowChangeInfo.MessageChangeUserInfoKey] = messageChangeInfos
         }
         if let changeInfo = windowChangeInfo {
-            userInfo["messageWindowChangeInfo"] = changeInfo
+            userInfo[MessageWindowChangeInfo.MessageWindowChangeUserInfoKey] = changeInfo
         }
         guard !userInfo.isEmpty else {
             zmLog.debug("No changes to post for window \(window)")

--- a/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
@@ -20,6 +20,10 @@
 import Foundation
 
 @objc public final class MessageWindowChangeInfo: NSObject, SetChangeInfoOwner {
+    
+    public static let MessageWindowChangeUserInfoKey = "messageWindowChangeInfo"
+    public static let MessageChangeUserInfoKey = "messageChangeInfos"
+    
     public typealias ChangeInfoContent = ZMMessage
     public var setChangeInfo: SetChangeInfo<ZMMessage>
     
@@ -66,10 +70,10 @@ extension MessageWindowChangeInfo {
         return NotificationCenterObserverToken(name: .MessageWindowDidChange, object: window)
         { [weak observer] (note) in
             guard let `observer` = observer, let window = note.object as? ZMConversationMessageWindow else { return }
-            if let changeInfo = note.userInfo?["messageWindowChangeInfo"] as? MessageWindowChangeInfo{
+            if let changeInfo = note.userInfo?[self.MessageWindowChangeUserInfoKey] as? MessageWindowChangeInfo {
                 observer.conversationWindowDidChange(changeInfo)
             }
-            if let messageChangeInfos = note.userInfo?["messageChangeInfos"] as? [MessageChangeInfo] {
+            if let messageChangeInfos = note.userInfo?[self.MessageChangeUserInfoKey] as? [MessageChangeInfo] {
                 observer.messagesInsideWindow?(window, didChange: messageChangeInfos)
             }
         } 

--- a/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageWindowChangeInfo.swift
@@ -31,6 +31,9 @@ import Foundation
     public var isFetchingMessagesChanged = false
     public var isFetchingMessages = false
     
+    /// Set to true when there might be some changes that are not reflected in the change info and it's better to reload
+    public var needsReload = false
+    
     init(setChangeInfo: SetChangeInfo<ZMMessage>) {
         self.setChangeInfo = setChangeInfo
     }


### PR DESCRIPTION
When ephemeral message expires with app in the background, after it goes back to foreground the message list is not updated. The same happens if someone likes a message for example.

So the solution is a bit blunt, but should fix other yet unreported bugs - we added a flag that UI should pick up and reload the conversation even if there are no computed changes.