### PR TITLE
Fix/unread message

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -155,7 +155,12 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
 
 - (BOOL)isUnreadMessage
 {
-    return (self.conversation != nil) && (self.conversation.lastReadServerTimeStamp != nil) && (self.serverTimestamp != nil) && ([self.serverTimestamp compare:self.conversation.lastReadServerTimeStamp] == NSOrderedDescending);
+    NSDate *lastReadTimeStamp = self.conversation.lastReadServerTimeStamp;
+    
+    // has conversation && (no last read timestamp || last read timstamp is earlier than msg timestamp)
+    return self.conversation != nil &&
+            (lastReadTimeStamp == nil ||
+             (self.serverTimestamp != nil && [self.serverTimestamp compare:lastReadTimeStamp] == NSOrderedDescending));
 }
 
 - (BOOL)shouldGenerateUnreadCount

--- a/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
@@ -122,7 +122,7 @@ class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
     }
     
     
-    func testThatItDoesNotNotifyObserversWhenTheConversationHasNoLastRead() {
+    func testThatItNotifiesObserversWhenTheConversationHasNoLastRead() {
         
         // given
         let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
@@ -136,7 +136,7 @@ class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
         self.uiMOC.saveOrRollback()
         
         // then
-        XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 0)
+        XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 1)
     }
     
     func testThatItDoesNotNotifyObserversWhenItHasNoConversation() {


### PR DESCRIPTION
## What's in this PR?

Changed the condition for determining if a `ZMMessage` is considered unread. Now, if the message's `conversation.lastReadServerTimeStamp` property is `nil`, then we consider the message unread since it follows that none of the messages have been read yet.

## Why?
This property is used by `NewUnreadMessageObserver` to identify if a message should trigger an internal notification. `SoundEventListener` (in the UI) listens for these notifications in order to play sounds. In the case that the user receives new messages in a conversation that has never been opened before (and thus has no last read server time stamp), the user would see chat heads and notifications, but the `SoundEventListener` wouldn't get notified to play new sounds because it wouldn't see these messages are unread.

Note: This property is internal to DataModel and is used exclusively for the `NewUnreadMessageObserver`, and this observer class appears to be used only by the `SoundEventListener` class in UI, so it shouldn't affect other parts of the app. 