### PR TITLE
Consider team group conversations with one participant 1-to-1

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -124,6 +124,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 @property (nonatomic) NSString *normalizedUserDefinedName;
 @property (nonatomic) ZMConversationType conversationType;
+@property (nonatomic, readonly) ZMConversationType internalConversationType;
 
 @property (nonatomic) NSDate *tempMaxLastReadServerTimeStamp;
 @property (nonatomic) NSMutableOrderedSet *unreadTimeStamps;
@@ -146,6 +147,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @property (nonatomic) NSDate *primitiveLastReadServerTimeStamp;
 @property (nonatomic) NSDate *primitiveLastServerTimeStamp;
 @property (nonatomic) NSUUID *primitiveRemoteIdentifier;
+@property (nonatomic) NSNumber *primitiveConversationType;
 @property (nonatomic) NSData *remoteIdentifier_data;
 
 @property (nonatomic) ZMConversationSecurityLevel securityLevel;
@@ -278,7 +280,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     NSMutableOrderedSet *activeParticipants = [NSMutableOrderedSet orderedSet];
     
-    if (self.conversationType != ZMConversationTypeGroup) {
+    if (self.internalConversationType != ZMConversationTypeGroup) {
         [activeParticipants addObject:[ZMUser selfUserInContext:self.managedObjectContext]];
         if (self.connectedUser != nil) {
             [activeParticipants addObject:self.connectedUser];
@@ -312,9 +314,15 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMUser *)connectedUser
 {
-    if(self.conversationType == ZMConversationTypeOneOnOne || self.conversationType == ZMConversationTypeConnection) {
+    ZMConversationType conversationType = self.internalConversationType;
+    
+    if (conversationType == ZMConversationTypeOneOnOne || conversationType == ZMConversationTypeConnection) {
         return self.connection.to;
     }
+    else if (conversationType == ZMConversationTypeGroup && self.otherActiveParticipants.count == 1) {
+        return self.otherActiveParticipants.firstObject;
+    }
+    
     return nil;
 }
 
@@ -471,6 +479,24 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     [self didChangeValueForKey:ZMConversationUserDefinedNameKey];
     
     self.normalizedUserDefinedName = [self.userDefinedName normalizedString];
+}
+
+- (ZMConversationType)conversationType
+{
+    [self willAccessValueForKey:ZMConversationConversationTypeKey];
+    ZMConversationType conversationType = [self internalConversationType];
+    
+    if (conversationType == ZMConversationTypeGroup && self.teamRemoteIdentifier != nil && self.otherActiveParticipants.count == 1) {
+        conversationType = ZMConversationTypeOneOnOne;
+    }
+    
+    [self didAccessValueForKey:ZMConversationConversationTypeKey];
+    return conversationType;
+}
+
+- (ZMConversationType)internalConversationType
+{
+    return (ZMConversationType)[[self primitiveConversationType] shortValue];
 }
 
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -483,20 +483,21 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMConversationType)conversationType
 {
-    [self willAccessValueForKey:ZMConversationConversationTypeKey];
     ZMConversationType conversationType = [self internalConversationType];
     
     if (conversationType == ZMConversationTypeGroup && self.teamRemoteIdentifier != nil && self.otherActiveParticipants.count == 1) {
         conversationType = ZMConversationTypeOneOnOne;
     }
     
-    [self didAccessValueForKey:ZMConversationConversationTypeKey];
     return conversationType;
 }
 
 - (ZMConversationType)internalConversationType
 {
-    return (ZMConversationType)[[self primitiveConversationType] shortValue];
+    [self willAccessValueForKey:ZMConversationConversationTypeKey];
+    ZMConversationType conversationType =  (ZMConversationType)[[self primitiveConversationType] shortValue];
+    [self didAccessValueForKey:ZMConversationConversationTypeKey];
+    return conversationType;
 }
 
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -514,7 +514,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (void)addParticipants:(nonnull NSSet<ZMUser *> *)participants
 {
-    VerifyReturn(self.conversationType == ZMConversationTypeGroup);
+    VerifyReturn(self.internalConversationType == ZMConversationTypeGroup);
     [participants enumerateObjectsUsingBlock:^(ZMUser * _Nonnull participant, BOOL * _Nonnull stop __unused) {
         RequireString(participant != [ZMUser selfUserInContext:self.managedObjectContext], "Can't add self user to a conversation");
     }];

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -919,6 +919,64 @@
 @end // general
 
 
+@implementation ZMConversationTests (GroupOneToOne)
+
+- (void)testThatGroupConversationInTeamWithOnlyTwoParticipantsIsConsideredOneToOne
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
+}
+
+- (void)testThatGroupConversationInTeamWithMoreThanTwoParticipantsIsNotConsideredOneToOne
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *user2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    [conversation addParticipant:user1];
+    [conversation addParticipant:user2];
+    
+    // then
+    XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
+}
+
+- (void)testThatGroupConversationInPersonalSpaceWithOnlyTwoParticipantsIsNotConsideredOneToOne
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
+}
+
+- (void)testThatOneToOneConversationInTeamReturnsAConnectedUser
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertEqual(conversation.connectedUser, user1);
+}
+
+@end
+
+
 
 @implementation ZMConversationTests (ReadOnly)
 


### PR DESCRIPTION
We want to consider team group conversations with only 2 participants to be one-to-one. This means supporting the same features (delivery recipes, video calling) and design.

see: https://github.com/wireapp/architecture/blob/master/teams/clients.md#one-to-one-conversation-inside-teams