### PR TITLE
Fix for double system message

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -859,7 +859,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
                                       prefetchResult:(ZMFetchRequestBatchResult *)prefetchResult
 {
     ZMSystemMessageType type = [self.class systemMessageTypeFromEventType:updateEvent.type];
-    if(type == ZMSystemMessageTypeInvalid) {
+    if (type == ZMSystemMessageTypeInvalid) {
         return nil;
     }
     
@@ -879,9 +879,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
         return nil;
     }
     
+    NSString *messageText = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"message"] stringByRemovingExtremeCombiningCharacters];
+    NSString *name = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"name"] stringByRemovingExtremeCombiningCharacters];
+    
     NSMutableSet *usersSet = [NSMutableSet set];
-    for(NSString *userId in [[updateEvent.payload dictionaryForKey:@"data"] optionalArrayForKey:@"user_ids"])
-    {
+    for(NSString *userId in [[updateEvent.payload dictionaryForKey:@"data"] optionalArrayForKey:@"user_ids"]) {
         ZMUser *user = [ZMUser userWithRemoteID:[NSUUID uuidWithTransportString:userId] createIfNeeded:YES inContext:moc];
         [usersSet addObject:user];
     }
@@ -895,17 +897,9 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     if (![usersSet isEqual:[NSSet setWithObject:message.sender]]) {
         [usersSet removeObject:message.sender];
     }
+    
     message.users = usersSet;
-
-    NSString *messageText = [[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"message"];
-    NSString *name = [[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"name"];
-    if (messageText != nil) {
-        message.text = messageText.stringByRemovingExtremeCombiningCharacters;
-    }
-    else if (name != nil) {
-        message.text = name.stringByRemovingExtremeCombiningCharacters;
-    }
-
+    message.text = messageText != nil ? messageText : name;
     message.isEncrypted = NO;
     message.isPlainText = YES;
     


### PR DESCRIPTION
Clean up ZMSystemMessage. No logical changes.

---

## Problem
When a user changes a conversation name or add/remove a participant we currently will insert
two system message for this event. This happens because the change event arrives twice, first
in the response of POST response and second in the notification stream.

## Solution
Add a check before inserting these system messages for if the change has already been applied.