### PR TITLE
Add lightweight managed object context change observer

### DIFF
--- a/Source/Notifications/ManagedObjectObserver.swift
+++ b/Source/Notifications/ManagedObjectObserver.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Source/Notifications/ManagedObjectObserver.swift
+++ b/Source/Notifications/ManagedObjectObserver.swift
@@ -31,10 +31,10 @@ import Foundation
         self.context = context
         self.callback = callback
         super.init()
-        addSaveNotificationObsever()
+        addSaveNotificationObserver()
     }
 
-    private func addSaveNotificationObsever() {
+    private func addSaveNotificationObserver() {
         token = NotificationCenter.default.addObserver(
             forName: .NSManagedObjectContextObjectsDidChange,
             object: context,

--- a/Source/Notifications/ManagedObjectObserver.swift
+++ b/Source/Notifications/ManagedObjectObserver.swift
@@ -1,0 +1,41 @@
+//
+//  ManagedObjectObserver.swift
+//  WireDataModel
+//
+//  Created by Silvan Dähn on 26.06.17.
+//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+//
+
+
+import Foundation
+
+
+@objc final public class ManagedObjectContextChangeObserver: NSObject {
+
+    public typealias ChangeCallback = () -> Void
+    private unowned var context: NSManagedObjectContext
+    private let callback: ChangeCallback
+    private var token: NSObjectProtocol?
+
+    public init(context: NSManagedObjectContext, callback: @escaping ChangeCallback) {
+        self.context = context
+        self.callback = callback
+        super.init()
+        addSaveNotificationObsever()
+    }
+
+    private func addSaveNotificationObsever() {
+        token = NotificationCenter.default.addObserver(
+            forName: .NSManagedObjectContextObjectsDidChange,
+            object: context,
+            queue: nil,
+            using: {  [weak self] _ in self?.callback() }
+        )
+    }
+
+    deinit {
+        guard let token = token else { return }
+        NotificationCenter.default.removeObserver(token)
+    }
+
+}

--- a/Source/Notifications/ManagedObjectObserver.swift
+++ b/Source/Notifications/ManagedObjectObserver.swift
@@ -1,9 +1,19 @@
 //
-//  ManagedObjectObserver.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Silvan Dähn on 26.06.17.
-//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -1,0 +1,91 @@
+//
+//  ManagedObjectContextChangeObserverTests.swift
+//  WireDataModel
+//
+//  Created by Silvan Dähn on 26.06.17.
+//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+
+
+class ManagedObjectContextChangeObserverTests : ZMBaseManagedObjectTest {
+
+
+    func testThatItCallsTheCallbackWhenObjectsAreInserted() {
+        // given
+        let changeExpectation = expectation(description: "The callback should be called")
+        let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
+            changeExpectation.fulfill()
+        }
+
+        // when
+        uiMOC.perform {
+            ZMMessage.insertNewObject(in: self.uiMOC)
+        }
+
+        // then
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.1))
+        _ = sut
+    }
+
+    func testThatItCallsTheCallbackWhenObjectsAreDelted() {
+        // given
+        let message = ZMMessage.insertNewObject(in: uiMOC)
+        XCTAssert(uiMOC.saveOrRollback())
+
+        let changeExpectation = expectation(description: "The callback should be called")
+        let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
+            changeExpectation.fulfill()
+        }
+
+        // when
+        uiMOC.perform {
+            self.uiMOC.delete(message)
+        }
+
+        // then
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.1))
+        _ = sut
+    }
+
+    func testThatItCallsTheCallbackWhenObjectsAreUpdated() {
+        // given
+        let message = ZMMessage.insertNewObject(in: uiMOC)
+        XCTAssert(uiMOC.saveOrRollback())
+
+        let changeExpectation = expectation(description: "The callback should be called")
+        let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
+            changeExpectation.fulfill()
+        }
+
+        // when
+        uiMOC.perform {
+            message.markAsSent()
+        }
+
+        // then
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.1))
+        _ = sut
+    }
+
+    func testThatItRemovesItselfAsObserverWhenReleased() {
+        // given
+        var called = false
+        var sut: ManagedObjectContextChangeObserver? = ManagedObjectContextChangeObserver(context: uiMOC) {
+            called = true
+        }
+
+        // when
+        _ = sut
+        sut = nil
+        uiMOC.perform {
+            ZMMessage.insertNewObject(in: self.uiMOC)
+        }
+
+        // then
+        spinMainQueue(withTimeout: 0.05)
+        XCTAssertFalse(called)
+    }
+
+}

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -1,10 +1,21 @@
 //
-//  ManagedObjectContextChangeObserverTests.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Silvan Dähn on 26.06.17.
-//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 
 import Foundation
 

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -40,7 +40,7 @@ class ManagedObjectContextChangeObserverTests : ZMBaseManagedObjectTest {
         _ = sut
     }
 
-    func testThatItCallsTheCallbackWhenObjectsAreDelted() {
+    func testThatItCallsTheCallbackWhenObjectsAreDeleted() {
         // given
         let message = ZMMessage.insertNewObject(in: uiMOC)
         XCTAssert(uiMOC.saveOrRollback())

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		87C125F71EF94EE800D28DC1 /* ZMManagedObject+Grouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C125F61EF94EE800D28DC1 /* ZMManagedObject+Grouping.swift */; };
 		87C125F91EF94F2E00D28DC1 /* ZMManagedObjectGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C125F81EF94F2E00D28DC1 /* ZMManagedObjectGroupingTests.swift */; };
 		BF0D07FB1E4C7B7A00B934EB /* TextSearchQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0D07F91E4C7B1100B934EB /* TextSearchQueryTests.swift */; };
+		BF103F9D1F0112F30047FDE5 /* ManagedObjectObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF103F9C1F0112F30047FDE5 /* ManagedObjectObserver.swift */; };
+		BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF103FA01F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift */; };
 		BF10B58B1E6432ED00E7036E /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF10B58A1E6432ED00E7036E /* Message.swift */; };
 		BF10B5971E64591600E7036E /* AnalyticsType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF10B5951E64591600E7036E /* AnalyticsType.swift */; };
 		BF10B5981E64591600E7036E /* NSManagedObjectContext+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF10B5961E64591600E7036E /* NSManagedObjectContext+Analytics.swift */; };
@@ -484,6 +486,8 @@
 		87C125F61EF94EE800D28DC1 /* ZMManagedObject+Grouping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMManagedObject+Grouping.swift"; sourceTree = "<group>"; };
 		87C125F81EF94F2E00D28DC1 /* ZMManagedObjectGroupingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMManagedObjectGroupingTests.swift; sourceTree = "<group>"; };
 		BF0D07F91E4C7B1100B934EB /* TextSearchQueryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextSearchQueryTests.swift; sourceTree = "<group>"; };
+		BF103F9C1F0112F30047FDE5 /* ManagedObjectObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectObserver.swift; sourceTree = "<group>"; };
+		BF103FA01F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagedObjectContextChangeObserverTests.swift; sourceTree = "<group>"; };
 		BF10B58A1E6432ED00E7036E /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		BF10B5951E64591600E7036E /* AnalyticsType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsType.swift; sourceTree = "<group>"; };
 		BF10B5961E64591600E7036E /* NSManagedObjectContext+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Analytics.swift"; sourceTree = "<group>"; };
@@ -1230,6 +1234,7 @@
 				F9C3488C1E2E219C0015D69D /* MessageWindowObserverCenter.swift */,
 				F9DBA5211E28EB4000BE23C0 /* SideEffectSources.swift */,
 				F9DBA51F1E28EA8B00BE23C0 /* DependencyKeyStore.swift */,
+				BF103F9C1F0112F30047FDE5 /* ManagedObjectObserver.swift */,
 			);
 			name = Notifications;
 			path = Source/Notifications;
@@ -1367,6 +1372,7 @@
 				F9A708071CAEEB7400C2F5FE /* NSManagedObjectContext+TestHelpers.m */,
 				F9A708081CAEEB7400C2F5FE /* PersistentStoreCoordinatorTests.m */,
 				5473CC741E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift */,
+				BF103FA01F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift */,
 			);
 			name = ManagedObjectContext;
 			path = Tests/Source/ManagedObjectContext;
@@ -2159,6 +2165,7 @@
 				F9A7068C1CAEE01D00C2F5FE /* ZMSearchUser.m in Sources */,
 				F18998A61E7BE03800E579A2 /* zmessaging.xcdatamodeld in Sources */,
 				F920AE501E3FA285001BC14F /* DisplayNameGenerator.swift in Sources */,
+				BF103F9D1F0112F30047FDE5 /* ManagedObjectObserver.swift in Sources */,
 				F9A706B71CAEE01D00C2F5FE /* UserChangeInfo.swift in Sources */,
 				F9A7067F1CAEE01D00C2F5FE /* ZMImageMessage.m in Sources */,
 				5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */,
@@ -2305,6 +2312,7 @@
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				BF7AFFCC1D747B5D00B2E089 /* DatabaseBaseTest.m in Sources */,
 				F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */,
+				BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */,
 				F9DBA5251E28EE1500BE23C0 /* ConversationObserverTests.swift in Sources */,
 				BFE3A96C1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift in Sources */,
 				BF707C511EB9F9CC00108D4E /* ClusterizerTests.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

Add a lightweight managed object context observer `ManagedObjectContextChangeObserver`, which should be used when in the background. For example, when replying to a message from a push notification we want to observe the delivery state of the sent message. If the send operation fails we want to present a "Failed to send message" notification to the user. As our custom observer system is not active while the application is in the background and would be quite expensive to start just for observing one message (due to the snapshot creation), the added observer can be used to get notified when objects in a specified context change.