### PR TITLE
Don't create fake one-to-one conversations for connected users

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -257,25 +257,12 @@ static NSString *const CreatedTeamsKey = @"createdTeams";
 
 - (ZMConversation *)oneToOneConversation
 {
-    // !!!: This is a placeholder as removing this still breaks a lot at the moment.
-
-    // TODO:
-    // There will be users which we are not connected to but which are in a team,
-    // in that case we can create or return the existing conversation.
-    // There can also be users which are in multiple teams with us,
-    // which is why we need to specify in which team the 1:1 (but internally group) conversation should be.
-
-    return [self oneToOneConversationInTeam:nil];
-}
-
-- (ZMConversation *)oneToOneConversationInTeam:(Team *)team
-{
-    if (nil == team) {
-        return self.connection.conversation;
-    } else {
+    if (self.isTeamMember) {
         return [ZMConversation fetchOrCreateTeamConversationInManagedObjectContext:self.managedObjectContext
                                                                    withParticipant:self
-                                                                              team:team];
+                                                                              team:self.team];
+    } else {
+        return self.connection.conversation;
     }
 }
 

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -241,10 +241,8 @@ public class UserClient: ZMManagedObject, UserClientType {
     private func conversation(for user: ZMUser, in context: NSManagedObjectContext) -> ZMConversation? {
         if user.isSelfUser {
             return ZMConversation.selfConversation(in: context)
-        } else if let team = user.team {
-            return user.oneToOneConversation(in: team)
         } else {
-            return user.oneToOneConversation(in: nil)
+            return user.oneToOneConversation
         }
     }
 

--- a/Source/Public/ZMUser+OneOnOne.h
+++ b/Source/Public/ZMUser+OneOnOne.h
@@ -24,7 +24,6 @@
 
 @interface ZMUser (OneOnOne)
 
-- (nullable ZMConversation *)oneToOneConversationInTeam:(nullable Team *)team;
-@property (nonatomic, nullable) ZMConversation *oneToOneConversation; // TODO: Fix this
+@property (nonatomic, nullable) ZMConversation *oneToOneConversation;
 
 @end

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -114,10 +114,7 @@ class Conversationtests_Teams: BaseTeamTests {
         oneOnOne.connection?.to = userOutsideTeam
 
         // then
-        let teamConversationWithGuest = userOutsideTeam.oneToOneConversation(in: team)
-        XCTAssertNotNil(teamConversationWithGuest)
-        XCTAssertNotEqual(teamConversationWithGuest, oneOnOne)
-        XCTAssertEqual(userOutsideTeam.oneToOneConversation(in: nil), oneOnOne)
+        XCTAssertEqual(userOutsideTeam.oneToOneConversation, oneOnOne)
     }
 
     func testThatItCreatesOneOnOneConversationInDifferentTeam() {
@@ -148,10 +145,10 @@ class Conversationtests_Teams: BaseTeamTests {
 
         // then
         XCTAssertNotNil(conversation)
-        XCTAssertNil(userOutsideTeam.oneToOneConversation(in: nil))
+        XCTAssertNil(userOutsideTeam.oneToOneConversation)
     }
 
-    func testThatItReturnsTeamConversationForOneOnOneConversation() {
+    func testThatItReturnsTeamConversationForOneOnOneConversationWithTeamMember() {
         // given
         let oneOnOne = ZMConversation.insertNewObject(in: uiMOC)
         oneOnOne.conversationType = .oneOnOne
@@ -163,8 +160,8 @@ class Conversationtests_Teams: BaseTeamTests {
         let teamOneOnOne = ZMConversation.fetchOrCreateTeamConversation(in: uiMOC, withParticipant: otherUser, team: team)
 
         // then
-        XCTAssertEqual(otherUser.oneToOneConversation(in: nil), oneOnOne)
-        XCTAssertEqual(otherUser.oneToOneConversation(in: team), teamOneOnOne)
+        XCTAssertNotEqual(otherUser.oneToOneConversation, oneOnOne)
+        XCTAssertEqual(otherUser.oneToOneConversation, teamOneOnOne)
     }
 
     func testThatItCreatesAConversationWithMultipleParticipantsInATeam() {

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1206,8 +1206,8 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     connection.to = connectedUser;
     
     // then
-    XCTAssertNil([unconnectedUser oneToOneConversationInTeam:nil]);
-    XCTAssertEqual(oneToOne, [connectedUser oneToOneConversationInTeam:nil]);
+    XCTAssertNil(unconnectedUser.oneToOneConversation);
+    XCTAssertEqual(oneToOne, connectedUser.oneToOneConversation);
 }
 
 

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -371,7 +371,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
             otherMember.team = team
             otherMember.user = otherUser
 
-            expectedConversation = otherUser.oneToOneConversation(in: team)
+            expectedConversation = otherUser.oneToOneConversation
             selfClient.trustClient(otherClient)
 
             // when


### PR DESCRIPTION
Change the logic to only create fake one-to-one conversations if a user is member of your team. Also since an account can now only have one team there's no need to pass in the team when requesting a one-to-one conversation.

https://wearezeta.atlassian.net/browse/ZIOS-8810