### PR TITLE
Don't cascade a team deletion to its conversations

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.30.0.xcdatamodel/contents
@@ -156,7 +156,7 @@
         <attribute name="pictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
         <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
-        <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Conversation" inverseName="team" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="team" inverseEntity="Conversation" syncable="YES"/>
         <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdTeams" inverseEntity="User" syncable="YES"/>
         <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Member" inverseName="team" inverseEntity="Member" syncable="YES"/>
     </entity>

--- a/Tests/Source/Model/TeamDeletionRuleTests.swift
+++ b/Tests/Source/Model/TeamDeletionRuleTests.swift
@@ -23,14 +23,14 @@ import WireTesting
 
 class TeamDeletionRuleTests: BaseZMClientMessageTests {
 
-    func testThatItDeletesConversationsWhichArePartOfATeamWhenTeamGetsDeleted() {
+    func testThatItDoesntDeleteConversationsWhichArePartOfATeamWhenTeamGetsDeleted() {
         // given
         let team = Team.insertNewObject(in: uiMOC)
         let (uuid1, uuid2, uuid3) = (UUID.create(), UUID.create(), UUID.create())
         let conversation1 = ZMConversation.insertNewObject(in: uiMOC)
         conversation1.remoteIdentifier = uuid1
         let conversation2 = ZMConversation.insertNewObject(in: uiMOC)
-        conversation1.remoteIdentifier = uuid2
+        conversation2.remoteIdentifier = uuid2
         let conversation3 = ZMConversation.insertNewObject(in: uiMOC)
         conversation3.remoteIdentifier = uuid3
 
@@ -47,8 +47,8 @@ class TeamDeletionRuleTests: BaseZMClientMessageTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.1))
 
         // then
-        XCTAssertNil(ZMConversation.fetch(withRemoteIdentifier: uuid1, in: uiMOC))
-        XCTAssertNil(ZMConversation.fetch(withRemoteIdentifier: uuid2, in: uiMOC))
+        XCTAssertNotNil(ZMConversation.fetch(withRemoteIdentifier: uuid1, in: uiMOC))
+        XCTAssertNotNil(ZMConversation.fetch(withRemoteIdentifier: uuid2, in: uiMOC))
         XCTAssertEqual(ZMConversation.fetch(withRemoteIdentifier: uuid3, in: uiMOC), conversation3)
     }
 


### PR DESCRIPTION
# What's in this PR?

* Change the deletion rule from `Team` to its conversations to no longer cascade but instead nullify.
* I did not add a new model schema, but a migration should not be required when only changing a deletion rule.