### PR TITLE
Wrap timer inside background activity

### DIFF
--- a/Source/Utilis/ZMMessageTimer.h
+++ b/Source/Utilis/ZMMessageTimer.h
@@ -51,4 +51,7 @@
 /// Returns YES if there is a timer for this message
 - (BOOL)isTimerRunningForMessage:(ZMMessage *)message;
 
+/// Returns the timer created for this message
+- (ZMTimer *)timerForMessage:(ZMMessage *)message;
+
 @end

--- a/Source/Utilis/ZMMessageTimer.m
+++ b/Source/Utilis/ZMMessageTimer.m
@@ -19,6 +19,7 @@
 
 @import WireSystem;
 @import WireUtilities;
+@import WireTransport;
 
 #import "ZMMessageTimer.h"
 #import "ZMMessage+Internal.h"
@@ -67,9 +68,11 @@ ZM_EMPTY_ASSERTING_INIT()
 - (void)startTimerForMessageIfNeeded:(ZMMessage*)message fireDate:(NSDate *)fireDate userInfo:(NSDictionary *)userInfo
 {
     if ( ![self isTimerRunningForMessage:message] ) {
+        ZMBackgroundActivity *bgActivity = [BackgroundActivityFactory.sharedInstance backgroundActivityWithName:@"MessageTimer"];
         ZMTimer *timer = [ZMTimer timerWithTarget:self];
         NSMutableDictionary *info = [NSMutableDictionary dictionaryWithDictionary:userInfo ?: @{}];
         info[@"message"] = message;
+        info[@"bgActivity"] = bgActivity;
         timer.userInfo = [NSDictionary dictionaryWithDictionary:info];
         [self.objectToTimerMap setObject:timer forKey:message];
         
@@ -91,7 +94,6 @@ ZM_EMPTY_ASSERTING_INIT()
     RequireString(strongMoc != nil, "MOC is nil");
     
     [strongMoc performGroupedBlock:^{
-        [self removeTimerForMessage:message];
         
         if (message == nil || message.isZombieObject) {
             return;
@@ -99,7 +101,12 @@ ZM_EMPTY_ASSERTING_INIT()
         if (self.timerCompletionBlock != nil) {
             self.timerCompletionBlock(message, timer.userInfo);
         }
+
+        // it's important to remove timer last, b/c in the case we're in the background
+        // we want to call endActivity after the completion block finishes.
+        [self removeTimerForMessage:message];
     }];
+    
 }
 
 
@@ -116,6 +123,8 @@ ZM_EMPTY_ASSERTING_INIT()
 
 
 - (void)removeTimerForMessage:(ZMMessage *)message {
+    ZMTimer *timer = [self.objectToTimerMap objectForKey:message];
+    [self endBackgroundActivityForTimer:timer];
     [self.objectToTimerMap removeObjectForKey:message];
 }
 
@@ -124,9 +133,16 @@ ZM_EMPTY_ASSERTING_INIT()
 {
     for (ZMTimer *timer in self.objectToTimerMap.objectEnumerator) {
         [timer cancel];
+        [self endBackgroundActivityForTimer:timer];
     }
     
     self.tearDownCalled = YES;
+}
+
+- (void)endBackgroundActivityForTimer:(ZMTimer *)timer
+{
+    ZMBackgroundActivity *bgActivity = timer.userInfo[@"bgActivity"];
+    [bgActivity endActivity];
 }
 
 @end

--- a/Source/Utilis/ZMMessageTimer.m
+++ b/Source/Utilis/ZMMessageTimer.m
@@ -83,7 +83,7 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (BOOL)isTimerRunningForMessage:(ZMMessage *)message
 {
-    return [self.objectToTimerMap objectForKey:message] != nil;
+    return [self timerForMessage:message] != nil;
 }
 
 - (void)timerDidFire:(ZMTimer *)timer
@@ -112,7 +112,7 @@ ZM_EMPTY_ASSERTING_INIT()
 
 - (void)stopTimerForMessage:(ZMMessage *)message;
 {
-    ZMTimer *timer = [self.objectToTimerMap objectForKey:message];
+    ZMTimer *timer = [self timerForMessage:message];
     if(timer == nil) {
         return;
     }
@@ -123,11 +123,21 @@ ZM_EMPTY_ASSERTING_INIT()
 
 
 - (void)removeTimerForMessage:(ZMMessage *)message {
-    ZMTimer *timer = [self.objectToTimerMap objectForKey:message];
+    ZMTimer *timer = [self timerForMessage:message];
     [self endBackgroundActivityForTimer:timer];
     [self.objectToTimerMap removeObjectForKey:message];
 }
 
+- (ZMTimer *)timerForMessage:(ZMMessage *)message
+{
+    return [self.objectToTimerMap objectForKey:message];
+}
+
+- (void)endBackgroundActivityForTimer:(ZMTimer *)timer
+{
+    ZMBackgroundActivity *bgActivity = timer.userInfo[@"bgActivity"];
+    [bgActivity endActivity];
+}
 
 - (void)tearDown;
 {
@@ -137,12 +147,6 @@ ZM_EMPTY_ASSERTING_INIT()
     }
     
     self.tearDownCalled = YES;
-}
-
-- (void)endBackgroundActivityForTimer:(ZMTimer *)timer
-{
-    ZMBackgroundActivity *bgActivity = timer.userInfo[@"bgActivity"];
-    [bgActivity endActivity];
 }
 
 @end

--- a/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
@@ -1,9 +1,19 @@
 //
-//  ZMMessageTimerTests.swift
-//  WireDataModelTests
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 14.11.17.
-//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import XCTest

--- a/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
@@ -1,0 +1,71 @@
+//
+//  ZMMessageTimerTests.swift
+//  WireDataModelTests
+//
+//  Created by John Nguyen on 14.11.17.
+//  Copyright © 2017 Wire Swiss GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import WireDataModel
+import WireTransport
+
+class ZMMessageTimerTests: BaseZMMessageTests {
+    
+    let application = UIApplication.shared
+    let groupQueue = DispatchGroupQueue(queue: .main)
+    var sut: ZMMessageTimer!
+    
+    override func setUp() {
+        super.setUp()
+        BackgroundActivityFactory.sharedInstance().application = application
+        BackgroundActivityFactory.sharedInstance().mainGroupQueue = groupQueue
+        sut = ZMMessageTimer(managedObjectContext: uiMOC)!
+    }
+    
+    override func tearDown() {
+        sut.tearDown()
+        sut = nil
+        super.tearDown()
+    }
+    
+    func testThatItCreatesTheBackgroundActivityWhenTimerStarted() {
+        // given
+        let message = createClientTextMessage("hello", encrypted: false)
+        
+        // when
+        sut.start(forMessageIfNeeded: message, fire: Date(timeIntervalSinceNow: 1.0), userInfo: [:])
+        
+        // then
+        let timer = sut.timer(for: message)
+        XCTAssertNotNil(timer)
+        let bgActivity = timer!.userInfo["bgActivity"] as? ZMBackgroundActivity
+        XCTAssertNotNil(bgActivity)
+    }
+    
+    func testThatItRemovesTheInternalTimerAfterTimerFired() {
+        // given
+        let message = createClientTextMessage("hello", encrypted: false)
+        let expectation = self.expectation(description: "timer fired")
+        sut.timerCompletionBlock = { _, _ in expectation.fulfill() }
+        
+        // when
+        sut.start(forMessageIfNeeded: message, fire: Date(), userInfo: [:])
+        _ = waitForCustomExpectations(withTimeout: 0.5)
+        
+        // then
+        XCTAssertNil(sut.timer(for: message))
+    }
+
+    func testThatItRemovesTheInternalTimerWhenTimerStopped() {
+        // given
+        let message = createClientTextMessage("hello", encrypted: false)
+        sut.start(forMessageIfNeeded: message, fire: Date(), userInfo: [:])
+        
+        // when
+        sut.stop(for: message)
+        
+        // then
+        XCTAssertNil(sut.timer(for: message))
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		CEB15E531D7EE5AB0048A011 /* ZMClientMessagesTests+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB15E501D7EE53A0048A011 /* ZMClientMessagesTests+Reaction.swift */; };
 		CEE525AA1CCA4C97001D06F9 /* NSString+RandomString.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE525A91CCA4C97001D06F9 /* NSString+RandomString.m */; };
 		EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */; };
+		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */; };
 		F118CB921F41D520004DCF96 /* ZMTestSession.m in Sources */ = {isa = PBXBuildFile; fileRef = F94A2C511F2B20480011ED42 /* ZMTestSession.m */; };
 		F118CB931F41D528004DCF96 /* ZMTestSession.h in Headers */ = {isa = PBXBuildFile; fileRef = F94A2C501F2B20480011ED42 /* ZMTestSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -610,6 +611,7 @@
 		CEE525A81CCA4C97001D06F9 /* NSString+RandomString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+RandomString.h"; sourceTree = "<group>"; };
 		CEE525A91CCA4C97001D06F9 /* NSString+RandomString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+RandomString.m"; sourceTree = "<group>"; };
 		EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStorageInitialization.swift; sourceTree = "<group>"; };
+		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Filename.swift"; sourceTree = "<group>"; };
 		F11F3E881FA32463007B6D3D /* InvalidClientsRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidClientsRemoval.swift; sourceTree = "<group>"; };
 		F11F3E8A1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidClientsRemovalTests.swift; sourceTree = "<group>"; };
@@ -1583,6 +1585,7 @@
 		F9B71F5C1CB2BC85001DB03F /* Messages */ = {
 			isa = PBXGroup;
 			children = (
+				EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */,
 				54EDE6811CBBF6260044A17E /* AssetCacheTests.swift */,
 				F9331C541CB3BCDA00139ECC /* OtrBaseTest.swift */,
 				F9331C501CB3BC6800139ECC /* CryptoBoxTests.swift */,
@@ -2375,6 +2378,7 @@
 				F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,
 				F9A7083E1CAEEB7500C2F5FE /* NSFetchRequestTests+ZMRelationshipKeyPaths.m in Sources */,
+				EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */,
 				F9B71F931CB2BF00001DB03F /* ZMMessageTests.m in Sources */,
 				54FB03AD1E41F6C2000E13DC /* PersistedDataPatchesTests.swift in Sources */,
 				F9B71FA71CB2BF37001DB03F /* ZMConversationTests+UnreadCount.m in Sources */,


### PR DESCRIPTION
## Issue
We were not receiving APNS notifications for a failed message.

## Cause
When sending a message, a `MessageExpirationTimer` (defined in `WireMessageStrategy` and a subclass of `ZMMessageTimer`) is started and if it fires, `LocalNotificationDispatcher` is alerted to generate the APNS notification. However, if the app is backgrounded while the timer is running, it would only fire the next the app is foregrounded because the timer doesn't run as a background task.

## Solution
Run the timer as a background task, and end the activity once the completion handler is finished, or the timer is stopped or torn down.

## Note
`ZMMessageTimer` is actually not a single timer object, but rather a collection of concurrent timers. Thus we wish to run *each individual timer* in its own background task, to avoid other timers interfering with each other. The background activity reference is stored in the `userInfo` of its associated timer object.