### PR TITLE
Do not crash when sending the ephemeral to an empty group

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Encryption.swift
@@ -75,7 +75,9 @@ extension ZMAssetClientMessage {
         (userEnries: [ZMUserEntry], strategy: MissingClientsStrategy)? {
         guard let conversation = self.conversation else { return nil }
             
-        let (recipientUsers, strategy) = genericMessage.recipientUsersforMessage(in: conversation, selfUser: selfClient.user!)
+        guard let (recipientUsers, strategy) = genericMessage.recipientUsersForMessage(in: conversation, selfUser: selfClient.user!) else {
+            return nil
+        }
         var recipients : [ZMUserEntry] = []
         selfClient.keysStore.encryptionContext.perform { (sessionsDirectory) in
             recipients = genericMessage.recipientsWithEncryptedData(selfClient, recipients: recipientUsers, sessionDirectory: sessionsDirectory)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WireCryptobox
 import WireLinkPreview
+import WireTesting
 
 @testable import WireDataModel
 
@@ -298,6 +299,26 @@ extension ZMClientMessageTests_Ephemeral {
             //when
             guard let _ = textMessage.encryptedMessagePayloadData()
                 else { return XCTFail()}
+        }
+    }
+    
+    func testThatItCreatesNoPayloadForEphemeralMessageInEmptyConversation() {
+        syncMOC.performGroupedBlockAndWait {
+            //given
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            conversation.conversationType = .group
+            conversation.remoteIdentifier = UUID.create()
+            conversation.messageDestructionTimeout = 10
+            
+            self.syncMOC.saveOrRollback()
+            
+            let textMessage = conversation.appendOTRMessage(withText: "foo", nonce: UUID.create(), fetchLinkPreview: true)
+            
+            //when
+            self.performIgnoringZMLogError {
+                guard textMessage.encryptedMessagePayloadData() == nil
+                    else { return XCTFail()}
+            }
         }
     }
 }


### PR DESCRIPTION
- Optional here and there to allow indication of the fact that the payload cannot be generated.