### PR TITLE
Fix non-unique conversation list identifiers

### DIFF
--- a/Source/ConversationList/ZMConversationList+Internal.h
+++ b/Source/ConversationList/ZMConversationList+Internal.h
@@ -28,7 +28,7 @@
 
 @property (nonatomic, readonly) NSManagedObjectContext* managedObjectContext;
 
-- (instancetype)initWithAllConversations:(NSArray *)conversations filteringPredicate:(NSPredicate *)filteringPredicate moc:(NSManagedObjectContext *)moc debugDescription:(NSString *)debugDescription NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAllConversations:(NSArray *)conversations filteringPredicate:(NSPredicate *)filteringPredicate moc:(NSManagedObjectContext *)moc identifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithObjects:(const id [])objects count:(NSUInteger)cnt NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;

--- a/Source/ConversationList/ZMConversationList.m
+++ b/Source/ConversationList/ZMConversationList.m
@@ -69,13 +69,13 @@
 - (instancetype)initWithAllConversations:(NSArray *)conversations
                       filteringPredicate:(NSPredicate *)filteringPredicate
                                      moc:(NSManagedObjectContext *)moc
-                        debugDescription:(NSString *)debugDescription;
+                              identifier:(NSString *)identifier;
 {
     self = [super init];
     if (self) {
         self.moc = moc;
-        _identifier = debugDescription;
-        self.customDebugDescription = debugDescription;
+        _identifier = identifier;
+        self.customDebugDescription = identifier;
         self.filteringPredicate = filteringPredicate;
         self.sortDescriptors = [ZMConversation defaultSortDescriptors];
         [self calculateKeysAffectingPredicateAndSort];

--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -53,18 +53,19 @@ static NSString * const PendingKey = @"Pending";
     if (self) {
         self.team = team;
         NSArray *allConversations = [self fetchAllConversations:moc team:team];
+        NSString *teamSuffix = team ? team.remoteIdentifier.transportString : @"";
         self.unarchivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                          filteringPredicate:[ZMConversation predicateForConversationsExcludingArchivedInTeam:team]
                                                                                         moc:moc
-                                                                           debugDescription:@"unarchivedConversations"];
+                                                                           identifier:[@"unarchivedConversations" stringByAppendingString:teamSuffix]];
         self.archivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                        filteringPredicate:[ZMConversation predicateForArchivedConversationsInTeam:team]
                                                                                       moc:moc
-                                                                         debugDescription:@"archivedConversations"];
+                                                                         identifier:@"archivedConversations"];
         self.conversationsIncludingArchived = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                                 filteringPredicate:[ZMConversation predicateForConversationsIncludingArchivedInTeam:team]
                                                                                                moc:moc
-                                                                                  debugDescription:@"conversationsIncludingArchived"];
+                                                                                  identifier:[@"conversationsIncludingArchived" stringByAppendingString:teamSuffix]];
 
         // There are no connection requests inside of a team, we need
         // to ensure that we won't show the private ones
@@ -72,11 +73,11 @@ static NSString * const PendingKey = @"Pending";
         self.pendingConnectionConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                                 filteringPredicate:pendingConnectionsPredicate
                                                                                                moc:moc
-                                                                                  debugDescription:@"pendingConnectionConversations"];
+                                                                                  identifier:@"pendingConnectionConversations"];
         self.clearedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                       filteringPredicate:[ZMConversation predicateForClearedConversationsInTeam:team]
                                                                                      moc:moc
-                                                                        debugDescription:@"clearedConversations"];
+                                                                        identifier:[@"clearedConversations" stringByAppendingString:teamSuffix]];
     }
     return self;
 }


### PR DESCRIPTION
# What's in this PR?

* The `debugDescription` was also used as a unique identifier. We now append the team Id if we have any.