### PR TITLE
Fix ZIOS-9173: Share extension thinks that we need to login

### DIFF
--- a/Source/ManagedObjectContext/PersistentStoreRelocator.swift
+++ b/Source/ManagedObjectContext/PersistentStoreRelocator.swift
@@ -36,7 +36,7 @@ public struct MainPersistentStoreRelocator {
     /// Returns the list of possible locations for legacy stores. If accountIdentifier is supplied it also 
     /// includes account directories used after multiple account support was added.
     
-    private static var hostBundleIdentifier = Bundle.main.infoDictionary?["HostBundleIdentifier"] as? String
+    public static var hostBundleIdentifier = Bundle.main.infoDictionary?["HostBundleIdentifier"] as? String
     
     static func possiblePreviousStoreFiles(applicationContainer: URL, accountIdentifier: UUID?) -> [URL] {
         let locations = possibleLegacyAccountFolders(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier)

--- a/Source/ManagedObjectContext/PersistentStoreRelocator.swift
+++ b/Source/ManagedObjectContext/PersistentStoreRelocator.swift
@@ -35,6 +35,9 @@ extension URL {
 public struct MainPersistentStoreRelocator {
     /// Returns the list of possible locations for legacy stores. If accountIdentifier is supplied it also 
     /// includes account directories used after multiple account support was added.
+    
+    private static var hostBundleIdentifier = Bundle.main.infoDictionary?["HostBundleIdentifier"] as? String
+    
     static func possiblePreviousStoreFiles(applicationContainer: URL, accountIdentifier: UUID?) -> [URL] {
         let locations = possibleLegacyAccountFolders(applicationContainer: applicationContainer, accountIdentifier: accountIdentifier)
         return locations.map{ $0.appendingStoreFile() }
@@ -43,7 +46,8 @@ public struct MainPersistentStoreRelocator {
     static func possibleLegacyAccountFolders(applicationContainer: URL, accountIdentifier: UUID?) -> [URL] {
         var accountsFolders = possibleCommonLegacyDirectories()
         
-        let sharedContainerAccountFolder = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        guard let hostBundleIdentifier = hostBundleIdentifier else { return [] }
+        let sharedContainerAccountFolder = applicationContainer.appendingPathComponent(hostBundleIdentifier)
         accountsFolders.append(sharedContainerAccountFolder)
         
         if let accountIdentifier = accountIdentifier {
@@ -54,7 +58,8 @@ public struct MainPersistentStoreRelocator {
     }
 
     static func possibleLegacyKeystoreFolders(applicationContainer: URL, accountIdentifier: UUID) -> [URL] {
-        let bundleIdFolder = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        guard let hostBundleIdentifier = hostBundleIdentifier else { return [] }
+        let bundleIdFolder = applicationContainer.appendingPathComponent(hostBundleIdentifier)
         let bundleIdAccountFolder = bundleIdFolder.appendingPathComponent(accountIdentifier.uuidString)
         return possibleCommonLegacyDirectories() + [applicationContainer, bundleIdAccountFolder]
     }

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -34,6 +34,7 @@ import WireTesting
     override public func setUp() {
         super.setUp()
         self.clearStorageFolder()
+        MainPersistentStoreRelocator.hostBundleIdentifier = Bundle.main.bundleIdentifier!
         try! FileManager.default.createDirectory(at: self.applicationContainer, withIntermediateDirectories: true)
         let legacyDatabaseDirectory = applicationContainer.appendingPathComponent(Bundle.main.bundleIdentifier!)
         try! FileManager.default.createDirectory(at: legacyDatabaseDirectory, withIntermediateDirectories: true)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When sharing a content from a team account via Share Extension, `NotSignedInViewController` was shown. This was reported only in few cases and only with internal builds.

### Causes

I compiled the internal build with Xcode and loaded into @vytis phone. I discovered that the sharing session was stopped at:

https://github.com/wireapp/wire-ios-share-engine/blob/4ea5131a6ae17be232ff66e83d68af6abe512ba3/Sources/SharingSession.swift#L236

Going more deeper, I found that `possibleLegacyAccountFolders(applicationContainer: accountIdentifier:)` was fetching the `Bundle.main.bundleIdentifier` to compose the path of legacy folders. The problem in this case was that bundle identifiers are different between the main app and the Share Extension. In fact, this was the result of:
https://github.com/wireapp/wire-ios-data-model/blob/1a077b2eed85ea1860acf11eed70ffa897d70d08/Source/ManagedObjectContext/PersistentStoreRelocator.swift#L38-L41

```
Previous Store Locations: 
[file:///var/mobile/Containers/Data/PluginKitPlugin/15BC50DA-032F-4646-8B1F-2E5C62EDEBE1/Library/Caches/store.wiredatabase, 
file:///var/mobile/Containers/Data/PluginKitPlugin/15BC50DA-032F-4646-8B1F-2E5C62EDEBE1/Library/Application%20Support/store.wiredatabase, 
file:///var/mobile/Containers/Data/PluginKitPlugin/15BC50DA-032F-4646-8B1F-2E5C62EDEBE1/Library/store.wiredatabase, 
file:///private/var/mobile/Containers/Shared/AppGroup/ADEE2DD5-1311-4332-A9A8-1C4FC5FD815E/com.wearezeta.zclient.ios-internal.extension-share/store.wiredatabase, 
file:///private/var/mobile/Containers/Shared/AppGroup/ADEE2DD5-1311-4332-A9A8-1C4FC5FD815E/com.wearezeta.zclient.ios-internal.extension-share/<USER-IDENTIFIER>/store/store.wiredatabase]

Filtered Locations: 
[file:///private/var/mobile/Containers/Shared/AppGroup/ADEE2DD5-1311-4332-A9A8-1C4FC5FD815E/com.wearezeta.zclient.ios-internal.extension-share/<USER-IDENTIFIER>/store/store.wiredatabase]
```

This is the same code executed on the main app:

```
Previous Store Locations: 
[file:///var/mobile/Containers/Data/Application/62882CCA-FA22-4409-9EC6-C2457D63C6D3/Library/Caches/store.wiredatabase, 
file:///var/mobile/Containers/Data/Application/62882CCA-FA22-4409-9EC6-C2457D63C6D3/Library/Application%20Support/store.wiredatabase, 
file:///var/mobile/Containers/Data/Application/62882CCA-FA22-4409-9EC6-C2457D63C6D3/Library/store.wiredatabase, 
file:///private/var/mobile/Containers/Shared/AppGroup/ADEE2DD5-1311-4332-A9A8-1C4FC5FD815E/com.wearezeta.zclient.ios-internal/store.wiredatabase, 
file:///private/var/mobile/Containers/Shared/AppGroup/ADEE2DD5-1311-4332-A9A8-1C4FC5FD815E/com.wearezeta.zclient.ios-internal/3336DB86-E7F7-415C-97A2-CF8390390ED7/store/store.wiredatabase]

Filtered Locations: 
[]
``` 

As you can see, the two bundle identifiers are different (`com.wearezeta.zclient.ios-internal.extension-share` and `com.wearezeta.zclient.ios-internal`). This causes the throwing of the `InitializationError.needsMigration` error.

### Solutions

I'm fetching and using the bundle identifier of the main app with this variable:

https://github.com/wireapp/wire-ios-data-model/blob/2de4c3451473d65ba19aa020c43ca10610d1abbf/Source/ManagedObjectContext/PersistentStoreRelocator.swift#L39

## Notes

**After this change, @vytis was forced to log out from the team account and he lost all the conversations stored into the phone** (sorry 😥), so we need **more investigation** on this issue. I'm not sure about that, but I think that the problem was caused from a partial implementation of the new bundle identifier: I opened the app after changing the ID into the method `possibleLegacyAccountFolders(applicationContainer:, accountIdentifier:)` and not into `possibleLegacyKeystoreFolders(applicationContainer, accountIdentifier:)`.