### PR TITLE
Add functions to delete persisted accounts

### DIFF
--- a/Source/Model/AccountManager.swift
+++ b/Source/Model/AccountManager.swift
@@ -53,6 +53,12 @@ public final class AccountManager: NSObject {
         updateAccounts()
     }
 
+    /// Deletes all content stored by an `AccountManager` on disk at the given URL, including the selected account.
+    static public func delete(at root: URL) {
+        AccountStore.delete(at: root)
+        UserDefaults.shared().selectedAccountIdentifier = nil
+    }
+
     /// Adds an account to the manager and persists it.
     /// - parameter account: The account to add.
     public func add(_ account: Account) {
@@ -60,7 +66,7 @@ public final class AccountManager: NSObject {
         updateAccounts()
     }
 
-    /// Removes an account from the manager and the persistsence layer.
+    /// Removes an account from the manager and the persistence layer.
     /// - parameter account: The account to remove.
     public func remove(_ account: Account) {
         store.remove(account)

--- a/Source/Model/AccountStore.swift
+++ b/Source/Model/AccountStore.swift
@@ -90,8 +90,8 @@ public final class AccountStore: NSObject {
     }
 
     /// Deletes the persistence layer of an `AccountStore` from the file system.
-    /// Mostly useful for cleaning up in tests or complete resets.
-    /// - parameter root: The root url at which the sotre which should be deleted.
+    /// Mostly useful for cleaning up after tests or for complete account resets.
+    /// - parameter root: The root url of the store that should be deleted.
     @discardableResult static func delete(at root: URL) -> Bool {
         do {
             try FileManager.default.removeItem(at: root.appendingPathComponent(directoryName))
@@ -125,7 +125,7 @@ public final class AccountStore: NSObject {
     }
 
     /// Create a local url for an `Account` inside this `AccountStore`.
-    /// - parameter account: The account for which th eurl should be generated.
+    /// - parameter account: The account for which the url should be generated.
     /// - returns: The `URL` for the given account.
     private func url(for account: Account) -> URL {
         return url(for: account.userIdentifier)

--- a/Source/Model/AccountStore.swift
+++ b/Source/Model/AccountStore.swift
@@ -89,6 +89,19 @@ public final class AccountStore: NSObject {
         }
     }
 
+    /// Deletes the persistence layer of an `AccountStore` from the file system.
+    /// Mostly useful for cleaning up in tests or complete resets.
+    /// - parameter root: The root url at which the sotre which should be deleted.
+    @discardableResult static func delete(at root: URL) -> Bool {
+        do {
+            try FileManager.default.removeItem(at: root.appendingPathComponent(directoryName))
+            return true
+        } catch {
+            log.error("Unable to remove all accounts at \(root): \(error)")
+            return false
+        }
+    }
+
     /// Check if an `Account` is already stored in this `AccountStore`.
     /// - parameter account: The account which should be deleted.
     /// - returns: Whether or not the account is stored in this `AccountStore`.

--- a/Tests/Source/Model/AccountManagerTests.swift
+++ b/Tests/Source/Model/AccountManagerTests.swift
@@ -94,6 +94,34 @@ final class AccountManagerTests: ZMConversationTestsBase {
         XCTAssertEqual(manager.accounts, [account])
     }
 
+    func testThatItCanDeleteAnAccountManager() {
+        // given
+        do {
+            let manager = AccountManager(sharedDirectory: url)
+            let account1 = Account(userName: "Silvan", userIdentifier: .create())
+            let account2 = Account(userName: "Vytis", userIdentifier: .create(), teamName: "Wire")
+
+            // when
+            manager.add(account1)
+            manager.add(account2)
+            manager.select(account2)
+
+            // then
+            XCTAssertEqual(manager.selectedAccount, account2)
+            XCTAssertEqual(manager.accounts, [account1, account2])
+        }
+
+        // when
+        AccountManager.delete(at: url)
+
+        // then
+        do {
+            let manager = AccountManager(sharedDirectory: url)
+            XCTAssertNil(manager.selectedAccount)
+            XCTAssertEqual(manager.accounts, [])
+        }
+    }
+    
     func testThatItRemovesTheSelectedAccountWhenItIsRemoved() {
         // given
         let manager = AccountManager(sharedDirectory: url)

--- a/Tests/Source/Model/AccountStoreTests.swift
+++ b/Tests/Source/Model/AccountStoreTests.swift
@@ -94,6 +94,13 @@ final class AccountStoreTests: ZMConversationTestsBase {
         }
     }
 
+    func testThatItReturnsFalseWhenTryingToDeleteANonExistentAccountStore() {
+        // then
+        performIgnoringZMLogError {
+            XCTAssertFalse(AccountStore.delete(at: self.url))
+        }
+    }
+
     func testThatItCanStoreMultipleAccounts() {
         // given
         let store = AccountStore(root: url)

--- a/Tests/Source/Model/AccountStoreTests.swift
+++ b/Tests/Source/Model/AccountStoreTests.swift
@@ -74,6 +74,26 @@ final class AccountStoreTests: ZMConversationTestsBase {
         XCTAssertEqual(store.load(), [])
     }
 
+    func testThatItCanDeleteAnAccountStore() {
+        // given
+        do {
+            let store = AccountStore(root: url)
+            let account = Account(userName: "John", userIdentifier: .create())
+
+            XCTAssert(store.add(account))
+            XCTAssertEqual(store.load(), [account])
+        }
+
+        // when
+        XCTAssert(AccountStore.delete(at: url))
+
+        // then
+        do {
+            let store = AccountStore(root: url)
+            XCTAssertEqual(store.load(), [])
+        }
+    }
+
     func testThatItCanStoreMultipleAccounts() {
         // given
         let store = AccountStore(root: url)


### PR DESCRIPTION
# What's in this PR?

* Add functions to delete persisted accounts, which will mostly be used to clean up after tests.