### PR TITLE
Conversation Display Name

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -491,6 +491,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"NSManagedObjectContext";
 {
     [self performBlockAndWait:^{
         self.userInfo[IsSyncContextKey] = @YES;
+        self.userInfo[DisplayNameGeneratorKey] = [[DisplayNameGenerator alloc] initWithManagedObjectContext:self];
     }];
 }
 

--- a/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
+++ b/Tests/Source/Model/User/DisplayNameGeneratorTests.swift
@@ -358,5 +358,66 @@ extension DisplayNameGeneratorTests {
         }
     }
     
+    func testThatItGeneratesAMeaningfulConversationDisplayName() {
+        // given
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        selfUser.name = "Biff Tannen"
+        
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        user1.name = "Emmett Brown"
+        user2.name = "Marty McFly"
+        
+        let groupConversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [user1, user2])!
+        groupConversation.userDefinedName = "Future Stuff"
+       
+        let groupConversationNoName = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [user1, user2])!
+        
+        let oneOnOneConversation = ZMConversation.insertNewObject(in: uiMOC)
+        oneOnOneConversation.conversationType = .oneOnOne
+        oneOnOneConversation.connection = ZMConnection.insertNewObject(in: uiMOC)
+        oneOnOneConversation.connection?.to = user1
+        
+        let connectionConversation = ZMConversation.insertNewObject(in: uiMOC)
+        connectionConversation.conversationType = .connection
+        connectionConversation.connection = ZMConnection.insertNewObject(in: uiMOC)
+        connectionConversation.connection?.to = user2
+        
+        let selfConversation = ZMConversation.insertNewObject(in: uiMOC)
+        selfConversation.conversationType = .self
+        
+        // then
+        XCTAssertEqual(groupConversation.meaningfulDisplayName, "Future Stuff")
+        XCTAssertEqual(groupConversationNoName.meaningfulDisplayName, "Emmett, Marty")
+        XCTAssertEqual(oneOnOneConversation.meaningfulDisplayName, "Emmett Brown")
+        XCTAssertEqual(connectionConversation.meaningfulDisplayName, "Marty McFly")
+        XCTAssertEqual(selfConversation.meaningfulDisplayName, "Biff Tannen")
+    }
     
+    func testThatItReturnsNilIfNoMeaningfulConversationDisplayNameAvailable() {
+        // given
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        
+        let groupConversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [user1, user2])!
+        
+        let oneOnOneConversation = ZMConversation.insertNewObject(in: uiMOC)
+        oneOnOneConversation.conversationType = .oneOnOne
+        
+        let connectionConversation = ZMConversation.insertNewObject(in: uiMOC)
+        connectionConversation.conversationType = .connection
+        
+        let selfConversation = ZMConversation.insertNewObject(in: uiMOC)
+        selfConversation.conversationType = .self
+        
+        let invalidConversation = ZMConversation.insertNewObject(in: uiMOC)
+        invalidConversation.conversationType = .invalid
+        
+        // then
+        XCTAssertNil(groupConversation.meaningfulDisplayName)
+        XCTAssertNil(oneOnOneConversation.meaningfulDisplayName)
+        XCTAssertNil(connectionConversation.meaningfulDisplayName)
+        XCTAssertNil(selfConversation.meaningfulDisplayName)
+        XCTAssertNil(invalidConversation.meaningfulDisplayName)
+    }
 }


### PR DESCRIPTION
# What's in this PR?

### DisplayNameGenerator
Allow the `DisplayNameGenerator` to be used on the sync context. This is used when building local notifications in Sync Engine.
 
### Meaningful Display Name
Provide a way to query for a *meaningful* display name. Previously, we would first try to construct a conversation display name by using only existing data. In the case that still no name could be generated (due to missing information), a fallback placeholder name is return, such as "..." or "Empty group conversation". When configuring the title text for a local notification, we would rather not show a title if there is no meaningful name, rather than one of these placeholders. Now it is possible to know if a meaningful name exists.

Note, the conversation's `displayName` simply returns the `meaningfulDisplayName` if it exists, otherwise it falls back to the placeholder name.