### PR TITLE
Add logic to check if the self user is guest in a conversation

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -60,6 +60,8 @@
         <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
         <attribute name="securityLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="silencedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="teamRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="teamRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="userDefinedName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="voiceChannel" optional="YES" transient="YES" syncable="YES"/>
         <relationship name="callParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="activeCallConversations" inverseEntity="User" syncable="YES"/>
@@ -237,7 +239,7 @@
         <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="225"/>
         <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="555"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="585"/>
         <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
         <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
         <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -131,6 +131,7 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, nullable) NSDate *silencedChangedTimestamp;
 
 @property (nonatomic, nullable) NSUUID *remoteIdentifier;
+@property (nonatomic, nullable) NSUUID *teamRemoteIdentifier;
 @property (readonly, nonatomic, nonnull) NSMutableOrderedSet *mutableMessages;
 @property (readonly, nonatomic, nonnull) NSOrderedSet *hiddenMessages;
 @property (nonatomic, nullable) ZMConnection *connection;

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -135,6 +135,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSUUID *teamId = [payload optionalUuidForKey:ConversationInfoTeamIdKey];
     if (nil != teamId) {
         BOOL created = NO;
+        self.teamRemoteIdentifier = teamId;
         self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext created:&created];
         // If we are added to a conversation in a team than we should have gotten the
         // team creation update event and fetched the team before.

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -97,6 +97,7 @@ static NSString *const LastServerSyncedActiveParticipantsKey = @"lastServerSynce
 static NSString *const NeedsToBeUpdatedFromBackendKey = @"needsToBeUpdatedFromBackend";
 static NSString *const RemoteIdentifierKey = @"remoteIdentifier";
 static NSString *const TeamRemoteIdentifierKey = @"teamRemoteIdentifier";
+static NSString *const TeamRemoteIdentifierDataKey = @"teamRemoteIdentifier_data";
 static NSString *const VoiceChannelKey = @"voiceChannel";
 static NSString *const VoiceChannelStateKey = @"voiceChannelState";
 static NSString *const CallDeviceIsActiveKey = @"callDeviceIsActive";
@@ -376,7 +377,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             LastReadEventIDDataKey,
             TeamKey,
             TeamManagedKey,
-            TeamRemoteIdentifierKey
+            TeamRemoteIdentifierKey,
+            TeamRemoteIdentifierDataKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -96,6 +96,7 @@ static NSString *const LastReadMessageKey = @"lastReadMessage";
 static NSString *const LastServerSyncedActiveParticipantsKey = @"lastServerSyncedActiveParticipants";
 static NSString *const NeedsToBeUpdatedFromBackendKey = @"needsToBeUpdatedFromBackend";
 static NSString *const RemoteIdentifierKey = @"remoteIdentifier";
+static NSString *const TeamRemoteIdentifierKey = @"teamRemoteIdentifier";
 static NSString *const VoiceChannelKey = @"voiceChannel";
 static NSString *const VoiceChannelStateKey = @"voiceChannelState";
 static NSString *const CallDeviceIsActiveKey = @"callDeviceIsActive";
@@ -374,7 +375,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             ArchivedEventIDDataKey,
             LastReadEventIDDataKey,
             TeamKey,
-            TeamManagedKey
+            TeamManagedKey,
+            TeamRemoteIdentifierKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];
@@ -446,6 +448,17 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     [self setTransientUUID:remoteIdentifier forKey:RemoteIdentifierKey];
 }
+
+- (NSUUID *)teamRemoteIdentifier;
+{
+    return [self transientUUIDForKey:TeamRemoteIdentifierKey];
+}
+
+- (void)setTeamRemoteIdentifier:(NSUUID *)teamRemoteIdentifier;
+{
+    [self setTransientUUID:teamRemoteIdentifier forKey:TeamRemoteIdentifierKey];
+}
+
 
 + (NSSet *)keyPathsForValuesAffectingRemoteIdentifier
 {

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -49,9 +49,17 @@ public extension ZMUser {
     }
 
     public func isGuest(in conversation: ZMConversation) -> Bool {
-        return conversation.otherActiveParticipants.contains(self)
-            && conversation.team != nil
-            && !isMember(of: conversation.team!)
+        if isSelfUser {
+            // In case the self user is a guest in a team conversation, the backend will
+            // return a 403, ["label": "no-team-member"] when fetching said team.
+            // We store the teamRemoteIdentifier of the team to check if we don't have a local team,
+            // but received a teamId in the conversation payload, which means we are a guest in the conversation.
+            return conversation.team == nil && conversation.teamRemoteIdentifier != nil
+        } else {
+            return conversation.otherActiveParticipants.contains(self)
+                && conversation.team != nil
+                && !isMember(of: conversation.team!)
+        }
     }
 
     public func membership(in team: Team) -> Member? {

--- a/Tests/Source/Model/BaseTeamTests.swift
+++ b/Tests/Source/Model/BaseTeamTests.swift
@@ -36,6 +36,7 @@ class BaseTeamTests: ZMConversationTestsBase {
     @discardableResult func createUserAndAddMember(to team: Team) -> (ZMUser, Member) {
         let member = Member.insertNewObject(in: uiMOC)
         member.user = .insertNewObject(in: uiMOC)
+        member.user?.remoteIdentifier = .create()
         member.team = team
         return (member.user!, member)
     }

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -1,0 +1,129 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import WireTesting
+@testable import WireDataModel
+
+
+class ZMConversationTests_Teams: BaseTeamTests {
+
+    var team: Team!
+    var conversation: ZMConversation!
+
+    override func setUp() {
+        super.setUp()
+        team = Team.insertNewObject(in: uiMOC)
+        team.remoteIdentifier = .create()
+        conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.remoteIdentifier = .create()
+    }
+
+    override func tearDown() {
+        team = nil
+        conversation = nil
+        super.tearDown()
+    }
+
+    func testThatItDoesNotReportIsGuestForANonTeamConversation() {
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
+    }
+
+    func testThatItDoesNotReportIsGuestForATeamConversation() {
+        // given
+        conversation.team = team
+        conversation.teamRemoteIdentifier = team.remoteIdentifier
+
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
+    }
+
+    func testThatItReportsIsGuestWhenAConversationDoesNotHaveATeam() {
+        // given
+        conversation.teamRemoteIdentifier = team.remoteIdentifier
+
+        // then
+        XCTAssert(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
+    }
+
+    func testThatItSetsTheConversationTeamRemoteIdentifierWhenUpdatingWithTransportData() {
+        // given
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.remoteIdentifier = .create()
+        let teamId = UUID.create()
+        let payload = payloadForConversationmetaData(conversation, activeUsers: [user], teamId: teamId)
+
+        // when
+        performPretendingUiMocIsSyncMoc {
+            self.conversation.update(withTransportData: payload)
+        }
+
+        // then
+        guard let team = Team.fetch(withRemoteIdentifier: teamId, in: uiMOC) else { return XCTFail("No team") }
+        XCTAssertNotNil(conversation.teamRemoteIdentifier)
+        XCTAssertEqual(conversation.teamRemoteIdentifier, teamId)
+        XCTAssertTrue(team.needsToBeUpdatedFromBackend)
+
+        // when we receive a 403 and delete the team
+        // We need to nil the relationship before deleting the team (otherwise the delete will cascade and delete the conversation as well)
+        conversation.team = nil
+        uiMOC.delete(team)
+        XCTAssert(uiMOC.saveOrRollback())
+
+        // then
+        XCTAssertNil(conversation.team)
+        XCTAssertEqual(conversation.teamRemoteIdentifier, teamId)
+        XCTAssert(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
+    }
+
+    // MARK: - Helper
+
+    private func payloadForConversationmetaData(_ conversation: ZMConversation, activeUsers: [ZMUser], teamId: UUID?) -> [String: Any] {
+        var payload: [String: Any] = [
+            "last_event_time": "2014-04-30T16:30:16.625Z",
+            "name": NSNull(),
+            "type": NSNumber(value: ZMBackendConversationType.convTypeGroup.rawValue),
+            "id": conversation.remoteIdentifier!.transportString(),
+            "creator": UUID.create().transportString(),
+            "members": [
+                "others": activeUsers.map { ["status": NSNumber(value: 0), "id": $0.remoteIdentifier!.transportString()] },
+                "self": [
+                    "status": NSNumber(value: 0),
+                    "muted_time": NSNull(),
+                    "status_ref": "0.0",
+                    "last_read": "5.800112314308490f",
+                    "status_time": "2014-03-14T16:47:37.573Z",
+                    "id": "3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
+                    "otr_archived": NSNumber(value: 0),
+                    "otr_archived_ref": NSNull(),
+                    "otr_muted": NSNumber(value: 0),
+                    "otr_muted_ref": NSNull()
+                ]
+            ]
+        ]
+
+        if let teamId = teamId {
+            payload["team"] = ["teamid": teamId, "managed": false] as [String: Any]
+        } else {
+            payload["team"] = NSNull()
+        }
+
+        return payload
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */; };
 		BFE3A96C1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE3A96B1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift */; };
 		BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE3A96D1ED301020024A05B /* ZMConversationListTests+Teams.swift */; };
+		BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE764421ED5AAE400C65C3E /* ZMConversation+TeamsTests.swift */; };
 		BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */; };
 		BFFBFD951D59E49D0079773E /* ZMClientMessageTests+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */; };
 		CE4EDC091D6D9A3D002A20AA /* Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4EDC081D6D9A3D002A20AA /* Reaction.swift */; };
@@ -523,6 +524,7 @@
 		BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMGenericMessage+UpdateEvent.m"; sourceTree = "<group>"; };
 		BFE3A96B1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationListDirectoryTests+Teams.swift"; sourceTree = "<group>"; };
 		BFE3A96D1ED301020024A05B /* ZMConversationListTests+Teams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationListTests+Teams.swift"; sourceTree = "<group>"; };
+		BFE764421ED5AAE400C65C3E /* ZMConversation+TeamsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+TeamsTests.swift"; sourceTree = "<group>"; };
 		BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Deletion.swift"; sourceTree = "<group>"; };
 		BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Deletion.swift"; sourceTree = "<group>"; };
 		CE4EDC081D6D9A3D002A20AA /* Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reaction.swift; path = Reaction/Reaction.swift; sourceTree = "<group>"; };
@@ -981,6 +983,7 @@
 				BF3493FF1EC46D3D00B0C314 /* ZMConversationTests+Teams.swift */,
 				BF1B980C1EC3410000DE033B /* PermissionsTests.swift */,
 				BF3493EA1EC34C0B00B0C314 /* TeamTests.swift */,
+				BFE764421ED5AAE400C65C3E /* ZMConversation+TeamsTests.swift */,
 				BF3493EF1EC3569800B0C314 /* MemberTests.swift */,
 				BF3494051EC4B86500B0C314 /* BaseTeamTests.swift */,
 			);
@@ -2195,6 +2198,7 @@
 				F90E5AB31D2276FD00555CD0 /* ZMConversationTests+Timestamp.m in Sources */,
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
+				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,
 				F9331C621CB3C7D500139ECC /* DatabaseMovingTests.m in Sources */,
 				F9FD75761E2E79BF00B4558B /* ConversationListObserverTests.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* We need to know if the self user is a guest in a conversation.
* We now set the `teamRemoteIdentifier` on the conversation in addition to setting the `team` relation, this is needed as we will delete the team when we receive a `403` from the backend when fetching `/teams/{id}` for said team but are only a guest. In this case we will now nil the relation but keep the id to know that we are only a guest.