### PR TITLE
Correct picture keys

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -151,9 +151,10 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="needsToRedownloadMembers" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pictureAssetId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
         <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
-        <attribute name="teamPictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Conversation" inverseName="team" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdTeams" inverseEntity="User" syncable="YES"/>
         <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Member" inverseName="team" inverseEntity="Member" syncable="YES"/>
@@ -246,7 +247,7 @@
         <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
         <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
         <element name="SystemMessage" positionX="0" positionY="0" width="128" height="195"/>
-        <element name="Team" positionX="9" positionY="153" width="128" height="195"/>
+        <element name="Team" positionX="9" positionY="153" width="128" height="210"/>
         <element name="TextMessage" positionX="0" positionY="0" width="128" height="60"/>
         <element name="User" positionX="0" positionY="0" width="128" height="630"/>
         <element name="UserClient" positionX="9" positionY="153" width="128" height="450"/>

--- a/Source/Model/Conversation/Member.swift
+++ b/Source/Model/Conversation/Member.swift
@@ -60,10 +60,10 @@ extension Member {
     public static func createOrUpdate(with payload: [String: Any], in team: Team, context: NSManagedObjectContext) -> Member? {
         guard let id = (payload["user"] as? String).flatMap(UUID.init),
             let user = ZMUser(remoteID: id, createIfNeeded: true, in: context),
-            let permissions = payload["permissions"] as? [String] else { return nil }
+            let permissions = payload["permissions"] as? Int else { return nil }
 
         let member = getOrCreateMember(for: user, in: team, context: context)
-        member.permissions = Permissions(payload: permissions)
+        member.permissions = Permissions(rawValue: Int32(permissions))
         return member
     }
 

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -26,75 +26,24 @@ public struct Permissions: OptionSet {
     }
 
     // MARK: - Base Values
-    public static let createConversation       = Permissions(rawValue: 1 << 0)
-    public static let deleteConversation       = Permissions(rawValue: 1 << 1)
-    public static let addTeamMember            = Permissions(rawValue: 1 << 2)
-    public static let removeTeamMember         = Permissions(rawValue: 1 << 3)
-    public static let addConversationMember    = Permissions(rawValue: 1 << 4)
-    public static let removeConversationMember = Permissions(rawValue: 1 << 5)
-    public static let getMemberPermissions     = Permissions(rawValue: 1 << 6)
-    public static let getTeamConversations     = Permissions(rawValue: 1 << 7)
-    public static let getBilling               = Permissions(rawValue: 1 << 8)
-    public static let setBilling               = Permissions(rawValue: 1 << 9)
-    public static let setTeamData              = Permissions(rawValue: 1 << 10)
-    public static let deleteTeam               = Permissions(rawValue: 1 << 11)
+    public static let createConversation       = Permissions(rawValue: 0x001)
+    public static let deleteConversation       = Permissions(rawValue: 0x002)
+    public static let addTeamMember            = Permissions(rawValue: 0x004)
+    public static let removeTeamMember         = Permissions(rawValue: 0x008)
+    public static let addConversationMember    = Permissions(rawValue: 0x010)
+    public static let removeConversationMember = Permissions(rawValue: 0x020)
+    public static let getBilling               = Permissions(rawValue: 0x040)
+    public static let setBilling               = Permissions(rawValue: 0x080)
+    public static let setTeamData              = Permissions(rawValue: 0x100)
+    public static let getMemberPermissions     = Permissions(rawValue: 0x200)
+    public static let getTeamConversations     = Permissions(rawValue: 0x400)
+    public static let deleteTeam               = Permissions(rawValue: 0x800)
 
     // MARK: - Common Combined Values
     public static let member: Permissions = [.createConversation, .deleteConversation, .addConversationMember, .removeConversationMember, .getTeamConversations, .getMemberPermissions]
     public static let admin: Permissions  = [.member, .addTeamMember, .removeTeamMember, .setTeamData]
     public static let owner: Permissions  = [.admin, .getBilling, .setBilling, .deleteTeam]
 
-
-    public enum TransportString: String {
-        case createConversation = "CreateConversation"
-        case deleteConversation = "DeleteConversation"
-        case addTeamMember = "AddTeamMember"
-        case removeTeamMember = "RemoveTeamMember"
-        case addConversationMember = "AddConversationMember"
-        case removeConversationMember = "RemoveConversationMember"
-        case getMemberPermissions = "GetMemberPermissions"
-        case getTeamConversations = "GetTeamConversations"
-        case getBilling  = "GetBilling"
-        case setBilling = "SetBilling"
-        case setTeamData = "SetTeamData"
-        case deleteTeam = "DeleteTeam"
-
-        var permissions: Permissions {
-            switch self {
-            case .createConversation: return .createConversation
-            case .deleteConversation: return .deleteConversation
-            case .addTeamMember: return .addTeamMember
-            case .removeTeamMember: return .removeTeamMember
-            case .addConversationMember: return .addConversationMember
-            case .removeConversationMember: return .removeConversationMember
-            case .getMemberPermissions: return .getMemberPermissions
-            case .getTeamConversations: return .getTeamConversations
-            case .getBilling: return .getBilling
-            case .setBilling: return .setBilling
-            case .setTeamData: return .setTeamData
-            case .deleteTeam: return .deleteTeam
-            }
-        }
-    }
-
-}
-
-
-// MARK: - Transport Data
-
-
-extension Permissions {
-
-    public init(payload: [String]) {
-        var permissions: Permissions = []
-        payload.flatMap(Permissions.init).forEach { permissions.formUnion($0) }
-        self = permissions
-    }
-
-    public init?(string: String) {
-        guard let value = Permissions.TransportString(rawValue: string)?.permissions else { return nil }
-        self = value
-    }
 }
 
 
@@ -103,23 +52,23 @@ extension Permissions {
 
 extension Permissions: CustomDebugStringConvertible {
 
-    private static let descriptions: [Permissions: Permissions.TransportString] = [
-        .createConversation: .createConversation,
-        .deleteConversation: .deleteConversation,
-        .addTeamMember: .addTeamMember,
-        .removeTeamMember: .removeTeamMember,
-        .addConversationMember: .addConversationMember,
-        .removeConversationMember: .removeConversationMember,
-        .getMemberPermissions: .getMemberPermissions,
-        .getTeamConversations: .getTeamConversations,
-        .getBilling : .getBilling,
-        .setBilling: .setBilling,
-        .setTeamData: .setTeamData,
-        .deleteTeam: .deleteTeam
+    private static let descriptions: [Permissions: String] = [
+        .createConversation: "CreateConversation",
+        .deleteConversation: "DeleteConversation",
+        .addTeamMember: "AddTeamMember",
+        .removeTeamMember: "RemoveTeamMember",
+        .addConversationMember: "AddConversationMember",
+        .removeConversationMember: "RemoveConversationMember",
+        .getMemberPermissions: "GetMemberPermissions",
+        .getTeamConversations: "GetTeamConversations",
+        .getBilling : "GetBilling",
+        .setBilling: "SetBilling",
+        .setTeamData: "SetTeamData",
+        .deleteTeam: "DeleteTeam"
     ]
 
     public var debugDescription: String {
-        return "[\(Permissions.descriptions.filter { contains($0.0) }.map { $0.1.rawValue }.joined(separator: ", "))]"
+        return "[\(Permissions.descriptions.filter { contains($0.0) }.map { $0.1 }.joined(separator: ", "))]"
     }
 
 }

--- a/Source/Model/Conversation/Team+Transport.swift
+++ b/Source/Model/Conversation/Team+Transport.swift
@@ -16,16 +16,30 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+
+private enum TeamTransportKey: String {
+    case name, creator, icon, iconKey = "icon_key"
+}
+
+
 extension Team {
 
     public func update(with payload: [String: Any]) {
-        if let teamName = payload["name"] as? String {
+        if let teamName = payload[TeamTransportKey.name.rawValue] as? String {
             name = teamName
         }
 
-        if let creatorId = (payload["creator"] as? String).flatMap(UUID.init) {
+        if let creatorId = (payload[TeamTransportKey.creator.rawValue] as? String).flatMap(UUID.init) {
             creator = ZMUser(remoteID: creatorId, createIfNeeded: true, in: managedObjectContext!)
             creator?.needsToBeUpdatedFromBackend = true
+        }
+
+        if let icon = payload[TeamTransportKey.icon.rawValue] as? String {
+            pictureAssetId = icon
+        }
+
+        if let iconKey = payload[TeamTransportKey.iconKey.rawValue] as? String {
+            pictureAssetKey = iconKey
         }
     }
 

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -59,14 +59,16 @@ public class Team: ZMManagedObject, TeamType {
         return false
     }
 
-    @objc(fetchOrCreateTeamWithRemoteIdentifier:createIfNeeded:inContext:)
-    public static func fetchOrCreate(with identifier: UUID, create: Bool, in context: NSManagedObjectContext) -> Team? {
+    @objc(fetchOrCreateTeamWithRemoteIdentifier:createIfNeeded:inContext:created:)
+    public static func fetchOrCreate(with identifier: UUID, create: Bool, in context: NSManagedObjectContext, created: UnsafeMutablePointer<Bool>?) -> Team? {
         precondition(!create || context.zm_isSyncContext, "Needs to be called on the sync context")
         if let existing = Team.fetch(withRemoteIdentifier: identifier, in: context) {
+            created?.pointee = false
             return existing
         } else if create {
             let team = Team.insertNewObject(in: context)
             team.remoteIdentifier = identifier
+            created?.pointee = true
             return team
         }
 

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -21,7 +21,8 @@ public protocol TeamType: class {
 
     var conversations: Set<ZMConversation> { get }
     var name: String? { get }
-    var teamPictureAssetKey: String? { get }
+    var pictureAssetId: String? { get }
+    var pictureAssetKey: String? { get }
     var isActive: Bool { get set }
     var remoteIdentifier: UUID? { get }
 
@@ -33,7 +34,8 @@ public class Team: ZMManagedObject, TeamType {
     @NSManaged public var conversations: Set<ZMConversation>
     @NSManaged public var members: Set<Member>
     @NSManaged public var name: String?
-    @NSManaged public var teamPictureAssetKey: String?
+    @NSManaged public var pictureAssetId: String?
+    @NSManaged public var pictureAssetKey: String?
     @NSManaged public var isActive: Bool
     @NSManaged public var creator: ZMUser?
 

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -135,6 +135,10 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSUUID *teamId = [payload optionalUuidForKey:ConversationInfoTeamIdKey];
     if (nil != teamId) {
         self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext];
+        // FIXME: Do we really need to refetch the team here?
+        // If we are added to a conversation in a team than we should have gotten the
+        // team creation update event and fetched the team before.
+        self.team.needsToBeUpdatedFromBackend = YES;
 
         NSNumber *managed = [payload optionalNumberForKey:ConversationInfoManagedTeamKey];
         if (nil != managed) {

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -134,7 +134,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 {
     NSUUID *teamId = [payload optionalUuidForKey:ConversationInfoTeamIdKey];
     if (nil != teamId) {
-        BOOL created = nil;
+        BOOL created = NO;
         self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext created:&created];
         // If we are added to a conversation in a team than we should have gotten the
         // team creation update event and fetched the team before.

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -134,11 +134,12 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 {
     NSUUID *teamId = [payload optionalUuidForKey:ConversationInfoTeamIdKey];
     if (nil != teamId) {
-        self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext];
-        // FIXME: Do we really need to refetch the team here?
+        BOOL created = nil;
+        self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext created:&created];
         // If we are added to a conversation in a team than we should have gotten the
         // team creation update event and fetched the team before.
-        self.team.needsToBeUpdatedFromBackend = YES;
+        // If not and we just created the team then we need to refetch it.
+        self.team.needsToBeUpdatedFromBackend = created;
 
         NSNumber *managed = [payload optionalNumberForKey:ConversationInfoManagedTeamKey];
         if (nil != managed) {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -225,6 +225,7 @@ class Conversationtests_Teams: BaseTeamTests {
             let conversation = try team.addConversation(with: [otherUser])
             XCTAssertNotNil(conversation)
             XCTAssertEqual(conversation?.otherActiveParticipants, [otherUser])
+            XCTAssertTrue(otherUser.isMember(of: team))
             XCTAssertEqual(conversation?.team, team)
         } catch {
             XCTFail("Eror: \(error)")

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -85,39 +85,15 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     // MARK: - Transport Data
 
-    func testThatItCreatesPermissionsFromStrings() {
-        XCTAssertNil(Permissions(string: ""))
-        XCTAssertEqual(Permissions(string: "CreateConversation"), .createConversation)
-        XCTAssertEqual(Permissions(string: "DeleteConversation"), .deleteConversation)
-        XCTAssertEqual(Permissions(string: "AddTeamMember"), .addTeamMember)
-        XCTAssertEqual(Permissions(string: "RemoveTeamMember"), .removeTeamMember)
-        XCTAssertEqual(Permissions(string: "AddConversationMember"), .addConversationMember)
-        XCTAssertEqual(Permissions(string: "RemoveConversationMember"), .removeConversationMember)
-        XCTAssertEqual(Permissions(string: "GetMemberPermissions"), .getMemberPermissions)
-        XCTAssertEqual(Permissions(string: "GetTeamConversations"), .getTeamConversations)
-        XCTAssertEqual(Permissions(string: "GetBilling"), .getBilling)
-        XCTAssertEqual(Permissions(string: "SetBilling"), .setBilling)
-        XCTAssertEqual(Permissions(string: "SetTeamData"), .setTeamData)
-        XCTAssertEqual(Permissions(string: "DeleteTeam"), .deleteTeam)
-    }
-
     func testThatItCreatesPermissionsFromPayload() {
-        XCTAssertEqual(Permissions(payload: ["CreateConversation", "DeleteTeam"]), [.createConversation, .deleteTeam])
-
-        let memberPayload = [
-            "CreateConversation",
-            "DeleteConversation",
-            "AddConversationMember",
-            "RemoveConversationMember",
-            "GetMemberPermissions",
-            "GetTeamConversations"
-            ]
-
-        XCTAssertEqual(Permissions(payload: memberPayload), .member)
+        XCTAssertEqual(Permissions(rawValue: 5), [.createConversation, .addTeamMember])
+        XCTAssertEqual(Permissions(rawValue: 1587), .member)
+        XCTAssertEqual(Permissions(rawValue: 1855), .admin)
+        XCTAssertEqual(Permissions(rawValue: 4095), .owner)
     }
 
     func testThatItCreatesEmptyPermissionsFromEmptyPayload() {
-        XCTAssertEqual(Permissions(payload: []), [])
+        XCTAssertEqual(Permissions(rawValue: 0), [])
     }
 
     // MARK: - Objective-C Interoperability

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -97,5 +97,30 @@ class TeamTests: BaseTeamTests {
             XCTFail("Eror: \(error)")
         }
     }
+
+    func testThatItUpdatesATeamWithPayload() {
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            let team = Team.insertNewObject(in: self.syncMOC)
+            let userId = UUID.create()
+            let assetId = UUID.create().transportString(), assetKey = UUID.create().transportString()
+
+            let payload = [
+                "name": "Wire GmbH",
+                "creator": userId.transportString(),
+                "icon": assetId,
+                "icon_key": assetKey
+            ]
+
+            // when
+            team.update(with: payload)
+
+            // then
+            XCTAssertEqual(team.creator?.remoteIdentifier, userId)
+            XCTAssertEqual(team.name, "Wire GmbH")
+            XCTAssertEqual(team.pictureAssetId, assetId)
+            XCTAssertEqual(team.pictureAssetKey, assetKey)
+        }
+    }
     
 }


### PR DESCRIPTION
# What's in this PR?

* Add team `pictureId` and `pictureKey` fields to model schema for consistency.
* Refetch team when receiving when getting it through a conversation update (see the comment).