### PR TITLE
Add creator and flag specifying if members need redownload

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -149,10 +149,12 @@
         <attribute name="isActive" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToRedownloadMembers" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
         <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
         <attribute name="teamPictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Conversation" inverseName="team" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdTeams" inverseEntity="User" syncable="YES"/>
         <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Member" inverseName="team" inverseEntity="Member" syncable="YES"/>
     </entity>
     <entity name="TextMessage" representedClassName="ZMTextMessage" parentEntity="Message" syncable="YES">
@@ -191,6 +193,7 @@
         <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="user" inverseEntity="UserClient" syncable="YES"/>
         <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="to" inverseEntity="Connection" syncable="YES"/>
         <relationship name="conversationsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="createdTeams" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Team" inverseName="creator" inverseEntity="Team" syncable="YES"/>
         <relationship name="lastServerSyncedActiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="lastServerSyncedActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="memberships" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Member" inverseName="user" inverseEntity="Member" syncable="YES"/>
         <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Reaction" inverseName="users" inverseEntity="Reaction" syncable="YES"/>
@@ -242,9 +245,9 @@
         <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
         <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
         <element name="SystemMessage" positionX="0" positionY="0" width="128" height="195"/>
-        <element name="Team" positionX="9" positionY="153" width="128" height="165"/>
+        <element name="Team" positionX="9" positionY="153" width="128" height="195"/>
         <element name="TextMessage" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="615"/>
+        <element name="User" positionX="0" positionY="0" width="128" height="630"/>
         <element name="UserClient" positionX="9" positionY="153" width="128" height="450"/>
     </elements>
 </model>

--- a/Source/Model/Conversation/Member.swift
+++ b/Source/Model/Conversation/Member.swift
@@ -50,3 +50,21 @@ public class Member: ZMManagedObject {
     }
 
 }
+
+
+// MARK: - Transport
+
+extension Member {
+
+    @discardableResult
+    public static func createOrUpdate(with payload: [String: Any], in team: Team, context: NSManagedObjectContext) -> Member? {
+        guard let id = (payload["user"] as? String).flatMap(UUID.init),
+            let user = ZMUser(remoteID: id, createIfNeeded: true, in: context),
+            let permissions = payload["permissions"] as? [String] else { return nil }
+
+        let member = getOrCreateMember(for: user, in: team, context: context)
+        member.permissions = Permissions(payload: permissions)
+        return member
+    }
+
+}

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -104,6 +104,7 @@ extension Permissions: CustomDebugStringConvertible {
 
 }
 
+
 extension Permissions: Hashable {
 
     public var hashValue : Int {
@@ -111,7 +112,6 @@ extension Permissions: Hashable {
     }
 
 }
-
 
 // MARK: - Objective-C Interoperability
 

--- a/Source/Model/Conversation/Team+Transport.swift
+++ b/Source/Model/Conversation/Team+Transport.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+extension Team {
+
+    public func update(with payload: [String: Any]) {
+        if let teamName = payload["name"] as? String {
+            name = teamName
+        }
+
+        if let creatorId = (payload["creator"] as? String).flatMap(UUID.init) {
+            creator = ZMUser(remoteID: creatorId, createIfNeeded: true, in: managedObjectContext!)
+            creator?.needsToBeUpdatedFromBackend = true
+        }
+    }
+
+}

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -35,7 +35,9 @@ public class Team: ZMManagedObject, TeamType {
     @NSManaged public var name: String?
     @NSManaged public var teamPictureAssetKey: String?
     @NSManaged public var isActive: Bool
+    @NSManaged public var creator: ZMUser?
 
+    @NSManaged public var needsToRedownloadMembers: Bool
     @NSManaged private var remoteIdentifier_data: Data?
 
     public var remoteIdentifier: UUID? {

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -25,6 +25,7 @@
 #import "ZMUser+OneOnOne.h"
 
 @class ZMConnection;
+@class Team;
 
 extern NSString * __nonnull const SessionObjectIDKey;
 extern NSString * __nonnull const ZMUserActiveConversationsKey;
@@ -38,6 +39,8 @@ extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 @property (nonnull, nonatomic) NSOrderedSet *showingUserAdded;
 @property (nonnull, nonatomic) NSOrderedSet *showingUserRemoved;
+
+@property (nonnull, nonatomic) NSSet<Team *> *createdTeams;
 
 @property (nonnull, nonatomic, readonly) NSString *normalizedName;
 @property (nonnull, nonatomic, readonly) NSString *normalizedEmailAddress;

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -78,6 +78,7 @@ static NSString *const UserClientsKey = @"clients";
 static NSString *const ReactionsKey = @"reactions";
 static NSString *const AddressBookEntryKey = @"addressBookEntry";
 static NSString *const MembershipsKey = @"memberships";
+static NSString *const CreatedTeamsKey = @"createdTeams";
 
 @interface ZMBoxedSelfUser : NSObject
 
@@ -383,6 +384,7 @@ static NSString *const MembershipsKey = @"memberships";
 @dynamic connection;
 @dynamic showingUserAdded;
 @dynamic showingUserRemoved;
+@dynamic createdTeams;
 
 - (NSSet *)keysTrackedForLocalModifications
 {
@@ -420,7 +422,8 @@ static NSString *const MembershipsKey = @"memberships";
                                            ReactionsKey,
                                            AddressBookEntryKey,
                                            HandleKey, // this is not set on the user directly
-                                           MembershipsKey
+                                           MembershipsKey,
+                                           CreatedTeamsKey
                                            ]];
         keys = [ignoredKeys copy];
     });

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		BF1B98091EC31A4200DE033B /* Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1B98081EC31A4200DE033B /* Permissions.swift */; };
 		BF1B980B1EC31D6100DE033B /* TeamDeletionRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1B980A1EC31D6100DE033B /* TeamDeletionRuleTests.swift */; };
 		BF1B980D1EC3410000DE033B /* PermissionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1B980C1EC3410000DE033B /* PermissionsTests.swift */; };
+		BF1F52BA1ECC3C9E002FB553 /* Team+Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F52B91ECC3C9E002FB553 /* Team+Transport.swift */; };
 		BF2ADF631E28CF1E00E81B1E /* SharedObjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */; };
 		BF3493EB1EC34C0B00B0C314 /* TeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3493EA1EC34C0B00B0C314 /* TeamTests.swift */; };
 		BF3493ED1EC34FF700B0C314 /* store2-29-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF3493EC1EC34FF700B0C314 /* store2-29-0.wiredatabase */; };
@@ -481,6 +482,7 @@
 		BF1B98081EC31A4200DE033B /* Permissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permissions.swift; sourceTree = "<group>"; };
 		BF1B980A1EC31D6100DE033B /* TeamDeletionRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamDeletionRuleTests.swift; sourceTree = "<group>"; };
 		BF1B980C1EC3410000DE033B /* PermissionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsTests.swift; sourceTree = "<group>"; };
+		BF1F52B91ECC3C9E002FB553 /* Team+Transport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Team+Transport.swift"; sourceTree = "<group>"; };
 		BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedObjectStore.swift; sourceTree = "<group>"; };
 		BF3493EA1EC34C0B00B0C314 /* TeamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamTests.swift; sourceTree = "<group>"; };
 		BF3493EC1EC34FF700B0C314 /* store2-29-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-29-0.wiredatabase"; path = "Tests/Resources/store2-29-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
@@ -956,6 +958,7 @@
 			isa = PBXGroup;
 			children = (
 				BF1B98031EC313C600DE033B /* Team.swift */,
+				BF1F52B91ECC3C9E002FB553 /* Team+Transport.swift */,
 				BF1B98061EC31A3C00DE033B /* Member.swift */,
 				BF1B98081EC31A4200DE033B /* Permissions.swift */,
 			);
@@ -2149,6 +2152,7 @@
 				BF1B98091EC31A4200DE033B /* Permissions.swift in Sources */,
 				F9A706901CAEE01D00C2F5FE /* ZMUser.m in Sources */,
 				F9A706C31CAEE01D00C2F5FE /* UserImageLocalCache.swift in Sources */,
+				BF1F52BA1ECC3C9E002FB553 /* Team+Transport.swift in Sources */,
 				F9A706B21CAEE01D00C2F5FE /* NewUnreadMessageChangeInfos.swift in Sources */,
 				F963E96D1D9ADD5A00098AD3 /* ZMGenericMessage+Helper.swift in Sources */,
 				161541BA1E27EBD400AC2FFB /* ZMConversation+Calling.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* Add `creator` relation (inverse `createdTeams`) to `Team` entity. 
* Add methods to create or update teams and members from transport data.