### PR TITLE
Move conversation list identifier creation into ZMConversationList

### DIFF
--- a/Source/ConversationList/ZMConversationList+Internal.h
+++ b/Source/ConversationList/ZMConversationList+Internal.h
@@ -24,11 +24,17 @@
 @class NSFetchRequest;
 @class ZMConversation;
 
+
 @interface ZMConversationList ()
 
 @property (nonatomic, readonly) NSManagedObjectContext* managedObjectContext;
 
-- (instancetype)initWithAllConversations:(NSArray *)conversations filteringPredicate:(NSPredicate *)filteringPredicate moc:(NSManagedObjectContext *)moc identifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithAllConversations:(NSArray *)conversations
+                      filteringPredicate:(NSPredicate *)filteringPredicate
+                                     moc:(NSManagedObjectContext *)moc
+                            description:(NSString *)description
+                                    team:(Team *)team NS_DESIGNATED_INITIALIZER;
+
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithObjects:(const id [])objects count:(NSUInteger)cnt NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;

--- a/Source/ConversationList/ZMConversationList.m
+++ b/Source/ConversationList/ZMConversationList.m
@@ -24,6 +24,7 @@
 #import "ZMConversationListDirectory.h"
 #import <WireDataModel/WireDataModel-Swift.h>
 
+
 @import CoreData;
 
 @interface ZMConversationList ()
@@ -69,13 +70,14 @@
 - (instancetype)initWithAllConversations:(NSArray *)conversations
                       filteringPredicate:(NSPredicate *)filteringPredicate
                                      moc:(NSManagedObjectContext *)moc
-                              identifier:(NSString *)identifier;
+                             description:(NSString *)description
+                                    team:(Team *)team
 {
     self = [super init];
     if (self) {
         self.moc = moc;
-        _identifier = identifier;
-        self.customDebugDescription = identifier;
+        _identifier = [self identifierWithDescription:description team:team];
+        self.customDebugDescription = self.identifier;
         self.filteringPredicate = filteringPredicate;
         self.sortDescriptors = [ZMConversation defaultSortDescriptors];
         [self calculateKeysAffectingPredicateAndSort];
@@ -83,6 +85,14 @@
         [moc.conversationListObserverCenter startObservingList:self];
     }
     return self;
+}
+
+- (NSString *)identifierWithDescription:(NSString *)description team:(Team *)team
+{
+    if (nil != team) {
+        return [description stringByAppendingFormat:@"-%@", team.remoteIdentifier.transportString];
+    }
+    return description;
 }
 
 - (NSManagedObjectContext *)managedObjectContext

--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -53,31 +53,34 @@ static NSString * const PendingKey = @"Pending";
     if (self) {
         self.team = team;
         NSArray *allConversations = [self fetchAllConversations:moc team:team];
-        NSString *teamSuffix = team ? team.remoteIdentifier.transportString : @"";
+
         self.unarchivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                          filteringPredicate:[ZMConversation predicateForConversationsExcludingArchivedInTeam:team]
                                                                                         moc:moc
-                                                                           identifier:[@"unarchivedConversations" stringByAppendingString:teamSuffix]];
+                                                                                description:@"unarchivedConversations"
+                                                                                       team:team];
         self.archivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                        filteringPredicate:[ZMConversation predicateForArchivedConversationsInTeam:team]
                                                                                       moc:moc
-                                                                         identifier:@"archivedConversations"];
+                                                                              description:@"archivedConversations" team:team];
         self.conversationsIncludingArchived = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                                 filteringPredicate:[ZMConversation predicateForConversationsIncludingArchivedInTeam:team]
                                                                                                moc:moc
-                                                                                  identifier:[@"conversationsIncludingArchived" stringByAppendingString:teamSuffix]];
-
+                                                                                       description:@"conversationsIncludingArchived"
+                                                                                              team:team];
         // There are no connection requests inside of a team, we need
         // to ensure that we won't show the private ones
         NSPredicate *pendingConnectionsPredicate = team ? [NSPredicate predicateWithValue:NO] : ZMConversation.predicateForPendingConversations;
         self.pendingConnectionConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                                 filteringPredicate:pendingConnectionsPredicate
                                                                                                moc:moc
-                                                                                  identifier:@"pendingConnectionConversations"];
+                                                                                  description:@"pendingConnectionConversations"
+                                                                                              team:nil];
         self.clearedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                       filteringPredicate:[ZMConversation predicateForClearedConversationsInTeam:team]
                                                                                      moc:moc
-                                                                        identifier:[@"clearedConversations" stringByAppendingString:teamSuffix]];
+                                                                             description:@"clearedConversations"
+                                                                                    team:team];
     }
     return self;
 }

--- a/Source/Public/ZMConversationList.h
+++ b/Source/Public/ZMConversationList.h
@@ -20,6 +20,7 @@
 @class ZMUserSession;
 @protocol ZMManagedObjectContextProvider;
 
+
 /// Use @c ZMConversationListChangeNotification to get notified about changes.
 @interface ZMConversationList : NSArray
 

--- a/Tests/Source/Model/ConversationList/ZMConversationListTests+Teams.swift
+++ b/Tests/Source/Model/ConversationList/ZMConversationListTests+Teams.swift
@@ -311,6 +311,32 @@ final class ZMConversationListTests_Teams: ZMBaseManagedObjectTest {
         XCTAssertEqual(clearedList.arrayValue, [conversation1])
     }
 
+    func testThatItDoesNotReturnAConversationAnymoreOnceItGotUnarchived() {
+        // given
+        let conversation = createGroupConversation(in: team)
+        conversation.isArchived = true
+
+        // then
+        do {
+            let archivedList = ZMConversation.archivedConversations(in: uiMOC, team: team)
+            let activeList = ZMConversation.conversationsExcludingArchived(in: uiMOC, team: team)
+            XCTAssertEqual(archivedList.arrayValue, [conversation])
+            XCTAssertEqual(activeList.count, 0)
+        }
+
+        // when
+        conversation.isArchived = false
+        XCTAssert(uiMOC.saveOrRollback())
+
+        // then
+        do {
+            let archivedList = ZMConversation.archivedConversations(in: uiMOC, team: team)
+            let activeList = ZMConversation.conversationsExcludingArchived(in: uiMOC, team: team)
+            XCTAssertEqual(activeList.arrayValue, [conversation])
+            XCTAssertEqual(archivedList.count, 0)
+        }
+    }
+
     // MARK: - Helper
 
     private func createTeam() -> Team {


### PR DESCRIPTION
#What's in this PR?

* The archived conversation list did not have a unique identifier for each team, which made observing archived team conversation fail.
* We now inject the team into the conversation list initializer and append its `remoteIdentifier` to the identifier if the team is nonnull.
* I was thinking of just creating a new `UUID` inside `ZMConversationList` to decouple the list from teams, but using the same identifier as the team makes debugging a lot easier.