### PR TITLE
Fix: connection list ordering issue after accepting connection

### DIFF
--- a/Source/Model/Connection/ZMConnection.m
+++ b/Source/Model/Connection/ZMConnection.m
@@ -229,6 +229,8 @@ struct stringAndStatus {
                 self.conversation = realConversation;
                 self.conversation.needsToBeUpdatedFromBackend = YES;
             }
+            // The conversation will not have any modified date until the first message, use connection date in the meantime
+            self.conversation.lastModifiedDate = lastUpdateDate;
         } else {
             self.conversation = [ZMConversation conversationWithRemoteID:conversationID createIfNeeded:YES inContext:self.managedObjectContext];
             self.conversation.needsToBeUpdatedFromBackend = YES;

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -307,14 +307,16 @@ static NSString *const AddressBookEntryKey = @"addressBookEntry";
                 // Do nothing
                 break;
             case ZMConnectionStatusPending:
+                // We should get the real modified date after syncing with the server, using current date until then.
+                self.connection.conversation.lastModifiedDate = [NSDate date];
             case ZMConnectionStatusIgnored:
             case ZMConnectionStatusBlocked:
                 self.connection.status = ZMConnectionStatusAccepted;
+
                 if(self.connection.conversation.conversationType == ZMConversationTypeConnection) {
                     self.connection.conversation.conversationType = ZMConversationTypeOneOnOne;
                 }
                 break;
-                
         }
     }
     if (handler) {

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -312,7 +312,6 @@ static NSString *const AddressBookEntryKey = @"addressBookEntry";
             case ZMConnectionStatusIgnored:
             case ZMConnectionStatusBlocked:
                 self.connection.status = ZMConnectionStatusAccepted;
-
                 if(self.connection.conversation.conversationType == ZMConversationTypeConnection) {
                     self.connection.conversation.conversationType = ZMConversationTypeOneOnOne;
                 }

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1485,7 +1485,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqualObjects(connection.message, originalText, @"This will stay whatever the other user set it to.");
 }
 
-- (void)testThatConnectingToAPendingUserSetsTheConnectionStatusToAcceptedAndConversationTypeToOneToOne;
+- (void)testThatConnectingToAPendingUserSetsTheConnectionStatusToAcceptedAndConversationTypeToOneToOneAndUpdatesModificationDate
 {
     // given
     NSUUID *uuid = [NSUUID createUUID];
@@ -1509,7 +1509,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqual(connection.status, ZMConnectionStatusAccepted);
     XCTAssertEqualObjects(connection.message, originalText, @"This will stay whatever the other user set it to.");
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
-    
+    XCTAssertEqualWithAccuracy(conversation.lastModifiedDate.timeIntervalSince1970, [NSDate date].timeIntervalSince1970, 0.1);
 }
 
 - (void)testThatConnectingToAUserSetsTheConnectionStatusAsHavingLocalModifications

--- a/Tests/Source/Model/ZMConnectionTests.m
+++ b/Tests/Source/Model/ZMConnectionTests.m
@@ -674,6 +674,29 @@
     }];
 }
 
+- (void)testThatItUpdatesTheConversationModificationDateAfterAcceptingConnection
+{
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        NSDictionary *payload = [self validPayloadForConnectionWithStatus:@"accepted"];
+        ZMConnection *connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
+        ZMUser *sender = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
+        sender.remoteIdentifier = [payload uuidForKey:@"to"];
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.remoteIdentifier = [NSUUID createUUID];
+        connection.conversation = conversation;
+        connection.to = sender;
+        
+        // when
+        [self performIgnoringZMLogError:^{
+            [connection updateFromTransportData:payload];
+        }];
+        
+        // then
+        XCTAssertEqual(connection.conversation.lastModifiedDate, connection.lastUpdateDate);
+    }];
+}
+
 - (void)testThatItReturnsTheListOfAllConnectionsInTheUserSession;
 {
     // given

--- a/WireDataModel.xcodeproj/xcshareddata/xcschemes/WireDataModel.xcscheme
+++ b/WireDataModel.xcodeproj/xcshareddata/xcschemes/WireDataModel.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
After accepting incoming connection the conversation doesn't have any messages and its `lastModifiedDate` is `1970-01-01`. We use this for sorting the conversation list and it then goes to the absolute bottom.
The fix is to use connection date as `lastModifiedDate`.