### PR TITLE
Use atomic write to store to avoid potential data corruption with share extension

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -98,7 +98,7 @@ extension Account {
 
     func write(to url: URL) throws {
         let data = try JSONSerialization.data(withJSONObject: jsonRepresentation())
-        try data.write(to: url)
+        try data.write(to: url, options: [.atomic])
     }
 
     static func load(from url: URL) -> Account? {


### PR DESCRIPTION
- Atomic write is OK from apple side for small documents async read / write
See section "Building Your Content in Memory and Writing It to Disk All at Once":

https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/TechniquesforReadingandWritingCustomFiles/TechniquesforReadingandWritingCustomFiles.html

