### PR TITLE
Normalize database by removing duplicates

### DIFF
--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -38,8 +38,8 @@ extern NSString * __nonnull const UserClientsKey;
 
 @property (nonnull, nonatomic) NSOrderedSet *activeConversations;
 
-@property (nonnull, nonatomic) NSOrderedSet *showingUserAdded;
-@property (nonnull, nonatomic) NSOrderedSet *showingUserRemoved;
+@property (nonnull, nonatomic) NSSet *showingUserAdded;
+@property (nonnull, nonatomic) NSSet *showingUserRemoved;
 
 @property (nonnull, nonatomic) NSSet<Team *> *createdTeams;
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -180,7 +180,6 @@ static NSString *const CreatedTeamsKey = @"createdTeams";
 @dynamic clients;
 @dynamic handle;
 @dynamic addressBookEntry;
-@dynamic membership;
 
 - (UserClient *)selfClient
 {

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -193,6 +193,20 @@ extension ZMUser {
     @NSManaged public var previewProfileAssetIdentifier: String?
     @NSManaged public var completeProfileAssetIdentifier: String?
     
+    /// Conversation in which the user is active, according to the server
+    @NSManaged var lastServerSyncedActiveConversations: NSOrderedSet
+    
+    /// Conversations created by this user
+    @NSManaged var conversationsCreated: Set<ZMConversation>
+    
+    /// Team membership for this user
+    @NSManaged internal(set) var membership: Member?
+
+    /// Reactions expressed by this user
+    @NSManaged var reactions: Set<Reaction>
+    
+    /// System messages referencing this user
+    @NSManaged var systemMessages: Set<ZMSystemMessage>
     
     @objc(setImageData:size:)
     public func setImage(data: Data?, size: ProfileImageSize) {

--- a/Source/Public/ZMUser.h
+++ b/Source/Public/ZMUser.h
@@ -36,9 +36,6 @@ extern NSString *const ZMPersistedClientIdKey;
 @property (nonatomic, readonly) NSString *phoneNumber;
 @property (nonatomic) AddressBookEntry *addressBookEntry;
 
-@property (nonatomic, readonly) Member *membership;
-
-///
 @property (nonatomic, readonly) NSSet<UserClient *> *clients;
 
 /// New self clients which the self user hasn't been informed about (only valid for the self user)

--- a/Source/Utilis/DuplicatedEntityRemoval.swift
+++ b/Source/Utilis/DuplicatedEntityRemoval.swift
@@ -1,0 +1,178 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct DuplicatedEntityRemoval {
+    
+    static func removeDuplicated(in moc: NSManagedObjectContext) {
+        // will skip this during test unless on disk
+        guard moc.persistentStoreCoordinator!.persistentStores.first!.type != NSInMemoryStoreType else { return }
+        self.deleteDuplicatedClients(in: moc)
+        moc.saveOrRollback()
+        self.deleteDuplicatedUsers(in: moc)
+        moc.saveOrRollback()
+        self.deleteDuplicatedConversations(in: moc)
+        moc.saveOrRollback()
+    }
+    
+    static func deleteDuplicatedClients(in context: NSManagedObjectContext) {
+        // Fetch clients having the same remote identifiers
+        context.findDuplicated(by: #keyPath(UserClient.remoteIdentifier)).forEach { (remoteId: String?, clients: [UserClient]) in
+            // Group clients having the same remote identifiers by user
+            clients.filter { !($0.user?.isSelfUser ?? true) }.group(by: ZMUserClientUserKey).forEach { (user: ZMUser, clients: [UserClient]) in
+                guard let firstClient = clients.first, clients.count > 1 else {
+                    return
+                }
+                
+                let tail = clients.dropFirst()
+                // Merge clients having the same remote identifier and same user
+                
+                tail.forEach {
+                    firstClient.merge(with: $0)
+                    context.delete($0)
+                }
+            }
+        }
+    }
+    
+    static func deleteDuplicatedUsers(in context: NSManagedObjectContext) {
+        // Fetch users having the same remote identifiers
+        
+        context.findDuplicated(by: "remoteIdentifier_data").forEach { (remoteId: Data, users: [ZMUser]) in
+            // Group users having the same remote identifiers
+            guard let firstUser = users.first, users.count > 1 else {
+                return
+            }
+            
+            let tail = users.dropFirst()
+            // Merge users having the same remote identifier
+            
+            tail.forEach {
+                firstUser.merge(with: $0)
+                context.delete($0)
+            }
+            firstUser.needsToBeUpdatedFromBackend = true
+            firstUser.activeConversations.forEach { ($0 as? ZMConversation)?.needsToBeUpdatedFromBackend = true }
+        }
+    }
+    
+    static func deleteDuplicatedConversations(in context: NSManagedObjectContext) {
+        // Fetch conversations having the same remote identifiers
+        context.findDuplicated(by: "remoteIdentifier_data").forEach { (remoteId: Data, conversations: [ZMConversation]) in
+            // Group conversations having the same remote identifiers
+            guard let firstConversation = conversations.first, conversations.count > 1 else {
+                return
+            }
+            
+            let tail = conversations.dropFirst()
+            // Merge conversations having the same remote identifier
+            
+            tail.forEach {
+                firstConversation.merge(with: $0)
+                if let connection = $0.connection {
+                    context.delete(connection)
+                }
+                context.delete($0)
+            }
+            firstConversation.needsToBeUpdatedFromBackend = true
+        }
+    }
+    
+}
+
+extension UserClient {
+    // Migration method for merging two duplicated @c UserClient entities
+    func merge(with client: UserClient) {
+        precondition(!(self.user?.isSelfUser ?? false), "Cannot merge self user's clients")
+        precondition(client.remoteIdentifier == self.remoteIdentifier, "UserClient's remoteIdentifier should be equal to merge")
+        precondition(client.user == self.user, "UserClient's Users should be equal to merge")
+        
+        let addedOrRemovedInSystemMessages = client.addedOrRemovedInSystemMessages
+        let ignoredByClients = client.ignoredByClients
+        let messagesMissingRecipient = client.messagesMissingRecipient
+        let trustedByClients = client.trustedByClients
+        
+        self.addedOrRemovedInSystemMessages.formUnion(addedOrRemovedInSystemMessages)
+        self.ignoredByClients.formUnion(ignoredByClients)
+        self.messagesMissingRecipient.formUnion(messagesMissingRecipient)
+        self.trustedByClients.formUnion(trustedByClients)
+        
+        if let missedByClient = client.missedByClient {
+            self.missedByClient = missedByClient
+        }
+    }
+}
+
+extension ZMUser {
+    // Migration method for merging two duplicated @c ZMUser entities
+    func merge(with user: ZMUser) {
+        precondition(user.remoteIdentifier == self.remoteIdentifier, "ZMUser's remoteIdentifier should be equal to merge")
+        
+        // NOTE:
+        // we are not merging clients since they are re-created on demand
+        
+        self.connection = ZMManagedObject.firstNonNullAndDeleteSecond(self.connection, user.connection)
+        self.addressBookEntry = ZMManagedObject.firstNonNullAndDeleteSecond(self.addressBookEntry, user.addressBookEntry)
+        self.lastServerSyncedActiveConversations = self.lastServerSyncedActiveConversations.adding(orderedSet: user.lastServerSyncedActiveConversations)
+        self.conversationsCreated = self.conversationsCreated.union(user.conversationsCreated)
+        self.activeConversations = self.lastServerSyncedActiveConversations // discard local changes, will refetch from server
+        self.createdTeams = self.createdTeams.union(user.createdTeams)
+        self.membership = ZMManagedObject.firstNonNullAndDeleteSecond(self.membership, user.membership)
+        self.reactions = self.reactions.union(user.reactions)
+        self.showingUserAdded = self.showingUserAdded.union(user.showingUserAdded)
+        self.showingUserRemoved = self.showingUserRemoved.union(user.showingUserRemoved)
+        self.systemMessages = self.systemMessages.union(user.systemMessages)
+    }
+}
+
+extension ZMConversation {
+    // Migration method for merging two duplicated @c ZMConversation entities
+    func merge(with conversation: ZMConversation) {
+        precondition(conversation.remoteIdentifier == self.remoteIdentifier, "ZMConversation's remoteIdentifier should be equal to merge")
+        
+        // NOTE:
+        // connection will be fixed when merging the users
+        // creator will be fixed when merging the users
+        // lastServerSyncedActiveParticipants will be fixed when merging the users
+        // otherActiveParticipants will be fixed when merging the users
+        let mutableHiddenMessages = self.mutableOrderedSetValue(forKey: ZMConversationHiddenMessagesKey)
+        mutableHiddenMessages.union(conversation.hiddenMessages)
+        self.mutableMessages.union(conversation.messages)
+        self.team = self.team ?? conversation.team // I don't want to delete a team just in case it's needed
+        self.connection = ZMManagedObject.firstNonNullAndDeleteSecond(self.connection, conversation.connection)
+    }
+}
+
+extension ZMManagedObject {
+    
+    /// Returns the first of two objects that is not null. If both are
+    /// not null, deletes the second one
+    fileprivate static func firstNonNullAndDeleteSecond<Object: ZMManagedObject>(
+        _ obj1: Object?,
+        _ obj2: Object?) -> Object?
+    {
+        if let obj1 = obj1 {
+            if let obj2 = obj2 {
+                obj2.managedObjectContext?.delete(obj2)
+            }
+            return obj1
+        }
+        return obj2
+    }
+}

--- a/Source/Utilis/DuplicatedEntityRemoval.swift
+++ b/Source/Utilis/DuplicatedEntityRemoval.swift
@@ -149,13 +149,14 @@ extension ZMConversation {
         // NOTE:
         // connection will be fixed when merging the users
         // creator will be fixed when merging the users
-        // lastServerSyncedActiveParticipants will be fixed when merging the users
-        // otherActiveParticipants will be fixed when merging the users
         let mutableHiddenMessages = self.mutableOrderedSetValue(forKey: ZMConversationHiddenMessagesKey)
         mutableHiddenMessages.union(conversation.hiddenMessages)
         self.mutableMessages.union(conversation.messages)
         self.team = self.team ?? conversation.team // I don't want to delete a team just in case it's needed
         self.connection = ZMManagedObject.firstNonNullAndDeleteSecond(self.connection, conversation.connection)
+        self.mutableLastServerSyncedActiveParticipants?.union(conversation.mutableLastServerSyncedActiveParticipants ?? NSOrderedSet())
+        self.mutableOtherActiveParticipants.removeAllObjects()
+        self.mutableOtherActiveParticipants.union(self.mutableLastServerSyncedActiveParticipants ?? NSOrderedSet())
     }
 }
 

--- a/Source/Utilis/PersistedDataPatches+Directory.swift
+++ b/Source/Utilis/PersistedDataPatches+Directory.swift
@@ -25,7 +25,8 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "41.0.0", block: UserClient.migrateAllSessionsClientIdentifiers),
         PersistedDataPatch(version: "43.0.4", block: ZMConversation.migrateAllSecureWithIgnored),
         PersistedDataPatch(version: "58.4.1", block: Team.deleteLocalTeamsAndMembers),
-        PersistedDataPatch(version: "62.1.0", block: Member.migrateRemoteIdentifiers) // TODO: Verify this is the correct version
+        PersistedDataPatch(version: "62.1.0", block: Member.migrateRemoteIdentifiers),
+        PersistedDataPatch(version: "78.1.0", block: DuplicatedEntityRemoval.removeDuplicated)
     ]
 
 }

--- a/Tests/Source/Utils/DiskDatabaseTests.swift
+++ b/Tests/Source/Utils/DiskDatabaseTests.swift
@@ -1,0 +1,86 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import XCTest
+import WireTesting
+@testable import WireDataModel
+
+public class DiskDatabaseTest: ZMTBaseTest {
+    var sharedContainerURL : URL!
+    var accountId : UUID!
+    var moc: NSManagedObjectContext {
+        return contextDirectory.uiContext
+    }
+    var contextDirectory: ManagedObjectContextDirectory!
+    
+    var storeURL : URL {
+        return StorageStack.accountFolder(
+            accountIdentifier: accountId,
+            applicationContainer: sharedContainerURL
+            ).appendingPersistentStoreLocation()
+    }
+    
+    public override func setUp() {
+        super.setUp()
+        
+        accountId = .create()
+        let bundleIdentifier = Bundle.main.bundleIdentifier
+        sharedContainerURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("\(UUID().uuidString)")
+        cleanUp()
+        createDatabase()
+        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 1))
+        XCTAssert(FileManager.default.fileExists(atPath: storeURL.path))
+    }
+    
+    public override func tearDown() {
+        cleanUp()
+        contextDirectory = nil
+        sharedContainerURL = nil
+        accountId = nil
+        super.tearDown()
+    }
+    
+    private func createDatabase() {
+        StorageStack.reset()
+        StorageStack.shared.createStorageAsInMemory = false
+        
+        let expectation = self.expectation(description: "Created context")
+        StorageStack.shared.createManagedObjectContextDirectory(accountIdentifier: accountId, applicationContainer: storeURL, dispatchGroup: self.dispatchGroup) {
+            self.contextDirectory = $0
+            expectation.fulfill()
+        }
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+        self.moc.performGroupedBlockAndWait {
+            let selfUser = ZMUser.selfUser(in: self.moc)
+            selfUser.remoteIdentifier = self.accountId
+        }
+    }
+    
+    private func cleanUp() {
+        try? FileManager.default.contentsOfDirectory(at: sharedContainerURL, includingPropertiesForKeys: nil, options: .skipsHiddenFiles).forEach {
+            try? FileManager.default.removeItem(at: $0)
+        }
+        
+        StorageStack.reset()
+    }
+}
+
+

--- a/Tests/Source/Utils/DuplicateEntityRemovalTests.swift
+++ b/Tests/Source/Utils/DuplicateEntityRemovalTests.swift
@@ -1,0 +1,759 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import WireTesting
+@testable import WireDataModel
+
+public final class DuplicatedEntityRemovalTests: DiskDatabaseTest {
+    
+    func createClient(user: ZMUser) -> UserClient {
+        let client = UserClient.insertNewObject(in: self.moc)
+        client.user = user
+        client.remoteIdentifier = UUID().transportString()
+        return client
+    }
+
+    func createUser() -> ZMUser {
+        let user = ZMUser.insertNewObject(in: self.moc)
+        user.remoteIdentifier = UUID()
+        return user
+    }
+
+    func createConversation() -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: self.moc)
+        conversation.remoteIdentifier = UUID()
+        conversation.conversationType = .group
+        return conversation
+    }
+
+    func createTeam() -> Team {
+        let team = Team.insertNewObject(in: self.moc)
+        team.remoteIdentifier = UUID()
+        return team
+    }
+
+    func createMembership(user: ZMUser, team: Team) -> Member {
+        let member = Member.insertNewObject(in: self.moc)
+        member.user = user
+        member.team = team
+        return member
+    }
+    
+    func createConnection(to: ZMUser, conversation: ZMConversation) -> ZMConnection {
+        let connection = ZMConnection.insertNewObject(in: self.moc)
+        connection.to = to
+        connection.conversation = conversation
+        connection.status = .accepted
+        return connection
+    }
+
+
+    func appendSystemMessage(conversation: ZMConversation,
+                             type: ZMSystemMessageType,
+                             sender: ZMUser,
+                             users: Set<ZMUser>?,
+                             addedUsers: Set<ZMUser> = Set(),
+                             clients: Set<UserClient>?,
+                             timestamp: Date?,
+                             duration: TimeInterval? = nil
+        ) -> ZMSystemMessage {
+
+        let systemMessage = ZMSystemMessage.insertNewObject(in: self.moc)
+        systemMessage.systemMessageType = type
+        systemMessage.sender = sender
+        systemMessage.isEncrypted = false
+        systemMessage.isPlainText = true
+        systemMessage.users = users ?? Set()
+        systemMessage.addedUsers = addedUsers
+        systemMessage.clients = clients ?? Set()
+        systemMessage.nonce = UUID()
+        systemMessage.serverTimestamp = timestamp
+        if let duration = duration {
+            systemMessage.duration = duration
+        }
+
+        conversation.sortedAppendMessage(systemMessage)
+        systemMessage.visibleInConversation = conversation
+        return systemMessage
+    }
+
+    func addedOrRemovedSystemMessages(conversation: ZMConversation,
+                                      client: UserClient
+                                      ) -> [ZMSystemMessage] {
+        let addedMessage = self.appendSystemMessage(conversation: conversation,
+                                                    type: .newClient,
+                                                    sender: ZMUser.selfUser(in: self.moc),
+                                                    users: Set(arrayLiteral: client.user!),
+                                                    addedUsers: Set(arrayLiteral: client.user!),
+                                                    clients: Set(arrayLiteral: client),
+                                                    timestamp: Date())
+
+        let ignoredMessage = self.appendSystemMessage(conversation: conversation,
+                                                      type: .ignoredClient,
+                                                      sender: ZMUser.selfUser(in: self.moc),
+                                                      users: Set(arrayLiteral: client.user!),
+                                                      clients: Set(arrayLiteral: client),
+                                                      timestamp: Date())
+
+        return [addedMessage, ignoredMessage]
+    }
+
+    func messages(conversation: ZMConversation) -> [ZMMessage] {
+        return (0..<5).map { conversation.appendMessage(withText: "Message \($0)")! as! ZMMessage }
+    }
+}
+
+// MARK: - Merge tests
+extension DuplicatedEntityRemovalTests {
+    
+    public func testThatItMergesTwoUserClients() {
+        
+        // GIVEN
+        let user = createUser()
+        let conversation = createConversation()
+        let client1 = createClient(user: user)
+
+        let client2 = createClient(user: user)
+        client2.remoteIdentifier = client1.remoteIdentifier
+
+        let addedOrRemovedInSystemMessages = Set<ZMSystemMessage>(
+            addedOrRemovedSystemMessages(conversation: conversation, client: client2)
+        )
+        let ignoredByClients = Set((0..<5).map { _ in createClient(user: user) })
+        let messagesMissingRecipient = Set<ZMMessage>(messages(conversation: conversation))
+        let trustedByClients = Set((0..<5).map { _ in createClient(user: user) })
+        let missedByClient = createClient(user: user)
+
+        client2.addedOrRemovedInSystemMessages = addedOrRemovedInSystemMessages
+        client2.ignoredByClients = ignoredByClients
+        client2.messagesMissingRecipient = messagesMissingRecipient
+        client2.trustedByClients = trustedByClients
+        client2.missedByClient = missedByClient
+
+        // WHEN
+        client1.merge(with: client2)
+        self.moc.delete(client2)
+        self.moc.saveOrRollback()
+
+        // THEN
+        XCTAssertEqual(addedOrRemovedInSystemMessages.count, 2)
+
+        XCTAssertEqual(client1.addedOrRemovedInSystemMessages, addedOrRemovedInSystemMessages)
+        XCTAssertEqual(client1.ignoredByClients, ignoredByClients)
+        XCTAssertEqual(client1.messagesMissingRecipient, messagesMissingRecipient)
+        XCTAssertEqual(client1.trustedByClients, trustedByClients)
+        XCTAssertEqual(client1.missedByClient, missedByClient)
+
+        addedOrRemovedInSystemMessages.forEach {
+            XCTAssertTrue($0.clients.contains(client1))
+            XCTAssertFalse($0.clients.contains(client2))
+        }
+    }
+
+    public func testThatItMergesTwoUsers() {
+        // GIVEN
+        let conversation = createConversation()
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+
+        let team = createTeam()
+        let membership = createMembership(user: user1, team: team)
+        let reaction = Reaction.insertNewObject(in: self.moc)
+        let systemMessage = ZMSystemMessage.insertNewObject(in: self.moc)
+
+        let lastServerSyncedActiveConversations = NSOrderedSet(object: conversation)
+        let conversationsCreated = Set<ZMConversation>([conversation])
+        let createdTeams = Set<Team>([team])
+        let reactions = Set<Reaction>([reaction])
+        let showingUserAdded = Set<ZMMessage>([systemMessage])
+        let showingUserRemoved = Set<ZMMessage>([systemMessage])
+        let systemMessages = Set<ZMSystemMessage>([systemMessage])
+
+        user2.lastServerSyncedActiveConversations = lastServerSyncedActiveConversations
+        user2.conversationsCreated = conversationsCreated
+        user2.createdTeams = createdTeams
+        user2.membership = membership
+        user2.reactions = reactions
+        user2.showingUserAdded = showingUserAdded
+        user2.showingUserRemoved = showingUserRemoved
+        user2.systemMessages = systemMessages
+
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.delete(user2)
+        self.moc.saveOrRollback()
+
+        // THEN
+        XCTAssertEqual(user1.activeConversations, lastServerSyncedActiveConversations)
+        XCTAssertEqual(user1.conversationsCreated, conversationsCreated)
+        XCTAssertEqual(user1.createdTeams, createdTeams)
+        XCTAssertEqual(user1.membership, membership)
+        XCTAssertEqual(user1.reactions, reactions)
+        XCTAssertEqual(user1.showingUserAdded, showingUserAdded)
+        XCTAssertEqual(user1.showingUserRemoved, showingUserRemoved)
+        XCTAssertEqual(user1.systemMessages, systemMessages)
+        XCTAssertTrue(user1.needsToBeUpdatedFromBackend)
+    }
+    
+    public func testThatItMergeUsers_Connection_user1HasIt() {
+    
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation = createConversation()
+        conversation.conversationType = .oneOnOne
+        let connection = createConnection(to: user1, conversation: conversation)
+        user1.connection = connection
+        conversation.internalAddParticipants(Set([user1]), isAuthoritative: true)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.connection, connection)
+        XCTAssertEqual(connection.to, user1)
+        XCTAssertFalse(connection.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_Connection_user2HasIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation = createConversation()
+        conversation.conversationType = .oneOnOne
+        let connection = createConnection(to: user2, conversation: conversation)
+        user2.connection = connection
+        conversation.internalAddParticipants(Set([user2]), isAuthoritative: true)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.connection, connection)
+        XCTAssertEqual(connection.to, user1)
+        XCTAssertFalse(connection.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_Connection_bothUserHaveIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation1 = createConversation()
+        conversation1.conversationType = .oneOnOne
+        conversation1.internalAddParticipants(Set([user1]), isAuthoritative: true)
+        let conversation2 = createConversation()
+        conversation2.conversationType = .oneOnOne
+        conversation2.internalAddParticipants(Set([user2]), isAuthoritative: true)
+        let connection1 = createConnection(to: user1, conversation: conversation1)
+        user1.connection = connection1
+        let connection2 = createConnection(to: user2, conversation: conversation2)
+        user2.connection = connection2
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.connection, connection1)
+        XCTAssertEqual(connection1.to, user1)
+        XCTAssertFalse(connection1.isZombieObject)
+        XCTAssertTrue(connection2.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_ABEntry_user1HasIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let ABEntry = AddressBookEntry.insertNewObject(in: self.moc)
+        ABEntry.user = user1
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.addressBookEntry, ABEntry)
+        XCTAssertEqual(ABEntry.user, user1)
+        XCTAssertFalse(ABEntry.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_ABEntry_user2HasIt() {
+        
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let ABEntry = AddressBookEntry.insertNewObject(in: self.moc)
+        ABEntry.user = user2
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.addressBookEntry, ABEntry)
+        XCTAssertEqual(ABEntry.user, user1)
+        XCTAssertFalse(ABEntry.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_ABEntry_bothUserHaveIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let ABEntry1 = AddressBookEntry.insertNewObject(in: self.moc)
+        ABEntry1.user = user1
+        let ABEntry2 = AddressBookEntry.insertNewObject(in: self.moc)
+        ABEntry2.user = user2
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.addressBookEntry, ABEntry1)
+        XCTAssertEqual(ABEntry1.user, user1)
+        XCTAssertFalse(ABEntry1.isZombieObject)
+        XCTAssertTrue(ABEntry2.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_LastServerSynchedActiveConversations() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        let conversation3 = createConversation()
+        conversation1.internalAddParticipants(Set([user1, user2]), isAuthoritative: true)
+        conversation2.internalAddParticipants(Set([user1]), isAuthoritative: true)
+        conversation3.internalAddParticipants(Set([user2]), isAuthoritative: true)
+        self.moc.saveOrRollback()
+        
+        // sanity check
+        XCTAssertEqual(user1.lastServerSyncedActiveConversations.set, Set([conversation1, conversation2]))
+        XCTAssertEqual(user2.lastServerSyncedActiveConversations.set, Set([conversation1, conversation3]))
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.lastServerSyncedActiveConversations.set, Set([conversation1, conversation2, conversation3]))
+    }
+    
+    public func testThatItMergeUsers_ActiveConversations() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        let conversation3 = createConversation()
+        conversation1.internalAddParticipants(Set([user1, user2]), isAuthoritative: true)
+        conversation2.internalAddParticipants(Set([user1]), isAuthoritative: true)
+        conversation3.internalAddParticipants(Set([user2]), isAuthoritative: true)
+        self.moc.saveOrRollback()
+        
+        // sanity check
+        XCTAssertEqual(user1.activeConversations.set, Set([conversation1, conversation2]))
+        XCTAssertEqual(user2.activeConversations.set, Set([conversation1, conversation3]))
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.activeConversations.set, Set([conversation1, conversation2, conversation3]))
+    }
+    
+    public func testThatItMergeUsers_ActiveConversations_whenLocalPendingChanges() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        let conversation3 = createConversation()
+        conversation1.internalAddParticipants(Set([user1, user2]), isAuthoritative: true)
+        conversation2.internalAddParticipants(Set([user1]), isAuthoritative: true)
+        conversation3.internalAddParticipants(Set([user2]), isAuthoritative: true)
+        conversation1.mutableOtherActiveParticipants.remove(user1) // local pending change: remove user1
+        self.moc.saveOrRollback()
+        
+        // sanity check
+        XCTAssertFalse(conversation1.otherActiveParticipants.contains(user1))
+        XCTAssertEqual(user1.activeConversations.set, Set([conversation2]))
+        XCTAssertEqual(user1.lastServerSyncedActiveConversations.set, Set([conversation1, conversation2]))
+        XCTAssertEqual(user2.activeConversations.set, Set([conversation1, conversation3]))
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.activeConversations.set, Set([conversation1, conversation2, conversation3]))
+    }
+    
+    public func testThatItMergeUsers_ConversationCreated() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        user1.conversationsCreated = Set([conversation1])
+        user2.conversationsCreated = Set([conversation2])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.conversationsCreated, Set([conversation1, conversation2]))
+    }
+    
+    public func testThatItMergeUsers_CreatedTeams() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let team1 = createTeam()
+        let team2 = createTeam()
+        user1.createdTeams = Set([team1])
+        user2.createdTeams = Set([team2])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.createdTeams, Set([team1, team2]))
+        
+    }
+    
+    public func testThatItMergeUsers_Membership_user1HasIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        let team = createTeam()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let membership = self.createMembership(user: user1, team: team)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.membership, membership)
+        XCTAssertEqual(membership.user, user1)
+        XCTAssertFalse(membership.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_Membership_user2HasIt() {
+        
+        let user1 = createUser()
+        let user2 = createUser()
+        let team = createTeam()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let membership = self.createMembership(user: user2, team: team)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.membership, membership)
+        XCTAssertEqual(membership.user, user1)
+        XCTAssertFalse(membership.isZombieObject)
+    }
+    
+    public func testThatItMergeUsers_Membership_bothUserHaveIt() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        let team = createTeam()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let membership1 = self.createMembership(user: user1, team: team)
+        let membership2 = self.createMembership(user: user2, team: team)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.membership, membership1)
+        XCTAssertEqual(membership1.user, user1)
+        XCTAssertFalse(membership1.isZombieObject)
+        XCTAssertTrue(membership2.isZombieObject)
+    }
+    
+    public func testThatItMergesTwoConversations() {
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation1.remoteIdentifier = conversation2.remoteIdentifier
+        
+        let message1 = ZMClientMessage.insertNewObject(in: self.moc)
+        let message2 = ZMClientMessage.insertNewObject(in: self.moc)
+        
+        let messages = NSOrderedSet(arrayLiteral: message1)
+        let hiddenMessages = NSOrderedSet(arrayLiteral: message2)
+        
+        conversation2.setValue(messages, forKey: "messages")
+        conversation2.setValue(hiddenMessages, forKey: "hiddenMessages")
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.delete(conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.messages, messages)
+        XCTAssertEqual(conversation1.hiddenMessages, hiddenMessages)
+    }
+}
+
+// MARK: - Testing deletion from patch
+extension DuplicatedEntityRemovalTests {
+
+    public func testThatItRemovesDuplicatedClients() {
+        // GIVEN
+        let user = createUser()
+        let client1 = createClient(user: user)
+        let duplicates: [UserClient] = (0..<5).map { _ in
+            let otherClient = createClient(user: user)
+            otherClient.remoteIdentifier = client1.remoteIdentifier
+            return otherClient
+        }
+
+        self.moc.saveOrRollback()
+
+        // WHEN
+        WireDataModel.DuplicatedEntityRemoval.deleteDuplicatedClients(in: self.moc)
+        self.moc.saveOrRollback()
+
+        // THEN
+        let totalDeleted = (duplicates + [client1]).filter {
+            $0.managedObjectContext == nil
+            }.count
+
+        XCTAssertEqual(totalDeleted, 5)
+    }
+
+    public func testThatItRemovesDuplicatedUsers() {
+        // GIVEN
+        let user1 = createUser()
+        let duplicates: [ZMUser] = (0..<5).map { _ in
+            let otherUser = createUser()
+            otherUser.remoteIdentifier = user1.remoteIdentifier
+            return otherUser
+        }
+
+        self.moc.saveOrRollback()
+
+        // WHEN
+        WireDataModel.DuplicatedEntityRemoval.deleteDuplicatedUsers(in: self.moc)
+        self.moc.saveOrRollback()
+
+        // THEN
+        let totalDeleted = (duplicates + [user1]).filter {
+            $0.managedObjectContext == nil
+            }.count
+
+        XCTAssertEqual(totalDeleted, 5)
+    }
+
+    public func testThatItRemovesDuplicatedConversations() {
+        // GIVEN
+        let conversation1 = createConversation()
+        let duplicates: [ZMConversation] = (0..<5).map { _ in
+            let otherConversation = createConversation()
+            otherConversation.remoteIdentifier = conversation1.remoteIdentifier
+            return otherConversation
+        }
+
+        self.moc.saveOrRollback()
+
+        // WHEN
+        WireDataModel.DuplicatedEntityRemoval.deleteDuplicatedConversations(in: self.moc)
+        self.moc.saveOrRollback()
+
+        // THEN
+        let totalDeleted = (duplicates + [conversation1]).filter {
+            $0.managedObjectContext == nil
+            }.count
+
+        XCTAssertEqual(totalDeleted, 5)
+    }
+
+    public func testThatItRemovesAllDuplicates() {
+
+        // GIVEN
+        let userA1 = ZMUser.insertNewObject(in: self.moc)
+        userA1.remoteIdentifier = UUID()
+        userA1.name = "userA1"
+        userA1.needsToBeUpdatedFromBackend = false
+        let userA2 = ZMUser.insertNewObject(in: self.moc)
+        userA2.remoteIdentifier = userA1.remoteIdentifier
+        userA2.name = "userA2"
+        userA2.needsToBeUpdatedFromBackend = false
+        let userB = ZMUser.insertNewObject(in: self.moc)
+        userB.remoteIdentifier = UUID()
+        userB.name = "userB"
+        userB.needsToBeUpdatedFromBackend = false
+        let userC = ZMUser.insertNewObject(in: self.moc)
+        userC.remoteIdentifier = UUID()
+        userC.name = "userC"
+        userC.needsToBeUpdatedFromBackend = false
+
+        let convoA1 = ZMConversation.insertNewObject(in: self.moc)
+        convoA1.remoteIdentifier = UUID()
+        convoA1.conversationType = .oneOnOne
+        convoA1.mutableLastServerSyncedActiveParticipants?.add(userA1)
+        convoA1.mutableOtherActiveParticipants.add(userA1)
+        convoA1.creator = userA1
+        convoA1.userDefinedName = "convoA1"
+        convoA1.needsToBeUpdatedFromBackend = false
+        let convoA2 = ZMConversation.insertNewObject(in: self.moc)
+        convoA2.remoteIdentifier = convoA1.remoteIdentifier
+        convoA2.conversationType = .oneOnOne
+        convoA2.mutableLastServerSyncedActiveParticipants?.add(userA2)
+        convoA2.creator = userA2
+        convoA2.mutableOtherActiveParticipants.add(userA2)
+        convoA2.mutableOtherActiveParticipants.add(userB) // should not be there after merge
+        convoA2.userDefinedName = "convoA2"
+        convoA2.needsToBeUpdatedFromBackend = false
+        let convoB1 = ZMConversation.insertNewObject(in: self.moc)
+        convoB1.remoteIdentifier = UUID()
+        convoB1.conversationType = .group
+        convoB1.mutableLastServerSyncedActiveParticipants?.add(userA1)
+        convoB1.mutableLastServerSyncedActiveParticipants?.add(userB)
+        convoB1.creator = userB
+        convoB1.mutableOtherActiveParticipants.add(userA1) // missing userB
+        convoB1.userDefinedName = "convoB1"
+        convoB1.needsToBeUpdatedFromBackend = false
+        let convoB2 = ZMConversation.insertNewObject(in: self.moc)
+        convoB2.remoteIdentifier = convoB1.remoteIdentifier
+        convoB2.conversationType = .group
+        convoB2.mutableLastServerSyncedActiveParticipants?.add(userC)
+        convoB2.mutableLastServerSyncedActiveParticipants?.add(userB)
+        convoB2.creator = userB
+        convoB2.mutableOtherActiveParticipants.add(userC)
+        convoB2.mutableOtherActiveParticipants.add(userB)
+        convoB2.userDefinedName = "convoB2"
+        convoB2.needsToBeUpdatedFromBackend = false
+        let convoC = ZMConversation.insertNewObject(in: self.moc)
+        convoC.remoteIdentifier = UUID()
+        convoC.conversationType = .group
+        convoC.mutableLastServerSyncedActiveParticipants?.add(userA2)
+        convoC.mutableLastServerSyncedActiveParticipants?.add(userC)
+        convoC.creator = userC
+        convoC.mutableOtherActiveParticipants.add(userA2) // missing user C
+        convoC.userDefinedName = "convoC"
+        convoC.needsToBeUpdatedFromBackend = false
+
+        let connectionA1 = ZMConnection.insertNewObject(in: self.moc)
+        connectionA1.to = userA1
+        connectionA1.conversation = convoA1
+        connectionA1.status = .accepted
+        
+        let connectionA2 = ZMConnection.insertNewObject(in: self.moc)
+        connectionA2.to = userA2
+        connectionA2.conversation = convoA2
+        connectionA2.status = .accepted
+
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        WireDataModel.DuplicatedEntityRemoval.removeDuplicated(in: self.moc)
+        
+        // THEN
+        XCTAssertEqual([userA1, userA2].nonZombies.count, 1)
+        guard let userA = [userA1, userA2].nonZombies.first else {
+            return XCTFail("Both deleted!")
+        }
+        
+        XCTAssertEqual([convoA1, convoA2].nonZombies.count, 1)
+        guard let convoA = [convoA1, convoA2].nonZombies.first else {
+            return XCTFail("Both deleted!")
+        }
+        
+        XCTAssertEqual([convoB1, convoB2].nonZombies.count, 1)
+        guard let convoB = [convoB1, convoB2].nonZombies.first else {
+            return XCTFail("Both deleted!")
+        }
+        
+        XCTAssertEqual([connectionA1, connectionA2].nonZombies.count, 1)
+        guard let connectionA = [connectionA1, connectionA2].nonZombies.first else {
+            return XCTFail("Both deleted!")
+        }
+        
+        XCTAssertEqual(convoA.otherActiveParticipants.set, Set([userA]))
+        XCTAssertEqual(convoA.mutableLastServerSyncedActiveParticipants!.set, Set([userA]))
+        XCTAssertEqual(convoB.activeParticipants.set, Set([userA, userB, userC]))
+        XCTAssertEqual(convoC.activeParticipants.set, Set([userA, userB, userC]))
+        
+        XCTAssertTrue(convoA.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(convoB.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(convoC.needsToBeUpdatedFromBackend)
+        
+        XCTAssertTrue(userA.needsToBeUpdatedFromBackend)
+        XCTAssertFalse(userC.needsToBeUpdatedFromBackend)
+        
+        XCTAssertEqual(connectionA.to, userA)
+    }
+}
+
+extension Array where Element: ZMManagedObject {
+    
+    fileprivate var nonZombies: [Element] {
+        return self.filter { !($0.isZombieObject || $0.isDeleted) }
+    }
+}
+

--- a/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
+++ b/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
@@ -213,7 +213,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertTrue(user1.needsToBeUpdatedFromBackend)
     }
     
-    public func testThatItMergeUsers_Connection_user1HasIt() {
+    public func testThatItMergesUsers_Connection_user1HasIt() {
     
         // GIVEN
         let user1 = createUser()
@@ -236,7 +236,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(connection.isZombieObject)
     }
     
-    public func testThatItMergeUsers_Connection_user2HasIt() {
+    public func testThatItMergesUsers_Connection_user2HasIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -259,7 +259,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(connection.isZombieObject)
     }
     
-    public func testThatItMergeUsers_Connection_bothUserHaveIt() {
+    public func testThatItMergesUsers_Connection_bothUserHaveIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -288,7 +288,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertTrue(connection2.isZombieObject)
     }
     
-    public func testThatItMergeUsers_ABEntry_user1HasIt() {
+    public func testThatItMergesUsers_ABEntry_user1HasIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -308,7 +308,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(ABEntry.isZombieObject)
     }
     
-    public func testThatItMergeUsers_ABEntry_user2HasIt() {
+    public func testThatItMergesUsers_ABEntry_user2HasIt() {
         
         let user1 = createUser()
         let user2 = createUser()
@@ -327,7 +327,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(ABEntry.isZombieObject)
     }
     
-    public func testThatItMergeUsers_ABEntry_bothUserHaveIt() {
+    public func testThatItMergesUsers_ABEntry_bothUserHaveIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -350,7 +350,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertTrue(ABEntry2.isZombieObject)
     }
     
-    public func testThatItMergeUsers_LastServerSynchedActiveConversations() {
+    public func testThatItMergesUsers_LastServerSynchedActiveConversations() {
         
         // GIVEN
         let user1 = createUser()
@@ -376,7 +376,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertEqual(user1.lastServerSyncedActiveConversations.set, Set([conversation1, conversation2, conversation3]))
     }
     
-    public func testThatItMergeUsers_ActiveConversations() {
+    public func testThatItMergesUsers_ActiveConversations() {
         
         // GIVEN
         let user1 = createUser()
@@ -402,7 +402,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertEqual(user1.activeConversations.set, Set([conversation1, conversation2, conversation3]))
     }
     
-    public func testThatItMergeUsers_ActiveConversations_whenLocalPendingChanges() {
+    public func testThatItMergesUsers_ActiveConversations_whenLocalPendingChanges() {
         
         // GIVEN
         let user1 = createUser()
@@ -431,7 +431,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertEqual(user1.activeConversations.set, Set([conversation1, conversation2, conversation3]))
     }
     
-    public func testThatItMergeUsers_ConversationCreated() {
+    public func testThatItMergesUsers_ConversationCreated() {
         
         // GIVEN
         let user1 = createUser()
@@ -451,7 +451,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertEqual(user1.conversationsCreated, Set([conversation1, conversation2]))
     }
     
-    public func testThatItMergeUsers_CreatedTeams() {
+    public func testThatItMergesUsers_CreatedTeams() {
         
         // GIVEN
         let user1 = createUser()
@@ -472,7 +472,7 @@ extension DuplicatedEntityRemovalTests {
         
     }
     
-    public func testThatItMergeUsers_Membership_user1HasIt() {
+    public func testThatItMergesUsers_Membership_user1HasIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -492,7 +492,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(membership.isZombieObject)
     }
     
-    public func testThatItMergeUsers_Membership_user2HasIt() {
+    public func testThatItMergesUsers_Membership_user2HasIt() {
         
         let user1 = createUser()
         let user2 = createUser()
@@ -511,7 +511,7 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertFalse(membership.isZombieObject)
     }
     
-    public func testThatItMergeUsers_Membership_bothUserHaveIt() {
+    public func testThatItMergesUsers_Membership_bothUserHaveIt() {
         
         // GIVEN
         let user1 = createUser()
@@ -533,7 +533,126 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertTrue(membership2.isZombieObject)
     }
     
-    public func testThatItMergesTwoConversations() {
+    public func testThatItMergesUsers_Reactions() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let reaction1 = Reaction.insertNewObject(in: self.moc)
+        let reaction2 = Reaction.insertNewObject(in: self.moc)
+        reaction1.users = Set([user1])
+        reaction2.users = Set([user1])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.reactions, Set([reaction1, reaction2]))
+    }
+    
+    public func testThatItMergesUsers_ShowingUserAdded() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation = createConversation()
+        let showingUserAdded1 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsAdded,
+            sender: user1,
+            users: Set([user1]),
+            clients: nil,
+            timestamp: nil)
+        showingUserAdded1.addedUsers = Set([user1])
+        let showingUserAdded2 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsAdded,
+            sender: user2,
+            users: Set([user2]),
+            clients: nil,
+            timestamp: nil)
+        showingUserAdded2.addedUsers = Set([user2])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.showingUserAdded, Set([showingUserAdded1, showingUserAdded2]))
+    }
+    
+    public func testThatItMergesUsers_ShowingUserRemoved() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation = createConversation()
+        let showingUserRemoved1 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsRemoved,
+            sender: user1,
+            users: Set([user1]),
+            clients: nil,
+            timestamp: nil)
+        showingUserRemoved1.removedUsers = Set([user1])
+        let showingUserRemoved2 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsRemoved,
+            sender: user2,
+            users: Set([user2]),
+            clients: nil,
+            timestamp: nil)
+        showingUserRemoved2.removedUsers = Set([user2])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.showingUserRemoved, Set([showingUserRemoved1, showingUserRemoved2]))
+    }
+    
+    public func testThatItMergesUsers_SystemMessages() {
+        
+        // GIVEN
+        let user1 = createUser()
+        let user2 = createUser()
+        user2.remoteIdentifier = user1.remoteIdentifier
+        let conversation = createConversation()
+        let showingUserRemoved1 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsRemoved,
+            sender: user1,
+            users: Set([user1]),
+            clients: nil,
+            timestamp: nil)
+        showingUserRemoved1.removedUsers = Set([user1])
+        let showingUserRemoved2 = appendSystemMessage(
+            conversation: conversation,
+            type: .participantsRemoved,
+            sender: user2,
+            users: Set([user2]),
+            clients: nil,
+            timestamp: nil)
+        showingUserRemoved2.removedUsers = Set([user2])
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        user1.merge(with: user2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(user1.systemMessages, Set([showingUserRemoved1, showingUserRemoved2]))
+    }
+    
+    public func testThatItMergesConversations_messages() {
         // GIVEN
         let conversation1 = createConversation()
         let conversation2 = createConversation()
@@ -542,20 +661,151 @@ extension DuplicatedEntityRemovalTests {
         let message1 = ZMClientMessage.insertNewObject(in: self.moc)
         let message2 = ZMClientMessage.insertNewObject(in: self.moc)
         
-        let messages = NSOrderedSet(arrayLiteral: message1)
-        let hiddenMessages = NSOrderedSet(arrayLiteral: message2)
-        
-        conversation2.setValue(messages, forKey: "messages")
-        conversation2.setValue(hiddenMessages, forKey: "hiddenMessages")
+        conversation1.mutableMessages.add(message1)
+        conversation2.mutableMessages.add(message2)
+        self.moc.saveOrRollback()
         
         // WHEN
         conversation1.merge(with: conversation2)
-        self.moc.delete(conversation2)
         self.moc.saveOrRollback()
         
         // THEN
-        XCTAssertEqual(conversation1.messages, messages)
-        XCTAssertEqual(conversation1.hiddenMessages, hiddenMessages)
+        XCTAssertEqual(conversation1.messages.set, Set([message1, message2]))
+    }
+    
+    public func testThatItMergesConversations_hiddenMessages() {
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation1.remoteIdentifier = conversation2.remoteIdentifier
+        
+        let message1 = ZMClientMessage.insertNewObject(in: self.moc)
+        let message2 = ZMClientMessage.insertNewObject(in: self.moc)
+        
+        message1.hiddenInConversation = conversation1
+        message2.hiddenInConversation = conversation2
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.hiddenMessages.set, Set([message1, message2]))
+    }
+    
+    public func testThatItMergesConversations_team_convo1HasIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let team = createTeam()
+        conversation1.team = team
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.team, team)
+    }
+    
+    public func testThatItMergesConversations_team_convo2HasIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let team = createTeam()
+        conversation2.team = team
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.team, team)
+    }
+    
+    public func testThatItMergesConversations_team_bothHaveIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let team1 = createTeam()
+        let team2 = createTeam()
+        conversation1.team = team1
+        conversation2.team = team2
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.team, team1)
+        XCTAssertFalse(team2.isZombieObject)
+    }
+    
+    public func testThatItMergesConversations_connection_convo1HasIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let user = createUser()
+        let connection = createConnection(to: user, conversation: conversation1)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.connection, connection)
+    }
+    
+    public func testThatItMergesConversations_connection_convo2HasIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let user = createUser()
+        let connection = createConnection(to: user, conversation: conversation2)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.connection, connection)
+    }
+    
+    public func testThatItMergesConversations_connection_bothHaveIt() {
+        
+        // GIVEN
+        let conversation1 = createConversation()
+        let conversation2 = createConversation()
+        let user = createUser()
+        conversation2.remoteIdentifier = conversation1.remoteIdentifier
+        let connection1 = createConnection(to: user, conversation: conversation1)
+        let connection2 = createConnection(to: user, conversation: conversation2)
+        self.moc.saveOrRollback()
+        
+        // WHEN
+        conversation1.merge(with: conversation2)
+        self.moc.saveOrRollback()
+        
+        // THEN
+        XCTAssertEqual(conversation1.connection, connection1)
+        XCTAssertFalse(connection1.isZombieObject)
+        XCTAssertTrue(connection2.isZombieObject)
     }
 }
 
@@ -685,7 +935,6 @@ extension DuplicatedEntityRemovalTests {
         convoB2.mutableLastServerSyncedActiveParticipants?.add(userB)
         convoB2.creator = userB
         convoB2.mutableOtherActiveParticipants.add(userC)
-        convoB2.mutableOtherActiveParticipants.add(userB)
         convoB2.userDefinedName = "convoB2"
         convoB2.needsToBeUpdatedFromBackend = false
         let convoC = ZMConversation.insertNewObject(in: self.moc)
@@ -712,6 +961,7 @@ extension DuplicatedEntityRemovalTests {
         
         // WHEN
         WireDataModel.DuplicatedEntityRemoval.removeDuplicated(in: self.moc)
+        self.moc.saveOrRollback()
         
         // THEN
         XCTAssertEqual([userA1, userA2].nonZombies.count, 1)
@@ -736,8 +986,8 @@ extension DuplicatedEntityRemovalTests {
         
         XCTAssertEqual(convoA.otherActiveParticipants.set, Set([userA]))
         XCTAssertEqual(convoA.mutableLastServerSyncedActiveParticipants!.set, Set([userA]))
-        XCTAssertEqual(convoB.activeParticipants.set, Set([userA, userB, userC]))
-        XCTAssertEqual(convoC.activeParticipants.set, Set([userA, userB, userC]))
+        XCTAssertEqual(convoB.otherActiveParticipants.set, Set([userA, userB, userC]))
+        XCTAssertEqual(convoC.otherActiveParticipants.set, Set([userA, userB, userC]))
         
         XCTAssertTrue(convoA.needsToBeUpdatedFromBackend)
         XCTAssertTrue(convoB.needsToBeUpdatedFromBackend)

--- a/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
+++ b/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
@@ -987,7 +987,8 @@ extension DuplicatedEntityRemovalTests {
         XCTAssertEqual(convoA.otherActiveParticipants.set, Set([userA]))
         XCTAssertEqual(convoA.mutableLastServerSyncedActiveParticipants!.set, Set([userA]))
         XCTAssertEqual(convoB.otherActiveParticipants.set, Set([userA, userB, userC]))
-        XCTAssertEqual(convoC.otherActiveParticipants.set, Set([userA, userB, userC]))
+        XCTAssertEqual(convoC.mutableLastServerSyncedActiveParticipants!.set, Set([userA, userC]))
+        XCTAssertEqual(convoC.otherActiveParticipants.set, Set([userA]))
         
         XCTAssertTrue(convoA.needsToBeUpdatedFromBackend)
         XCTAssertTrue(convoB.needsToBeUpdatedFromBackend)

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 		54EDE6821CBBF6260044A17E /* AssetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EDE6811CBBF6260044A17E /* AssetCacheTests.swift */; };
 		54F581FF1F2F716B0051ACE8 /* StorageStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F581FD1F2F70CE0051ACE8 /* StorageStackTests.swift */; };
 		54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */; };
+		54F84CFD1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */; };
+		54F84D031F995B0200ABD7D5 /* DuplicateEntityRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */; };
+		54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */; };
 		54FB03A11E41E273000E13DC /* PersistedDataPatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */; };
 		54FB03A31E41E64A000E13DC /* UserClient+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB03A21E41E64A000E13DC /* UserClient+Patches.swift */; };
 		54FB03AA1E41F204000E13DC /* PersistedDataPatches+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB03A81E41F1B6000E13DC /* PersistedDataPatches+Directory.swift */; };
@@ -514,6 +517,9 @@
 		54EDE6811CBBF6260044A17E /* AssetCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetCacheTests.swift; sourceTree = "<group>"; };
 		54F581FD1F2F70CE0051ACE8 /* StorageStackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageStackTests.swift; sourceTree = "<group>"; };
 		54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Download.swift"; sourceTree = "<group>"; };
+		54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicatedEntityRemoval.swift; sourceTree = "<group>"; };
+		54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateEntityRemovalTests.swift; sourceTree = "<group>"; };
+		54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskDatabaseTests.swift; sourceTree = "<group>"; };
 		54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistedDataPatches.swift; sourceTree = "<group>"; };
 		54FB03A21E41E64A000E13DC /* UserClient+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserClient+Patches.swift"; sourceTree = "<group>"; };
 		54FB03A81E41F1B6000E13DC /* PersistedDataPatches+Directory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PersistedDataPatches+Directory.swift"; sourceTree = "<group>"; };
@@ -997,6 +1003,8 @@
 			isa = PBXGroup;
 			children = (
 				54FB03AC1E41F6C2000E13DC /* PersistedDataPatchesTests.swift */,
+				54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */,
+				54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -1375,6 +1383,7 @@
 				F963E97F1D9C09E700098AD3 /* ZMMessageTimer.m */,
 				54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */,
 				54FB03A81E41F1B6000E13DC /* PersistedDataPatches+Directory.swift */,
+				54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */,
 				F9AB00261F0CE5520037B437 /* FileManager+FileLocations.swift */,
 			);
 			name = Utilis;
@@ -2169,6 +2178,7 @@
 				F963E9761D9C002000098AD3 /* ZMGenericMessage+Assets.swift in Sources */,
 				F9DBA5201E28EA8B00BE23C0 /* DependencyKeyStore.swift in Sources */,
 				F125BAD71EE9849B0018C2F8 /* ZMConversation+Teams.swift in Sources */,
+				54F84CFD1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift in Sources */,
 				544E8C111E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift in Sources */,
 				BF1B98071EC31A3C00DE033B /* Member.swift in Sources */,
 				F118CB921F41D520004DCF96 /* ZMTestSession.m in Sources */,
@@ -2331,6 +2341,7 @@
 				F9331C5A1CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift in Sources */,
 				F9B71FFE1CB2C4C6001DB03F /* ZMChangedIndexesTests.m in Sources */,
 				F1B025621E53500400900C65 /* ZMConversationTests+PrepareToSend.swift in Sources */,
+				54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */,
 				54EDE6821CBBF6260044A17E /* AssetCacheTests.swift in Sources */,
 				54A885A81F62EEB600AFBA95 /* ZMConversationTests+Messages.swift in Sources */,
 				54ED3A9D1F38CB6A0066AD47 /* DatabaseMigrationTests.swift in Sources */,
@@ -2414,6 +2425,7 @@
 				BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */,
 				F9DBA5251E28EE1500BE23C0 /* ConversationObserverTests.swift in Sources */,
 				BFE3A96C1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift in Sources */,
+				54F84D031F995B0200ABD7D5 /* DuplicateEntityRemovalTests.swift in Sources */,
 				BF707C511EB9F9CC00108D4E /* ClusterizerTests.swift in Sources */,
 				BF491CEA1F063F440055EE44 /* AccountTests.swift in Sources */,
 				F9A7083F1CAEEB7500C2F5FE /* PersistentChangeTrackingTests.m in Sources */,
@@ -2579,7 +2591,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9C9A67D1CAD7A790039E10C /* ios-test-target.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -2607,7 +2618,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9C9A67D1CAD7A790039E10C /* ios-test-target.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -2591,6 +2591,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9C9A67D1CAD7A790039E10C /* ios-test-target.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -2618,6 +2619,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F9C9A67D1CAD7A790039E10C /* ios-test-target.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -79,7 +79,7 @@
 		54F581FF1F2F716B0051ACE8 /* StorageStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F581FD1F2F70CE0051ACE8 /* StorageStackTests.swift */; };
 		54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */; };
 		54F84CFD1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */; };
-		54F84D031F995B0200ABD7D5 /* DuplicateEntityRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */; };
+		54F84D031F995B0200ABD7D5 /* DuplicatedEntityRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84CFE1F99588D00ABD7D5 /* DuplicatedEntityRemovalTests.swift */; };
 		54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */; };
 		54FB03A11E41E273000E13DC /* PersistedDataPatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */; };
 		54FB03A31E41E64A000E13DC /* UserClient+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB03A21E41E64A000E13DC /* UserClient+Patches.swift */; };
@@ -518,7 +518,7 @@
 		54F581FD1F2F70CE0051ACE8 /* StorageStackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageStackTests.swift; sourceTree = "<group>"; };
 		54F6CEAA1CE2972200A1276D /* ZMAssetClientMessage+Download.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Download.swift"; sourceTree = "<group>"; };
 		54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicatedEntityRemoval.swift; sourceTree = "<group>"; };
-		54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateEntityRemovalTests.swift; sourceTree = "<group>"; };
+		54F84CFE1F99588D00ABD7D5 /* DuplicatedEntityRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicatedEntityRemovalTests.swift; sourceTree = "<group>"; };
 		54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskDatabaseTests.swift; sourceTree = "<group>"; };
 		54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistedDataPatches.swift; sourceTree = "<group>"; };
 		54FB03A21E41E64A000E13DC /* UserClient+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserClient+Patches.swift"; sourceTree = "<group>"; };
@@ -1003,7 +1003,7 @@
 			isa = PBXGroup;
 			children = (
 				54FB03AC1E41F6C2000E13DC /* PersistedDataPatchesTests.swift */,
-				54F84CFE1F99588D00ABD7D5 /* DuplicateEntityRemovalTests.swift */,
+				54F84CFE1F99588D00ABD7D5 /* DuplicatedEntityRemovalTests.swift */,
 				54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */,
 			);
 			name = Utils;
@@ -2425,7 +2425,7 @@
 				BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */,
 				F9DBA5251E28EE1500BE23C0 /* ConversationObserverTests.swift in Sources */,
 				BFE3A96C1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift in Sources */,
-				54F84D031F995B0200ABD7D5 /* DuplicateEntityRemovalTests.swift in Sources */,
+				54F84D031F995B0200ABD7D5 /* DuplicatedEntityRemovalTests.swift in Sources */,
 				BF707C511EB9F9CC00108D4E /* ClusterizerTests.swift in Sources */,
 				BF491CEA1F063F440055EE44 /* AccountTests.swift in Sources */,
 				F9A7083F1CAEEB7500C2F5FE /* PersistentChangeTrackingTests.m in Sources */,


### PR DESCRIPTION
Normalize database by removing duplicate entries at initialization.

- [x] TODO: one test is still failing, `testThatItRemovesAllDuplicates`