### PR TITLE
Fix using wrong legacy otr directory when migrating keystore

### DIFF
--- a/Source/ManagedObjectContext/PersistentStoreRelocator.swift
+++ b/Source/ManagedObjectContext/PersistentStoreRelocator.swift
@@ -40,14 +40,18 @@ public struct MainPersistentStoreRelocator {
     }
     
     static func possibleLegacyAccountFolders(applicationContainer: URL) -> [URL] {
-        var locations = [.cachesDirectory, .applicationSupportDirectory, .libraryDirectory].map {
+        let sharedContainerAccountFolder = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        return possibleCommonLegacyDirectories() + [sharedContainerAccountFolder]
+    }
+
+    static func possibleLegacyKeystoreFolders(applicationContainer: URL) -> [URL] {
+        return possibleCommonLegacyDirectories() + [applicationContainer]
+    }
+
+    private static func possibleCommonLegacyDirectories() -> [URL] {
+        return [.cachesDirectory, .applicationSupportDirectory, .libraryDirectory].map {
             FileManager.default.urls(for: $0, in: .userDomainMask).first!
         }
-
-        let sharedContainerAccountFolder = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
-        locations.append(sharedContainerAccountFolder)
-
-        return locations
     }
     
     /// Return the first existing legacy store, if any

--- a/Source/Utilis/CryptoBox.swift
+++ b/Source/Utilis/CryptoBox.swift
@@ -148,7 +148,7 @@ open class UserClientKeysStore: NSObject {
     }
     
     static func possibleLegacyKeyStores(applicationContainer: URL) -> [URL] {
-        return MainPersistentStoreRelocator.possibleLegacyAccountFolders(applicationContainer: applicationContainer).map{
+        return MainPersistentStoreRelocator.possibleLegacyKeystoreFolders(applicationContainer: applicationContainer).map {
             $0.appendingPathComponent(FileManager.keyStoreFolderPrefix)
         }
     }

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -132,4 +132,13 @@ import WireTesting
             self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
         ]
     }
+
+    /// Previous locations where the keystore was stored
+    var previousKeyStoreLocations: [URL] {
+        return [
+            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
+            self.applicationContainer,
+        ]
+    }
 }


### PR DESCRIPTION
# What's in this PR?

Fix using wrong legacy otr directory when migrating keystore. Similar to (and also introduced by) https://github.com/wireapp/wire-ios-data-model/pull/346. We were reusing the same possible legacy directory locations as used when migrating the database, but the keystone was stored in a different folder.