### PR TITLE
Inject serverTimeStamp into conversation transport update method

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.h
+++ b/Source/Model/Conversation/ZMConversation+Transport.h
@@ -36,7 +36,7 @@ extern NSString *const ZMConversationInfoOTRArchivedReferenceKey;
 
 - (void)updateLastReadFromPostPayloadEvent:(ZMUpdateEvent *)event;
 - (void)updateClearedFromPostPayloadEvent:(ZMUpdateEvent *)event;
-- (void)updateWithTransportData:(NSDictionary *)transportData;
+- (void)updateWithTransportData:(NSDictionary *)transportData serverTimeStamp:(NSDate *)serverTimeStamp;
 
 - (void)updatePotentialGapSystemMessagesIfNeededWithUsers:(NSSet <ZMUser *>*)users;
 

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -61,7 +61,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     [self updateClearedServerTimeStampIfNeeded:event.timeStamp andSync:YES];
 }
 
-- (void)updateWithTransportData:(NSDictionary *)transportData;
+- (void)updateWithTransportData:(NSDictionary *)transportData serverTimeStamp:(NSDate *)serverTimeStamp;
 {
     NSUUID *remoteId = [transportData uuidForKey:ConversationInfoIDKey];
     RequireString(remoteId == nil || [remoteId isEqual:self.remoteIdentifier],
@@ -75,7 +75,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     
     self.conversationType = [self conversationTypeFromTransportData:[transportData numberForKey:ConversationInfoTypeKey]];
     
-    NSDate *lastTimeStamp = [transportData dateForKey:ConversationInfoLastEventTimeKey];
+    NSDate *lastTimeStamp = serverTimeStamp ?: [transportData dateForKey:ConversationInfoLastEventTimeKey];
     [self updateLastModifiedDateIfNeeded:lastTimeStamp];
     [self updateLastServerTimeStampIfNeeded:lastTimeStamp];
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -111,7 +111,7 @@
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup isArchived:YES archivedRef:archivedDate isSilenced:YES silencedRef:silencedDate];
         
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
         
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
@@ -147,7 +147,7 @@
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs: @[user3UUID]];
         
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
         
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
@@ -175,6 +175,29 @@
     }];
 }
 
+- (void)testThatItSetsTheServerTimeStampAsLastModifiedAndLastServerTimeStamp
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        // given
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSUUID *uuid = NSUUID.createUUID;
+        conversation.remoteIdentifier = uuid;
+        
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:1 isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil];
+
+        // when
+        NSDate *serverTimeStamp = [NSDate date];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimeStamp];
+
+        // then
+        XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
+        XCTAssertNil(conversation.userDefinedName);
+        XCTAssertEqual(conversation.conversationType, ZMConversationTypeSelf);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimeStamp);
+        XCTAssertEqualObjects(conversation.creator.remoteIdentifier, [payload[@"creator"] UUID]);
+    }];
+}
+
 - (void)testThatItUpdatesItselfFromTransportDataForTeamConversation
 {
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -190,7 +213,7 @@
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:teamID];
 
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
@@ -235,7 +258,7 @@
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:team.remoteIdentifier];
 
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
@@ -279,7 +302,7 @@
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
 
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
@@ -320,7 +343,7 @@
         
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID, user3UUID] inactiveUserIDs:@[]];
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssertTrue([self.syncMOC saveOrRollback]);
         
         // then
@@ -340,7 +363,7 @@
     // when
     [self performPretendingUiMocIsSyncMoc:^{
         [self performIgnoringZMLogError:^{
-            [conversation updateWithTransportData:payload];
+            [conversation updateWithTransportData:payload serverTimeStamp:nil];
         }];
     }];
     
@@ -379,7 +402,7 @@
         // when
         [self performPretendingUiMocIsSyncMoc:^{
             [self performIgnoringZMLogError:^{
-                [conversation updateWithTransportData:payload];
+                [conversation updateWithTransportData:payload serverTimeStamp:nil];
             }];
         }];
         
@@ -410,7 +433,7 @@
         // when
         [self performPretendingUiMocIsSyncMoc:^{
             [self performIgnoringZMLogError:^{
-                [conversation updateWithTransportData:payload];
+                [conversation updateWithTransportData:payload serverTimeStamp:nil];
             }];
         }];
         
@@ -439,7 +462,7 @@
         // when
         [self performPretendingUiMocIsSyncMoc:^{
             [self performIgnoringZMLogError:^{
-                [conversation updateWithTransportData:payload];
+                [conversation updateWithTransportData:payload serverTimeStamp:nil];
             }];
         }];
         
@@ -470,7 +493,7 @@
         // when
         [self performPretendingUiMocIsSyncMoc:^{
             [self performIgnoringZMLogError:^{
-                [conversation updateWithTransportData:payload];
+                [conversation updateWithTransportData:payload serverTimeStamp:nil];
             }];
         }];
         

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -91,7 +91,7 @@
                                   };
         
         // when
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
         
         // then
         XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, user5, nil]));
@@ -255,7 +255,7 @@
     NSManagedObjectID *moid = conversation.objectID;
     [self.syncMOC performGroupedBlockAndWait:^{
         ZMConversation *syncConversation = (id) [self.syncMOC objectWithID:moid];
-        [syncConversation updateWithTransportData:payload];
+        [syncConversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssert([self.syncMOC saveOrRollback]);
     }];
     [self.uiMOC refreshObject:conversation mergeChanges:NO];
@@ -340,7 +340,7 @@
     NSManagedObjectID *moid = conversation.objectID;
     [self.syncMOC performGroupedBlockAndWait:^{
         ZMConversation *syncConversation = (id) [self.syncMOC objectWithID:moid];
-        [syncConversation updateWithTransportData:payload];
+        [syncConversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssert([self.syncMOC saveOrRollback]);
     }];
     [self.uiMOC refreshObject:conversation mergeChanges:NO];
@@ -420,7 +420,7 @@
     NSManagedObjectID *moid = conversation.objectID;
     [self.syncMOC performGroupedBlockAndWait:^{
         ZMConversation *syncConversation = (id) [self.syncMOC objectWithID:moid];
-        [syncConversation updateWithTransportData:payload];
+        [syncConversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssert([self.syncMOC saveOrRollback]);
     }];
     [self.uiMOC refreshObject:conversation mergeChanges:NO];
@@ -506,7 +506,7 @@
     NSManagedObjectID *moid = conversation.objectID;
     [self.syncMOC performGroupedBlockAndWait:^{
         ZMConversation *syncConversation = (id) [self.syncMOC objectWithID:moid];
-        [syncConversation updateWithTransportData:payload];
+        [syncConversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssert([self.syncMOC saveOrRollback]);
     }];
     [self.uiMOC refreshObject:conversation mergeChanges:NO];
@@ -966,7 +966,7 @@
     
     // when
     [self performPretendingUiMocIsSyncMoc:^{
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
     }];
     
     // then
@@ -1003,7 +1003,7 @@
     
     // when
     [self performPretendingUiMocIsSyncMoc:^{
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
     }];
     
     // then

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1901,7 +1901,7 @@
                                           },
                                   };
         
-        [conversation updateWithTransportData:payload];
+        [conversation updateWithTransportData:payload serverTimeStamp:nil];
         [self.syncMOC saveOrRollback];
     }];
     

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -156,7 +156,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
 
         // when
         performPretendingUiMocIsSyncMoc {
-            self.conversation.update(withTransportData: payload)
+            self.conversation.update(withTransportData: payload, serverTimeStamp: nil)
         }
 
         // then


### PR DESCRIPTION
# What's in this PR?

* The backend does no longer return the correct date in the conversation payload (`last_event_time`), which we used to update the `lastModifiedDate` when a conversation is created with us.
* This adds an additional parameter  to the update method to inject the timestamp from the update event.