### PR TITLE
Added clearedConversations to list of conversation lists

### DIFF
--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -106,6 +106,7 @@ static NSString * const PendingKey = @"Pending";
              self.archivedConversations,
              self.conversationsIncludingArchived,
              self.unarchivedConversations,
+             self.clearedConversations
              ];
 }
 

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -189,4 +189,15 @@
     XCTAssertFalse([[NSSet setWithArray:list] intersectsSet:exepected]);
 }
 
+- (void)testThatAllListsAreIncluded
+{
+    ZMConversationListDirectory *directory = self.uiMOC.conversationListDirectory;
+    // when & then
+    XCTAssertTrue([directory.allConversationLists containsObject:directory.unarchivedConversations]);
+    XCTAssertTrue([directory.allConversationLists containsObject:directory.conversationsIncludingArchived]);
+    XCTAssertTrue([directory.allConversationLists containsObject:directory.archivedConversations]);
+    XCTAssertTrue([directory.allConversationLists containsObject:directory.pendingConnectionConversations]);
+    XCTAssertTrue([directory.allConversationLists containsObject:directory.clearedConversations]);
+}
+
 @end


### PR DESCRIPTION
For some reason the `clearedConversations` list was missing from the list of conversation lists. Possible consequence: the list was not updated after the app went to the background, so it was not possible to find the conversation.