### PR TITLE
Remove usage of depreciated BE fields

### DIFF
--- a/Source/Model/Connection/ZMConnection.m
+++ b/Source/Model/Connection/ZMConnection.m
@@ -389,9 +389,7 @@ struct stringAndStatus {
         }
     }
     
-    if (connection.conversation.lastServerTimeStamp == nil) {
-        connection.conversation.needsToBeUpdatedFromBackend = YES;
-    }
+    connection.conversation.needsToBeUpdatedFromBackend = YES;
 }
 
 + (ZMConversationType)conversationTypeForConnectionStatus:(ZMConnectionStatus)status

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -193,6 +193,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)internalAddParticipants:(nonnull NSSet<ZMUser *> *)participants isAuthoritative:(BOOL)isAuthoritative;
 - (void)internalRemoveParticipants:(nonnull NSSet<ZMUser *> *)participants sender:(nonnull ZMUser *)sender;
+- (void)internalRemoveParticipants:(nonnull NSSet<ZMUser *> *)participants sender:(nonnull ZMUser *)sender isAuthoritative:(BOOL)isAuthoritative;
 
 @property (nonatomic) BOOL isSelfAnActiveMember; ///< whether the self user is an active member (as opposed to a past member)
 @property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *otherActiveParticipants;

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -129,8 +129,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSMutableOrderedSet<ZMUser *> *removedUsers = [lastSyncedUsers mutableCopy];
     [removedUsers minusOrderedSet:users];
     
-    [self internalAddParticipants:addedUsers isAuthoritative:YES];
-    [self internalRemoveParticipants:removedUsers sender:[ZMUser selfUserInContext:self.managedObjectContext] isAuthoritative:YES];
+    [self internalAddParticipants:addedUsers.set isAuthoritative:YES];
+    [self internalRemoveParticipants:removedUsers.set sender:[ZMUser selfUserInContext:self.managedObjectContext] isAuthoritative:YES];
 }
 
 - (void)updateTeamWithIdentifier:(NSUUID *)teamId

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -134,8 +134,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     }
     
     for (ZMUser *user in removedUsers) {
-        [self.mutableOtherActiveParticipants removeObject:user];
-        [self.mutableLastServerSyncedActiveParticipants removeObject:user];
+        [self internalRemoveParticipants:[NSSet setWithObject:user] sender:[ZMUser selfUserInContext:self.managedObjectContext] isAuthoritative:YES];
     }
 }
 

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -129,13 +129,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSMutableOrderedSet<ZMUser *> *removedUsers = [lastSyncedUsers mutableCopy];
     [removedUsers minusOrderedSet:users];
     
-    for (ZMUser *user in addedUsers) {
-        [self internalAddParticipants:[NSSet setWithObject:user] isAuthoritative:YES];
-    }
-    
-    for (ZMUser *user in removedUsers) {
-        [self internalRemoveParticipants:[NSSet setWithObject:user] sender:[ZMUser selfUserInContext:self.managedObjectContext] isAuthoritative:YES];
-    }
+    [self internalAddParticipants:addedUsers isAuthoritative:YES];
+    [self internalRemoveParticipants:removedUsers sender:[ZMUser selfUserInContext:self.managedObjectContext] isAuthoritative:YES];
 }
 
 - (void)updateTeamWithIdentifier:(NSUUID *)teamId

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -26,7 +26,6 @@
 #import "ZMUpdateEvent+WireDataModel.h"
 #import <WireDataModel/WireDataModel-Swift.h>
 
-static NSString *const ConversationInfoStatusKey = @"status";
 static NSString *const ConversationInfoNameKey = @"name";
 static NSString *const ConversationInfoTypeKey = @"type";
 static NSString *const ConversationInfoIDKey = @"id";
@@ -35,7 +34,6 @@ static NSString *const ConversationInfoOthersKey = @"others";
 static NSString *const ConversationInfoMembersKey = @"members";
 static NSString *const ConversationInfoCreatorKey = @"creator";
 static NSString *const ConversationInfoTeamIdKey = @"team";
-static NSString *const ConversationInfoLastEventTimeKey = @"last_event_time";
 
 NSString *const ZMConversationInfoOTRMutedValueKey = @"otr_muted";
 NSString *const ZMConversationInfoOTRMutedReferenceKey = @"otr_muted_ref";
@@ -75,9 +73,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     
     self.conversationType = [self conversationTypeFromTransportData:[transportData numberForKey:ConversationInfoTypeKey]];
     
-    NSDate *lastTimeStamp = serverTimeStamp ?: [transportData dateForKey:ConversationInfoLastEventTimeKey];
-    [self updateLastModifiedDateIfNeeded:lastTimeStamp];
-    [self updateLastServerTimeStampIfNeeded:lastTimeStamp];
+    [self updateLastModifiedDateIfNeeded:serverTimeStamp];
+    [self updateLastServerTimeStampIfNeeded:serverTimeStamp];
     
     NSDictionary *selfStatus = [[transportData dictionaryForKey:ConversationInfoMembersKey] dictionaryForKey:@"self"];
     if(selfStatus != nil) {
@@ -109,22 +106,36 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 
 - (void)updateMembersWithPayload:(NSDictionary *)members
 {
-    NSArray *users = [members arrayForKey:ConversationInfoOthersKey];
-    for(NSDictionary *userDict in [users asDictionaries]) {
+    NSArray *usersInfos = [members arrayForKey:ConversationInfoOthersKey];
+    NSMutableOrderedSet<ZMUser *> *users = [NSMutableOrderedSet orderedSet];
+    NSMutableOrderedSet<ZMUser *> *lastSyncedUsers = [NSMutableOrderedSet orderedSet];
+    
+    if (self.mutableLastServerSyncedActiveParticipants != nil) {
+        lastSyncedUsers = self.mutableLastServerSyncedActiveParticipants;
+    }
+    
+    for (NSDictionary *userDict in [usersInfos asDictionaries]) {
         
         NSUUID *userId = [userDict uuidForKey:ConversationInfoIDKey];
-        if(userId == nil) {
+        if (userId == nil) {
             continue;
         }
-        ZMUser *user = [ZMUser userWithRemoteID:userId createIfNeeded:YES inContext:self.managedObjectContext];
         
-        if([[userDict numberForKey:ConversationInfoStatusKey] intValue] == 0) {
-            [self internalAddParticipants:[NSSet setWithObject:user] isAuthoritative:YES];
-        }
-        else {
-            [self.mutableOtherActiveParticipants removeObject:user];
-            [self.mutableLastServerSyncedActiveParticipants removeObject:user];
-        }
+        [users addObject:[ZMUser userWithRemoteID:userId createIfNeeded:YES inContext:self.managedObjectContext]];
+    }
+    
+    NSMutableOrderedSet<ZMUser *> *addedUsers = [users mutableCopy];
+    [addedUsers minusOrderedSet:lastSyncedUsers];
+    NSMutableOrderedSet<ZMUser *> *removedUsers = [lastSyncedUsers mutableCopy];
+    [removedUsers minusOrderedSet:users];
+    
+    for (ZMUser *user in addedUsers) {
+        [self internalAddParticipants:[NSSet setWithObject:user] isAuthoritative:YES];
+    }
+    
+    for (ZMUser *user in removedUsers) {
+        [self.mutableOtherActiveParticipants removeObject:user];
+        [self.mutableLastServerSyncedActiveParticipants removeObject:user];
     }
 }
 
@@ -156,10 +167,7 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
 /// Pass timeStamp when the timeStamp equals the time of the lastRead / cleared event, otherwise pass nil
 - (void)updateSelfStatusFromDictionary:(NSDictionary *)dictionary timeStamp:(NSDate *)timeStamp previousLastServerTimeStamp:(NSDate *)previousLastServerTimestamp
 {
-    NSNumber *status = [dictionary optionalNumberForKey:ConversationInfoStatusKey];
-    if(status != nil) {
-        self.isSelfAnActiveMember = status.integerValue == 0;
-    }
+    self.isSelfAnActiveMember = YES;
     
     [self updateIsSilencedWithPayload:dictionary];
     if ([self updateIsArchivedWithPayload:dictionary] && self.isArchived && previousLastServerTimestamp != nil) {

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1549,6 +1549,11 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (void)internalRemoveParticipants:(NSSet<ZMUser *> *)participants sender:(ZMUser *)sender
 {
+    [self internalRemoveParticipants:participants sender:sender isAuthoritative:NO];
+}
+
+- (void)internalRemoveParticipants:(NSSet<ZMUser *> *)participants sender:(ZMUser *)sender isAuthoritative:(BOOL)isAuthoritative
+{
     VerifyReturn(participants != nil);
     
     [participants enumerateObjectsUsingBlock:^(ZMUser * _Nonnull participant, BOOL * _Nonnull stop __unused) {
@@ -1565,8 +1570,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         self.isArchived = sender.isSelfUser;
     }
     
-    if (! [self.otherActiveParticipants intersectsSet:otherUsers]) {
-        return;
+    if (isAuthoritative) {
+        [self.mutableLastServerSyncedActiveParticipants removeObjectsInArray:otherUsers.allObjects];
     }
     
     [self.mutableOtherActiveParticipants removeObjectsInArray:otherUsers.allObjects];

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1058,6 +1058,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     } else if (create) {
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:moc];
         conversation.remoteIdentifier = UUID;
+        conversation.lastModifiedDate = [NSDate dateWithTimeIntervalSince1970:0];
+        conversation.lastServerTimeStamp = [NSDate dateWithTimeIntervalSince1970:0];
         if (nil != created) {
             *created = YES;
         }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -138,7 +138,7 @@
         ZMUser *user2 = [ZMUser userWithRemoteID:user2UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user2);
         
-        XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
+        XCTAssertEqualObjects(conversation.otherActiveParticipants.set, ([NSSet setWithObjects:user1, user2, nil]) );
                         
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);
         XCTAssertEqual(conversation.unsyncedInactiveParticipants.count, 0u);
@@ -203,7 +203,7 @@
         ZMUser *user2 = [ZMUser userWithRemoteID:user2UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user2);
 
-        XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
+        XCTAssertEqualObjects(conversation.otherActiveParticipants.set, ([NSSet setWithObjects:user1, user2, nil]) );
         XCTAssertNil(conversation.team);
         XCTAssertEqualObjects(conversation.teamRemoteIdentifier, teamID);
 
@@ -247,7 +247,7 @@
         ZMUser *user2 = [ZMUser userWithRemoteID:user2UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user2);
 
-        XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
+        XCTAssertEqualObjects(conversation.otherActiveParticipants.set, ([NSSet setWithObjects:user1, user2, nil]) );
         XCTAssertNotNil(conversation.team);
         XCTAssertFalse(conversation.team.needsToBeUpdatedFromBackend);
         XCTAssertFalse(conversation.team.needsToRedownloadMembers);
@@ -291,7 +291,7 @@
         ZMUser *user2 = [ZMUser userWithRemoteID:user2UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user2);
 
-        XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
+        XCTAssertEqualObjects(conversation.otherActiveParticipants.set, ([NSSet setWithObjects:user1, user2, nil]) );
         XCTAssertNil(conversation.team);
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);
         XCTAssertEqual(conversation.unsyncedInactiveParticipants.count, 0u);

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -28,27 +28,17 @@
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation conversationType:(ZMBackendConversationType)conversationType isArchived:(BOOL)isArchived archivedRef:(NSDate *)archivedRef isSilenced:(BOOL)isSilenced
     silencedRef: (NSDate *)silencedRef;
 {
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:conversationType activeUserIDs:@[] inactiveUserIDs:@[]  lastServerTimestamp:nil isArchived:isArchived archivedRef:archivedRef isSilenced:isSilenced silencedRef:silencedRef teamID:nil];
+    return  [self payloadForMetaDataOfConversation:conversation conversationType:conversationType activeUserIDs:@[] isArchived:isArchived archivedRef:archivedRef isSilenced:isSilenced silencedRef:silencedRef teamID:nil];
 }
 
-- (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation activeUserIDs:(NSArray <NSUUID *>*)activeUserIDs inactiveUserIDs:(NSArray <NSUUID *>*)inactiveUserIDs;
+- (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation activeUserIDs:(NSArray <NSUUID *>*)activeUserIDs
 {
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs  lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
-}
-
-- (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
-                                     activeUserIDs:(NSArray <NSUUID *>*)activeUserIDs
-                                   inactiveUserIDs:(NSArray <NSUUID *>*)inactiveUserIDs
-                               lastServerTimestamp:(NSDate*)lastServerTimestamp
-{
-    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs inactiveUserIDs:inactiveUserIDs lastServerTimestamp:lastServerTimestamp isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
+    return  [self payloadForMetaDataOfConversation:conversation conversationType:1 activeUserIDs:activeUserIDs isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
                                   conversationType:(ZMBackendConversationType)conversationType
                                      activeUserIDs:(NSArray <NSUUID *>*)activeUserIDs
-                                   inactiveUserIDs:(NSArray <NSUUID *>*)inactiveUserIDs
-                               lastServerTimestamp:(NSDate*)lastServerTimestamp
                                         isArchived:(BOOL)isArchived
                                        archivedRef:(NSDate *)archivedRef
                                         isSilenced:(BOOL)isSilenced
@@ -58,31 +48,16 @@
     NSMutableArray *others = [NSMutableArray array];
     for (NSUUID *uuid in activeUserIDs) {
         NSDictionary *userInfo = @{
-                                   @"status": @0,
                                    @"id": [uuid transportString]
                                    };
         [others addObject:userInfo];
     }
     
-    for (NSUUID *uuid in inactiveUserIDs) {
-        NSDictionary *userInfo = @{
-                                   @"status": @1,
-                                   @"id": [uuid transportString]
-                                   };
-        [others addObject:userInfo];
-    }
-
     NSDictionary *payload = @{
-                              @"last_event_time" : lastServerTimestamp ? [lastServerTimestamp transportString] :@"2014-04-30T16:30:16.625Z",
                               @"name" : [NSNull null],
                               @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
                               @"members" : @{
                                       @"self" : @{
-                                              @"status" : @0,
-                                              @"muted_time" : [NSNull null],
-                                              @"status_ref" : @"0.0",
-                                              @"last_read" : @"5.800112314308490f",
-                                              @"status_time" : @"2014-03-14T16:47:37.573Z",
                                               @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
                                               @"otr_archived" : @(isArchived),
                                               @"otr_archived_ref" : archivedRef ? [archivedRef transportString] : [NSNull null],
@@ -105,20 +80,21 @@
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
+        NSDate *serverTimestamp = [NSDate date];
         NSDate *archivedDate = [NSDate date];
         NSDate *silencedDate = [archivedDate dateByAddingTimeInterval:10];
         
         NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup isArchived:YES archivedRef:archivedDate isSilenced:YES silencedRef:silencedDate];
         
         // when
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
         
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
         XCTAssertNil(conversation.userDefinedName);
         XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
-        XCTAssertEqualObjects(conversation.lastModifiedDate, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
-        XCTAssertEqualObjects(conversation.lastServerTimeStamp, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimestamp);
+        XCTAssertEqualObjects(conversation.lastServerTimeStamp, serverTimestamp);
         
         XCTAssertTrue(conversation.isArchived);
         XCTAssertEqualWithAccuracy([conversation.archivedChangedTimestamp timeIntervalSince1970], [archivedDate timeIntervalSince1970], 1.0);
@@ -137,23 +113,23 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSDate *serverTimestamp = [NSDate date];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         
         NSUUID *user1UUID = [NSUUID createUUID];
         NSUUID *user2UUID = [NSUUID createUUID];
-        NSUUID *user3UUID = [NSUUID createUUID];
         
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs: @[user3UUID]];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID]];
         
         // when
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
         
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
         XCTAssertNil(conversation.userDefinedName);
         XCTAssertEqual(conversation.conversationType, ZMConversationTypeSelf);
-        XCTAssertEqualObjects(conversation.lastModifiedDate, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimestamp);
         XCTAssertEqualObjects(conversation.creator.remoteIdentifier, [payload[@"creator"] UUID]);
         
         ZMUser *user1 = [ZMUser userWithRemoteID:user1UUID createIfNeeded:NO inContext:self.syncMOC];
@@ -163,10 +139,7 @@
         XCTAssertNotNil(user2);
         
         XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSOrderedSet orderedSetWithObjects:user1, user2, nil]) );
-        
-        ZMUser *user3 = [ZMUser userWithRemoteID:user3UUID createIfNeeded:NO inContext:self.syncMOC];
-        XCTAssertNotNil(user3);
-                
+                        
         XCTAssertEqual(conversation.unsyncedActiveParticipants.count, 0u);
         XCTAssertEqual(conversation.unsyncedInactiveParticipants.count, 0u);
         
@@ -203,6 +176,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSDate *serverTimestamp = [NSDate date];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
 
@@ -210,16 +184,16 @@
         NSUUID *user2UUID = [NSUUID createUUID];
         NSUUID *teamID = [NSUUID createUUID];
 
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:teamID];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:teamID];
 
         // when
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
         XCTAssertNil(conversation.userDefinedName);
         XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
-        XCTAssertEqualObjects(conversation.lastModifiedDate, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimestamp);
         XCTAssertEqualObjects(conversation.creator.remoteIdentifier, [payload[@"creator"] UUID]);
 
 
@@ -246,6 +220,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSDate *serverTimestamp = [NSDate date];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
 
@@ -253,16 +228,16 @@
         NSUUID *user2UUID = [NSUUID createUUID];
         Team *team = [Team fetchOrCreateTeamWithRemoteIdentifier:NSUUID.createUUID createIfNeeded:YES inContext:self.syncMOC created:nil];
 
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:team.remoteIdentifier];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:team.remoteIdentifier];
 
         // when
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
         XCTAssertNil(conversation.userDefinedName);
         XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
-        XCTAssertEqualObjects(conversation.lastModifiedDate, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimestamp);
         XCTAssertEqualObjects(conversation.creator.remoteIdentifier, [payload[@"creator"] UUID]);
 
 
@@ -291,24 +266,24 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSDate *serverTimestamp = [NSDate date];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
 
         NSUUID *user1UUID = [NSUUID createUUID];
         NSUUID *user2UUID = [NSUUID createUUID];
 
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] inactiveUserIDs:nil lastServerTimestamp:nil isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:ZMConvTypeGroup activeUserIDs:@[user1UUID, user2UUID] isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil teamID:nil];
 
         // when
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
 
         // then
         XCTAssertEqualObjects(conversation.remoteIdentifier, [payload[@"id"] UUID]);
         XCTAssertNil(conversation.userDefinedName);
         XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
-        XCTAssertEqualObjects(conversation.lastModifiedDate, [NSDate dateWithTransportString:payload[@"last_event_time"]]);
+        XCTAssertEqualObjects(conversation.lastModifiedDate, serverTimestamp);
         XCTAssertEqualObjects(conversation.creator.remoteIdentifier, [payload[@"creator"] UUID]);
-
 
         ZMUser *user1 = [ZMUser userWithRemoteID:user1UUID createIfNeeded:NO inContext:self.syncMOC];
         XCTAssertNotNil(user1);
@@ -339,7 +314,7 @@
         NSUUID *user2UUID = [NSUUID createUUID];
         NSUUID *user3UUID = [NSUUID createUUID];
         
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID, user3UUID] inactiveUserIDs:@[]];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation activeUserIDs:@[user1UUID, user2UUID, user3UUID]];
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:nil];
         XCTAssertTrue([self.syncMOC saveOrRollback]);
@@ -377,19 +352,10 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         NSDictionary *payload = @{
-                                  @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                                   @"name" : [NSNull null],
                                   @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                                  @"last_event" : @"5.800112314308490f",
                                   @"members" : @{
                                           @"self" : @{
-                                                  @"status" : @0,
-                                                  @"muted_time" : [NSNull null],
-                                                  @"status_ref" : @"0.0",
-                                                  @"last_read" : @"5.800112314308490f",
-                                                  @"muted" : [NSNull null],
-                                                  @"archived" : [NSNull null],
-                                                  @"status_time" : @"2014-03-14T16:47:37.573Z",
                                                   @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
                                                   },
                                           },
@@ -417,10 +383,8 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         NSDictionary *payload = @{
-                                  @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                                   @"name" : [NSNull null],
                                   @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                                  @"last_event" : @"5.800112314308490f",
                                   @"members" : @{
                                           @"others" : @[]
                                           },
@@ -448,10 +412,8 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         NSDictionary *payload = @{
-                                  @"last_event_time" : @4,
                                   @"name" : @5,
                                   @"creator" : @6,
-                                  @"last_event" : @7,
                                   @"members" : @8,
                                   @"type" : @"goo",
                                   @"id" : @100
@@ -477,10 +439,8 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         NSDictionary *payload = @{
-                                  @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                                   @"name" : [NSNull null],
                                   @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                                  @"last_event" : @"5.800112314308490f",
                                   @"members" : @{
                                           @"others" : @3
                                           },

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -34,11 +34,8 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         
-        
         NSUUID *user1UUID = [NSUUID createUUID];
         NSUUID *user2UUID = [NSUUID createUUID];
-        NSUUID *user3UUID = [NSUUID createUUID];
-        
         
         ZMUser *user4 = [self createUserOnMoc:self.syncMOC];
         ZMUser *user5 = [self createUserOnMoc:self.syncMOC];
@@ -67,11 +64,7 @@
                                                       },
                                                   @{
                                                       @"id": [user2UUID transportString]
-                                                      },
-                                                  @{
-                                                      @"id": [user3UUID transportString]
-                                                      },
-                                                  
+                                                      }
                                                   ]
                                           },
                                   @"type" : @0,
@@ -83,7 +76,7 @@
         
         // then
         XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, user5, nil]));
-        XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
+        XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, [NSMutableOrderedSet orderedSet]);
     }];
 }
 
@@ -170,7 +163,7 @@
 }
 
 
-- (void)testThatWhenAParticipantHasBeenAddedOnTheClientAndTheServerWeDoSyncItAnymore
+- (void)testThatWhenAParticipantHasBeenAddedOnTheClientAndTheServerWeDoNotSyncItAnymore
 {
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -181,11 +174,9 @@
     
     NSUUID *user1UUID = [NSUUID createUUID];
     NSUUID *user2UUID = [NSUUID createUUID];
-    NSUUID *user3UUID = [NSUUID createUUID];
-    
     
     ZMUser *user4 = [self createUser];
-    ZMUser *user5 = [self createUser];
+    ZMUser *user5 = [self createUser]; // will also added by the server
     ZMUser *user6 = [self createUser];
     
     [conversation addParticipant:user4];
@@ -211,9 +202,6 @@
                                                   },
                                               @{
                                                   @"id": [user2UUID transportString]
-                                                  },
-                                              @{
-                                                  @"id": [user3UUID transportString]
                                                   },
                                               @{
                                                   @"id": [user5.remoteIdentifier transportString]
@@ -237,7 +225,7 @@
     
     // then
     XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, nil]));
-    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
+    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, [NSMutableOrderedSet orderedSet]);
 }
 
 
@@ -253,7 +241,6 @@
     
     NSUUID *user1UUID = [NSUUID createUUID];
     NSUUID *user2UUID = [NSUUID createUUID];
-    NSUUID *user3UUID = [NSUUID createUUID];
     
     
     ZMUser *user4 = [self createUser];
@@ -265,7 +252,7 @@
     [conversation addParticipant:user6];
     
     [conversation synchronizeAddedUser:user6];
-    [conversation removeParticipant:user6];
+    [conversation removeParticipant:user6]; // // will also removed by the server
     
     XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, user5, nil]));
     XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
@@ -283,14 +270,7 @@
                                                   },
                                               @{
                                                   @"id": [user2UUID transportString]
-                                                  },
-                                              @{
-                                                  @"id": [user3UUID transportString]
-                                                  },
-                                              @{
-                                                  @"id": [user6.remoteIdentifier transportString]
-                                                  },
-                                              
+                                                  }
                                               ]
                                       },
                               @"type" : @0,
@@ -309,7 +289,7 @@
     
     // then
     XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, user5, nil]));
-    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSet]));
+    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, [NSMutableOrderedSet orderedSet]);
 }
 
 - (void)testThatWhenMovingAParticipantFromInactiveToActiveWeDoNotRemoveItAgain

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -55,32 +55,20 @@
         XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
         
         NSDictionary *payload = @{
-                                  @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                                   @"name" : [NSNull null],
                                   @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                                  @"last_event" : @"5.800112314308490f",
                                   @"members" : @{
                                           @"self" : @{
-                                                  @"status" : @0,
-                                                  @"muted_time" : [NSNull null],
-                                                  @"status_ref" : @"0.0",
-                                                  @"last_read" : @"5.800112314308490f",
-                                                  @"muted" : [NSNull null],
-                                                  @"archived" : [NSNull null],
-                                                  @"status_time" : @"2014-03-14T16:47:37.573Z",
                                                   @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
                                                   },
                                           @"others" : @[
                                                   @{
-                                                      @"status": @0,
                                                       @"id": [user1UUID transportString]
                                                       },
                                                   @{
-                                                      @"status": @0,
                                                       @"id": [user2UUID transportString]
                                                       },
                                                   @{
-                                                      @"status": @1,
                                                       @"id": [user3UUID transportString]
                                                       },
                                                   
@@ -211,36 +199,23 @@
     XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
     
     NSDictionary *payload = @{
-                              @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                               @"name" : [NSNull null],
                               @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                              @"last_event" : @"5.800112314308490f",
                               @"members" : @{
                                       @"self" : @{
-                                              @"status" : @0,
-                                              @"muted_time" : [NSNull null],
-                                              @"status_ref" : @"0.0",
-                                              @"last_read" : @"5.800112314308490f",
-                                              @"muted" : [NSNull null],
-                                              @"archived" : [NSNull null],
-                                              @"status_time" : @"2014-03-14T16:47:37.573Z",
                                               @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
                                               },
                                       @"others" : @[
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user1UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user2UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @1,
                                                   @"id": [user3UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user5.remoteIdentifier transportString]
                                                   },
                                               
@@ -296,36 +271,23 @@
     XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user6, nil]));
     
     NSDictionary *payload = @{
-                              @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                               @"name" : [NSNull null],
                               @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                              @"last_event" : @"5.800112314308490f",
                               @"members" : @{
                                       @"self" : @{
-                                              @"status" : @0,
-                                              @"muted_time" : [NSNull null],
-                                              @"status_ref" : @"0.0",
-                                              @"last_read" : @"5.800112314308490f",
-                                              @"muted" : [NSNull null],
-                                              @"archived" : [NSNull null],
-                                              @"status_time" : @"2014-03-14T16:47:37.573Z",
                                               @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
                                               },
                                       @"others" : @[
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user1UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user2UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @1,
                                                   @"id": [user3UUID transportString]
                                                   },
                                               @{
-                                                  @"status": @1,
                                                   @"id": [user6.remoteIdentifier transportString]
                                                   },
                                               
@@ -349,93 +311,6 @@
     XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user4, user5, nil]));
     XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSet]));
 }
-
-
-
-- (void)testThatWhenMovingAParticipantFromActiveToInactiveWeDoNotAddItAgain
-{
-    
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.conversationType = ZMConversationTypeGroup;
-    NSUUID *uuid = NSUUID.createUUID;
-    conversation.remoteIdentifier = uuid;
-    
-    
-    ZMUser *user1 = [self createUser];
-    ZMUser *user2 = [self createUser];
-    ZMUser *user3 = [self createUser];
-    
-    [conversation addParticipant:user1]; [conversation synchronizeAddedUser:user1];
-    [conversation addParticipant:user2]; [conversation synchronizeAddedUser:user2];
-    [conversation addParticipant:user3]; [conversation synchronizeAddedUser:user3];
-    
-    [self.uiMOC saveOrRollback];
-    
-    XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSet]));
-    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSet]));
-    
-    XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:ZMConversationUnsyncedInactiveParticipantsKey]);
-    XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:ZMConversationUnsyncedActiveParticipantsKey]);
-    
-    
-    NSDictionary *payload = @{
-                              @"last_event_time" : @"2014-04-30T16:30:16.625Z",
-                              @"name" : [NSNull null],
-                              @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                              @"last_event" : @"5.800112314308490f",
-                              @"members" : @{
-                                      @"self" : @{
-                                              @"status" : @0,
-                                              @"muted_time" : [NSNull null],
-                                              @"status_ref" : @"0.0",
-                                              @"last_read" : @"5.800112314308490f",
-                                              @"muted" : [NSNull null],
-                                              @"archived" : [NSNull null],
-                                              @"status_time" : @"2014-03-14T16:47:37.573Z",
-                                              @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
-                                              },
-                                      @"others" : @[
-                                              @{
-                                                  @"status": @0,
-                                                  @"id": [user1.remoteIdentifier transportString]
-                                                  },
-                                              @{
-                                                  @"status": @0,
-                                                  @"id": [user2.remoteIdentifier transportString]
-                                                  },
-                                              @{
-                                                  @"status": @1,
-                                                  @"id": [user3.remoteIdentifier transportString]
-                                                  }
-                                              
-                                              ]
-                                      },
-                              @"type" : @0,
-                              @"id" : [uuid transportString]
-                              };
-    
-    // when
-    XCTAssert([self.uiMOC saveOrRollback]);
-    NSManagedObjectID *moid = conversation.objectID;
-    [self.syncMOC performGroupedBlockAndWait:^{
-        ZMConversation *syncConversation = (id) [self.syncMOC objectWithID:moid];
-        [syncConversation updateWithTransportData:payload serverTimeStamp:nil];
-        XCTAssert([self.syncMOC saveOrRollback]);
-    }];
-    [self.uiMOC refreshObject:conversation mergeChanges:NO];
-    
-    // then
-    XCTAssertEqualObjects(conversation.unsyncedActiveParticipants, ([NSMutableOrderedSet orderedSet]));
-    XCTAssertEqualObjects(conversation.unsyncedInactiveParticipants, ([NSMutableOrderedSet orderedSet]));
-    
-    XCTAssertEqualObjects(conversation.otherActiveParticipants, ([NSMutableOrderedSet orderedSetWithObjects:user1, user2, nil]));
-    
-    XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:ZMConversationUnsyncedActiveParticipantsKey]);
-    XCTAssertFalse([conversation.keysThatHaveLocalModifications containsObject:ZMConversationUnsyncedInactiveParticipantsKey]);
-}
-
-
 
 - (void)testThatWhenMovingAParticipantFromInactiveToActiveWeDoNotRemoveItAgain
 {
@@ -466,32 +341,20 @@
     
     
     NSDictionary *payload = @{
-                              @"last_event_time" : @"2014-04-30T16:30:16.625Z",
                               @"name" : [NSNull null],
                               @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-                              @"last_event" : @"5.800112314308490f",
                               @"members" : @{
                                       @"self" : @{
-                                              @"status" : @0,
-                                              @"muted_time" : [NSNull null],
-                                              @"status_ref" : @"0.0",
-                                              @"last_read" : @"5.800112314308490f",
-                                              @"muted" : [NSNull null],
-                                              @"archived" : [NSNull null],
-                                              @"status_time" : @"2014-03-14T16:47:37.573Z",
                                               @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
                                               },
                                       @"others" : @[
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user1.remoteIdentifier transportString]
                                                   },
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user2.remoteIdentifier transportString]
                                                   },
                                               @{
-                                                  @"status": @0,
                                                   @"id": [user3.remoteIdentifier transportString]
                                                   }
                                               
@@ -933,82 +796,6 @@
     
     XCTAssertNoThrow([conversation setLocallyModifiedKeys:[NSSet setWithObject:ZMConversationUnsyncedInactiveParticipantsKey]]);
     
-}
-
-- (void)testThatIsActiveMemberIsTrueWhenUpdatingFromTransportData
-{
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    conversation.isSelfAnActiveMember = NO;
-    
-    NSDictionary *payload = @{
-                              @"creator" : @"39562cc3-717d-4395-979c-5387ae17f5c3",
-                              @"id" : conversation.remoteIdentifier.transportString,
-                              @"last_event" : @"1.800122000a4a0dd1",
-                              @"last_event_time" : @"2014-06-02T12:50:43.047Z",
-                              @"members" : @{
-                                      @"others" : @[],
-                                      @"self" : @{
-                                              @"archived" : [NSNull null],
-                                              @"id" : @"39562cc3-717d-4395-979c-5387ae17f5c3",
-                                              @"last_read" : @"1.800122000a4a0dd1",
-                                              @"muted" : [NSNull null],
-                                              @"muted_time" : [NSNull null],
-                                              @"status" : @0,
-                                              @"status_ref" : @"0.0",
-                                              @"status_time" : @"2014-06-02T12:50:43.047Z"
-                                              }
-                                      },
-                              @"name" : [NSNull null],
-                              @"type" : @1
-                              };
-    
-    // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
-    }];
-    
-    // then
-    XCTAssertTrue(conversation.isSelfAnActiveMember);
-}
-
-- (void)testThatIsActiveMemberIsFalseWhenUpdatingFromTransportData
-{
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.isSelfAnActiveMember = YES;
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    NSDictionary *payload = @{
-                              @"creator" : @"39562cc3-717d-4395-979c-5387ae17f5c3",
-                              @"id" : conversation.remoteIdentifier.transportString,
-                              @"last_event" : @"1.800122000a4a0dd1",
-                              @"last_event_time" : @"2014-06-02T12:50:43.047Z",
-                              @"members" : @{
-                                      @"others" : @[],
-                                      @"self" : @{
-                                              @"archived" : [NSNull null],
-                                              @"id" : @"39562cc3-717d-4395-979c-5387ae17f5c3",
-                                              @"last_read" : @"1.800122000a4a0dd1",
-                                              @"muted" : [NSNull null],
-                                              @"muted_time" : [NSNull null],
-                                              @"status" : @1,
-                                              @"status_ref" : @"0.0",
-                                              @"status_time" : @"2014-06-02T12:50:43.047Z"
-                                              }
-                                      },
-                              @"name" : [NSNull null],
-                              @"type" : @1
-                              };
-    
-    // when
-    [self performPretendingUiMocIsSyncMoc:^{
-        [conversation updateWithTransportData:payload serverTimeStamp:nil];
-    }];
-    
-    // then
-    XCTAssertFalse(conversation.isSelfAnActiveMember);
-
 }
 
 - (void)testThatActiveParticipantsContainsSelf

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1905,27 +1905,17 @@
         NSDictionary *payload = @{
                                   @"creator" : userID.transportString,
                                   @"id" : convID.transportString,
-                                  @"last_event" : @"10.aabb",
-                                  @"last_event_time" : @"2014-08-08T18:08:17.723Z",
                                   @"type" : @0,
                                   @"name" : @"Boo",
                                   @"members" :
                                       @{
                                           @"others" : @[
                                                   @{
-                                                      @"id" : userID.transportString,
-                                                      @"status" : @0
+                                                      @"id" : userID.transportString
                                                       }
                                                   ],
                                           @"self" : @{
-                                                  @"archived" : [NSNull null],
                                                   @"id" : @"90c74fe0-cef7-446a-affb-6cba0e75d5da",
-                                                  @"last_read" : @"5a4.800122000a64d6bf",
-                                                  @"muted" : [NSNull null],
-                                                  @"muted_time" : [NSNull null],
-                                                  @"status" : @0,
-                                                  @"status_ref" : @"0.0",
-                                                  @"status_time" : @"2014-06-18T12:08:44.428Z"
                                                   }
                                           },
                                   };

--- a/Tests/Source/Model/ZMConnectionTests.m
+++ b/Tests/Source/Model/ZMConnectionTests.m
@@ -282,34 +282,6 @@
     }];
 }
 
-- (void)testThatInsertingAConnectionDoesNotMarkTheExistingConversationAsNeededToBeDownloadedIfItHasALastServerTimeStamp;
-{
-    [self.syncMOC performGroupedBlockAndWait:^{
-        // given
-        ZMConversation *conv = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
-        conv.lastServerTimeStamp = [NSDate date];
-        conv.remoteIdentifier = [NSUUID createUUID];
-        
-        NSDictionary *payload =     // expected JSON response
-        @{
-          @"status": @"accepted",
-          @"from": @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
-          @"to": @"c3308f1d-82ee-49cd-897f-2a32ed9ae1d9",
-          @"last_update": @"2014-04-16T15:01:45.762Z",
-          @"conversation": conv.remoteIdentifier.transportString,
-          @"message": @"Hi Marco C,\n\nLet's connect in Zeta.\n\nJohn"
-          };
-        
-        // when
-        ZMConnection *connection = [ZMConnection connectionFromTransportData:payload managedObjectContext:self.syncMOC];
-        
-        // then
-        XCTAssertNotNil(connection);
-        XCTAssertNotNil(connection.conversation);
-        XCTAssertFalse(connection.conversation.needsToBeUpdatedFromBackend);
-    }];
-}
-
 - (void)testThatItReturnsNilIfMandatoryFieldsAreEmpty
 {
     [self.syncMOC performGroupedBlockAndWait:^{

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -178,19 +178,13 @@ class ZMConversationTests_Teams: BaseTeamTests {
 
     private func payloadForConversationMetaData(_ conversation: ZMConversation, activeUsers: [ZMUser], teamId: UUID?) -> [String: Any] {
         var payload: [String: Any] = [
-            "last_event_time": "2014-04-30T16:30:16.625Z",
             "name": NSNull(),
             "type": NSNumber(value: ZMBackendConversationType.convTypeGroup.rawValue),
             "id": conversation.remoteIdentifier!.transportString(),
             "creator": UUID.create().transportString(),
             "members": [
-                "others": activeUsers.map { ["status": NSNumber(value: 0), "id": $0.remoteIdentifier!.transportString()] },
+                "others": activeUsers.map { ["id": $0.remoteIdentifier!.transportString()] },
                 "self": [
-                    "status": NSNumber(value: 0),
-                    "muted_time": NSNull(),
-                    "status_ref": "0.0",
-                    "last_read": "5.800112314308490f",
-                    "status_time": "2014-03-14T16:47:37.573Z",
                     "id": "3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
                     "otr_archived": NSNumber(value: 0),
                     "otr_archived_ref": NSNull(),


### PR DESCRIPTION
Remove all usage of the following fields: 

remove `status`, `status_ref`,` status_time` from the self member object
remove `status` from the other member object (it is always 0)
remove `last_event` and `last_event_time` from the conversationMeta

in addition to that the following fields has also been removed:
`archived`, `clearedEventID`, `muted`, `mutedTime`, `lastRead`


### Fixes
After removing these fields the following changes were necessary:

* remove/add participants based if they are part of participants list instead of checking the `status` flag.
* Set default `lastModifiedDate` and `lastServerTimestamp` when creating conversations since we will no longer set one when reading the `last_event_time`.
