### PR TITLE
Respect to one relationships in core date snapshots

### DIFF
--- a/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -994,7 +994,7 @@ class ConversationListObserverTests : NotificationDispatcherTestBase {
         XCTAssertEqual(movedIndexes(first), [])
     }
     
-    func testThatItNotifiesObserversWhenAConversationsTeamDeletedSoItNowMatch() {
+    func testThatItNotifiesObserversWhenAConversationsTeamDeletedSoConversationAppears() {
         // NB! This test is checking the general behaviour of the conversation list observer, however in real life
         // the `conversation` object can possibly be faulted. It is not possible to implement the desired behaviour 
         // currently in the test setup.

--- a/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -993,6 +993,53 @@ class ConversationListObserverTests : NotificationDispatcherTestBase {
         XCTAssertEqual(first.updatedIndexes, IndexSet())
         XCTAssertEqual(movedIndexes(first), [])
     }
+    
+    func testThatItNotifiesObserversWhenAConversationsTeamDeletedSoItNowMatch() {
+        // NB! This test is checking the general behaviour of the conversation list observer, however in real life
+        // the `conversation` object can possibly be faulted. It is not possible to implement the desired behaviour 
+        // currently in the test setup.
+        
+        // given
+        var teamObjectID: NSManagedObjectID!
+        var conversationObjectID: NSManagedObjectID!
+        
+        syncMOC.performGroupedBlockAndWait {
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.remoteIdentifier = .create()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            conversation.conversationType = .group
+            conversation.team = team
+            self.syncMOC.saveOrRollback()
+            
+            teamObjectID = team.objectID
+            conversationObjectID = conversation.objectID
+        }
+        
+        let conversationList = ZMConversation.conversationsExcludingArchived(in: uiMOC, team: nil)
+
+        XCTAssert(uiMOC.saveOrRollback())
+        
+        let token = ConversationListChangeInfo.add(observer: testObserver, for: conversationList)
+        defer { ConversationListChangeInfo.remove(observer: token, for: conversationList) }
+        
+        // then
+        XCTAssertEqual(conversationList.count, 0)
+        
+        // when
+        let team = uiMOC.object(with: teamObjectID)
+        uiMOC.delete(team)
+
+        XCTAssert(uiMOC.saveOrRollback())
+        
+        // then
+        XCTAssertEqual(conversationList.count, 1)
+        XCTAssertEqual(testObserver.changes.count, 1)
+        guard let first = testObserver.changes.first else { return }
+        XCTAssertEqual(first.insertedIndexes, IndexSet(integer: 0))
+        XCTAssertEqual(first.deletedIndexes, IndexSet())
+        XCTAssertEqual(first.updatedIndexes, IndexSet())
+        XCTAssertEqual(movedIndexes(first), [])
+    }
 
     func testThatTheListIsOrderedAfterChangesInATeam() {
         // given

--- a/Tests/Source/Model/Observer/SnapshotCenterTests.swift
+++ b/Tests/Source/Model/Observer/SnapshotCenterTests.swift
@@ -142,11 +142,15 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                            "otherActiveParticipants": 0,
                                            "callParticipants": 0]
         
+        let expectedToOneRelationships = ["team": false,
+                                          "connection": false,
+                                          "creator": false]
+        
         expectedAttributes.forEach{
             XCTAssertEqual((snapshot.attributes[$0] ?? nil), $1, "values for \($0) don't match")
         }
         XCTAssertEqual(snapshot.toManyRelationships, expectedToManyRelationships)
-    
+        XCTAssertEqual(snapshot.toOneRelationships, expectedToOneRelationships)
     }
     
     func testThatReturnsChangedKeys() {


### PR DESCRIPTION
# What's in this PR?

* Add a separate dictionary to `Snapshot` to store the presence of to-one relations.

# Issue

When a user is added to a team conversation as a guest, the following sequence of events is happening:

1. We receive the event for adding the conversation.
2. We create the conversation from the payload, which contains the `team_id`.
3. We create the team locally and mark it for fetching.
→ The conversation is not yet shown in the general conversation list, since it has a team.
4. We fetch the team and receive a 403 indicating that the access is forbidden.
5. We delete the team.
6. CoreData is sending a save notification in which the conversation is faulted, and our snapshot does not contain the information about the one-to-one relation `team` on the conversation, so we are ignoring the change.
7. The conversation does not appear unless the list is reloaded / app restarted / a message in the conversation is received.

# Solution

Track one-to-one relationship state in our snapshots.