### PR TITLE
Fix crash during context teardown

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
@@ -36,10 +36,10 @@ extension NSManagedObjectContext {
         // We need to keep the context type information until all other values have been removed,
         // otherwise we risk running into assertions based on the context type.
         if let allKeys = userInfo.allKeys as? [String] {
+            var keys = Set(allKeys)
             keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
             userInfo.removeObjects(forKeys: Array(keys))
         }
-
         userInfo.removeAllObjects()
     }
 }

--- a/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
@@ -35,9 +35,11 @@ extension NSManagedObjectContext {
     private func tearDownUserInfo() {
         // We need to keep the context type information until all other values have been removed,
         // otherwise we risk running into assertions based on the context type.
-        var keys = Set(userInfo.allKeys as! [String])
-        keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
-        userInfo.removeObjects(forKeys: Array(keys))
+        if let allKeys = userInfo.allKeys as? [String] {
+            keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
+            userInfo.removeObjects(forKeys: Array(keys))
+        }
+
         userInfo.removeAllObjects()
     }
 }

--- a/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
@@ -24,11 +24,20 @@ extension NSManagedObjectContext {
     /// undefined behavior.
     public func tearDown() {
         self.performGroupedBlockAndWait {
-            self.userInfo.removeAllObjects()
+            self.tearDownUserInfo()
             let objects = self.registeredObjects
             objects.forEach {
                 self.refresh($0, mergeChanges: false)
             }
         }
+    }
+
+    private func tearDownUserInfo() {
+        // We need to keep the context type information until all other values have been removed,
+        // otherwise we risk running into assertions based on the context type.
+        var keys = Set(userInfo.allKeys as! [String])
+        keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
+        userInfo.removeObjects(forKeys: Array(keys))
+        userInfo.removeAllObjects()
     }
 }

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
@@ -25,6 +25,11 @@
 @class NSOperationQueue;
 @class DisplayNameGenerator;
 
+extern NSString * const IsUserInterfaceContextKey;
+extern NSString * const IsSyncContextKey;
+extern NSString * const IsSearchContextKey;
+extern NSString * const IsEventContextKey;
+
 @interface NSManagedObjectContext (zmessaging)
 
 + (NSManagedObjectModel *)loadManagedObjectModel;

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -34,12 +34,14 @@
 #import <WireUtilities/WireUtilities-Swift.h>
 #import <WireDataModel/WireDataModel-Swift.h>
 
-static NSString * const IsSyncContextKey = @"ZMIsSyncContext";
-static NSString * const IsSearchContextKey = @"ZMIsSearchContext";
+NSString * const IsSyncContextKey = @"ZMIsSyncContext";
+NSString * const IsSearchContextKey = @"ZMIsSearchContext";
+NSString * const IsUserInterfaceContextKey = @"ZMIsUserInterfaceContext";
+NSString * const IsEventContextKey = @"ZMIsEventDecoderContext";
+
 static NSString * const SyncContextKey = @"ZMSyncContext";
 static NSString * const UserInterfaceContextKey = @"ZMUserInterfaceContext";
 static NSString * const IsRefreshOfObjectsDisabled = @"ZMIsRefreshOfObjectsDisabled";
-static NSString * const IsUserInterfaceContextKey = @"ZMIsUserInterfaceContext";
 static NSString * const IsSaveDisabled = @"ZMIsSaveDisabled";
 static NSString * const IsFailingToSave = @"ZMIsFailingToSave";
 


### PR DESCRIPTION
# What's in this PR?

We were running into an assertion during the context teardown, as the information about the context type was already lost.
We now ensure this is the last information we remove from the context `userInfo`.