### PR TITLE
obfuscate with seeded random generator

### DIFF
--- a/Source/Utilis/Protos/ZMGenericMessage+Obfuscation.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Obfuscation.swift
@@ -24,11 +24,12 @@ extension String {
     static func randomChar() -> UnicodeScalar {
         let string = "abcdefghijklmnopqrstuvxyz"
         let chars = Array(string.unicodeScalars)
-        let random = Int(arc4random_uniform(UInt32(chars.count)))
+        let random = Int((drand48() * 100)) % chars.count
         return chars[random]
     }
     
     func obfuscated() -> String {
+        srand48(self.hashValue)
         var obfuscatedVersion = UnicodeScalarView()
         for char in self.unicodeScalars {
             if NSCharacterSet.whitespacesAndNewlines.contains(char) {


### PR DESCRIPTION
By using the string’s hash value as the seed, this string will always generate the same obfuscated value.

As a result, when this obfuscated string is shown in the redacted type font, it will always appear the same, which finally allows us to include ephemeral messages using the redacted type font in snapshot tests.