### PR TITLE
store unread conversation account

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -19,6 +19,9 @@
 
 import Foundation
 
+extension Notification.Name {
+    public static let AccountUnreadCountDidChangeNotification = Notification.Name("AccountUnreadCountDidChangeNotification")
+}
 
 /// An `Account` holds information related to a single account,
 /// such as the accounts users name,
@@ -29,6 +32,12 @@ public final class Account: NSObject {
     public var teamName: String?
     public let userIdentifier: UUID
     public var imageData: Data?
+    
+    public var unreadConversationCount: Int = 0 {
+        didSet {
+            NotificationCenter.default.post(name: .AccountUnreadCountDidChangeNotification, object: self)
+        }
+    }
 
     public required init(userName: String, userIdentifier: UUID, teamName: String? = nil, imageData: Data? = nil) {
         self.userName = userName
@@ -36,6 +45,17 @@ public final class Account: NSObject {
         self.teamName = teamName
         self.imageData = imageData
         super.init()
+    }
+    
+    /// Updates the properties of the receiver with the given account. Use this method
+    /// when you wish to update an exisiting account object with newly fetched properties
+    /// from the account store.
+    ///
+    public func updateWith(_ account: Account) {
+        guard self.userIdentifier == account.userIdentifier else { return }
+        self.userName = account.userName
+        self.teamName = account.teamName
+        self.imageData = account.imageData
     }
 
     public override func isEqual(_ object: Any?) -> Bool {

--- a/Tests/Source/Model/AccountManagerTests.swift
+++ b/Tests/Source/Model/AccountManagerTests.swift
@@ -163,6 +163,24 @@ final class AccountManagerTests: ZMConversationTestsBase {
         XCTAssertNil(manager.selectedAccount)
         XCTAssertEqual(manager.accounts, [])
     }
+    
+    func testThatItUpdatesExisitingAccountPropertiesFromStore() {
+        // given
+        let manager = AccountManager(sharedDirectory: url)
+        let accountID = UUID.create()
+        manager.addAndSelect(Account(userName: "Jacob", userIdentifier: accountID))
+        let account = manager.selectedAccount!
+        
+        // when
+        let updatedAccount = Account(userName: "Vytis", userIdentifier: accountID, teamName: "Wire")
+        manager.addAndSelect(updatedAccount)
+        
+        // then
+        XCTAssertTrue(manager.selectedAccount === account)
+        XCTAssertEqual(account.userIdentifier, accountID)
+        XCTAssertEqual(account.userName, "Vytis")
+        XCTAssertEqual(account.teamName, "Wire")
+    }
 
     func testThatItSortsAccountsWithoutTeamBeforeAccountsWithTeam() {
         // given


### PR DESCRIPTION
## What's in this PR?
- We want to store the unread conversations count per account and fire a notification when this value changes, so that the UI can respond.

- Each time the `AccountManager` updates the accounts, new `Account` objects were being instantiated and stored in the `accounts` array. That means that the address of the account objects were changing, even if the accounts remained unchanged semantically. This create problems when sending and receiving notifications tied to a specific object. Consequently, we **should not** recreate new `Account` objects to replace the existing corresponding objects in the `accounts` array, but rather update the properties of these existing account objects. As a result, any loaded account will always maintain the same address.