### PR TITLE
Create a ZMAsset in the original link preview protocol buffer

### DIFF
--- a/Source/Model/Message/LinkPreview+ProtocolBuffer.swift
+++ b/Source/Model/Message/LinkPreview+ProtocolBuffer.swift
@@ -37,6 +37,14 @@ extension LinkPreview {
         return linkPreviewBuilder.build()
     }
     
+    fileprivate func createImageAssetIfAvailable() -> ZMAsset? {
+        guard let imageData = imageData.first else { return nil }
+        
+        let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 0, height: 0)
+        let original = ZMAssetOriginal.original(withSize: UInt64(imageData.count), mimeType: "image/jpeg", name: nil, imageMetaData: imageMetaData)
+        return ZMAsset.asset(withOriginal: original, preview: nil)
+    }
+    
 }
 
 extension ZMLinkPreview {
@@ -72,7 +80,7 @@ extension Article {
             offset: Int32(characterOffsetInText),
             title: title,
             summary: summary,
-            imageAsset: nil
+            imageAsset: createImageAssetIfAvailable()
         )
     }
 }
@@ -99,7 +107,7 @@ extension TwitterStatus {
             offset: Int32(characterOffsetInText),
             title: message,
             summary: nil,
-            imageAsset: nil,
+            imageAsset: createImageAssetIfAvailable(),
             tweet: ZMTweet.tweet(withAuthor: author, username: username)
         )
     }

--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -127,13 +127,7 @@ extension ZMClientMessage: ZMImageOwner {
             ?? self.managedObjectContext?.zm_imageAssetCache.assetData(self.nonce, format: .medium, encrypted: false)
     }
     
-    var hasImageData: Bool {
-        //  If we already have processed the image, we can check the protobuf if it has an image,
-        // there is a case however when sending a message that we don't have processed it yet but have the original image in the cache.
-        if self.imageData != nil {
-            return true
-        }
-        
+    var hasImageData: Bool {        
         guard let linkPreview = self.firstZMLinkPreview else { return false }
         return linkPreview.article.hasImage() || linkPreview.hasImage()
     }


### PR DESCRIPTION
## Problem

The sender of a link preview will now in the UI code if the link preview has an image or not until the image has been preprocessed. This has the effect that the image will not be displayed until the message is scrolled in and out of view.

## Solution

Create an asset only containing ZMOriginal immediately so that UI will know if the image well be there or not.