### PR TITLE
Re-organize folder structure

### DIFF
--- a/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
+++ b/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
@@ -23,6 +23,7 @@ extension NSPersistentStoreCoordinator {
     /// Creates a filesystem-based persistent store at the given url with the given model
     convenience init(
         storeFile: URL,
+        accountIdentifier: UUID?,
         applicationContainer: URL,
         model: NSManagedObjectModel,
         startedMigrationCallback: (() -> Void)?)
@@ -36,9 +37,12 @@ extension NSPersistentStoreCoordinator {
             }
         }
         
-        MainPersistentStoreRelocator.moveLegacyStoreIfNecessary(storeFile: storeFile,
-                                                                applicationContainer: applicationContainer,
-                                                                startedMigrationCallback: startedMigrationCallback)
+        if let accountIdentifier = accountIdentifier {
+            MainPersistentStoreRelocator.moveLegacyStoreIfNecessary(storeFile: storeFile,
+                                                                    accountIdentifier: accountIdentifier,
+                                                                    applicationContainer: applicationContainer,
+                                                                    startedMigrationCallback: startedMigrationCallback)
+        }
         
         let containingFolder = storeFile.deletingLastPathComponent()
         FileManager.default.createAndProtectDirectory(at: containingFolder)

--- a/Source/ManagedObjectContext/PersistentStorageInitialization.swift
+++ b/Source/ManagedObjectContext/PersistentStorageInitialization.swift
@@ -33,6 +33,7 @@ extension NSPersistentStoreCoordinator {
             let model = NSManagedObjectModel.loadModel()
             completionHandler(NSPersistentStoreCoordinator(
                 storeFile: storeFile,
+                accountIdentifier: nil,
                 applicationContainer: applicationContainer,
                 model: model,
                 startedMigrationCallback: nil
@@ -44,6 +45,7 @@ extension NSPersistentStoreCoordinator {
     /// the legacy store and keystore if they exist. The callback will be invoked on an arbitrary queue.
     static func createAndMigrate(
         storeFile: URL,
+        accountIdentifier: UUID,
         accountDirectory: URL,
         applicationContainer: URL,
         startedMigrationCallback: (() -> Void)?,
@@ -52,10 +54,11 @@ extension NSPersistentStoreCoordinator {
         
         PersistentStorageInitialization.executeWhenFileIsAccessible(storeFile) {
             let model = NSManagedObjectModel.loadModel()
-            UserClientKeysStore.migrateIfNeeded(accountDirectory: accountDirectory, applicationContainer: applicationContainer)
+            UserClientKeysStore.migrateIfNeeded(accountIdentifier: accountIdentifier, accountDirectory: accountDirectory, applicationContainer: applicationContainer)
             
             completionHandler(NSPersistentStoreCoordinator(
                 storeFile: storeFile,
+                accountIdentifier: accountIdentifier,
                 applicationContainer: applicationContainer,
                 model: model,
                 startedMigrationCallback: startedMigrationCallback

--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -183,7 +183,7 @@ import UIKit
 public extension StorageStack {
     
     /// Returns the URL that holds the data for the given account
-    /// It will be in the format <application container>/<bundle ID>/<account identifier>
+    /// It will be in the format <application container>/AccountData/<account identifier>
     @objc public static func accountFolder(accountIdentifier: UUID, applicationContainer: URL) -> URL {
         return applicationContainer
             .appendingPathComponent(StorageStack.accountDataFolder)

--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -23,6 +23,9 @@ import UIKit
 /// Singleton to manage the creation of the CoreData stack
 @objc public class StorageStack: NSObject {
     
+    /// Root folder for account specific data
+    fileprivate static let accountDataFolder = "AccountData"
+    
     /// In-memory stores. These are mainly used for testing
     private var inMemoryStores: [String: ManagedObjectContextDirectory] = [:]
     
@@ -55,7 +58,7 @@ import UIKit
         completionHandler: @escaping (UUID?) -> Void
         )
     {
-        guard let oldLocation = MainPersistentStoreRelocator.exisingLegacyStore(applicationContainer: applicationContainer) else {
+        guard let oldLocation = MainPersistentStoreRelocator.exisingLegacyStore(applicationContainer: applicationContainer, accountIdentifier: nil) else {
             completionHandler(nil)
             return
         }
@@ -110,6 +113,7 @@ import UIKit
             let storeFile = accountDirectory.appendingPersistentStoreLocation()
             isolationQueue.async {
                 self.createOnDiskStack(
+                    accountIdentifier: accountIdentifier,
                     accountDirectory: accountDirectory,
                     storeFile: storeFile,
                     applicationContainer: applicationContainer,
@@ -134,7 +138,7 @@ import UIKit
         guard !self.createStorageAsInMemory else { return false }
         let accountDirectory = StorageStack.accountFolder(accountIdentifier: accountIdentifier, applicationContainer: applicationContainer)
         let storeFile = accountDirectory.appendingPersistentStoreLocation()
-        if MainPersistentStoreRelocator.needsToMoveLegacyStore(storeFile: storeFile, applicationContainer: applicationContainer) {
+        if MainPersistentStoreRelocator.needsToMoveLegacyStore(storeFile: storeFile, accountIdentifier: accountIdentifier, applicationContainer: applicationContainer) {
             return true
         }
         let model = NSManagedObjectModel.loadModel()
@@ -143,6 +147,7 @@ import UIKit
 
     /// Creates a managed object context directory on disk
     func createOnDiskStack(
+        accountIdentifier: UUID,
         accountDirectory: URL,
         storeFile: URL,
         applicationContainer: URL,
@@ -153,6 +158,7 @@ import UIKit
     {
         NSPersistentStoreCoordinator.createAndMigrate(
             storeFile: storeFile,
+            accountIdentifier: accountIdentifier,
             accountDirectory: accountDirectory,
             applicationContainer: applicationContainer,
             startedMigrationCallback: startedMigrationCallback)
@@ -179,13 +185,8 @@ public extension StorageStack {
     /// Returns the URL that holds the data for the given account
     /// It will be in the format <application container>/<bundle ID>/<account identifier>
     @objc public static func accountFolder(accountIdentifier: UUID, applicationContainer: URL) -> URL {
-        
-        guard let bundleId = Bundle.main.bundleIdentifier ?? Bundle(for: ZMUser.self).bundleIdentifier else {
-            fatal("No bundle??")
-        }
-        
         return applicationContainer
-            .appendingPathComponent(bundleId)
+            .appendingPathComponent(StorageStack.accountDataFolder)
             .appendingPathComponent(accountIdentifier.uuidString)
     }
 }

--- a/Source/Model/Conversation/SharedObjectStore.swift
+++ b/Source/Model/Conversation/SharedObjectStore.swift
@@ -41,8 +41,8 @@ fileprivate extension Notification {
 
     private let objectStore: SharedObjectStore<[AnyHashable: AnyObject]>
 
-    public required init(sharedContainerURL url: URL) {
-        objectStore = SharedObjectStore(sharedContainerURL: url, fileName: "ContextDidChangeNotifications")
+    public required init(accountContainer url: URL) {
+        objectStore = SharedObjectStore(accountContainer: url, fileName: "ContextDidChangeNotifications")
     }
 
     @discardableResult public func add(_ note: Notification) -> Bool {
@@ -91,8 +91,8 @@ fileprivate extension Notification {
 @objc public class ShareExtensionAnalyticsPersistence: NSObject {
     private let objectStore: SharedObjectStore<[String: Any]>
 
-    public required init(sharedContainerURL url: URL) {
-        objectStore = SharedObjectStore(sharedContainerURL: url, fileName: "ShareExtensionAnalytics")
+    public required init(accountContainer url: URL) {
+        objectStore = SharedObjectStore(accountContainer: url, fileName: "ShareExtensionAnalytics")
     }
 
     @discardableResult public func add(_ storableEvent: StorableTrackingEvent) -> Bool {
@@ -126,10 +126,10 @@ public class SharedObjectStore<T>: NSObject, NSKeyedUnarchiverDelegate {
     private let directory: URL
     private let url: URL
     private let fileManager = FileManager.default
-    private let directoryName = "SharedObjectStore"
+    private let directoryName = "sharedObjectStore"
 
-    public required init(sharedContainerURL: URL, fileName: String) {
-        self.directory = sharedContainerURL.appendingPathComponent(directoryName)
+    public required init(accountContainer: URL, fileName: String) {
+        self.directory = accountContainer.appendingPathComponent(directoryName)
         self.url = directory.appendingPathComponent(fileName)
         super.init()
         FileManager.default.createAndProtectDirectory(at:directory)

--- a/Source/Utilis/CryptoBox.swift
+++ b/Source/Utilis/CryptoBox.swift
@@ -105,7 +105,7 @@ open class UserClientKeysStore: NSObject {
     
     /// Moves the key store if needed from all possible legacy locations to the keystore
     /// directory within the given account directory.
-    public static func migrateIfNeeded(accountDirectory: URL, applicationContainer: URL) {
+    public static func migrateIfNeeded(accountIdentifier: UUID, accountDirectory: URL, applicationContainer: URL) {
         let directory = FileManager.keyStoreURL(accountDirectory: accountDirectory, createParentIfNeeded: true)
         let fm = FileManager.default
         fm.createAndProtectDirectory(at: directory.deletingLastPathComponent())
@@ -113,7 +113,7 @@ open class UserClientKeysStore: NSObject {
         /// migrate old directories if needed
         var didMigrate = false
         
-        possibleLegacyKeyStores(applicationContainer: applicationContainer).forEach {
+        possibleLegacyKeyStores(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier).forEach {
             guard directory != $0, fm.fileExists(atPath: $0.path) else { return }
             if !didMigrate {
                 do {
@@ -143,18 +143,18 @@ open class UserClientKeysStore: NSObject {
     }
     
     /// Whether we need to migrate to a new identity (legacy e2ee transition phase)
-    open static func needToMigrateIdentity(applicationContainer: URL) -> Bool {
-        return getFirstExistingLegacyKeyStore(applicationContainer: applicationContainer) != nil
+    open static func needToMigrateIdentity(applicationContainer: URL, accountIdentifier: UUID) -> Bool {
+        return getFirstExistingLegacyKeyStore(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier) != nil
     }
     
-    static func possibleLegacyKeyStores(applicationContainer: URL) -> [URL] {
-        return MainPersistentStoreRelocator.possibleLegacyKeystoreFolders(applicationContainer: applicationContainer).map {
+    static func possibleLegacyKeyStores(applicationContainer: URL, accountIdentifier : UUID) -> [URL] {
+        return MainPersistentStoreRelocator.possibleLegacyKeystoreFolders(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier).map {
             $0.appendingPathComponent(FileManager.keyStoreFolderPrefix)
         }
     }
     
-    private static func getFirstExistingLegacyKeyStore(applicationContainer: URL) -> URL? {
-        return possibleLegacyKeyStores(applicationContainer: applicationContainer).first{
+    private static func getFirstExistingLegacyKeyStore(applicationContainer: URL, accountIdentifier: UUID) -> URL? {
+        return possibleLegacyKeyStores(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier).first{
             FileManager.default.fileExists(atPath: $0.path)
         }
     }

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -22,6 +22,8 @@ import WireTesting
 
 @objc public class DatabaseBaseTest: ZMTBaseTest {
     
+    var accountID : UUID = UUID.create()
+    
     public var applicationContainer: URL {
         return FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
@@ -73,14 +75,41 @@ import WireTesting
     /// Create storage stack at a legacy location
     @objc public func createLegacyStore(filePath: URL, customization: ((ManagedObjectContextDirectory)->())? = nil) {
         
-        StorageStack.shared.createOnDiskStack(
-            accountDirectory: filePath.deletingLastPathComponent(),
+//        StorageStack.shared.createOnDiskStack(
+//            accountDirectory: filePath.deletingLastPathComponent(),
+//            storeFile: filePath,
+//            applicationContainer: self.applicationContainer,
+//            migrateIfNeeded: false,
+//            completionHandler: { mocs in
+//                customization?(mocs)
+//        })
+        
+        NSPersistentStoreCoordinator.create(
             storeFile: filePath,
-            applicationContainer: self.applicationContainer,
-            migrateIfNeeded: false,
-            completionHandler: { mocs in
-                customization?(mocs)
-        })
+            applicationContainer: applicationContainer)
+        { (psc) in
+            let directory = ManagedObjectContextDirectory(
+                persistentStoreCoordinator: psc,
+                accountDirectory: filePath.deletingLastPathComponent(),
+                applicationContainer: self.applicationContainer)
+            MemoryReferenceDebugger.register(directory)
+            customization?(directory)
+        }
+        
+//        NSPersistentStoreCoordinator.createAndMigrate(
+//            storeFile: storeFile,
+//            accountIdentifier: accountIdentifier,
+//            accountDirectory: accountDirectory,
+//            applicationContainer: applicationContainer,
+//            startedMigrationCallback: startedMigrationCallback)
+//        { psc in
+//            let directory = ManagedObjectContextDirectory(
+//                persistentStoreCoordinator: psc,
+//                accountDirectory: accountDirectory,
+//                applicationContainer: applicationContainer)
+//            MemoryReferenceDebugger.register(directory)
+//            completionHandler(directory)
+//        }
         
         StorageStack.reset()
         self.createDummyExternalSupportFileForDatabase(storeFile: filePath)
@@ -137,8 +166,13 @@ import WireTesting
         return [
             FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
             FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
-            self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+            self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!),
+            self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!).appendingPathComponent(accountID.transportString()).appendingPathComponent("store")
         ]
+    }
+    
+    var previousDatabaseLocationsBeforeMultiAccountSupport: ArraySlice<URL> {
+        return previousDatabaseLocations.prefix(3)
     }
 
     /// Previous locations where the keystore was stored
@@ -147,6 +181,7 @@ import WireTesting
             FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
             FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
             self.applicationContainer,
+            self.applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!).appendingPathComponent(accountID.transportString())
         ]
     }
 }

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -75,15 +75,6 @@ import WireTesting
     /// Create storage stack at a legacy location
     @objc public func createLegacyStore(filePath: URL, customization: ((ManagedObjectContextDirectory)->())? = nil) {
         
-//        StorageStack.shared.createOnDiskStack(
-//            accountDirectory: filePath.deletingLastPathComponent(),
-//            storeFile: filePath,
-//            applicationContainer: self.applicationContainer,
-//            migrateIfNeeded: false,
-//            completionHandler: { mocs in
-//                customization?(mocs)
-//        })
-        
         NSPersistentStoreCoordinator.create(
             storeFile: filePath,
             applicationContainer: applicationContainer)
@@ -95,21 +86,6 @@ import WireTesting
             MemoryReferenceDebugger.register(directory)
             customization?(directory)
         }
-        
-//        NSPersistentStoreCoordinator.createAndMigrate(
-//            storeFile: storeFile,
-//            accountIdentifier: accountIdentifier,
-//            accountDirectory: accountDirectory,
-//            applicationContainer: applicationContainer,
-//            startedMigrationCallback: startedMigrationCallback)
-//        { psc in
-//            let directory = ManagedObjectContextDirectory(
-//                persistentStoreCoordinator: psc,
-//                accountDirectory: accountDirectory,
-//                applicationContainer: applicationContainer)
-//            MemoryReferenceDebugger.register(directory)
-//            completionHandler(directory)
-//        }
         
         StorageStack.reset()
         self.createDummyExternalSupportFileForDatabase(storeFile: filePath)

--- a/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
+++ b/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
@@ -40,7 +40,7 @@ class ContextDidSaveNotificationPersistenceTests: BaseZMMessageTests {
     override func setUp() {
         super.setUp()
         let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        sut = ContextDidSaveNotificationPersistence(sharedContainerURL: url)
+        sut = ContextDidSaveNotificationPersistence(accountContainer: url)
     }
 
     override func tearDown() {
@@ -133,7 +133,7 @@ class ShareExtensionAnalyticsPersistenceTests: BaseZMMessageTests {
     override func setUp() {
         super.setUp()
         let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        sut = ShareExtensionAnalyticsPersistence(sharedContainerURL: url)
+        sut = ShareExtensionAnalyticsPersistence(accountContainer: url)
     }
 
     override func tearDown() {
@@ -190,7 +190,7 @@ class ShareObjectStoreTests: ZMTBaseTest {
     
     func createStore() -> SharedObjectStore<WireDataModel.SharedObjectTestClass> {
         let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        return SharedObjectStore(sharedContainerURL: url, fileName: "store")
+        return SharedObjectStore(accountContainer: url, fileName: "store")
     }
     
     func testThatItCanDecodeClassSavedBeforeProjectRename() {

--- a/Tests/Source/Model/Messages/OtrBaseTest.swift
+++ b/Tests/Source/Model/Messages/OtrBaseTest.swift
@@ -43,4 +43,8 @@ class OtrBaseTest: XCTestCase {
         return FileManager.keyStoreURL(accountDirectory: self.sharedContainerURL, createParentIfNeeded: true)
     }
     
+    static func legacyAccountOtrDirectory(accountIdentifier: UUID) -> URL {
+        return FileManager.keyStoreURL(accountDirectory: self.sharedContainerURL.appendingPathComponent(accountIdentifier.transportString()), createParentIfNeeded: true)
+    }
+    
 }

--- a/Tests/Source/Model/UserClient/UserClientKeyStoreTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientKeyStoreTests.swift
@@ -30,9 +30,9 @@ class UserClientKeysStoreTests: OtrBaseTest {
     
     override func setUp() {
         super.setUp()
-        self.cleanOTRFolder()
         self.accountID = UUID()
         self.accountFolder = StorageStack.accountFolder(accountIdentifier: accountID, applicationContainer: OtrBaseTest.sharedContainerURL)
+        self.cleanOTRFolder()
         self.sut = UserClientKeysStore(accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
     }
     
@@ -46,7 +46,7 @@ class UserClientKeysStoreTests: OtrBaseTest {
     
     func cleanOTRFolder() {
         let fm = FileManager.default
-        var paths = UserClientKeysStore.possibleLegacyKeyStores(applicationContainer: OtrBaseTest.sharedContainerURL).map{$0.path}
+        var paths = UserClientKeysStore.possibleLegacyKeyStores(applicationContainer: OtrBaseTest.sharedContainerURL, accountIdentifier: accountID).map{$0.path}
         if let accountID = accountID {
             paths.append(OtrBaseTest.otrDirectoryURL(accountIdentifier: accountID).path)
         }
@@ -123,8 +123,7 @@ class UserClientKeysStoreTests: OtrBaseTest {
         
     }
     
-    fileprivate func createLegacyOTRFolderWithDummyFile(fileName: String, data: Data) -> URL {
-        let folder = OtrBaseTest.legacyOtrDirectory
+    fileprivate func createLegacyOTRFolderWithDummyFile(fileName: String, data: Data, folder: URL = OtrBaseTest.legacyOtrDirectory) -> URL {
         try! FileManager.default.createDirectory(atPath: folder.path, withIntermediateDirectories: true, attributes: [:])
         try! data.write(to: folder.appendingPathComponent(fileName))
         return folder
@@ -132,23 +131,26 @@ class UserClientKeysStoreTests: OtrBaseTest {
 
     func testThatItMovesTheOTRFolderToTheGivenURL() {
         
-        // given
-        self.sut = nil
-        self.cleanOTRFolder()
-        let accountFolder = StorageStack.accountFolder(accountIdentifier: self.accountID, applicationContainer: OtrBaseTest.sharedContainerURL)
-        let data = "foo".data(using: String.Encoding.utf8)!
-        _ = self.createLegacyOTRFolderWithDummyFile(fileName: "dummy.txt", data: data)
+        let possibleLegacyKeyStores = UserClientKeysStore.possibleLegacyKeyStores(applicationContainer: OtrBaseTest.sharedContainerURL, accountIdentifier: accountID)
         
-        // when
-        UserClientKeysStore.migrateIfNeeded(accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
-        
-        // then
-        let expectedFileURL = FileManager.keyStoreURL(accountDirectory: accountFolder, createParentIfNeeded: false).appendingPathComponent("dummy.txt")
-        let fooData = try! Data(contentsOf: expectedFileURL)
-        let fooString = String(data: fooData, encoding: String.Encoding.utf8)!
-        XCTAssertEqual(fooString, "foo")
-        XCTAssertFalse(UserClientKeysStore.needToMigrateIdentity(applicationContainer: OtrBaseTest.sharedContainerURL))
-
+        for legacyKeyStoreLocation in possibleLegacyKeyStores {
+            // given
+            self.sut = nil
+            self.cleanOTRFolder()
+            let accountFolder = StorageStack.accountFolder(accountIdentifier: self.accountID, applicationContainer: OtrBaseTest.sharedContainerURL)
+            let data = "foo".data(using: String.Encoding.utf8)!
+            _ = self.createLegacyOTRFolderWithDummyFile(fileName: "dummy.txt", data: data, folder: legacyKeyStoreLocation)
+            
+            // when
+            UserClientKeysStore.migrateIfNeeded(accountIdentifier: accountID, accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
+            
+            // then
+            let expectedFileURL = FileManager.keyStoreURL(accountDirectory: accountFolder, createParentIfNeeded: false).appendingPathComponent("dummy.txt")
+            let fooData = try! Data(contentsOf: expectedFileURL)
+            let fooString = String(data: fooData, encoding: String.Encoding.utf8)!
+            XCTAssertEqual(fooString, "foo")
+            XCTAssertFalse(UserClientKeysStore.needToMigrateIdentity(applicationContainer: OtrBaseTest.sharedContainerURL, accountIdentifier: accountID))
+        }
     }
     
     func testThatItMovesTheOTRFolderAgainIfTheFirstMigrationFailed() {
@@ -165,19 +167,19 @@ class UserClientKeysStoreTests: OtrBaseTest {
         
         // first migration
         _ = self.createLegacyOTRFolderWithDummyFile(fileName: "whatever.dat", data: data)
-        UserClientKeysStore.migrateIfNeeded(accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
+        UserClientKeysStore.migrateIfNeeded(accountIdentifier: accountID, accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
         
         // to pretend it's not done, re-create the folder
         _ = self.createLegacyOTRFolderWithDummyFile(fileName: fileName, data: data)
         
         // when
-        UserClientKeysStore.migrateIfNeeded(accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
+        UserClientKeysStore.migrateIfNeeded(accountIdentifier: accountID, accountDirectory: accountFolder, applicationContainer: OtrBaseTest.sharedContainerURL)
         
         // then
         let fooData = try! Data(contentsOf: OtrBaseTest.otrDirectoryURL(accountIdentifier: accountID).appendingPathComponent(fileName))
         let fooString = String(data: fooData, encoding: String.Encoding.utf8)!
         XCTAssertEqual(fooString, "foo")
-        XCTAssertFalse(UserClientKeysStore.needToMigrateIdentity(applicationContainer: OtrBaseTest.sharedContainerURL))
+        XCTAssertFalse(UserClientKeysStore.needToMigrateIdentity(applicationContainer: OtrBaseTest.sharedContainerURL, accountIdentifier: accountID))
         
     }
 }


### PR DESCRIPTION
### Why the change
The various data we persist for an account is scattered in different folders so
we decided we need clean it up and put everything inside one folder per account.

### New folder structure
We store our data in a shared container. A shared container has the same structure
as the main bundle container. We want keep all the account related data in a folder
named by the account-id (UUID) so that it's easy to delete.

```
Accounts/
    <UUID>                    -- JSON file storing basic account information
    ...

AccountData/
    <UUID>/
        otr/                  -- folder containing cryptobox sessions
        store/                -- persistence store for messages etc.
        events/               -- persistence store for unprocessed events
        drafts/               -- persistence store for message drafts
        sharedObjectStore     -- booking keeping to sync changes between share extension and main app
    ...

Library/Caches/
    wire-account-<UUID>/
        <PIN cache folders>   -- store images and other data we can download on demand.
```

### What changed
We need migrate the `store` and `otr` folder. Since we don't want break users upgrading from the internal version we also need to support migration for users with the new multi account folder structure.