### PR TITLE
Fix and move canAddUsers check into data model

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -42,13 +42,13 @@ public extension ZMUser {
 
     @objc(canAddUserToConversation:)
     public func canAddUser(to conversation: ZMConversation) -> Bool {
-        guard !isGuest(in: conversation) else { return false }
+        guard !isGuest(in: conversation), conversation.isSelfAnActiveMember else { return false }
         return conversation.team.flatMap(permissions)?.contains(.addConversationMember) ?? true
     }
 
     @objc(canRemoveUserFromConversation:)
     public func canRemoveUser(from conversation: ZMConversation) -> Bool {
-        guard !isGuest(in: conversation) else { return false }
+        guard !isGuest(in: conversation), conversation.isSelfAnActiveMember else { return false }
         return conversation.team.flatMap(permissions)?.contains(.removeConversationMember) ?? true
     }
 

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -40,6 +40,18 @@ public extension ZMUser {
         return membership(in: team)?.permissions
     }
 
+    @objc(canAddUserToConversation:)
+    public func canAddUser(to conversation: ZMConversation) -> Bool {
+        guard !isGuest(in: conversation) else { return false }
+        return conversation.team.flatMap(permissions)?.contains(.addConversationMember) ?? true
+    }
+
+    @objc(canRemoveUserFromConversation:)
+    public func canRemoveUser(from conversation: ZMConversation) -> Bool {
+        guard !isGuest(in: conversation) else { return false }
+        return conversation.team.flatMap(permissions)?.contains(.removeConversationMember) ?? true
+    }
+
     public func canCreateConversation(in team: Team) -> Bool {
         return permissions(in: team)?.contains(.createConversation) ?? false
     }

--- a/Source/Notifications/ConversationListObserverCenter.swift
+++ b/Source/Notifications/ConversationListObserverCenter.swift
@@ -141,12 +141,12 @@ public class ConversationListObserverCenter : NSObject, ZMConversationObserver, 
         // We should always recreate the snapshots when reenerting the foreground
         // Therefore it would be safe to clear the snapshots here
         listSnapshots = [:]
-        zmLog.debug("ApplicationDidEnterBackground, clearing listSnapshots")
+        zmLog.debug("\(#function), clearing listSnapshots")
     }
     
     public func applicationWillEnterForeground() {
         // list snapshots are automaically recreated when the lists are recreated and `recreateSnapshot(for conversation:)` is called
-        zmLog.debug("ApplicationWillEnterBackground")
+        zmLog.debug(#function)
     }
 }
 

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -101,6 +101,7 @@ class TeamTests: BaseTeamTests {
 
             // then
             XCTAssertTrue(guest.isGuest(in: conversation1))
+            XCTAssertFalse(guest.canCreateConversation(in: team))
             XCTAssertFalse(guest.isGuest(in: conversation2))
             XCTAssertFalse(guest.isGuest(in: conversation2))
             XCTAssertFalse(otherUser.isGuest(in: conversation1))
@@ -188,6 +189,5 @@ class TeamTests: BaseTeamTests {
         // then
         XCTAssertEqual(result, [membership])
     }
-
     
 }

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -101,7 +101,7 @@ class TeamTests: BaseTeamTests {
 
             // then
             XCTAssertTrue(guest.isGuest(in: conversation1))
-            XCTAssertFalse(guest.canCreateConversation(in: team))
+            XCTAssertFalse(guest.canAddUser(to: conversation1))
             XCTAssertFalse(guest.isGuest(in: conversation2))
             XCTAssertFalse(guest.isGuest(in: conversation2))
             XCTAssertFalse(otherUser.isGuest(in: conversation1))

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -74,6 +74,14 @@ class ZMConversationTests_Teams: BaseTeamTests {
         XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
     }
 
+    func testThatAUserCantAddUsersToAConversationWhereHeIsNotAnActiveMember() {
+        // when
+        conversation.isSelfAnActiveMember = false
+
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+    }
+
     func testThatAUserCantAddUsersToAConversationWhereHeIsMemberWithUnsufficientPermissions() {
         // when
         let selfUser = ZMUser.selfUser(in: uiMOC)
@@ -104,6 +112,14 @@ class ZMConversationTests_Teams: BaseTeamTests {
     func testThatAUserCantRemoveUsersToAConversationWhereHeIsGuest() {
         // when
         conversation.teamRemoteIdentifier = team.remoteIdentifier
+
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canRemoveUser(from: conversation))
+    }
+
+    func testThatAUserCantRemoveUsersToAConversationWhereHeIsNotAnActiveMember() {
+        // when
+        conversation.isSelfAnActiveMember = false
 
         // then
         XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canRemoveUser(from: conversation))

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -77,10 +77,10 @@ class ZMConversationTests_Teams: BaseTeamTests {
     func testThatAUserCantAddUsersToAConversationWhereHeIsMemberWithMissingPermissions() {
         // when
         let selfUser = ZMUser.selfUser(in: uiMOC)
-        let member = Member.getOrCreateMember(for: selfUser, in: team, context: uiMOC)
+        _ = Member.getOrCreateMember(for: selfUser, in: team, context: uiMOC)
 
         // then
-        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+        XCTAssertFalse(selfUser.canAddUser(to: conversation))
     }
 
     func testThatAUserCanAddUsersToAConversationWhereHeIsMemberWithSufficientPermissions() {
@@ -90,7 +90,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
         member.permissions = .member
 
         // then
-        XCTAssert(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+        XCTAssert(selfUser.canAddUser(to: conversation))
     }
 
     func testThatItSetsTheConversationTeamRemoteIdentifierWhenUpdatingWithTransportData() {

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -61,6 +61,38 @@ class ZMConversationTests_Teams: BaseTeamTests {
         XCTAssert(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
     }
 
+    func testThatAUserCanAddUsersToAConversationWithoutTeamAndWithoutTeamRemoteIdentifier() {
+        // when & then
+        XCTAssert(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+    }
+
+    func testThatAUserCantAddUsersToAConversationWhereHeIsGuest() {
+        // when
+        conversation.teamRemoteIdentifier = team.remoteIdentifier
+
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+    }
+
+    func testThatAUserCantAddUsersToAConversationWhereHeIsMemberWithMissingPermissions() {
+        // when
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        let member = Member.getOrCreateMember(for: selfUser, in: team, context: uiMOC)
+
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+    }
+
+    func testThatAUserCanAddUsersToAConversationWhereHeIsMemberWithSufficientPermissions() {
+        // when
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        let member = Member.getOrCreateMember(for: selfUser, in: team, context: uiMOC)
+        member.permissions = .member
+
+        // then
+        XCTAssert(ZMUser.selfUser(in: uiMOC).canAddUser(to: conversation))
+    }
+
     func testThatItSetsTheConversationTeamRemoteIdentifierWhenUpdatingWithTransportData() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)


### PR DESCRIPTION
# What's in this PR?

* Fix and move canAddUsers check into data model, add tests.
* The check is currently in the UI project in an extension on `ZMUser`, but makes more sense to be in `wire-ios-data-model`, also the check didn't take the result of `isGuest(in:)` into account.