### PR TITLE
Update conversation creation rules and transport data parsing

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -51,6 +51,7 @@
         <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="managed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="messageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -235,7 +236,7 @@
         <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="225"/>
         <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="540"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="555"/>
         <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
         <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
         <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -35,6 +35,8 @@ static NSString *const ConversationInfoOthersKey = @"others";
 static NSString *const ConversationInfoMembersKey = @"members";
 static NSString *const ConversationInfoCreatorKey = @"creator";
 static NSString *const ConversationInfoTeamKey = @"team";
+static NSString *const ConversationInfoTeamIdKey = @"teamid";
+static NSString *const ConversationInfoManagedTeamKey = @"managed";
 static NSString *const ConversationInfoLastEventTimeKey = @"last_event_time";
 
 NSString *const ZMConversationInfoOTRMutedValueKey = @"otr_muted";
@@ -101,9 +103,9 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
         ZMLogError(@"Invalid members in conversation JSON: %@", transportData);
     }
 
-    NSUUID *teamId = [transportData optionalUuidForKey:ConversationInfoTeamKey];
-    if (nil != teamId) {
-        self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext];
+    NSDictionary *team = [transportData optionalDictionaryForKey:ConversationInfoTeamKey];
+    if (nil != team) {
+        [self updateTeamWithPayload:team];
     }
 }
 
@@ -124,6 +126,19 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
         else {
             [self.mutableOtherActiveParticipants removeObject:user];
             [self.mutableLastServerSyncedActiveParticipants removeObject:user];
+        }
+    }
+}
+
+- (void)updateTeamWithPayload:(NSDictionary *)payload
+{
+    NSUUID *teamId = [payload optionalUuidForKey:ConversationInfoTeamIdKey];
+    if (nil != teamId) {
+        self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext];
+
+        NSNumber *managed = [payload optionalNumberForKey:ConversationInfoManagedTeamKey];
+        if (nil != managed) {
+            self.managed = managed.boolValue;
         }
     }
 }

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -111,6 +111,7 @@ static NSString *const ArchivedEventIDDataKey = @"archivedEventID_data";
 static NSString *const LastReadEventIDDataKey = @"lastReadEventID_data";
 
 static NSString *const TeamKey = @"team";
+static NSString *const TeamManagedKey = @"managed";
 
 NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 3.0;
 
@@ -170,6 +171,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic messageDestructionTimeout;
 @dynamic callParticipants;
 @dynamic team;
+@dynamic managed;
 
 @synthesize tempMaxLastReadServerTimeStamp;
 @synthesize lastReadTimestampSaveDelay;
@@ -371,7 +373,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             ClearedEventIDDataKey,
             ArchivedEventIDDataKey,
             LastReadEventIDDataKey,
-            TeamKey
+            TeamKey,
+            TeamManagedKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -82,6 +82,9 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 @property (nonatomic, copy, nullable) NSString *draftMessageText;
 @property (nonatomic, nullable) Team *team;
 
+/// Whether the conversation is a managed team conversation
+@property (nonatomic) BOOL managed;
+
 /// This is read only. Use -setVisibleWindowFromMessage:toMessage: to update this.
 /// This will return @c nil if the last read message has not yet been sync'd to this device, or if the conversation has no last read message.
 @property (nonatomic, readonly, nullable) ZMMessage *lastReadMessage;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -92,6 +92,18 @@ class Conversationtests_Teams: BaseTeamTests {
         XCTAssertNotEqual(conversation, newConversation)
     }
 
+    func testThatItReturnsANewConversationIfAnExistingOneHasAUserDefinedName() {
+        // given
+        let conversation = ZMConversation.fetchOrCreateTeamConversation(in: uiMOC, withParticipant: otherUser, team: team)
+        conversation?.userDefinedName = "Best Conversation"
+
+        // when
+        let newConversation = ZMConversation.fetchOrCreateTeamConversation(in: uiMOC, withParticipant: otherUser, team: team)
+
+        // then
+        XCTAssertNotEqual(conversation, newConversation)
+    }
+
     func testThatItReturnsNotNilWhenAskedForOneOnOneConversationWithoutTeam() {
         // given
         let oneOnOne = ZMConversation.insertNewObject(in: uiMOC)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -28,12 +28,12 @@
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation conversationType:(ZMBackendConversationType)conversationType isArchived:(BOOL)isArchived archivedRef:(NSDate *)archivedRef isSilenced:(BOOL)isSilenced
     silencedRef: (NSDate *)silencedRef;
 {
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:conversationType activeUserIDs:@[] inactiveUserIDs:@[]  lastServerTimestamp:nil isArchived:isArchived archivedRef:archivedRef isSilenced:isSilenced silencedRef:silencedRef teamID:nil];
+    return  [self payloadForMetaDataOfConversation:conversation conversationType:conversationType activeUserIDs:@[] inactiveUserIDs:@[]  lastServerTimestamp:nil isArchived:isArchived archivedRef:archivedRef isSilenced:isSilenced silencedRef:silencedRef teamID:nil managed:NO];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation activeUserIDs:(NSArray <NSUUID *>*)activeUserIDs inactiveUserIDs:(NSArray <NSUUID *>*)inactiveUserIDs;
 {
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs  lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
+    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs  lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil managed:NO];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
@@ -41,7 +41,7 @@
                                    inactiveUserIDs:(NSArray <NSUUID *>*)inactiveUserIDs
                                lastServerTimestamp:(NSDate*)lastServerTimestamp
 {
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs lastServerTimestamp:lastServerTimestamp isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
+    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs lastServerTimestamp:lastServerTimestamp isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil managed:NO];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
@@ -53,7 +53,8 @@
                                        archivedRef:(NSDate *)archivedRef
                                         isSilenced:(BOOL)isSilenced
                                        silencedRef:(NSDate *)silencedRef
-                                            teamID:(NSUUID *)teamID;
+                                            teamID:(NSUUID *)teamID
+                                           managed:(BOOL)managed
 {
     NSMutableArray *others = [NSMutableArray array];
     for (NSUUID *uuid in activeUserIDs) {
@@ -71,6 +72,8 @@
                                    };
         [others addObject:userInfo];
     }
+
+
 
     NSDictionary *payload = @{
                               @"last_event_time" : lastServerTimestamp ? [lastServerTimestamp transportString] :@"2014-04-30T16:30:16.625Z",
@@ -93,7 +96,10 @@
                                       },
                               @"type" : @(conversationType),
                               @"id" : [conversation.remoteIdentifier transportString],
-                              @"team": [teamID transportString] ?: [NSNull null]
+                              @"team": @{
+                                      @"teamid": [teamID transportString] ?: [NSNull null],
+                                      @"managed": @(managed)
+                                      }
                               };
     return  payload;
 }
@@ -187,7 +193,7 @@
         NSUUID *user2UUID = [NSUUID createUUID];
         NSUUID *teamID = [NSUUID createUUID];
 
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:teamID];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:teamID managed:YES];
 
         // when
         [conversation updateWithTransportData:payload];
@@ -208,6 +214,7 @@
 
         XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
         XCTAssertNotNil(conversation.team);
+        XCTAssertTrue(conversation.managed);
         XCTAssertEqualObjects(conversation.team.remoteIdentifier, teamID);
 
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);


### PR DESCRIPTION
# What's in this PR?

* Add `managed` attribute to `ZMConversation`, indicating if a team conversation is managed or not.
* Update team payload parsing from conversation transport data.
* Create new team conversation if existing one has a user defined name.