### PR TITLE
Do not consider team named groups as 1-1

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -473,7 +473,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     ZMConversationType conversationType = [self internalConversationType];
     
-    if (conversationType == ZMConversationTypeGroup && self.teamRemoteIdentifier != nil && self.otherActiveParticipants.count == 1) {
+    if (conversationType == ZMConversationTypeGroup && self.teamRemoteIdentifier != nil && self.otherActiveParticipants.count == 1 && self.userDefinedName.length == 0) {
         conversationType = ZMConversationTypeOneOnOne;
     }
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -879,6 +879,20 @@
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
 }
 
+- (void)testThatGroupConversationWithNameInTeamWithOnlyTwoParticipantsIsNotConsideredOneToOne
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.userDefinedName = @"Some conversation";
+    conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
+}
+
 - (void)testThatGroupConversationInTeamWithMoreThanTwoParticipantsIsNotConsideredOneToOne
 {
     // given


### PR DESCRIPTION
# Issue

If user creates team conversation with 2+ participants and gives it a name, then removes all but one participants, the conversation used to convert to 1-1.