### PR TITLE
Fix removing email or phone via user update

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -550,12 +550,12 @@ static NSString *const CreatedTeamsKey = @"createdTeams";
     }
     
     NSString *email = [transportData optionalStringForKey:@"email"];
-    if (email != nil || authoritative) {
+    if ([transportData objectForKey:@"email"] || authoritative) {
         self.emailAddress = email.stringByRemovingExtremeCombiningCharacters;
     }
     
     NSString *phone = [transportData optionalStringForKey:@"phone"];
-    if (phone != nil || authoritative) {
+    if ([transportData objectForKey:@"phone"] || authoritative) {
         self.phoneNumber = phone.stringByRemovingExtremeCombiningCharacters;
     }
     

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -588,6 +588,24 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqualObjects(user.emailAddress, originalValue);
 }
 
+- (void)testThatItSetsEmailToNilIfItIsNull
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+    user.emailAddress =  @"gino@pino.it";
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    [payload setObject:[NSNull null] forKey:@"email"];
+    
+    // when
+    [user updateWithTransportData:payload authoritative:NO];
+    
+    // then
+    XCTAssertNil(user.emailAddress);
+}
+
 - (void)testThatItSetsEmailToNilIfItIsMissing
 {
     // given
@@ -604,6 +622,24 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
 
     // then
     XCTAssertNil(user.emailAddress);
+}
+
+- (void)testThatItSetsPhoneToNilIfItIsNull
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+    user.phoneNumber =  @"555-fake-number";
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    [payload setObject:[NSNull null] forKey:@"phone"];
+    
+    // when
+    [user updateWithTransportData:payload authoritative:NO];
+    
+    // then
+    XCTAssertNil(user.phoneNumber);
 }
 
 - (void)testThatItSetsPhoneToNilIfItIsMissing


### PR DESCRIPTION
We wouldn't delete an email or phone from a `user.update` event. This will happen if you have two devices and delete your email, the second device will then receive a `user.update` event setting the `email` field to nil.