### PR TITLE
Check if team is already needs to be updated from BE

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -138,7 +138,9 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     // If we are added to a conversation in a team than we should have gotten the
     // team creation update event and fetched the team before.
     // If not and we just created the team then we need to refetch it.
-    self.team.needsToBeUpdatedFromBackend = created;
+    if (!self.team.needsToBeUpdatedFromBackend) {
+        self.team.needsToBeUpdatedFromBackend = created;
+    }
 }
 
 - (void)updatePotentialGapSystemMessagesIfNeededWithUsers:(NSSet <ZMUser *>*)users


### PR DESCRIPTION
The bug as I see it:
1. App is offline.
2. Someone adds you to the team (A) and to the team conversation (B).
3. When A happens, we create Team and mark it to be fetched.
4. We see the event B and reset the needs to be fetched flag to false.