### PR TITLE
Exclude self user from team member search

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -98,7 +98,11 @@ extension Team {
     
     public func members(matchingQuery query: String) -> [Member] {
         guard let matchingName = NSPredicate(formatDictionary: ["normalizedName" : "%K MATCHES %@"], matchingSearch: query) else { return [] }
-        return members.filter({ matchingName.evaluate(with: $0.user) })
+        return members.filter({ member in
+            guard let user = member.user else { return false }
+            
+            return matchingName.evaluate(with: user) && !user.isSelfUser
+        })
     }
     
 }

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -101,7 +101,7 @@ extension Team {
         return members.filter({ member in
             guard let user = member.user else { return false }
             
-            return matchingName.evaluate(with: user) && !user.isSelfUser
+            return !user.isSelfUser && matchingName.evaluate(with: user)
         })
     }
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -50,32 +50,10 @@
 
 @implementation ZMConversationTestsBase
 
-- (void)setUp;
-{
-    [super setUp];
-    
-    [self setupSelfConversation]; // when updating lastRead we are posting to the selfConversation
-}
-
 - (void)tearDown
 {
     self.receivedNotifications = nil;
     [super tearDown];
-}
-
-- (void)setupSelfConversation
-{
-    NSUUID *selfUserID =  [NSUUID UUID];
-    [ZMUser selfUserInContext:self.uiMOC].remoteIdentifier = selfUserID;
-    ZMConversation *selfConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    selfConversation.remoteIdentifier = selfUserID;
-    selfConversation.conversationType = ZMConversationTypeSelf;
-    [self.uiMOC saveOrRollback];
-    
-    [self.syncMOC performGroupedBlockAndWait:^{
-        [self.syncMOC refreshObject:[ZMUser selfUserInContext:self.syncMOC] mergeChanges:NO];
-    }];
-    WaitForAllGroupsToBeEmpty(0.5);
 }
 
 - (void)didReceiveWindowNotification:(NSNotification *)notification

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -153,6 +153,23 @@ class TeamTests: BaseTeamTests {
         // then
         XCTAssertEqual(result, [membership])
     }
+    
+    func testThatMembersMatchingQueryDoesNotReturnSelfUser() {
+        // given
+        let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
+        
+        // we add actual team members as well"
+        let (user1, membership) = createUserAndAddMember(to: team)
+        
+        user1.name = "UserA"
+        selfUser.name = "UserB"
+        
+        // when
+        let result = team.members(matchingQuery: "user")
+        
+        // then
+        XCTAssertEqual(result, [membership])
+    }
 
     
 }


### PR DESCRIPTION
Also selfUser was created twice in the `ZMConversationTestsBase`