### PR TITLE
remove unneccessary check

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -865,20 +865,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     
     ZMConversation *conversation = [self conversationForUpdateEvent:updateEvent inContext:moc prefetchResult:prefetchResult];
     VerifyReturnNil(conversation != nil);
-    
-    if ((conversation.conversationType != ZMConversationTypeGroup) &&
-        ((updateEvent.type == ZMUpdateEventConversationMemberJoin) ||
-         (updateEvent.type == ZMUpdateEventConversationMemberLeave) ||
-         (updateEvent.type == ZMUpdateEventConversationMemberUpdate) ||
-         (updateEvent.type == ZMUpdateEventConversationMessageAdd) ||
-         (updateEvent.type == ZMUpdateEventConversationClientMessageAdd) ||
-         (updateEvent.type == ZMUpdateEventConversationOtrMessageAdd) ||
-         (updateEvent.type == ZMUpdateEventConversationOtrAssetAdd)
-         ))
-    {
-        return nil;
-    }
-    
+        
     NSString *messageText = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"message"] stringByRemovingExtremeCombiningCharacters];
     NSString *name = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"name"] stringByRemovingExtremeCombiningCharacters];
     

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -871,7 +871,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     // We don't explicitly check for group conversation type b/c if this is the first time we were added to the conversation,
     // then the default conversation type is `invalid` (b/c we haven't fetched from BE yet), so we assume BE sent the
     // update event for a group conversation.
-    if (type == ZMSystemMessageTypeConnectionRequest && conversation.conversationType != ZMConversationTypeConnection) {
+    if (conversation.conversationType == ZMConversationTypeConnection && type != ZMSystemMessageTypeConnectionRequest) {
         return nil;
     }
     

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -865,7 +865,16 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     
     ZMConversation *conversation = [self conversationForUpdateEvent:updateEvent inContext:moc prefetchResult:prefetchResult];
     VerifyReturnNil(conversation != nil);
-        
+    
+    // Only create connection request system message if conversation type is valid.
+    // Note: if type is not connection request, then it relates to group conversations (see first line of this method).
+    // We don't explicitly check for group conversation type b/c if this is the first time we were added to the conversation,
+    // then the default conversation type is `invalid` (b/c we haven't fetched from BE yet), so we assume BE sent the
+    // update event for a group conversation.
+    if (type == ZMSystemMessageTypeConnectionRequest && conversation.conversationType != ZMConversationTypeConnection) {
+        return nil;
+    }
+    
     NSString *messageText = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"message"] stringByRemovingExtremeCombiningCharacters];
     NSString *name = [[[updateEvent.payload dictionaryForKey:@"data"] optionalStringForKey:@"name"] stringByRemovingExtremeCombiningCharacters];
     


### PR DESCRIPTION
This check was preventing system messages being created for first time self member join events, b/c the brand new conversation has not had it’s `conversationType` set to `group` yet, and it defaults to `invalid`. Thus we were returning nil. 

However, in the first line of the method we already do event type checking (only `memberJoin`, `memberLeave`, `conversationRename` and `connectRequest` are permitted), so most of these removed checks are unneccessary. Having said that, we are assuming/expecting that the conversation referenced on the Backend actually is a group conversation.