### PR TITLE
Mark conversation as read or unread

### DIFF
--- a/Source/Model/Conversation/ZMConversation+UnreadCount.h
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.h
@@ -44,6 +44,9 @@
 /// call updateUnread() when updating the lastReadServerTimeStamp
 - (void)updateUnread;
 
+/// Sets the estimatedUnreadCount value
+- (BOOL)updateUnreadCount;
+
 /// call [updateUnreadMessagesWithMessage:] when inserting / updating a message
 - (void)updateUnreadMessagesWithMessage:(ZMMessage *)message;
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -984,28 +984,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         ZMLogError(@"Cannot mark as read: no message to mark in %@", self);
         return;
     }
-    NSDate *serverTimestamp = lastMessageCanBeConsideredUnread.serverTimestamp;
-    NSManagedObjectID *conversationID = self.objectID;
     
-    NSManagedObjectContext *syncContext = self.managedObjectContext.zm_syncContext;
-    [syncContext performGroupedBlock:^{
-        NSError *error = nil;
-        ZMConversation *syncConversation = [syncContext existingObjectWithID:conversationID error:&error];
-
-        if (syncConversation == nil || error != nil) {
-            ZMLogError(@"Cannot fetch the sync converastion: %@", error);
-            return;
-        }
-        syncConversation.lastReadServerTimeStamp = [NSDate dateWithTimeInterval:-0.01 sinceDate:serverTimestamp];
-        [syncConversation setLocallyModifiedKeys:[NSSet setWithObject:ZMConversationLastReadServerTimeStampKey]];
-        [syncConversation updateUnreadCount];
-        [syncContext saveOrRollback];
-        [[[NotificationInContext alloc] initWithName:ZMConversation.lastReadDidChangeNotificationName
-                                             context:syncConversation.managedObjectContext.notificationContext
-                                              object:syncConversation
-                                            userInfo:nil
-          ] post];
-     }];
+    [lastMessageCanBeConsideredUnread markAsUnread];
 }
 
 @end

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -19,6 +19,8 @@
 
 import Foundation
 
+private var zmLog = ZMSLog(tag: "Message")
+
 @objc
 public enum ZMDeliveryState : UInt {
     case invalid = 0
@@ -117,6 +119,10 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     /// Returns whether this is a message that caused the security level of the conversation to degrade in this session (since the 
     /// app was restarted)
     var causedSecurityLevelDegradation : Bool { get }
+    
+    /// Marks the message as the last unread message in the conversation, moving the unread mark exactly before this
+    /// message.
+    func markAsUnread()
 }
 
 // MARK:- Conversation managed properties
@@ -136,6 +142,37 @@ extension ZMMessage {
 extension ZMMessage : ZMConversationMessage {
     public var causedSecurityLevelDegradation : Bool {
         return false
+    }
+    
+    public func markAsUnread() {
+        guard let serverTimestamp = self.serverTimestamp,
+              let conversation = self.conversation,
+              let managedObjectContext = self.managedObjectContext,
+              let syncContext = managedObjectContext.zm_sync else {
+                
+                zmLog.error("Cannot mark as unread message outside of the conversation.")
+                return
+        }
+        
+        let conversationID = conversation.objectID
+        
+        conversation.lastReadServerTimeStamp = Date(timeInterval: -0.01, since: serverTimestamp)
+        managedObjectContext.saveOrRollback()
+        
+        syncContext.performGroupedBlock {
+            guard let syncObject = try? syncContext.existingObject(with: conversationID),
+                  let syncConversation = syncObject as? ZMConversation else {
+                zmLog.error("Cannot mark as unread message outside of the conversation: sync conversation cannot be fetched.")
+                return
+            }
+            
+            syncConversation.updateUnreadCount()
+            syncContext.saveOrRollback()
+            
+            NotificationInContext(name: ZMConversation.lastReadDidChangeNotificationName,
+                                  context: syncContext.notificationContext,
+                                  object: syncConversation).post()
+        }
     }
 }
 

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -107,6 +107,10 @@ extern NSString * _Null_unspecified const ZMIsDimmedKey; ///< Specifies that a r
 /// This method loads messages in a window when there are visible messages
 - (void)setVisibleWindowFromMessage:(nullable ZMMessage *)oldestMessage toMessage:(nullable ZMMessage *)newestMessage;
 
+- (void)markAsRead;
+- (BOOL)canMarkAsUnread;
+- (void)markAsUnread;
+
 /// completes a pending lastRead save, e.g. when leaving the conversation view
 - (void)savePendingLastRead;
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1853,7 +1853,7 @@
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, serverTimeStamp);
 }
 
-- (void)testThatItMakrsTheMessagesAsRead;
+- (void)testThatItMarksTheMessagesAsRead;
 {
     // GIVEN
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -1893,12 +1893,14 @@
     XCTAssertTrue([conversation canMarkAsUnread]);
 }
 
-- (void)testThatItMakrsTheMessagesAsUnread;
+- (void)testThatItMakrksTheMessagesAsUnread;
 {
     // GIVEN
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeConnection;
     conversation.remoteIdentifier = NSUUID.createUUID;
+    
+    [self.uiMOC saveOrRollback];
     
     ZMMessage* unreadMessage = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
 
@@ -1909,7 +1911,6 @@
     [conversation markAsUnread];
     
     XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
-    
     // THEN
     XCTAssertEqual(conversation.lastReadMessage, nil);
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1853,6 +1853,67 @@
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, serverTimeStamp);
 }
 
+- (void)testThatItMakrsTheMessagesAsRead;
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeConnection;
+    conversation.remoteIdentifier = NSUUID.createUUID;
+    
+    ZMMessage* unreadMessage = [self insertNonUnreadDotGeneratingMessageIntoConversation:conversation];
+    
+    XCTAssertEqual(conversation.lastReadMessage, nil);
+    
+    // WHEN
+    [conversation markAsRead];
+    
+    // THEN
+    XCTAssertEqual(conversation.lastReadMessage, unreadMessage);
+}
+
+- (void)testThatItCannotMarkAsUnreadEmptyConversation;
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeConnection;
+    conversation.remoteIdentifier = NSUUID.createUUID;
+    // WHEN & THEN
+    XCTAssertFalse([conversation canMarkAsUnread]);
+}
+
+- (void)testThatItCanMarkAsUnreadAConversation;
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeConnection;
+    conversation.remoteIdentifier = NSUUID.createUUID;
+    [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
+    [conversation markAsRead];
+    // WHEN & THEN
+    XCTAssertTrue([conversation canMarkAsUnread]);
+}
+
+- (void)testThatItMakrsTheMessagesAsUnread;
+{
+    // GIVEN
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeConnection;
+    conversation.remoteIdentifier = NSUUID.createUUID;
+    
+    ZMMessage* unreadMessage = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
+
+    [conversation markAsRead];
+    XCTAssertEqual(conversation.lastReadMessage, unreadMessage);
+    
+    // WHEN
+    [conversation markAsUnread];
+    
+    XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
+    
+    // THEN
+    XCTAssertEqual(conversation.lastReadMessage, nil);
+}
+
 @end
 
 @implementation ZMConversationTests (LastEditableMessage)


### PR DESCRIPTION
This feature is useful to mark some conversation as the one requiring attention when you already finished reading it or marking a non-important conversation as read.

Not every conversation can be marked as unread, since it must contain at least one message with the timestamp.

# Todo

- Verify syncing of updated timestamps.