### PR TITLE
Do not insert local team when updating a conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -131,16 +131,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 - (void)updateTeamWithIdentifier:(NSUUID *)teamId
 {
     VerifyReturn(nil != teamId);
-
-    BOOL created = NO;
     self.teamRemoteIdentifier = teamId;
-    self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:YES inContext:self.managedObjectContext created:&created];
-    // If we are added to a conversation in a team than we should have gotten the
-    // team creation update event and fetched the team before.
-    // If not and we just created the team then we need to refetch it.
-    if (!self.team.needsToBeUpdatedFromBackend) {
-        self.team.needsToBeUpdatedFromBackend = created;
-    }
+    self.team = [Team fetchOrCreateTeamWithRemoteIdentifier:teamId createIfNeeded:NO inContext:self.managedObjectContext created:nil];
 }
 
 - (void)updatePotentialGapSystemMessagesIfNeededWithUsers:(NSSet <ZMUser *>*)users

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -230,10 +230,8 @@
         XCTAssertNotNil(user2);
 
         XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
-        XCTAssertNotNil(conversation.team);
-        XCTAssertTrue(conversation.team.needsToBeUpdatedFromBackend);
-        XCTAssertFalse(conversation.team.needsToRedownloadMembers);
-        XCTAssertEqualObjects(conversation.team.remoteIdentifier, teamID);
+        XCTAssertNil(conversation.team);
+        XCTAssertEqualObjects(conversation.teamRemoteIdentifier, teamID);
 
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);
         XCTAssertEqual(conversation.unsyncedInactiveParticipants.count, 0u);

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -160,19 +160,8 @@ class ZMConversationTests_Teams: BaseTeamTests {
         }
 
         // then
-        guard let team = Team.fetch(withRemoteIdentifier: teamId, in: uiMOC) else { return XCTFail("No team") }
+        XCTAssertNil(Team.fetch(withRemoteIdentifier: teamId, in: uiMOC))
         XCTAssertNotNil(conversation.teamRemoteIdentifier)
-        XCTAssertEqual(conversation.teamRemoteIdentifier, teamId)
-        XCTAssertTrue(team.needsToBeUpdatedFromBackend)
-
-        // when we receive a 403 and delete the team
-        // We need to nil the relationship before deleting the team (otherwise the delete will cascade and delete the conversation as well)
-        conversation.team = nil
-        uiMOC.delete(team)
-        XCTAssert(uiMOC.saveOrRollback())
-
-        // then
-        XCTAssertNil(conversation.team)
         XCTAssertEqual(conversation.teamRemoteIdentifier, teamId)
         XCTAssert(ZMUser.selfUser(in: uiMOC).isGuest(in: conversation))
     }


### PR DESCRIPTION
# What's in this PR?

* Do not insert local team when updating a conversation.