### PR TITLE
Do not update lastModifiedDate for leave and rename update events

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -927,7 +927,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic messageDestructionTimeout;
 
 
-
 + (NSSet *)keyPathsForValuesAffectingIsArchived
 {
     return [NSSet setWithObject:ZMConversationIsArchivedKey];
@@ -1027,7 +1026,9 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 - (void)updateWithMessage:(ZMMessage *)message timeStamp:(NSDate *)timeStamp
 {
     [self updateLastServerTimeStampIfNeeded:timeStamp];
-    [self updateLastModifiedDateIfNeeded:timeStamp];
+    if (message.shouldUpdateLastModifiedDate) {
+        [self updateLastModifiedDateIfNeeded:timeStamp];
+    }
     [self updateUnreadMessagesWithMessage:message];
 }
 
@@ -1355,7 +1356,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     
     NSPredicate *localSystemMessagePredicate = [ZMSystemMessage predicateForSystemMessagesInsertedLocally];
     if ([message.serverTimestamp compare:self.lastModifiedDate] == NSOrderedDescending
-       && ![localSystemMessagePredicate evaluateWithObject:message]) {
+       && ![localSystemMessagePredicate evaluateWithObject:message] && message.shouldUpdateLastModifiedDate) {
         self.lastModifiedDate = message.serverTimestamp;
     }
     

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -73,6 +73,7 @@ extern NSString * _Nonnull const ZMMessageDeliveryStateKey;
 - (void)updateWithPostPayload:(NSDictionary * _Nonnull)payload updatedKeys:(__unused NSSet * _Nullable)updatedKeys;
 - (void)resend;
 - (BOOL)shouldGenerateUnreadCount;
+- (BOOL)shouldUpdateLastModifiedDate;
 
 /// Removes the message and deletes associated content
 /// @param clearingSender Whether information about the sender should be removed or not

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -165,6 +165,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     return YES;
 }
 
+- (BOOL)shouldUpdateLastModifiedDate
+{
+    return YES;
+}
+
 + (NSPredicate *)predicateForObjectsThatNeedToBeUpdatedUpstream;
 {
     return [NSPredicate predicateWithValue:NO];
@@ -1028,6 +1033,18 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
 - (id<ZMSystemMessageData>)systemMessageData
 {
     return self;
+}
+
+- (BOOL)shouldUpdateLastModifiedDate
+{
+    switch (self.systemMessageType) {
+        case ZMSystemMessageTypeParticipantsRemoved:
+        case ZMSystemMessageTypeConversationNameChanged:
+            return NO;
+
+        default:
+            return YES;
+    }
 }
 
 - (BOOL)shouldGenerateUnreadCount;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+messages.m
@@ -74,6 +74,27 @@
     XCTAssertEqualObjects(conversation.lastModifiedDate, msg2.serverTimestamp);
 }
 
+- (void)testThatItDoesNotUpdateTheLastModifiedDateForRenameAndLeaveSystemMessages
+{
+    NSArray<NSNumber *> *types = @[@(ZMSystemMessageTypeTeamMemberLeave), @(ZMSystemMessageTypeConversationNameChanged)];
+    for (NSNumber *type in types) {
+        // given
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+        NSDate *lastModified = [NSDate dateWithTimeIntervalSince1970:10];
+        conversation.lastModifiedDate = lastModified;
+
+        ZMSystemMessage *systemMessage = [ZMSystemMessage insertNewObjectInManagedObjectContext:self.uiMOC];
+        systemMessage.systemMessageType = (ZMSystemMessageType)type.intValue;
+        systemMessage.serverTimestamp = [lastModified dateByAddingTimeInterval:100];
+
+        // when
+        [conversation sortedAppendMessage:systemMessage];
+
+        // then
+        XCTAssertEqualObjects(conversation.lastModifiedDate, lastModified);
+    }
+}
+
 - (void)testThatItIsSafeToPassInAMutableStringWhenCreatingATextMessage
 {
     // given


### PR DESCRIPTION
# What's in this PR?

* Do not update `lastModifiedDate` for leave and rename update events.