### PR TITLE
Making PersistentStoreRelocator more useful

### DIFF
--- a/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
+++ b/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
@@ -39,7 +39,7 @@ extension NSPersistentStoreCoordinator {
         }
         
         if migrateIfNeeded {
-            PersistentStoreRelocator.moveLegacyStoreIfNecessary(storeFile: storeFile,
+            MainPersistentStoreRelocator.moveLegacyStoreIfNecessary(storeFile: storeFile,
                                                                 applicationContainer: applicationContainer,
                                                                 startedMigrationCallback: startedMigrationCallback)
         }

--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -49,7 +49,7 @@ import UIKit
         completionHandler: @escaping (UUID?) -> Void
         )
     {
-        guard let oldLocation = PersistentStoreRelocator.exisingLegacyStore(applicationContainer: applicationContainer) else {
+        guard let oldLocation = MainPersistentStoreRelocator.exisingLegacyStore(applicationContainer: applicationContainer) else {
             completionHandler(nil)
             return
         }


### PR DESCRIPTION
In SyncEngine we have another CoreData stack for storing events. We need to migrate it to support multi accounts, but `PersistentStoreRelocator` was made to work only for main store. This PR moves all main store specific information into `MainPersistentStoreRelocator` while making the original one simpler.