### PR TITLE
IN clause in a subquery seems to not do what it should

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -109,7 +109,7 @@ extension Team {
     
     public static func predicateTeamsWithGuestUserInAnyConversation(guestUser: ZMUser) -> NSPredicate {
         let notInThisTeam = NSPredicate(format: "NOT (SELF IN %@)", guestUser.teams)
-        let participantInAnyConversation = NSPredicate(format: "SUBQUERY(%K, $conversation, %@ IN $conversation.%K).@count > 0", #keyPath(Team.conversations), guestUser, #keyPath(ZMConversation.otherActiveParticipants))
+        let participantInAnyConversation = NSPredicate(format: "SUBQUERY(%K, $conversation, ANY $conversation.%K == %@).@count > 0", #keyPath(Team.conversations), #keyPath(ZMConversation.otherActiveParticipants), guestUser)
         return NSCompoundPredicate(andPredicateWithSubpredicates: [notInThisTeam, participantInAnyConversation])
     }
     


### PR DESCRIPTION
There was a discussion in  #283 to convert slightly esoteric `ANY foo == bar` predicate into simple `{foo} IN {bar}`. However it doesn't seem to work on device, but the tests pass in both cases. I assume this is because in-memory CoreData store works slightly differently regarding relationships.