### PR TITLE
Don't return a connected user for a group conversation with only 2 participants

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -314,12 +314,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMUser *)connectedUser
 {
-    ZMConversationType conversationType = self.internalConversationType;
+    ZMConversationType internalConversationType = self.internalConversationType;
     
-    if (conversationType == ZMConversationTypeOneOnOne || conversationType == ZMConversationTypeConnection) {
+    if (internalConversationType == ZMConversationTypeOneOnOne || internalConversationType == ZMConversationTypeConnection) {
         return self.connection.to;
     }
-    else if (conversationType == ZMConversationTypeGroup && self.otherActiveParticipants.count == 1) {
+    else if (self.conversationType == ZMConversationTypeOneOnOne) {
         return self.otherActiveParticipants.firstObject;
     }
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -974,6 +974,18 @@
     XCTAssertEqual(conversation.connectedUser, user1);
 }
 
+- (void)testThatGroupConversationWithOnlyTwoParticipantsDoesNotReturnAConnectedUser
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertNil(conversation.connectedUser);
+}
+
 @end
 
 


### PR DESCRIPTION
UI was depending on `connectedUser` only being set for one-to-one conversations.