### PR TITLE
notify when accounts updated

### DIFF
--- a/Source/Model/AccountManager.swift
+++ b/Source/Model/AccountManager.swift
@@ -22,6 +22,7 @@ import Foundation
 
 private let log = ZMSLog(tag: "Accounts")
 
+public let AccountManagerDidUpdateAccountsNotificationName = Notification.Name("AccountManagerDidUpdateAccountsNotification")
 
 fileprivate extension UserDefaults {
 
@@ -129,6 +130,8 @@ public final class AccountManager: NSObject {
         } else {
             selectedAccount = computedAccount
         }
+        
+        NotificationCenter.default.post(name: AccountManagerDidUpdateAccountsNotificationName, object: self)
     }
     
     public func account(with id: UUID) -> Account? {


### PR DESCRIPTION
## What's in this PR?
We're posting a notification when the `AccountManager` has finished updating the accounts because it's useful for the new landing page in the UI. If we access the landing page from the settings screen, we may wish to cancel and go back to the authenticated account. In order to get the most updated state of the accounts, the UI needs to check the `AccountManager` at the right time.