### PR TITLE
Do not allow sending the ephemeral message to the empty conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -74,6 +74,9 @@ public extension ZMConversation {
         return ZMConversationMessageDestructionTimeout(rawValue: messageDestructionTimeout) ?? .none
     }
 
+    public var canSendEphemeral: Bool {
+        return self.activeParticipants.count > 1
+    }
 }
 
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1194,7 +1194,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 - (ZMClientMessage *)appendGenericMessage:(ZMGenericMessage *)genericMessage expires:(BOOL)expires hidden:(BOOL)hidden
 {
     VerifyReturnNil(genericMessage != nil);
-    
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMClientMessage *message = [ZMClientMessage insertNewObjectInManagedObjectContext:self.managedObjectContext];
     [message addData:genericMessage.data];
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
@@ -1215,6 +1216,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 - (ZMClientMessage *)appendClientMessageWithData:(NSData *)data
 {
     VerifyReturnNil(data != nil);
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
     
     ZMClientMessage *message = [ZMClientMessage insertNewObjectInManagedObjectContext:self.managedObjectContext];
     [message addData:data];
@@ -1229,6 +1231,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMAssetClientMessage *)appendAssetClientMessageWithNonce:(NSUUID *)nonce hidden:(BOOL)hidden imageData:(NSData *)imageData
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithOriginalImageData:imageData
                                                                                             nonce:nonce
                                                                              managedObjectContext:self.managedObjectContext
@@ -1247,6 +1251,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMAssetClientMessage *)appendOTRMessageWithFileMetadata:(ZMFileMetadata *)fileMetadata nonce:(NSUUID *)nonce
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMAssetClientMessage *message = [ZMAssetClientMessage assetClientMessageWithFileMetadata:fileMetadata
                                                                                        nonce:nonce
                                                                         managedObjectContext:self.managedObjectContext
@@ -1261,6 +1267,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMClientMessage *)appendOTRMessageWithLocationData:(ZMLocationData *)locationData nonce:(NSUUID *)nonce
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMGenericMessage *genericMessage = [ZMGenericMessage genericMessageWithLocation:locationData.zmLocation messageID:nonce.transportString expiresAfter:@(self.messageDestructionTimeout)];
     ZMClientMessage *message = [self appendClientMessageWithData:genericMessage.data];
     message.isEncrypted = YES;
@@ -1269,6 +1277,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMClientMessage *)appendOTRKnockMessageWithNonce:(NSUUID *)nonce
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMGenericMessage *genericMessage = [ZMGenericMessage knockWithNonce:nonce.transportString expiresAfter:@(self.messageDestructionTimeout)];
     ZMClientMessage *message = [self appendClientMessageWithData:genericMessage.data];
     message.isEncrypted = YES;
@@ -1277,6 +1287,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMClientMessage *)appendOTRMessageWithText:(NSString *)text nonce:(NSUUID *)nonce fetchLinkPreview:(BOOL)fetchPreview
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithText:text.stringByRemovingExtremeCombiningCharacters
                                                                    nonce:nonce.transportString
                                                             expiresAfter:@(self.messageDestructionTimeout)];
@@ -1293,6 +1305,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (ZMAssetClientMessage *)appendOTRMessageWithImageData:(NSData *)imageData nonce:(NSUUID *)nonce
 {
+    VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
+
     NSError *metadataError = nil;
     NSData *imageDataWithoutMetadata = [imageData wr_imageDataWithoutMetadataAndReturnError:&metadataError];
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -88,7 +88,6 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
     func testThatSendingEphemeralToEmptyConversationIsNotPossible() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
-        conversation.conversationType = .oneOnOne
         conversation.conversationType = .group
 
         // when
@@ -101,7 +100,6 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
     func testThatSendingEphemeralToNormalConversationIsPossible() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
-        conversation.conversationType = .oneOnOne
         conversation.conversationType = .group
         
         // when

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -84,6 +84,35 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
         // then
         XCTAssertEqual(conversation.messageDestructionTimeout, 5)
     }
+ 
+    func testThatSendingEphemeralToEmptyConversationIsNotPossible() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.conversationType = .group
+
+        // when
+        conversation.internalAddParticipants(Set(arrayLiteral: selfUser), isAuthoritative: true)
+                
+        // then
+        XCTAssertEqual(conversation.canSendEphemeral, false)
+    }
     
+    func testThatSendingEphemeralToNormalConversationIsPossible() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.conversationType = .group
+        
+        // when
+        let user = ZMUser.insert(in: uiMOC, name: "Test")
+        user.remoteIdentifier = UUID()
+        
+        conversation.internalAddParticipants(Set(arrayLiteral: selfUser), isAuthoritative: true)
+        conversation.addParticipant(user)
+        
+        // then
+        XCTAssertEqual(conversation.canSendEphemeral, true)
+    }
 }
 

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -58,6 +58,10 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
     func testThatItDoesNotCategorizeTimedMessages() {
         
         // GIVEN
+        let otherUser = ZMUser.insertNewObject(in: self.conversation.managedObjectContext!)
+        otherUser.remoteIdentifier = UUID.create()
+        
+        self.conversation.mutableOtherActiveParticipants.addObjects(from: [otherUser])
         self.conversation.updateMessageDestructionTimeout(timeout: .thirtySeconds)
         let message = self.conversation.appendMessage(withText: "ramble on!")! as! ZMMessage
         

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -428,6 +428,9 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
+        conversation.conversationType = .group
+        conversation.mutableOtherActiveParticipants.addObjects(from: [user1, user2])
+        
         let message = conversation.appendMessage(withText: "This is a regular message in the conversation") as! ZMMessage
         let otherMessage = conversation.appendMessage(withText: "This is the another message in the conversation") as! ZMMessage
         conversation.messageDestructionTimeout = 300


### PR DESCRIPTION
# Issue

When sending the message to group conversation without the participants the sending is not possible, since there are no receivers (ephemeral is not sent to your own devices).

# Fix

Appending the message is failing in such conversations.