### PR TITLE
Support for observing when a conversation exists remotely

### DIFF
--- a/Source/Model/Conversation/ZMConversation+ObserverHelper.swift
+++ b/Source/Model/Conversation/ZMConversation+ObserverHelper.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class ConversationObserverToken : NSObject, ZMConversationObserver {
+    
+    let block : () -> Void
+    let filter : (ConversationChangeInfo) -> Bool
+    var token : NSObjectProtocol? = nil
+    
+    init(filter:  @escaping (ConversationChangeInfo) -> Bool, block: @escaping () -> Void ) {
+        self.block = block
+        self.filter = filter
+    }
+    
+    func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
+        if filter(changeInfo) {
+            block()
+        }
+    }
+    
+}
+
+public extension ZMConversation {
+    
+    public func onExistsRemotely(_ block : @escaping () -> Void) -> NSObjectProtocol? {
+        guard remoteIdentifier == nil else { block(); return nil }
+        
+        let observer = ConversationObserverToken(filter: { $0.existsRemotelyChanged }, block: block)
+        observer.token = ConversationChangeInfo.add(observer: observer, for: self)
+        return observer
+    }
+    
+}

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -37,7 +37,8 @@ extension ZMConversation : ObjectInSnapshot {
                     #keyPath(ZMConversation.otherActiveParticipants),
                     #keyPath(ZMConversation.isSelfAnActiveMember),
                     #keyPath(ZMConversation.relatedConnectionState),
-                    #keyPath(ZMConversation.team)
+                    #keyPath(ZMConversation.team),
+                    #keyPath(ZMConversation.remoteIdentifier)
             ])
     }
 
@@ -116,6 +117,10 @@ extension ZMConversation : ObjectInSnapshot {
         return changedKeysContain(keys: #keyPath(ZMConversation.otherActiveVideoCallParticipants))
     }
     
+    public var existsRemotelyChanged : Bool {
+        return changedKeysContain(keys: #keyPath(ZMConversation.remoteIdentifier))
+    }
+    
     public var conversation : ZMConversation { return self.object as! ZMConversation }
     
     public override var description : String { return self.debugDescription }
@@ -131,7 +136,8 @@ extension ZMConversation : ObjectInSnapshot {
         "conversationListIndicatorChanged \(conversationListIndicatorChanged)," +
         "clearedChanged \(clearedChanged)," +
         "securityLevelChanged \(securityLevelChanged)," +
-        "teamChanged \(teamChanged)"
+        "teamChanged \(teamChanged)" +
+        "existsRemotelyChanged \(existsRemotelyChanged)"
     }
     
     public required init(object: NSObject) {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+ObservationHelper.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+ObservationHelper.swift
@@ -1,0 +1,62 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@testable import WireDataModel
+
+class ZMConversationObservationHelperTests: NotificationDispatcherTestBase {
+    
+    
+    func testThatOnExistsRemotelyIsCalledWhenRemoteIdentifierIsModified() {
+        // given
+        let existsRemotely = expectation(description: "Exist remotely")
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        uiMOC.saveOrRollback()
+        
+        // expect
+        var token = conversation.onExistsRemotely {
+            existsRemotely.fulfill()
+        }
+        
+        // when
+        conversation.remoteIdentifier = UUID.create()
+        uiMOC.saveOrRollback()
+        XCTAssertNotNil(token)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        token = nil
+    }
+    
+    func testTHatOnExistsRemotelyIsCalledIfConversationAlreadyHasRemoteIdentifier() {
+        // given
+        let existsRemotely = expectation(description: "Exist remotely")
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.remoteIdentifier = UUID.create()
+        uiMOC.saveOrRollback()
+        
+        // expect
+        var token = conversation.onExistsRemotely {
+            existsRemotely.fulfill()
+        }
+        
+        XCTAssertNil(token)
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+        token = nil
+    }
+    
+}

--- a/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -51,7 +51,8 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
             "clearedChanged",
             "securityLevelChanged",
             "callParticipantsChanged",
-            "videoParticipantsChanged"
+            "videoParticipantsChanged",
+            "existsRemotelyChanged"
         ]
     }
     
@@ -655,6 +656,22 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
         XCTAssertTrue(securityNotification.securityLevelChanged)
 
         ConversationChangeInfo.remove(observer:token, for: conversation)
+    }
+    
+    func testThatItNotifiesWhenConversationExistsRemotely() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        conversation.conversationType = .group
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(conversation,
+                                                     modifier: { conversation, _ in
+                                                        conversation.remoteIdentifier = UUID.create()
+        },
+                                                     expectedChangedFields: ["existsRemotelyChanged"],
+                                                     expectedChangedKeys: ["remoteIdentifier"])
+        
     }
     
     func testThatItStopsNotifyingAfterUnregisteringTheToken() {

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */; };
 		16DCB6631DDA2715002A7AC2 /* PersistentStoreRelocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DCB6621DDA2715002A7AC2 /* PersistentStoreRelocator.swift */; };
 		16F5F16E1E4215DC0062F0AE /* libPhoneNumberiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16F5F16D1E4215DC0062F0AE /* libPhoneNumberiOS.framework */; };
+		16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */; };
+		16F6BB3C1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB3B1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift */; };
 		54178A1C1E02EA9900860ECE /* store2-24-1.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 54178A1A1E02E9FB00860ECE /* store2-24-1.wiredatabase */; };
 		541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541E4F941CBD182100D82D69 /* FileAssetCache.swift */; };
 		54363A011D7876200048FD7D /* ZMClientMessage+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */; };
@@ -426,6 +428,8 @@
 		16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMFileMetadata.swift; sourceTree = "<group>"; };
 		16DCB6621DDA2715002A7AC2 /* PersistentStoreRelocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStoreRelocator.swift; sourceTree = "<group>"; };
 		16F5F16D1E4215DC0062F0AE /* libPhoneNumberiOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = libPhoneNumberiOS.framework; path = Carthage/Build/iOS/libPhoneNumberiOS.framework; sourceTree = "<group>"; };
+		16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+ObserverHelper.swift"; sourceTree = "<group>"; };
+		16F6BB3B1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+ObservationHelper.swift"; sourceTree = "<group>"; };
 		54178A1A1E02E9FB00860ECE /* store2-24-1.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-24-1.wiredatabase"; path = "Tests/Resources/store2-24-1.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		541E4F941CBD182100D82D69 /* FileAssetCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileAssetCache.swift; sourceTree = "<group>"; };
 		543089B71D420165004D8AC4 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -1110,6 +1114,7 @@
 				545FA5D81E2FD3D20054171A /* ZMConversation+NotifyOnUI.swift */,
 				545FA5D61E2FD3750054171A /* ZMConversation+MessageDeletion.swift */,
 				BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */,
+				16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */,
 				BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */,
 				544E8C121E2F825700F9B8B8 /* ZMConversation+SecurityLevel.swift */,
 				161541B91E27EBD400AC2FFB /* ZMConversation+Calling.swift */,
@@ -1441,6 +1446,7 @@
 				F92C992B1DAFC58A0034AFDD /* ZMConversationTests+Ephemeral.swift */,
 				F1B025601E534CF900900C65 /* ZMConversationTests+PrepareToSend.swift */,
 				BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */,
+				16F6BB3B1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift */,
 				F9B71F571CB2BC85001DB03F /* ZMConversationTests.h */,
 				F9B71F581CB2BC85001DB03F /* ZMConversationTests.m */,
 				F9C8770A1E015AAF00792613 /* AssetColletionTests.swift */,
@@ -2141,6 +2147,7 @@
 				F9A7069C1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm in Sources */,
 				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
+				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMGenericMessage+Utils.m in Sources */,
 				F9FD75781E2F9A0600B4558B /* SearchUserObserverCenter.swift in Sources */,
@@ -2246,6 +2253,7 @@
 				F94A208D1CB51AC90059632A /* ZMSyncMergePolicyTests.m in Sources */,
 				F9B720051CB2C795001DB03F /* ZMGenericMessage_ExternalTests.m in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,
+				16F6BB3C1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift in Sources */,
 				F9DBA5271E28EEBD00BE23C0 /* UserObserverTests.swift in Sources */,
 				5473CC751E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift in Sources */,
 				F9C348901E2E2DFF0015D69D /* MessageWindowObserverTests.swift in Sources */,


### PR DESCRIPTION
Observe `remoteIdentifier` on ZMConversation and add a `onExistsRemotely`
helper method for executing a block when a conversation exists remotely.