### PR TITLE
Stop considering users in account without team as guests

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -60,7 +60,8 @@ public extension ZMUser {
             return conversation.team == nil
                 && conversation.teamRemoteIdentifier != nil
         } else {
-            return conversation.otherActiveParticipants.contains(self)
+            return ZMUser.selfUser(in: managedObjectContext!).hasTeam
+                && conversation.otherActiveParticipants.contains(self)
                 && membership == nil
         }
     }

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -60,7 +60,7 @@ public extension ZMUser {
             return conversation.team == nil
                 && conversation.teamRemoteIdentifier != nil
         } else {
-            return ZMUser.selfUser(in: managedObjectContext!).hasTeam
+            return ZMUser.selfUser(in: managedObjectContext!).hasTeam // There can't be guests in a team that doesn't exist
                 && conversation.otherActiveParticipants.contains(self)
                 && membership == nil
         }

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -79,6 +79,24 @@ class TeamTests: BaseTeamTests {
         XCTAssertFalse(guest.isTeamMember)
     }
 
+    func testThatItDoesNotReturnUsersAsGuestsIfThereIsNoTeam() {
+        // given
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.remoteIdentifier = .create()
+        let otherUser = ZMUser.insertNewObject(in: uiMOC)
+        otherUser.remoteIdentifier = .create()
+        let users = [user, otherUser]
+
+        // when
+        guard let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: users) else { return XCTFail("No conversation") }
+
+        // then
+        users.forEach {
+            XCTAssertFalse($0.isGuest(in: conversation))
+            XCTAssertFalse($0.isTeamMember)
+        }
+    }
+
     func testThatItDoesNotReturnGuestsOfOtherTeams() throws {
             // given
             let (team1, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)


### PR DESCRIPTION
# What's in this PR?

There can't be guests in accounts without a team, but we were showing all other users as guests in conversations in that case. This adds a check whether there is a team or not before checking if the user is a member of said team.