### PR TITLE
Don't return connection requests in a team conversation list

### DIFF
--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -65,8 +65,12 @@ static NSString * const PendingKey = @"Pending";
                                                                                 filteringPredicate:[ZMConversation predicateForConversationsIncludingArchivedInTeam:team]
                                                                                                moc:moc
                                                                                   debugDescription:@"conversationsIncludingArchived"];
+
+        // There are no connection requests inside of a team, we need
+        // to ensure that we won't show the private ones
+        NSPredicate *pendingConnectionsPredicate = team ? [NSPredicate predicateWithValue:NO] : ZMConversation.predicateForPendingConversations;
         self.pendingConnectionConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
-                                                                                filteringPredicate:[ZMConversation predicateForPendingConversationsInTeam:team]
+                                                                                filteringPredicate:pendingConnectionsPredicate
                                                                                                moc:moc
                                                                                   debugDescription:@"pendingConnectionConversations"];
         self.clearedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -43,11 +43,8 @@ extension ZMConversation {
         return .init(format: "%K == NULL", #keyPath(ZMConversation.team))
     }
 
-    @objc(predicateForPendingConversationsInTeam:)
-    class func predicateForPendingConversations(in team: Team?) -> NSPredicate {
-        // There are no connection requests inside of a team, we need 
-        // to ensure that we won't show the private ones
-        guard nil == team else { return .init(value: false) }
+    @objc(predicateForPendingConversations)
+    class func predicateForPendingConversations() -> NSPredicate {
         let basePredicate = predicateForFilteringResults()
         let pendingConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.connection.rawValue) AND \(ZMConversationConnectionKey).status == \(ZMConnectionStatus.pending.rawValue)")
         

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -45,10 +45,13 @@ extension ZMConversation {
 
     @objc(predicateForPendingConversationsInTeam:)
     class func predicateForPendingConversations(in team: Team?) -> NSPredicate {
+        // There are no connection requests inside of a team, we need 
+        // to ensure that we won't show the private ones
+        guard nil == team else { return .init(value: false) }
         let basePredicate = predicateForFilteringResults()
         let pendingConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.connection.rawValue) AND \(ZMConversationConnectionKey).status == \(ZMConnectionStatus.pending.rawValue)")
         
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, pendingConversationPredicate]).predicate(for: team)
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, pendingConversationPredicate])
     }
 
     @objc(predicateForClearedConversationsInTeam:)

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests+Teams.swift
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests+Teams.swift
@@ -105,6 +105,25 @@ final class ZMConversationListDirectoryTests_Teams: ZMBaseManagedObjectTest {
         XCTAssertFalse(conversations.setValue.contains(clearedTeamConversation))
     }
 
+    func testThatItDoesNotIncludePendingConnectionRequestsInTeamsConversationLists() {
+        // given
+        let connectionConversation = ZMConversation.insertNewObject(in: uiMOC)
+        connectionConversation.lastServerTimeStamp = Date()
+        connectionConversation.lastReadServerTimeStamp = connectionConversation.lastServerTimeStamp
+        connectionConversation.remoteIdentifier = .create()
+        connectionConversation.conversationType = .connection
+        connectionConversation.connection = .insertNewObject(in: uiMOC)
+        connectionConversation.connection?.status = .pending
+
+        // when
+        let pendingConversations = uiMOC.conversationListDirectory(for: nil).pendingConnectionConversations
+        let teamPendingConversations = uiMOC.conversationListDirectory(for: team).pendingConnectionConversations
+
+        // then
+        XCTAssert(teamPendingConversations.setValue.isEmpty)
+        XCTAssertEqual(pendingConversations.setValue, [connectionConversation])
+    }
+
     // MARK: - Helper
 
     func createGroupConversation(in team: Team?, archived: Bool = false) -> ZMConversation {


### PR DESCRIPTION
# What's in this PR?

* We don't want to show pending connection request in the team conversation list.