### PR TITLE
Remove conversation transport team object in favour of team id entry

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -51,7 +51,6 @@
         <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="managed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="messageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -239,7 +238,7 @@
         <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="225"/>
         <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
-        <element name="Conversation" positionX="0" positionY="0" width="128" height="585"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="570"/>
         <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
         <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
         <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -113,7 +113,6 @@ static NSString *const ArchivedEventIDDataKey = @"archivedEventID_data";
 static NSString *const LastReadEventIDDataKey = @"lastReadEventID_data";
 
 static NSString *const TeamKey = @"team";
-static NSString *const TeamManagedKey = @"managed";
 
 NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 3.0;
 
@@ -173,7 +172,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic messageDestructionTimeout;
 @dynamic callParticipants;
 @dynamic team;
-@dynamic managed;
 
 @synthesize tempMaxLastReadServerTimeStamp;
 @synthesize lastReadTimestampSaveDelay;
@@ -376,7 +374,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             ArchivedEventIDDataKey,
             LastReadEventIDDataKey,
             TeamKey,
-            TeamManagedKey,
             TeamRemoteIdentifierKey,
             TeamRemoteIdentifierDataKey
         };

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -82,9 +82,6 @@ extern NSString * _Null_unspecified const ZMConversationIsVerifiedNotificationNa
 @property (nonatomic, copy, nullable) NSString *draftMessageText;
 @property (nonatomic, nullable) Team *team;
 
-/// Whether the conversation is a managed team conversation
-@property (nonatomic) BOOL managed;
-
 /// This is read only. Use -setVisibleWindowFromMessage:toMessage: to update this.
 /// This will return @c nil if the last read message has not yet been sync'd to this device, or if the conversation has no last read message.
 @property (nonatomic, readonly, nullable) ZMMessage *lastReadMessage;

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -118,7 +118,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
         ]
 
         if let teamId = teamId {
-            payload["team"] = ["teamid": teamId, "managed": false] as [String: Any]
+            payload["team"] = teamId
         } else {
             payload["team"] = NSNull()
         }


### PR DESCRIPTION
# What's in this PR?

* In contrast to the initial believe the backend response when fetching a conversation does not include an object for the `team` field, but only the teamId.
* There is no migration for removing the `managed` field, clients build with dependencies pinned to the `smb` branches will lose history.