### PR TITLE
Only allow update to client message if they contain a link preview update

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -159,7 +159,7 @@ extension ZMAssetClientMessage {
         return isFileMessage ? self : nil
     }
     
-    public override func update(with message: ZMGenericMessage!, updateEvent: ZMUpdateEvent!) {
+    public override func update(with message: ZMGenericMessage!, updateEvent: ZMUpdateEvent!, initialUpdate: Bool) {
         self.add(message)
         
         if self.nonce == nil {

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -190,8 +190,12 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     return [NSSet setWithObject:ClientMessageDataSetKey];
 }
 
-- (void)updateWithGenericMessage:(ZMGenericMessage *)message updateEvent:(ZMUpdateEvent *__unused)updateEvent
+- (void)updateWithGenericMessage:(ZMGenericMessage *)message updateEvent:(ZMUpdateEvent *__unused)updateEvent initialUpdate:(BOOL)initialUpdate
 {
+    if (!initialUpdate && (message.text.linkPreview.count == 0 || ![self.messageText isEqualToString:message.text.content])) {
+        return; // We only update client messages if the update contains a link preview and the content didn't change
+    }
+    
     [self addData:message.data];
     [self updateNormalizedText];
 }

--- a/Source/Model/Message/ZMOTRMessage.h
+++ b/Source/Model/Message/ZMOTRMessage.h
@@ -36,7 +36,7 @@ extern NSString * const DeliveredKey;
 - (void)doesNotMissRecipient:(UserClient *)recipient;
 - (void)doesNotMissRecipients:(NSSet<UserClient *> *)recipients;
 
-- (void)updateWithGenericMessage:(ZMGenericMessage *)message updateEvent:(ZMUpdateEvent *)updateEvent;
+- (void)updateWithGenericMessage:(ZMGenericMessage *)message updateEvent:(ZMUpdateEvent *)updateEvent initialUpdate:(BOOL)initialUpdate;
 
 + (ZMMessage *)preExistingPlainMessageForGenericMessage:(ZMGenericMessage *)message
                                          inConversation:(ZMConversation *)conversation

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -119,7 +119,7 @@ NSString * const DeliveredKey = @"delivered";
     [super resend];
 }
 
-- (void)updateWithGenericMessage:(__unused ZMGenericMessage *)message updateEvent:(__unused ZMUpdateEvent *)updateEvent
+- (void)updateWithGenericMessage:(__unused ZMGenericMessage *)message updateEvent:(__unused ZMUpdateEvent *)updateEvent initialUpdate:(__unused BOOL)initialUpdate
 {
     NSAssert(FALSE, @"Subclasses should override this method: [%@ %@]", NSStringFromClass([self class]), NSStringFromSelector(_cmd));
 }
@@ -241,7 +241,7 @@ NSString * const DeliveredKey = @"delivered";
     clientMessage.senderClientID = updateEvent.senderClientID;
     
     // In case of AssetMessages: If the payload does not match the sha265 digest, calling `updateWithGenericMessage:updateEvent` will delete the object.
-    [clientMessage updateWithGenericMessage:message updateEvent:updateEvent];
+    [clientMessage updateWithGenericMessage:message updateEvent:updateEvent initialUpdate:isNewMessage];
     // It seems that if the object was inserted and immediately deleted, the isDeleted flag is not set to true. In addition the object will still have a managedObjectContext until the context is finally saved. In this case, we need to check the nonce (which would have previously been set) to avoid setting an invalid relationship between the deleted object and the conversation and / or sender
     if (clientMessage.isZombieObject || clientMessage.nonce == nil) {
         return nil;

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -106,7 +106,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let remoteMessage = ZMGenericMessage.genericMessage(pbMessage: assetWithImage(), messageID: message.nonce.transportString())
         
         let event = thumbnailEvent(for: message)
-        message.update(with: remoteMessage, updateEvent: event)
+        message.update(with: remoteMessage, updateEvent: event, initialUpdate: true)
     
         // then
         XCTAssertTrue(message.genericAssetMessage!.hasEphemeral())

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -520,7 +520,7 @@ extension ZMAssetClientMessageTests {
             asset: .asset(withOriginal: .original(withSize: 256, mimeType: mimeType, name: name)),
             messageID: nonce.transportString()
         )
-        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.fileMessageData?.size, 256)
@@ -541,7 +541,7 @@ extension ZMAssetClientMessageTests {
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
         let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
-        sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploaded)
@@ -558,7 +558,7 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
-        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploading)
@@ -575,7 +575,7 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce.transportString())
-        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertTrue(sut.isZombieObject)
@@ -594,9 +594,9 @@ extension ZMAssetClientMessageTests {
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
         let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
-        sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         let canceledMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce.transportString())
-        sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.uploaded)
@@ -613,7 +613,7 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .FAILED, messageID: nonce.transportString())
-        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent())
+        sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.fileMessageData?.transferState, ZMFileTransferState.failedUpload)
@@ -639,7 +639,7 @@ extension ZMAssetClientMessageTests {
         let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload!, uuid: UUID.create())
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
-        sut.update(with: originalMessage, updateEvent: updateEvent)
+        sut.update(with: originalMessage, updateEvent: updateEvent, initialUpdate: true)
         
         // then
         XCTAssertEqual(sut.assetId, assetId)
@@ -1087,7 +1087,7 @@ extension ZMAssetClientMessageTests {
             XCTAssertNil(sut.fileMessageData?.thumbnailAssetID)
             
             // when
-            sut.update(with: genericMessage, updateEvent: updateEvent)
+            sut.update(with: genericMessage, updateEvent: updateEvent, initialUpdate: true)
             
             // then
             XCTAssertEqual(sut.fileMessageData?.thumbnailAssetID, uuid)
@@ -1135,7 +1135,7 @@ extension ZMAssetClientMessageTests {
             
             
             // when
-            sut.update(with: genericMessage, updateEvent: updateEvent)
+            sut.update(with: genericMessage, updateEvent: updateEvent, initialUpdate: true)
             
             // then
             XCTAssertNil(sut.fileMessageData?.thumbnailAssetID)
@@ -1182,7 +1182,7 @@ extension ZMAssetClientMessageTests {
             let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID.create())
             XCTAssertNil(sutInSyncContext.fileMessageData?.thumbnailAssetID)
             
-            sutInSyncContext.update(with: genericMessage, updateEvent: updateEvent) // Append preview
+            sutInSyncContext.update(with: genericMessage, updateEvent: updateEvent, initialUpdate: true) // Append preview
             XCTAssertTrue(self.syncMOC.saveOrRollback())
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -2159,7 +2159,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
         XCTAssertEqual(sut.version, 3)
@@ -2171,7 +2171,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let (preview, _) = previewGenericMessage(with: nonce.transportString())
-        sut.update(with: preview, updateEvent: ZMUpdateEvent())
+        sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
         XCTAssertEqual(sut.version, 3)
@@ -2183,7 +2183,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString(), assetId: nil, token: nil)
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
         XCTAssertEqual(sut.version, 0)
@@ -2195,7 +2195,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let (preview, _) = previewGenericMessage(with: nonce.transportString(), assetId: nil, token: nil)
-        sut.update(with: preview, updateEvent: ZMUpdateEvent())
+        sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
         XCTAssertEqual(sut.version, 0)
@@ -2209,8 +2209,8 @@ extension ZMAssetClientMessageTests {
         let assetId = UUID.create().transportString()
         let assetData = Data.secureRandomData(length: 512)
 
-        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), name: "document.pdf"), updateEvent: ZMUpdateEvent())
-        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent())
+        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), name: "document.pdf"), updateEvent: ZMUpdateEvent(), initialUpdate: true)
+        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_fileAssetCache.storeAssetData(nonce, fileName: "document.pdf", encrypted: false, data: assetData)
 
 
@@ -2228,8 +2228,8 @@ extension ZMAssetClientMessageTests {
         let assetId = UUID.create().transportString()
         let assetData = Data.secureRandomData(length: 512)
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil), updateEvent: ZMUpdateEvent())
-        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent())
+        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil), updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .medium, encrypted: false, data: assetData)
 
         // then
@@ -2247,8 +2247,8 @@ extension ZMAssetClientMessageTests {
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
 
         // when
-        sut.update(with: original, updateEvent: ZMUpdateEvent())
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: false)
 
         // then
         XCTAssertTrue(sut.genericAssetMessage!.v3_isImage)
@@ -2268,8 +2268,8 @@ extension ZMAssetClientMessageTests {
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId)
 
         // when
-        sut.update(with: original, updateEvent: ZMUpdateEvent())
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: false)
 
         // then
         XCTAssertEqual("\(nonce.transportString())-123x4569", sut.imageMessageData?.imageDataIdentifier)
@@ -2281,7 +2281,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let (preview, previewMeta) = previewGenericMessage(with: nonce.transportString())
-        sut.update(with: preview, updateEvent: ZMUpdateEvent())
+        sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: false)
 
         // then
         XCTAssertEqual(sut.fileMessageData?.thumbnailAssetID, previewMeta.assetId)
@@ -2294,7 +2294,7 @@ extension ZMAssetClientMessageTests {
         // when
         let previewData = Data.secureRandomData(length: 512)
         let (preview, _) = previewGenericMessage(with: nonce.transportString())
-        sut.update(with: preview, updateEvent: ZMUpdateEvent())
+        sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .medium, encrypted: false, data: previewData)
 
         // then
@@ -2314,8 +2314,8 @@ extension ZMAssetClientMessageTests {
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
 
         // when
-        sut.update(with: original, updateEvent: ZMUpdateEvent())
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: false)
 
         uiMOC.zm_imageAssetCache.storeAssetData(nonce, format: .medium, encrypted: false, data: data)
 
@@ -2335,8 +2335,8 @@ extension ZMAssetClientMessageTests {
         let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
 
         // when
-        sut.update(with: original, updateEvent: ZMUpdateEvent())
-        sut.update(with: uploaded, updateEvent: ZMUpdateEvent())
+        sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: false)
         XCTAssertEqual(sut.transferState, .uploaded)
 
         // when


### PR DESCRIPTION
## Issue

It was theoretically possible to edit your own message without having the `edit` icon appear. 

## Cause

We were applying all updates to messages when actually the only valid update is if a link preview is added later.

## Solution

Enforce that we only allow updates if the link preview changes.