### PR TITLE
Fix: notification for change is not fired in certain cases

### DIFF
--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -48,18 +48,20 @@ extension Notification.Name {
 /// Creates an object that registers an observer in NSNotificationCenter
 /// When this object is deallocated, it automatically unregisters from NSNotificationCenter
 /// To receive notifications, make sure to hold a strong reference to this object
+/// Note: We keep strong reference to the `object` because the notifications would not get delivered
+/// if no one has references to it anymore. This could happen with faulted NSManagedObject.
 public class NotificationCenterObserverToken : NSObject {
     
-    var token : AnyObject?
+    let token : AnyObject
+    let object : AnyObject?
     
     deinit {
-        if let token = token {
-            NotificationCenter.default.removeObserver(token)
-        }
+        NotificationCenter.default.removeObserver(token)
     }
     
     public init(name: NSNotification.Name, object: AnyObject? = nil, queue: OperationQueue? = nil, block: @escaping (_ note: Notification) -> Void) {
         token = NotificationCenter.default.addObserver(forName: name, object: object, queue: queue, using: block)
+        self.object = object
     }
 }
 

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -194,6 +194,34 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         UserChangeInfo.remove(observer: token, forBareUser: user)
     }
     
+    func testThatItNotifiesAboutChangeWhenObjectIsFaultedAndDissapears(){
+        // given
+        var user: ZMUser? = ZMUser.insertNewObject(in: uiMOC)
+        user?.name = "foo"
+        uiMOC.saveOrRollback()
+        let objectID = user!.objectID
+        uiMOC.refresh(user!, mergeChanges: true)
+        XCTAssertTrue(user!.isFault)
+        let observer = UserObserver()
+        let token = UserChangeInfo.add(observer: observer, for: user)
+        
+        // when
+        user = nil
+        syncMOC.performGroupedBlockAndWait {
+            let syncUser = self.syncMOC.object(with: objectID) as! ZMUser
+            syncUser.name = "bar"
+            self.syncMOC.saveOrRollback()
+        }
+        mergeLastChanges()
+        
+        // then
+        XCTAssertEqual(observer.notifications.count, 1)
+        if let note = observer.notifications.first {
+            XCTAssertTrue(note.nameChanged)
+        }
+        UserChangeInfo.remove(observer: token, forBareUser: user)
+    }
+    
     func testThatItProcessesNonCoreDataChangeNotifications(){
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -194,7 +194,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         UserChangeInfo.remove(observer: token, forBareUser: user)
     }
     
-    func testThatItNotifiesAboutChangeWhenObjectIsFaultedAndDissapears(){
+    func testThatItNotifiesAboutChangeWhenObjectIsFaultedAndDisappears(){
         // given
         var user: ZMUser? = ZMUser.insertNewObject(in: uiMOC)
         user?.name = "foo"


### PR DESCRIPTION
CoreData has a concept of “Uniquing” which prevents creation of multiple NSManagedObject instances pointing to the same underlying CoreData record, but it does not guarantee the same behavior for faulted objects. When the last reference to the faulted object dissapears CoreData is free to re-create the object again when needed. This poses a problem when used together with NotificationCenter because it captures the “sender” object weakly. If the sender gets deallocated the notification is not delivered to the subscriber.

To work around this issue we keep a strong reference to the object until the token is alive.