### PR TITLE
Changed order of statuses - swapped Away with Busy

### DIFF
--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -21,7 +21,7 @@ import Foundation
 
 @objc
 public enum Availability : Int {
-    case none, available, away, busy
+    case none, available, busy, away
 }
 
 extension Availability {


### PR DESCRIPTION
## What's new in this PR?

Changed order of statuses - swapped Away with Busy. The new order, which will also appear in the UIActionSheet, is: None, Available, Busy, Away.