### PR TITLE
Do not remove context type keys at all

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+TearDown.swift
@@ -35,11 +35,9 @@ extension NSManagedObjectContext {
     private func tearDownUserInfo() {
         // We need to keep the context type information until all other values have been removed,
         // otherwise we risk running into assertions based on the context type.
-        if let allKeys = userInfo.allKeys as? [String] {
-            var keys = Set(allKeys)
-            keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
-            userInfo.removeObjects(forKeys: Array(keys))
-        }
-        userInfo.removeAllObjects()
+        guard let allKeys = userInfo.allKeys as? [String] else { return }
+        var keys = Set(allKeys)
+        keys.subtract([IsEventContextKey, IsSyncContextKey, IsUserInterfaceContextKey, IsSearchContextKey])
+        userInfo.removeObjects(forKeys: Array(keys))
     }
 }


### PR DESCRIPTION
# What's in this PR?

There were cases in which tests checked the context type after the context has been torn down. This should not happen, as no test should be running anymore and thus means some tests are not properly torn down or some asynchronous operations do not use the proper dispatch groups, but this also crashes the test suit, which is why we now keep the context type information present.