### PR TITLE
Enable search by user handle

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -97,11 +97,12 @@ extension Team {
 extension Team {
     
     public func members(matchingQuery query: String) -> [Member] {
-        guard let matchingName = NSPredicate(formatDictionary: ["normalizedName" : "%K MATCHES %@"], matchingSearch: query) else { return [] }
+        let searchPredicate = ZMUser.predicateForAllUsers(withSearch: query)
+
         return members.filter({ member in
             guard let user = member.user else { return false }
             
-            return !user.isSelfUser && matchingName.evaluate(with: user)
+            return !user.isSelfUser && searchPredicate.evaluate(with: user)
         }).sorted(by: { (first, second) -> Bool in
             return first.user?.normalizedName < second.user?.normalizedName
         })

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -57,23 +57,6 @@ extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 + (nonnull NSOrderedSet <ZMUser *> *)usersWithRemoteIDs:(nonnull NSOrderedSet <NSUUID *>*)UUIDs inContext:(nonnull NSManagedObjectContext *)moc;
 
-/// @method predicateForConnectedUsersWithSearchString:
-/// Retrieves users with name or email matching search string, having ZMConnectionStatusAccepted connection statuses.
-/// @param searchString - a predicate to search users
-+ (nonnull NSPredicate *)predicateForConnectedUsersWithSearchString:(nonnull NSString *)searchString;
-
-/// @method predicateForConnectedNonBotUsers
-/// Retrieves all users (excluding bots), having ZMConnectionStatusAccepted connection statuses.
-+ (nonnull NSPredicate *)predicateForConnectedNonBotUsers;
-
-/// @method predicateForUsersWithSearchString:connectionStatusInArray:
-/// Retrieves users with name or email matching search string, having one of given connection statuses.
-/// @param searchString - a predicate to search users
-/// @param connectionStatusArray - an array of connections status of the users. E.g. for connected users it is @[@(ZMConnectionStatusAccepted)]
-+ (nonnull NSPredicate *)predicateForUsersWithSearchString:(nonnull NSString *)searchString
-                           connectionStatusInArray:(nonnull NSArray<NSNumber *> *)connectionStatusArray;
-
-
 + (ZMAccentColor)accentColorFromPayloadValue:(nullable NSNumber *)payloadValue;
 
 /// @method Updates the user with a name or handle received through a search

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -650,57 +650,6 @@ static NSString *const CreatedTeamsKey = @"createdTeams";
     return [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, needsToBeUpdated, remoteIdentifiers]];
 }
 
-+ (NSPredicate *)predicateForConnectedNonBotUsers
-{
-    return [self predicateForUsersWithSearchString:@""
-                                     excludingBots:YES
-                           connectionStatusInArray:@[@(ZMConnectionStatusAccepted)]];
-}
-
-+ (NSPredicate *)predicateForConnectedUsersWithSearchString:(NSString *)searchString
-{
-    return [self predicateForUsersWithSearchString:searchString
-                           connectionStatusInArray:@[@(ZMConnectionStatusAccepted)]];
-}
-
-+ (NSPredicate *)predicateForUsersWithSearchString:(NSString *)searchString
-                           connectionStatusInArray:(NSArray<NSNumber *> *)connectionStatusArray
-{
-    return [self predicateForUsersWithSearchString:searchString excludingBots:NO connectionStatusInArray:connectionStatusArray];
-}
-
-+ (NSPredicate *)predicateForUsersWithSearchString:(NSString *)searchString
-                                     excludingBots:(BOOL)excludeBots
-                           connectionStatusInArray:(NSArray<NSNumber *> *)connectionStatusArray
-{
-    NSString *normalizedQueryString = [searchString normalizedString];
-    NSString *normalizedEmailQueryString = [searchString normalizedEmailaddress];
-    
-    NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"(%K.status IN (%@))",
-                                    ConnectionKey, connectionStatusArray];
-    
-    NSPredicate *predicate;
-    
-    if(searchString.length > 0) {
-        NSPredicate *namePredicate = [NSPredicate predicateWithFormatDictionary:@{NormalizedNameKey : @"%K MATCHES %@"}
-                                                           matchingSearchString:normalizedQueryString];
-        NSPredicate *emailPredicate = [NSPredicate predicateWithFormat: @"%K == %@",
-                                       NormalizedEmailAddressKey, normalizedEmailQueryString];
-        NSPredicate *searchPredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[emailPredicate, namePredicate]];
-        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[searchPredicate, statusPredicate]];
-    }
-    else {
-        predicate = statusPredicate;
-    }
-    
-    if (excludeBots) {
-        NSPredicate *notBotsPredicate = [ZMUser nonBotUsersPredicate];
-        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, notBotsPredicate]];
-    }
-    
-    return predicate;
-}
-
 - (void)updateWithSearchResultName:(NSString *)name handle:(NSString *)handle;
 {
     // We never refetch unconnected users, but when performing a search we

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireUtilities
 
 @objc public enum ProfileImageSize: Int {
     case preview
@@ -78,6 +79,83 @@ extension ZMUser {
     public static var nonBotUsersPredicate: NSPredicate {
         return NSPredicate(format: "NOT (%K IN %@)", #keyPath(ZMUser.handle), [ottoBotHandle, annaBotHandle])
     }
+    
+    /// Retrieves all users (excluding bots), having ZMConnectionStatusAccepted connection statuses.
+    @objc static var predicateForConnectedNonBotUsers: NSPredicate {
+        return predicateForUsers(withSearch: "", excludingBots: true, connectionStatuses: [ZMConnectionStatus.accepted.rawValue])
+    }
+    
+    /// Retrieves connected users with name or handle matching search string
+    ///
+    /// - Parameter query: search string
+    /// - Returns: predicate having search query and ZMConnectionStatusAccepted connection statuses
+    @objc(predicateForConnectedUsersWithSearchString:)
+    public static func predicateForConnectedUsers(withSearch query: String) -> NSPredicate {
+        return predicateForUsers(withSearch: query, excludingBots: false, connectionStatuses: [ZMConnectionStatus.accepted.rawValue])
+    }
+    
+    /// Retrieves all users with name or handle matching search string
+    ///
+    /// - Parameter query: search string
+    /// - Returns: predicate having search query
+    public static func predicateForAllUsers(withSearch query: String) -> NSPredicate {
+        return predicateForUsers(withSearch: query, excludingBots: false, connectionStatuses: nil)
+    }
+    
+    
+    
+    /// Retrieves users with name or handle matching search string, having one of given connection statuses
+    ///
+    /// - Parameters:
+    ///   - query: search string
+    ///   - connectionStatuses: an array of connections status of the users. E.g. for connected users it is [ZMConnectionStatus.accepted.rawValue]
+    /// - Returns: predicate having search query and supplied connection statuses
+    @objc(predicateForUsersWithSearchString:connectionStatusInArray:)
+    public static func predicateForUsers(withSearch query: String, connectionStatuses: [Int16]? ) -> NSPredicate {
+        return predicateForUsers(withSearch: query, excludingBots: false, connectionStatuses: connectionStatuses)
+    }
+    
+    /// Retrieves users with name or handle matching search string, having one of given connection statuses
+    ///
+    /// - Parameters:
+    ///   - query: search string
+    ///   - excludingBots: set to true to filter out anna and otto
+    ///   - connectionStatuses: an array of connections status of the users. E.g. for connected users it is [ZMConnectionStatus.accepted.rawValue]
+    /// - Returns: predicate having search query and supplied connection statuses
+    @objc(predicateForUsersWithSearchString:excludingBots:connectionStatusInArray:)
+    public static func predicateForUsers(withSearch query: String, excludingBots: Bool, connectionStatuses: [Int16]? ) -> NSPredicate {
+        let normalizedQuery = (query.normalizedForSearch() as String?) ?? ""
+        var allPredicates = [[NSPredicate]]()
+        if let statuses = connectionStatuses {
+            let statusPredicate = NSPredicate(format: "(%K IN (%@))", #keyPath(ZMUser.connection.status), statuses)
+            allPredicates.append([statusPredicate])
+        }
+        
+        if !normalizedQuery.isEmpty {
+            let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName) : "%K MATCHES %@"], matchingSearch: normalizedQuery)
+            let normalizedHandle: String
+            if query.hasPrefix("@") {
+                // Use query as provided by the user but strip the @ symbol
+                var withoutAt = query
+                withoutAt.remove(at: query.startIndex)
+                normalizedHandle = withoutAt
+            } else {
+                // User regular normalized query otherwise
+                normalizedHandle = normalizedQuery
+            }
+            
+            let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), normalizedHandle)
+            allPredicates.append([namePredicate, handlePredicate].flatMap {$0})
+        }
+    
+        if excludingBots {
+            allPredicates.append([ZMUser.nonBotUsersPredicate])
+        }
+        
+        let orPredicates = allPredicates.map { NSCompoundPredicate(orPredicateWithSubpredicates: $0) }
+        
+        return NSCompoundPredicate(andPredicateWithSubpredicates: orPredicates)
+    }
 }
 
 extension ZMUser {
@@ -94,6 +172,7 @@ extension ZMUser {
     @objc(setImageData:size:)
     public func setImage(data: Data?, size: ProfileImageSize) {
         let key = size.userKeyPath
+        
         willChangeValue(forKey: key)
         if isSelfUser {
             setPrimitiveValue(data, forKey: key)

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -172,7 +172,6 @@ extension ZMUser {
     @objc(setImageData:size:)
     public func setImage(data: Data?, size: ProfileImageSize) {
         let key = size.userKeyPath
-        
         willChangeValue(forKey: key)
         if isSelfUser {
             setPrimitiveValue(data, forKey: key)

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -173,6 +173,26 @@ class TeamTests: BaseTeamTests {
         XCTAssertEqual(result, [membership])
     }
     
+    func testThatMembersMatchingHandleReturnCorrectMember() {
+        // given
+        let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
+        
+        // we add actual team members as well
+        let (user1, membership) = createUserAndAddMember(to: team)
+        let (user2, _) = createUserAndAddMember(to: team)
+        
+        user1.name = "UserA"
+        user1.setHandle("098")
+        user2.name = "UserB"
+        user2.setHandle("another")
+        
+        // when
+        let result = team.members(matchingQuery: "098")
+        
+        // then
+        XCTAssertEqual(result, [membership])
+    }
+    
     func testThatMembersMatchingQueryDoesNotReturnSelfUser() {
         // given
         let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)


### PR DESCRIPTION
It seems that local search by user handle was not working, it was searching only by `normalizedName`. Updated predicates to handle this situation and re-using it in team members search.