### PR TITLE
Add debug logs when we modify the otherActiveParticipants

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -45,6 +45,7 @@
 #import <WireDataModel/WireDataModel-Swift.h>
 #import "NSPredicate+ZMSearch.h"
 
+static NSString* ZMLogTag ZM_UNUSED = @"Conversations";
 
 NSString *const ZMConversationConnectionKey = @"connection";
 NSString *const ZMConversationHasUnreadMissedCallKey = @"hasUnreadMissedCall";
@@ -1007,6 +1008,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     
     [self resetLocallyModifiedKeys:[NSSet setWithObject:ZMConversationUnsyncedActiveParticipantsKey]];
     [self resetLocallyModifiedKeys:[NSSet setWithObject:ZMConversationUnsyncedInactiveParticipantsKey]];
+    
+    ZMLogDebug(@"resetParticipantsBackToLastServerSync, mutableOtherActiveParticipants.count = %li", self.mutableOtherActiveParticipants.count);
 }
 
 - (void)mergeWithExistingConversationWithRemoteID:(NSUUID *)remoteID;
@@ -1576,6 +1579,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     
     [self.mutableOtherActiveParticipants removeObjectsInArray:otherUsers.allObjects];
     [self increaseSecurityLevelIfNeededAfterRemovingClientForUsers:otherUsers];
+    
+    ZMLogDebug(@"internalRemoveParticipants, mutableOtherActiveParticipants.count = %li", self.mutableOtherActiveParticipants.count);
 }
 
 @dynamic isSelfAnActiveMember;


### PR DESCRIPTION
### What changed

I'm adding debug logs to investigate a bug were group participants are involuntarily removed.