### PR TITLE
Add observation for teams

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -27,7 +27,11 @@ public extension ZMUser {
         guard let memberships = memberships else { return nil }
         return Set(memberships.flatMap { $0.team })
     }
-
+    
+    static func keyPathsForValuesAffectingTeams() -> Set<String> {
+        return Set([#keyPath(ZMUser.memberships)])
+    }
+    
     public var activeTeams: Set<Team>? {
         guard let teams = teams else { return nil }
         return Set(teams.filter { $0.isActive })

--- a/Source/Notifications/DependencyKeyStore.swift
+++ b/Source/Notifications/DependencyKeyStore.swift
@@ -113,6 +113,10 @@ class DependencyKeyStore {
             return Set([#keyPath(Reaction.users)])
         case ZMGenericMessageData.entityName():
             return Set()
+        case Team.entityName():
+            return Team.observableKeys
+        case Member.entityName():
+            return Set()
         default:
             zmLog.warn("There are no observable keys defined for \(classIdentifier)")
             return Set()
@@ -143,6 +147,10 @@ class DependencyKeyStore {
             return observableKeys.mapToDictionary{Reaction.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMGenericMessageData.entityName():
             return observableKeys.mapToDictionary{ZMGenericMessageData.keyPathsForValuesAffectingValue(forKey: $0)}
+        case Team.entityName():
+            return observableKeys.mapToDictionary{Team.keyPathsForValuesAffectingValue(forKey: $0)}
+        case Member.entityName():
+            return [:]
         default:
             zmLog.warn("There is no path to affecting keys defined for \(classIdentifier)")
             return [:]

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -38,6 +38,7 @@ extension Notification.Name {
     static let NewUnreadUnsentMessage = Notification.Name("ZMNewUnreadUnsentMessageNotification")
     static let VoiceChannelStateChange = Notification.Name("ZMVoiceChannelStateChangeNotification")
     static let VoiceChannelParticipantStateChange = Notification.Name("ZMVoiceChannelParticipantStateChangeNotification")
+    static let TeamChange = Notification.Name("TeamChangeNotification")
 
     public static let NonCoreDataChangeInManagedObject = Notification.Name("NonCoreDataChangeInManagedObject")
     
@@ -149,7 +150,9 @@ public class NotificationDispatcher : NSObject {
                                            ZMAssetClientMessage.classIdentifier,
                                            ZMSystemMessage.classIdentifier,
                                            Reaction.classIdentifier,
-                                           ZMGenericMessageData.classIdentifier]
+                                           ZMGenericMessageData.classIdentifier,
+                                           Team.classIdentifier,
+                                           Member.classIdentifier]
         self.affectingKeysStore = DependencyKeyStore(classIdentifiers : classIdentifiers)
         self.snapshotCenter = SnapshotCenter(managedObjectContext: managedObjectContext)
         super.init()

--- a/Source/Notifications/ObjectObserverTokens/ObjectChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ObjectChangeInfo.swift
@@ -63,6 +63,7 @@ extension ObjectChangeInfo {
         case let object as ZMUser:          return UserChangeInfo.changeInfo(for: object, changes: changes)
         case let object as ZMMessage:       return MessageChangeInfo.changeInfo(for: object, changes: changes)
         case let object as UserClient:      return UserClientChangeInfo.changeInfo(for: object, changes: changes)
+        case let object as Team:            return TeamChangeInfo.changeInfo(for: object, changes: changes)
         default:
             return nil
         }

--- a/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
@@ -1,0 +1,103 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import WireSystem
+
+extension Team : ObjectInSnapshot {
+    
+    static public var observableKeys : Set<String> {
+        return Set([#keyPath(Team.name),
+                    #keyPath(Team.members)])
+    }
+    
+    public var notificationName : Notification.Name {
+        return .TeamChange
+    }
+}
+
+
+@objc public class TeamChangeInfo : ObjectChangeInfo {
+    
+    static let MembersChangedKey = "membersChanged"
+    static let NameChangedKey = "nameChanged"
+    
+    static func changeInfo(for team: Team, changes: Changes) -> TeamChangeInfo? {
+        guard changes.changedKeys.count > 0 || changes.originalChanges.count > 0 else { return nil }
+        let changeInfo = TeamChangeInfo(object: team)
+        changeInfo.changeInfos = changes.originalChanges
+        changeInfo.changedKeys = changes.changedKeys
+        return changeInfo
+    }
+    
+    public required init(object: NSObject) {
+        self.team = object as! Team
+        super.init(object: object)
+    }
+    
+    public let team: TeamType
+    
+    public var membersChanged : Bool {
+        return changedKeys.contains(#keyPath(Team.members))
+    }
+
+    public var nameChanged : Bool {
+        return changedKeys.contains(#keyPath(Team.name))
+    }
+}
+
+
+
+@objc public protocol TeamObserver : NSObjectProtocol {
+    func teamDidChange(_ changeInfo: TeamChangeInfo)
+}
+
+
+extension TeamChangeInfo {
+    
+    // MARK: Registering UserObservers
+    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified
+    /// You must hold on to the token and use it to unregister
+    @objc(addTeamObserver:forTeam:)
+    static func add(observer: TeamObserver, for user: Team?) -> NSObjectProtocol {
+        return NotificationCenterObserverToken(name: .TeamChange, object: user)
+        { [weak observer] (note) in
+            guard let `observer` = observer,
+                let changeInfo = note.userInfo?["changeInfo"] as? TeamChangeInfo
+                else { return }
+            
+            observer.teamDidChange(changeInfo)
+        }
+    }
+    
+    @objc(removeTeamObserver:forTeam:)
+    static func remove(observer: NSObjectProtocol, for team: Team?) {
+        guard let token = (observer as? NotificationCenterObserverToken)?.token else {
+            NotificationCenter.default.removeObserver(observer, name: .TeamChange, object: team)
+            return
+        }
+        NotificationCenter.default.removeObserver(token, name: .TeamChange, object: team)
+    }
+    
+}
+
+
+
+
+

--- a/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
@@ -35,9 +35,6 @@ extension Team : ObjectInSnapshot {
 
 @objc public class TeamChangeInfo : ObjectChangeInfo {
     
-    static let MembersChangedKey = "membersChanged"
-    static let NameChangedKey = "nameChanged"
-    
     static func changeInfo(for team: Team, changes: Changes) -> TeamChangeInfo? {
         guard changes.changedKeys.count > 0 || changes.originalChanges.count > 0 else { return nil }
         let changeInfo = TeamChangeInfo(object: team)
@@ -71,8 +68,8 @@ extension Team : ObjectInSnapshot {
 
 extension TeamChangeInfo {
     
-    // MARK: Registering UserObservers
-    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified
+    // MARK: Registering TeamObservers
+    /// Adds an observer for the team if one specified or to all Teams is none is specified
     /// You must hold on to the token and use it to unregister
     @objc(addTeamObserver:forTeam:)
     static func add(observer: TeamObserver, for user: Team?) -> NSObjectProtocol {

--- a/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
@@ -24,7 +24,8 @@ extension Team : ObjectInSnapshot {
     
     static public var observableKeys : Set<String> {
         return Set([#keyPath(Team.name),
-                    #keyPath(Team.members)])
+                    #keyPath(Team.members),
+                    #keyPath(Team.isActive)])
     }
     
     public var notificationName : Notification.Name {
@@ -56,6 +57,10 @@ extension Team : ObjectInSnapshot {
 
     public var nameChanged : Bool {
         return changedKeys.contains(#keyPath(Team.name))
+    }
+    
+    public var isActiveChanged : Bool {
+        return changedKeys.contains(#keyPath(Team.isActive))
     }
 }
 

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -39,7 +39,8 @@ extension ZMUser : ObjectInSnapshot {
                     #keyPath(ZMUser.isPendingApprovalByOtherUser),
                     #keyPath(ZMUser.isPendingApprovalBySelfUser),
                     #keyPath(ZMUser.clients),
-                    #keyPath(ZMUser.handle)])
+                    #keyPath(ZMUser.handle),
+                    #keyPath(ZMUser.teams)])
     }
     
     public var notificationName : Notification.Name {
@@ -119,6 +120,9 @@ extension ZMUser : ObjectInSnapshot {
         return changedKeysContain(keys: #keyPath(ZMUser.handle))
     }
 
+    public var teamsChanged : Bool {
+        return changedKeys.contains(#keyPath(ZMUser.teams))
+    }
 
     open let user: ZMBareUser
     open var userClientChangeInfos : [UserClientChangeInfo] {

--- a/Tests/Source/Helper/NotificationObservers.swift
+++ b/Tests/Source/Helper/NotificationObservers.swift
@@ -112,3 +112,16 @@ class ConversationObserver: NSObject, ZMConversationObserver {
         }
     }
 }
+
+class TestTeamObserver : NSObject, TeamObserver {
+
+    var notifications = [TeamChangeInfo]()
+    
+    func clearNotifications(){
+        notifications = []
+    }
+    
+    func teamDidChange(_ changeInfo: TeamChangeInfo) {
+        notifications.append(changeInfo)
+    }
+}

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -21,6 +21,26 @@ import Foundation
 
 
 
+extension ObjectChangeInfo {
+
+    func checkForExpectedChangeFields(userInfoKeys: [String], expectedChangedFields: [String], file: StaticString = #file, line: UInt = #line){
+        guard Set(userInfoKeys).isSuperset(of: expectedChangedFields) else {
+            return XCTFail("Expected change fields \(expectedChangedFields) not in userInfoKeys \(userInfoKeys). Please add them to the list.", file: file, line: line)
+        }
+
+        for key in userInfoKeys {
+            guard let value = value(forKey: key) as? NSNumber else {
+                return XCTFail("Can't find key or key is not boolean for '\(key)'", file: file, line: line)
+            }
+            if expectedChangedFields.contains(key) {
+                XCTAssertTrue(value.boolValue, "\(key) was supposed to be true", file: file, line: line)
+            } else {
+                XCTAssertFalse(value.boolValue, "\(key) was supposed to be false", file: file, line: line)
+            }
+        }
+    }
+}
+
 @objc public class NotificationDispatcherTestBase : ZMBaseManagedObjectTest {
 
     var dispatcher : NotificationDispatcher! {

--- a/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
@@ -35,7 +35,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
     }
     
     var userInfoKeys : [String] {
-        return [TeamChangeInfo.MembersChangedKey, TeamChangeInfo.NameChangedKey]
+        return [#keyPath(TeamChangeInfo.membersChanged), #keyPath(TeamChangeInfo.nameChanged)]
     }
     
     func checkThatItNotifiesTheObserverOfAChange(_ team : Team, modifier: (Team) -> Void, expectedChangedFields: [String], customAffectedKeys: AffectedKeys? = nil) {
@@ -76,7 +76,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
         // when
         self.checkThatItNotifiesTheObserverOfAChange(team,
                                                      modifier: { $0.name =  "foo"},
-                                                     expectedChangedFields: [TeamChangeInfo.NameChangedKey]
+                                                     expectedChangedFields: [#keyPath(TeamChangeInfo.nameChanged)]
         )
         
     }
@@ -92,7 +92,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
                                                         let member = Member.insertNewObject(in: uiMOC)
                                                         member.team = $0
         },
-                                                     expectedChangedFields: [TeamChangeInfo.MembersChangedKey]
+                                                     expectedChangedFields: [#keyPath(TeamChangeInfo.membersChanged)]
         )
     }
     
@@ -111,7 +111,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
                                                         }
                                                         self.uiMOC.delete(member)
                                                         },
-                                                     expectedChangedFields: [TeamChangeInfo.MembersChangedKey]
+                                                     expectedChangedFields: [#keyPath(TeamChangeInfo.membersChanged)]
         )
     }
 }

--- a/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
@@ -1,0 +1,118 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+@testable import WireDataModel
+
+class TeamObserverTests: NotificationDispatcherTestBase {
+    
+    var teamObserver : TestTeamObserver!
+    
+    override func setUp() {
+        super.setUp()
+        teamObserver = TestTeamObserver()
+    }
+    
+    override func tearDown() {
+        teamObserver = nil
+        super.tearDown()
+    }
+    
+    var userInfoKeys : [String] {
+        return [TeamChangeInfo.MembersChangedKey, TeamChangeInfo.NameChangedKey]
+    }
+    
+    func checkThatItNotifiesTheObserverOfAChange(_ team : Team, modifier: (Team) -> Void, expectedChangedFields: [String], customAffectedKeys: AffectedKeys? = nil) {
+        
+        // given
+        self.uiMOC.saveOrRollback()
+        
+        let token = TeamChangeInfo.add(observer: teamObserver, for: team)
+        defer {
+            TeamChangeInfo.remove(observer: token, for: team)
+        }
+        
+        // when
+        modifier(team)
+        self.uiMOC.saveOrRollback()
+        
+        // then
+        let changeCount = teamObserver.notifications.count
+        XCTAssertEqual(changeCount, 1)
+        
+        // and when
+        self.uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertEqual(teamObserver.notifications.count, changeCount, "Should not have changed further once")
+        
+        guard let changes = teamObserver.notifications.first else { return }
+        changes.checkForExpectedChangeFields(userInfoKeys: userInfoKeys,
+                                             expectedChangedFields: expectedChangedFields)
+    }
+    
+    func testThatItNotifiesTheObserverOfChangedName() {
+        // given
+        let team = Team.insertNewObject(in: self.uiMOC)
+        team.name = "bar"
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(team,
+                                                     modifier: { $0.name =  "foo"},
+                                                     expectedChangedFields: [TeamChangeInfo.NameChangedKey]
+        )
+        
+    }
+    
+    func testThatItNotifiesTheObserverOfInsertedMembers() {
+        // given
+        let team = Team.insertNewObject(in: self.uiMOC)
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(team,
+                                                     modifier: {
+                                                        let member = Member.insertNewObject(in: uiMOC)
+                                                        member.team = $0
+        },
+                                                     expectedChangedFields: [TeamChangeInfo.MembersChangedKey]
+        )
+    }
+    
+    func testThatItNotifiesTheObserverOfDeletedMembers() {
+        // given
+        let team = Team.insertNewObject(in: self.uiMOC)
+        let member = Member.insertNewObject(in: uiMOC)
+        member.team = team
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(team,
+                                                     modifier: {
+                                                        guard let member = $0.members.first else {
+                                                            return XCTFail("No member? :(")
+                                                        }
+                                                        self.uiMOC.delete(member)
+                                                        },
+                                                     expectedChangedFields: [TeamChangeInfo.MembersChangedKey]
+        )
+    }
+}
+

--- a/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
@@ -35,7 +35,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
     }
     
     var userInfoKeys : [String] {
-        return [#keyPath(TeamChangeInfo.membersChanged), #keyPath(TeamChangeInfo.nameChanged)]
+        return [#keyPath(TeamChangeInfo.membersChanged), #keyPath(TeamChangeInfo.nameChanged), #keyPath(TeamChangeInfo.isActiveChanged)]
     }
     
     func checkThatItNotifiesTheObserverOfAChange(_ team : Team, modifier: (Team) -> Void, expectedChangedFields: [String], customAffectedKeys: AffectedKeys? = nil) {
@@ -77,6 +77,20 @@ class TeamObserverTests: NotificationDispatcherTestBase {
         self.checkThatItNotifiesTheObserverOfAChange(team,
                                                      modifier: { $0.name =  "foo"},
                                                      expectedChangedFields: [#keyPath(TeamChangeInfo.nameChanged)]
+        )
+        
+    }
+    
+    func testThatItNotifiesTheObserverOfChangedIsActive() {
+        // given
+        let team = Team.insertNewObject(in: self.uiMOC)
+        team.isActive = true
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(team,
+                                                     modifier: { $0.isActive =  false },
+                                                     expectedChangedFields: [#keyPath(TeamChangeInfo.isActiveChanged)]
         )
         
     }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -186,6 +186,8 @@
 		F964700A1D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m in Sources */ = {isa = PBXBuildFile; fileRef = F96470091D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m */; };
 		F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F991CE181CB55E95004D8465 /* ZMSearchUserTests.m */; };
 		F991CE1B1CB561B0004D8465 /* ZMAddressBookContact.m in Sources */ = {isa = PBXBuildFile; fileRef = F991CE1A1CB561B0004D8465 /* ZMAddressBookContact.m */; };
+		F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99C5B891ED460E20049CCD7 /* TeamChangeInfo.swift */; };
+		F99C5B8C1ED466760049CCD7 /* TeamObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99C5B8B1ED466760049CCD7 /* TeamObserverTests.swift */; };
 		F9A706501CAEE01D00C2F5FE /* NSManagedObjectContext+tests.h in Headers */ = {isa = PBXBuildFile; fileRef = F9A705CA1CAEE01D00C2F5FE /* NSManagedObjectContext+tests.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F9A706511CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging-Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = F9A705CB1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging-Internal.h */; };
 		F9A706521CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = F9A705CC1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -617,6 +619,8 @@
 		F991CE101CB5549D004D8465 /* ZMConversation+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMConversation+Testing.h"; sourceTree = "<group>"; };
 		F991CE181CB55E95004D8465 /* ZMSearchUserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMSearchUserTests.m; sourceTree = "<group>"; };
 		F991CE1A1CB561B0004D8465 /* ZMAddressBookContact.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMAddressBookContact.m; sourceTree = "<group>"; };
+		F99C5B891ED460E20049CCD7 /* TeamChangeInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamChangeInfo.swift; sourceTree = "<group>"; };
+		F99C5B8B1ED466760049CCD7 /* TeamObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamObserverTests.swift; sourceTree = "<group>"; };
 		F9A705CA1CAEE01D00C2F5FE /* NSManagedObjectContext+tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObjectContext+tests.h"; sourceTree = "<group>"; };
 		F9A705CB1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging-Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObjectContext+zmessaging-Internal.h"; sourceTree = "<group>"; };
 		F9A705CC1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObjectContext+zmessaging.h"; sourceTree = "<group>"; };
@@ -1248,6 +1252,7 @@
 				F9A706391CAEE01D00C2F5FE /* ObjectChangeInfo.swift */,
 				F9A7063B1CAEE01D00C2F5FE /* UserClientChangeInfo.swift */,
 				F9A7063C1CAEE01D00C2F5FE /* UserChangeInfo.swift */,
+				F99C5B891ED460E20049CCD7 /* TeamChangeInfo.swift */,
 			);
 			path = ObjectObserverTokens;
 			sourceTree = "<group>";
@@ -1534,6 +1539,7 @@
 				F9DBA5261E28EEBD00BE23C0 /* UserObserverTests.swift */,
 				F9DBA5281E29162A00BE23C0 /* MessageObserverTests.swift */,
 				F9C348821E2CC0730015D69D /* UserClientObserverTests.swift */,
+				F99C5B8B1ED466760049CCD7 /* TeamObserverTests.swift */,
 				F9C348851E2CC27D0015D69D /* NewUnreadMessageObserverTests.swift */,
 				F9C3488E1E2E2DEC0015D69D /* MessageWindowObserverTests.swift */,
 				F9FD75741E2E79B200B4558B /* ConversationListObserverTests.swift */,
@@ -2132,6 +2138,7 @@
 				F9A7069C1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm in Sources */,
 				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
+				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMGenericMessage+Utils.m in Sources */,
 				F9FD75781E2F9A0600B4558B /* SearchUserObserverCenter.swift in Sources */,
 				54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */,
@@ -2238,6 +2245,7 @@
 				F9DBA5271E28EEBD00BE23C0 /* UserObserverTests.swift in Sources */,
 				5473CC751E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift in Sources */,
 				F9C348901E2E2DFF0015D69D /* MessageWindowObserverTests.swift in Sources */,
+				F99C5B8C1ED466760049CCD7 /* TeamObserverTests.swift in Sources */,
 				F9A7083C1CAEEB7500C2F5FE /* MockModelObjectContextFactory.m in Sources */,
 				F9331C5C1CB3BF9F00139ECC /* UserClientKeyStoreTests.swift in Sources */,
 				F9A708361CAEEB7500C2F5FE /* NSManagedObjectContext+TestHelpers.m in Sources */,


### PR DESCRIPTION
Team changes (members added / removed, name change) can be observed by registering as a `TeamObserver`.

Team insertions and deleted can be observed by registering an observer on the selfUser. Insertion & deletions should cause a `UserChangeInfo` with `teamsChanged` set to true.

I also cleaned up the observer tests a bit because we had different methods doing the same thing but being more or less reliable at doing that :-/