### PR TITLE
Add convenience method to add and immediately select an account

### DIFF
--- a/Source/Model/AccountManager.swift
+++ b/Source/Model/AccountManager.swift
@@ -66,6 +66,13 @@ public final class AccountManager: NSObject {
         updateAccounts()
     }
 
+    /// Adds and selects an account to the manager and persists it.
+    /// - parameter account: The account to add and select.
+    public func addAndSelect(_ account: Account) {
+        add(account)
+        select(account)
+    }
+
     /// Removes an account from the manager and the persistence layer.
     /// - parameter account: The account to remove.
     public func remove(_ account: Account) {

--- a/Source/Model/AccountManager.swift
+++ b/Source/Model/AccountManager.swift
@@ -66,7 +66,7 @@ public final class AccountManager: NSObject {
         updateAccounts()
     }
 
-    /// Adds and selects an account to the manager and persists it.
+    /// Adds an account to the mananger and immediately and selects it.
     /// - parameter account: The account to add and select.
     public func addAndSelect(_ account: Account) {
         add(account)

--- a/Tests/Source/Model/AccountManagerTests.swift
+++ b/Tests/Source/Model/AccountManagerTests.swift
@@ -94,6 +94,27 @@ final class AccountManagerTests: ZMConversationTestsBase {
         XCTAssertEqual(manager.accounts, [account])
     }
 
+    func testThatItCanAddAndSelectAnAccount() {
+        // given
+        let manager = AccountManager(sharedDirectory: url)
+        let account1 = Account(userName: "Silvan", userIdentifier: .create())
+        let account2 = Account(userName: "Jacob", userIdentifier: .create())
+
+        // when
+        manager.addAndSelect(account1)
+
+        // then
+        XCTAssertEqual(manager.selectedAccount, account1)
+        XCTAssertEqual(manager.accounts, [account1])
+
+        // when
+        manager.addAndSelect(account2)
+
+        // then
+        XCTAssertEqual(manager.selectedAccount, account2)
+        XCTAssertEqual(manager.accounts, [account2, account1])
+    }
+
     func testThatItCanDeleteAnAccountManager() {
         // given
         do {


### PR DESCRIPTION
# What's in this PR?

Add convenience method to add and immediately select an account. This method internally calls `add` and `select` which means `updateAccounts` will be called twice which is unnecessary and could be optimised. However I would be very surprised if this becomes an performance issue.