### PR TITLE
Fix using the wrong legacy database location

### DIFF
--- a/Source/ManagedObjectContext/PersistentStoreRelocator.swift
+++ b/Source/ManagedObjectContext/PersistentStoreRelocator.swift
@@ -40,10 +40,13 @@ public struct MainPersistentStoreRelocator {
     }
     
     static func possibleLegacyAccountFolders(applicationContainer: URL) -> [URL] {
-        var locations = [.cachesDirectory, .applicationSupportDirectory, .libraryDirectory].map{
+        var locations = [.cachesDirectory, .applicationSupportDirectory, .libraryDirectory].map {
             FileManager.default.urls(for: $0, in: .userDomainMask).first!
         }
-        locations.append(applicationContainer)
+
+        let sharedContainerAccountFolder = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        locations.append(sharedContainerAccountFolder)
+
         return locations
     }
     

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -33,6 +33,8 @@ import WireTesting
         super.setUp()
         self.clearStorageFolder()
         try! FileManager.default.createDirectory(at: self.applicationContainer, withIntermediateDirectories: true)
+        let legacyDatabaseDirectory = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        try! FileManager.default.createDirectory(at: legacyDatabaseDirectory, withIntermediateDirectories: true)
     }
     
     override public func tearDown() {
@@ -127,7 +129,7 @@ import WireTesting
         return [
             FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
             FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
-            self.applicationContainer
+            self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
         ]
     }
 }


### PR DESCRIPTION
# What's in this PR?

The `MainPersistentStoreRelocator ` assumed we stored the database in `{AppGroup-Directory}/store.wiredatabase` at some point, whereas the correct location is  `{AppGroup-Directory}/{Bundle-ID}/store.wiredatabase`.