### PR TITLE
We were marking files as uploaded when they were canceled

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -181,17 +181,15 @@ extension ZMAssetClientMessage {
             }
         }
         
-        if let assetData = message.assetData,
-            assetData.hasUploaded()
+        if let assetData = message.assetData, assetData.hasUploaded()
         {
-            let isVersion_3 = assetData.uploaded.hasAssetId()
-            if isVersion_3 { // V3, we directly access the protobuf for the assetId
+            if assetData.uploaded.hasAssetId() { // V3, we directly access the protobuf for the assetId
                 self.version = 3
-            } else { // V2
-                self.assetId = (eventData["id"] as? String).flatMap { UUID(uuidString: $0) }
+                self.transferState = .uploaded
+            } else if let assetId = (eventData["id"] as? String).flatMap({ UUID(uuidString: $0) })  { // V2
+                self.assetId = assetId
+                self.transferState = .uploaded
             }
-            
-            self.transferState = .uploaded
         }
         
         if let assetData = message.assetData, assetData.hasNotUploaded(), self.transferState != .uploaded {

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -540,10 +540,28 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
-        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
+        sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent())
         
         // then
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploaded)
+    }
+    
+    func testThatItDoesntUpdateTheTransferStateWhenTheUploadedMessageIsMergedButDoesntContainAssetId()
+    {
+        // given
+        let nonce = UUID.create()
+        let sut = ZMAssetClientMessage.insertNewObject(in: uiMOC)
+        sut.nonce = nonce
+        XCTAssertTrue(uiMOC.saveOrRollback())
+        XCTAssertNotNil(sut)
+        
+        // when
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
+        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        
+        // then
+        XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploading)
     }
     
     func testThatItDeletesTheMessageWhenTheNotUploadedCanceledMessageIsMerged()
@@ -574,7 +592,8 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let uploadedMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
         sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent())
         let canceledMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce.transportString())
         sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent())


### PR DESCRIPTION
## Issue
When sending a file and canceling it the receiver would see it as uploaded.

## Cause
When canceling a file message we add a `NotUploaded.CANCELLED` state but it will also include a `uploaded: ZMAssetRemoteData` which was added when when the sender started to upload the file. This would cause the current logic to think that the file was uploaded when it was canceled.

This together with the fact we ignore a file cancellation if the file has been marked as uploaded was causing us to always ignore file cancellations.

## Solution
Only consider a file as uploaded if the `uploaded: ZMAssetRemoteData` contains a `assetId.