### PR TITLE
add option to fetch link preview when editing message

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -68,11 +68,19 @@ extension ZMMessage {
     }
     
     public static func edit(_ message: ZMConversationMessage, newText: String) -> ZMMessage? {
+        return edit(message, newText: newText, fetchLinkPreview: true)
+    }
+    
+    public static func edit(_ message: ZMConversationMessage, newText: String, fetchLinkPreview: Bool) -> ZMMessage? {
         guard let castedMessage = message as? ZMMessage else { return nil }
-        return castedMessage.edit(newText)
+        return castedMessage.edit(newText, fetchLinkPreview: fetchLinkPreview)
     }
     
     func edit(_ newText: String) -> ZMMessage? {
+        return edit(newText, fetchLinkPreview: true)
+    }
+    
+    func edit(_ newText: String, fetchLinkPreview: Bool) -> ZMMessage? {
         guard isEditableMessage else { return nil }
         guard !isZombieObject, let sender = sender , sender.isSelfUser else { return nil }
         guard let conversation = conversation else { return nil }
@@ -90,7 +98,7 @@ extension ZMMessage {
         hiddenInConversation = conversation
         visibleInConversation = nil
         normalizedText = nil
-        newMessage.linkPreviewState = .waitingToBeProcessed
+        newMessage.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
         return newMessage
     }
     

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -158,6 +158,29 @@
     XCTAssertEqual(newMessage.linkPreviewState, ZMLinkPreviewStateWaitingToBeProcessed);
 }
 
+- (void)testThatItDoesNotFetchLinkPreviewIfExplicitlyToldNotTo
+{
+    // given
+    NSString *oldText = @"Hallo";
+    NSString *newText = @"Hello";
+    
+    BOOL fetchLinkPreview = NO;
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+    ZMClientMessage *message = (ZMClientMessage *)[conversation appendMessageWithText:oldText fetchLinkPreview:fetchLinkPreview];
+    message.serverTimestamp = [NSDate dateWithTimeIntervalSinceNow:-20];
+    [message markAsSent];
+    
+    XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateDone);
+    
+    // when
+    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText fetchLinkPreview:fetchLinkPreview];
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // then
+    XCTAssertEqual(newMessage.linkPreviewState, ZMLinkPreviewStateDone);
+}
+
 - (void)testThatItDoesNotEditAMessageThatFailedToSend
 {
     // given


### PR DESCRIPTION
## Issue
Adding a link when editing a message will always create a link preview, even if the settings disable them

## Solution
Adding the option to fetch link previews when editing a `ZMMessage`.