### PR TITLE
Remove v2 profile picture upload

### DIFF
--- a/Source/Model/User/ZMRegistrationUser.m
+++ b/Source/Model/User/ZMRegistrationUser.m
@@ -42,12 +42,7 @@
 @synthesize name = _name;
 @synthesize accentColorValue = _accentColorValue;
 @synthesize phoneNumber = _phoneNumber;
-@synthesize originalProfileImageData = _originalProfileImageData;
-
-- (void)deleteProfileImage
-{
-    
-}
+@synthesize profileImageData = _profileImageData;
 
 + (instancetype)registrationUserWithEmail:(NSString *)email password:(NSString *)password
 {
@@ -93,12 +88,7 @@
 @synthesize name = _name;
 @synthesize accentColorValue = _accentColorValue;
 @synthesize phoneNumber = _phoneNumber;
-@synthesize originalProfileImageData = _originalProfileImageData;
-
-- (void)deleteProfileImage
-{
-    
-}
+@synthesize profileImageData = _profileImageData;
 
 /// This will assert if the email - password - phone - phoneVerificationCode is not set up properly.
 - (ZMCompleteRegistrationUser *)completeRegistrationUser
@@ -116,7 +106,7 @@
     
     user.name = self.name;
     user.accentColorValue = self.accentColorValue;
-    user.originalProfileImageData = self.originalProfileImageData;
+    user.profileImageData = self.profileImageData;
     user.invitationCode = self.invitationCode;
     return user;
 }

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -47,7 +47,6 @@ extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 @property (nullable, nonatomic) NSData *imageMediumData;
 @property (nullable, nonatomic) NSData *imageSmallProfileData;
-@property (nullable, nonatomic, readonly) NSData *originalProfileImageData;
 
 - (void)updateWithTransportData:(nonnull NSDictionary *)transportData authoritative:(BOOL)authoritative;
 
@@ -86,13 +85,12 @@ extern NSString * __nonnull const ZMUserActiveConversationsKey;
 
 
 
-@interface ZMUser (ImageData) <ZMImageOwner>
+@interface ZMUser (ImageData)
 
 @property (nullable, nonatomic) NSUUID *mediumRemoteIdentifier; ///< The remote identifier of the medium image for the receiver
 @property (nullable, nonatomic) NSUUID *smallProfileRemoteIdentifier; ///< The remote identifier of the small profile image for the receiver
 @property (nullable, nonatomic) NSUUID *localMediumRemoteIdentifier; ///< The remote identifier of the local "medium" image
 @property (nullable, nonatomic) NSUUID *localSmallProfileRemoteIdentifier; ///< The remote identifier of the local "small profile" image
-@property (nullable, nonatomic) NSUUID *imageCorrelationIdentifier; ///< Correlation id for the profile image
 
 + (nonnull NSPredicate *)predicateForMediumImageNeedingToBeUpdatedFromBackend;
 + (nonnull NSPredicate *)predicateForSmallImageNeedingToBeUpdatedFromBackend;

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -175,9 +175,6 @@ extension ZMUser {
         willChangeValue(forKey: key)
         if isSelfUser {
             setPrimitiveValue(data, forKey: key)
-            if originalProfileImageData != nil {
-                setLocallyModifiedKeys([key])
-            }
         } else {
             guard let imageData = data else {
                 managedObjectContext?.zm_userImageCache?.removeAllUserImages(self)

--- a/Source/Public/ZMEditableUser.h
+++ b/Source/Public/ZMEditableUser.h
@@ -32,12 +32,6 @@
 @property (nonatomic, copy, readonly) NSString *emailAddress;
 @property (nonatomic, copy, readonly) NSString *phoneNumber;
 
-/// Setting this to compressed image data (e.g. JPEG or PNG) will generate user images from it and upload it to the backend.
-/// Setting to @c nil is not supported. Use @c -deleteProfileImage to remove the profile image.
-@property (nonatomic) NSData *originalProfileImageData;
-/// Removes the profile image from the receiver.
-- (void)deleteProfileImage;
-
 @end
 
 
@@ -48,6 +42,7 @@
 @property (nonatomic, readonly, copy) NSString *phoneNumber;
 @property (nonatomic, readonly, copy) NSString *phoneVerificationCode;
 @property (nonatomic, readonly, copy) NSString *invitationCode;
+@property (nonatomic, copy) NSData *profileImageData;
 
 + (instancetype)registrationUserWithEmail:(NSString *)email password:(NSString *)password;
 + (instancetype)registrationUserWithPhoneNumber:(NSString *)phoneNumber phoneVerificationCode:(NSString *)phoneVerificationCode;
@@ -65,6 +60,7 @@
 @property (nonatomic, copy) NSString *phoneNumber;
 @property (nonatomic, copy) NSString *phoneVerificationCode;
 @property (nonatomic, copy) NSString *invitationCode;
+@property (nonatomic, copy) NSData *profileImageData;
 
 /// This will assert if the email - password - phone - phoneVerificationCode is not set up properly.
 - (ZMCompleteRegistrationUser *)completeRegistrationUser;

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -516,7 +516,6 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     user.remoteIdentifier = uuid;
     user.smallProfileRemoteIdentifier = [NSUUID createUUID];
     user.mediumRemoteIdentifier = [NSUUID createUUID];
-    user.imageCorrelationIdentifier = [NSUUID createUUID];
     user.imageSmallProfileData = [self dataForResource:@"tiny" extension:@"jpg"];
     user.imageMediumData = [self dataForResource:@"tiny" extension:@"jpg"];
     
@@ -532,38 +531,6 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.imageMediumData);
     XCTAssertNil(user.mediumRemoteIdentifier);
     XCTAssertNil(user.smallProfileRemoteIdentifier);
-}
-
-- (void)testThatItKeepPicturesWhenTheyHaveLocalModifications
-{
-    NSArray *keysProtectingImageFromRemoteUpdates = @[ImageMediumDataKey, ImageSmallProfileDataKey, SmallProfileRemoteIdentifierDataKey, MediumRemoteIdentifierDataKey];
-    
-    for (NSString *locallyModifiedKey in keysProtectingImageFromRemoteUpdates) {
-        
-        // given
-        ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
-        user.smallProfileRemoteIdentifier = [NSUUID createUUID];
-        user.mediumRemoteIdentifier = [NSUUID createUUID];
-        user.imageCorrelationIdentifier = [NSUUID createUUID];
-        user.imageSmallProfileData = [self dataForResource:@"tiny" extension:@"jpg"];
-        user.imageMediumData = [self dataForResource:@"tiny" extension:@"jpg"];
-        
-        NSMutableDictionary *payload = [self samplePayloadForUserID:user.remoteIdentifier];
-        payload[@"picture"] = @[];
-        
-        [user setLocallyModifiedKeys:[NSSet setWithObject:locallyModifiedKey]];
-        
-        // when
-        [user updateWithTransportData:payload authoritative:YES];
-        
-        // then
-        XCTAssertNotNil(user.imageSmallProfileData);
-        XCTAssertNotNil(user.imageMediumData);
-        XCTAssertNotNil(user.mediumRemoteIdentifier);
-        XCTAssertNotNil(user.smallProfileRemoteIdentifier);
-        
-        [user resetLocallyModifiedKeys:[NSSet setWithObject:locallyModifiedKey]];
-    }
 }
 
 - (void)testThatItHandlesEmptyOptionalData
@@ -1028,61 +995,6 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     
     // then
     XCTAssertEqualObjects(user.keysTrackedForLocalModifications, expected);
-}
-
-
-- (void)testThatItSetsImageRemoteIdentifiersToNilWhenDeletingTheProfileImage
-{
-    // given
-    ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
-    XCTAssertNotNil(user);
-    
-    user.mediumRemoteIdentifier = [NSUUID createUUID];
-    user.smallProfileRemoteIdentifier = [NSUUID createUUID];
-    
-    [user resetLocallyModifiedKeys:[NSSet setWithArray:@[@"mediumRemoteIdentifier_data", @"smallProfileRemoteIdentifier_data"]]];
-    
-    // when
-    [user deleteProfileImage];
-    
-    // then
-    XCTAssertNil(user.mediumRemoteIdentifier);
-    XCTAssertNil(user.smallProfileRemoteIdentifier);
-    XCTAssertTrue([user.keysThatHaveLocalModifications containsObject:@"mediumRemoteIdentifier_data"]);
-    XCTAssertTrue([user.keysThatHaveLocalModifications containsObject:@"smallProfileRemoteIdentifier_data"]);
-}
-
-- (void)testThatItSetsTheUserCorrelationIdentifierWhenSettingTheOriginalImageData
-{
-    // given
-    ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
-    XCTAssertNotNil(user);
-    XCTAssertNil(user.imageCorrelationIdentifier);
-    
-    NSData *tinyImageData = [self dataForResource:@"tiny" extension:@"jpg"];
-
-    // when
-    user.originalProfileImageData = tinyImageData;
-    
-    // then
-    XCTAssertNotNil(user.imageCorrelationIdentifier);
-}
-
-
-- (void)testThatItDeletesTheUserCorrelationIdentifierWhenDeletingTheOriginalImageData
-{
-    // given
-    ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
-    XCTAssertNotNil(user);
-    
-    user.imageCorrelationIdentifier = NSUUID.createUUID;
-    XCTAssertNotNil(user.imageCorrelationIdentifier);
-
-    // when
-    [user deleteProfileImage];
-    
-    // then
-    XCTAssertNil(user.imageCorrelationIdentifier);
 }
 
 - (void)testThatClientsRequiringUserAttentionContainsUntrustedClientsWithNeedsToNotifyFlagSet


### PR DESCRIPTION
Cleaned up as much code as I could find. There is one property (`originalProfileImageData`) that got deleted from CoreData, so ideally we could do only one new data model version together with #288.

Maybe I missed some code somewhere, would be glad to delete even more! 