### PR TITLE
Delete asset messages if they are cancelled

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -46,6 +46,7 @@ extension ZMAssetClientMessage {
     /// The generic asset message that is constructed by merging
     /// all generic messages from the dataset that contain an asset
     public var genericAssetMessage: ZMGenericMessage? {
+        guard !isZombieObject else { return nil }
         
         if self.cachedGenericAssetMessage == nil {
             self.cachedGenericAssetMessage = self.genericMessageMergedFromDataSet(filter: {
@@ -193,11 +194,11 @@ extension ZMAssetClientMessage {
             self.transferState = .uploaded
         }
         
-        if let assetData = message.assetData,
-            assetData.hasNotUploaded() {
+        if let assetData = message.assetData, assetData.hasNotUploaded(), self.transferState != .uploaded {
             switch assetData.notUploaded {
             case .CANCELLED:
                 self.transferState = .cancelledUpload
+                self.managedObjectContext?.delete(self)
             case .FAILED:
                 self.transferState = .failedUpload
             }

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -546,7 +546,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploaded)
     }
     
-    func testThatItUpdatesTheTransferStateWhenTheNotUploadedCanceledMessageIsMerged()
+    func testThatItDeletesTheMessageWhenTheNotUploadedCanceledMessageIsMerged()
     {
         // given
         let nonce = UUID.create()
@@ -560,7 +560,7 @@ extension ZMAssetClientMessageTests {
         sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
         
         // then
-        XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.cancelledUpload)
+        XCTAssertTrue(sut.isZombieObject)
     }
     
     /// This is testing a race condition on the receiver side if the sender cancels but not fast enough, and he BE just got the entire payload
@@ -580,7 +580,7 @@ extension ZMAssetClientMessageTests {
         sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent())
         
         // then
-        XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.cancelledUpload)
+        XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploaded)
     }
     
     func testThatItUpdatesTheTransferStateWhenTheNotUploadedFailedMessageIsMerged()


### PR DESCRIPTION
## Issue
If a remote user cancels a file upload the receiver will be stuck with placeholder message which never goes away.

## Cause  / Discussion
The desired behaviour is that a cancelled upload gets deleted and gets re-inserted at the bottom if the sender decides to resume the upload.

## Solution
We delete the message if get a `.cancelled` update. Due to a race condition with preview image downloader we need to guard against a zombie message, because accessing the `genericAssetMessage` property on a deleted  object will trigger a force unwrap.

## Note
I also changed the behaviour when a file message is canceled after it was uploaded. Previously we would mark it as canceled now we ignore it.