### PR TITLE
Only send delivery receipts for messages received in the last 7 days

### DIFF
--- a/Source/Model/Message/ZMOTRMessage+ConfirmationThreshold.swift
+++ b/Source/Model/Message/ZMOTRMessage+ConfirmationThreshold.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+
+extension ZMOTRMessage {
+
+    private static let dayThreshold = 7
+
+    @objc(shouldConfirmMessage:)
+    static func shouldConfirm(_ message: ZMMessage) -> Bool {
+        precondition(nil != message.serverTimestamp, "Can not decide whether to confirm message without timestamp")
+        return _shouldConfirm(message)
+    }
+
+    private static func _shouldConfirm(_ message: ZMMessage, currentDate: Date = .init()) -> Bool {
+        guard let timestamp = message.serverTimestamp else { return true }
+        let calendar = Calendar.current
+        guard let days = calendar.dateComponents([.day], from: timestamp, to: currentDate).day else { return true }
+        return days <= dayThreshold
+    }
+
+}
+

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -255,7 +255,7 @@ NSString * const DeliveredKey = @"delivered";
     
     BOOL needsConfirmation = NO;
     if (isNewMessage && !clientMessage.sender.isSelfUser && conversation.conversationType == ZMConversationTypeOneOnOne) {
-        needsConfirmation = YES;
+        needsConfirmation = [self shouldConfirmMessage:clientMessage];
     }
     
     

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -186,11 +186,11 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
         }
     }
     
-    func createUpdateEvent(_ nonce: UUID, conversationID: UUID, genericMessage: ZMGenericMessage, senderID: UUID = .create(), eventSource: ZMUpdateEventSource = .download) -> ZMUpdateEvent {
+    func createUpdateEvent(_ nonce: UUID, conversationID: UUID, timestamp: Date = .init(), genericMessage: ZMGenericMessage, senderID: UUID = .create(), eventSource: ZMUpdateEventSource = .download) -> ZMUpdateEvent {
         let payload : [String : Any] = [
             "conversation": conversationID.transportString(),
             "from": senderID.transportString(),
-            "time": Date().transportString(),
+            "time": timestamp.transportString(),
             "data": [
                 "text": genericMessage.data().base64String()
             ],

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		BF46662A1DCB71B0007463FF /* V3Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4666291DCB71B0007463FF /* V3Asset.swift */; };
 		BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF491CCE1F02A6CF0055EE44 /* Member+Patches.swift */; };
 		BF491CD71F0402F80055EE44 /* store2-31-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF491CD61F0402F80055EE44 /* store2-31-0.wiredatabase */; };
+		BF491CD91F0506150055EE44 /* ZMOTRMessage+ConfirmationThreshold.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF491CD81F0506150055EE44 /* ZMOTRMessage+ConfirmationThreshold.swift */; };
 		BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */; };
 		BF707C391EB8780800108D4E /* MessageCountTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C381EB8780800108D4E /* MessageCountTracker.swift */; };
 		BF707C3B1EB8879300108D4E /* MessageCountTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */; };
@@ -514,6 +515,7 @@
 		BF4666291DCB71B0007463FF /* V3Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = V3Asset.swift; sourceTree = "<group>"; };
 		BF491CCE1F02A6CF0055EE44 /* Member+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Member+Patches.swift"; sourceTree = "<group>"; };
 		BF491CD61F0402F80055EE44 /* store2-31-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-31-0.wiredatabase"; path = "Tests/Resources/store2-31-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
+		BF491CD81F0506150055EE44 /* ZMOTRMessage+ConfirmationThreshold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+ConfirmationThreshold.swift"; sourceTree = "<group>"; };
 		BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+DisplayName.swift"; sourceTree = "<group>"; };
 		BF707C381EB8780800108D4E /* MessageCountTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTracker.swift; sourceTree = "<group>"; };
 		BF707C3A1EB8879300108D4E /* MessageCountTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCountTrackerTests.swift; sourceTree = "<group>"; };
@@ -1186,6 +1188,7 @@
 				F9A706011CAEE01D00C2F5FE /* ZMOTRMessage.h */,
 				BFABEB8B1E647054003BE9F3 /* GenericMessageScheduleNotification.swift */,
 				F9A706021CAEE01D00C2F5FE /* ZMOTRMessage.m */,
+				BF491CD81F0506150055EE44 /* ZMOTRMessage+ConfirmationThreshold.swift */,
 				544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */,
 				F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
@@ -2175,6 +2178,7 @@
 				F18998A61E7BE03800E579A2 /* zmessaging.xcdatamodeld in Sources */,
 				F920AE501E3FA285001BC14F /* DisplayNameGenerator.swift in Sources */,
 				BF103F9D1F0112F30047FDE5 /* ManagedObjectObserver.swift in Sources */,
+				BF491CD91F0506150055EE44 /* ZMOTRMessage+ConfirmationThreshold.swift in Sources */,
 				F9A706B71CAEE01D00C2F5FE /* UserChangeInfo.swift in Sources */,
 				F9A7067F1CAEE01D00C2F5FE /* ZMImageMessage.m in Sources */,
 				5473CC731E14245C00814C03 /* NSManagedObjectContext+Debugging.swift in Sources */,


### PR DESCRIPTION
# What's in this PR?

* Only send delivery receipts for messages received in the last 7 days.
* The exact value of this threshold is still under discussion.