### PR TITLE
Split imageData logic into personal and team avatars

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -34,6 +34,7 @@ public final class Account: NSObject {
     public var teamName: String?
     public let userIdentifier: UUID
     public var imageData: Data?
+    public var teamImageData: Data?
     
     public var unreadConversationCount: Int = 0 {
         didSet {
@@ -47,11 +48,13 @@ public final class Account: NSObject {
                          userIdentifier: UUID,
                          teamName: String? = nil,
                          imageData: Data? = nil,
+                         teamImageData: Data? = nil,
                          unreadConversationCount: Int = 0) {
         self.userName = userName
         self.userIdentifier = userIdentifier
         self.teamName = teamName
         self.imageData = imageData
+        self.teamImageData = teamImageData
         self.unreadConversationCount = unreadConversationCount
         super.init()
     }
@@ -65,6 +68,7 @@ public final class Account: NSObject {
         self.userName = account.userName
         self.teamName = account.teamName
         self.imageData = account.imageData
+        self.teamImageData = account.teamImageData
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -73,6 +77,7 @@ public final class Account: NSObject {
             && teamName == other.teamName
             && userIdentifier == other.userIdentifier
             && imageData == other.imageData
+            && teamImageData == other.teamImageData
     }
 
     public override var hash: Int {
@@ -80,7 +85,7 @@ public final class Account: NSObject {
     }
 
     public override var debugDescription: String {
-        return "<Account>:\n\tname: \(userName)\n\tid: \(userIdentifier)\n\tteam: \(String(describing: teamName))\n\timage: \(String(describing: imageData?.count))\n"
+        return "<Account>:\n\tname: \(userName)\n\tid: \(userIdentifier)\n\tteam: \(String(describing: teamName))\n\timage: \(String(describing: imageData?.count))\n\tteamImageData: \(String(describing: teamImageData?.count))\n"
     }
 }
 
@@ -91,7 +96,7 @@ extension Account {
     /// The use of a separate enum, instead of using #keyPath
     /// is intentional here to allow easy renaming of properties.
     private enum Key: String {
-        case name, identifier, team, image, unreadConversationCount
+        case name, identifier, team, image, teamImage, unreadConversationCount
     }
 
     public convenience init?(json: [String: Any]) {
@@ -102,6 +107,7 @@ extension Account {
             userIdentifier: id,
             teamName: json[Key.team.rawValue] as? String,
             imageData: (json[Key.image.rawValue] as? String).flatMap { Data(base64Encoded: $0) },
+            teamImageData: (json[Key.teamImage.rawValue] as? String).flatMap { Data(base64Encoded: $0) },
             unreadConversationCount: (json[Key.unreadConversationCount.rawValue] as? Int) ?? 0
         )
     }
@@ -116,6 +122,9 @@ extension Account {
         }
         if let imageData = imageData {
             json[Key.image.rawValue] = imageData.base64EncodedString()
+        }
+        if let teamImageData = teamImageData {
+            json[Key.teamImage.rawValue] = teamImageData.base64EncodedString()
         }
         json[Key.unreadConversationCount.rawValue] = self.unreadConversationCount
         return json

--- a/Tests/Source/Model/AccountStoreTests.swift
+++ b/Tests/Source/Model/AccountStoreTests.swift
@@ -177,6 +177,33 @@ final class AccountStoreTests: ZMConversationTestsBase {
         XCTAssertEqual(account.userName, name)
         XCTAssertEqual(account.teamName, team)
         XCTAssertNil(account.imageData)
+        XCTAssertNil(account.teamImageData)
+    }
+    
+    func testThatItUpdatesAnExistingAccount_WithImages() {
+        // given
+        let store = AccountStore(root: url)
+        let uuid = UUID.create()
+        
+        do {
+            let account = Account(userName: "Silvan", userIdentifier: uuid)
+            XCTAssert(store.add(account))
+            XCTAssertEqual(store.load(), [account])
+        }
+        
+        // when
+        let name = "Marco", team = "Wire", image = verySmallJPEGData()
+        do {
+            let account = Account(userName: name, userIdentifier: uuid, teamName: team, imageData: image, teamImageData: image)
+            XCTAssert(store.add(account))
+        }
+        
+        // then
+        guard let account = store.load(uuid) else { return XCTFail("Unable to load account") }
+        XCTAssertEqual(account.userName, name)
+        XCTAssertEqual(account.teamName, team)
+        XCTAssertEqual(account.imageData, image)
+        XCTAssertEqual(account.teamImageData, image)
     }
 
     func testThatItCanLoadAnAccountByUUID() {

--- a/Tests/Source/Model/AccountTests.swift
+++ b/Tests/Source/Model/AccountTests.swift
@@ -32,7 +32,8 @@ final class AccountTests: ZMConversationTestsBase {
             userName: "Bruno",
             userIdentifier: .create(),
             teamName: "Wire",
-            imageData: verySmallJPEGData()
+            imageData: verySmallJPEGData(),
+            teamImageData: verySmallJPEGData()
         )
 
         // when
@@ -53,6 +54,7 @@ final class AccountTests: ZMConversationTestsBase {
                                   userIdentifier: id,
                                   teamName: team,
                                   imageData: image,
+                                  teamImageData: image,
                                   unreadConversationCount: count)
             try account.write(to: url)
         }
@@ -65,6 +67,7 @@ final class AccountTests: ZMConversationTestsBase {
         XCTAssertEqual(account.teamName, team)
         XCTAssertEqual(account.userIdentifier, id)
         XCTAssertEqual(account.imageData, image)
+        XCTAssertEqual(account.teamImageData, image)
         XCTAssertEqual(account.unreadConversationCount, count)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `imageData` field of the `Account` object is actually designed to contain the avatar of a personal account, or an eventual image of a team account (which actually is nil).

This is causing the `SkeletonViewController` to show a grey screen while switching from personal to team account.

### Solutions

I've added a new field to the `Account` class, `teamImageData`. In this way, `imageData` always contains the personal avatar for both personal and team accounts, and `teamImageData` could contain a team avatar in the future - so we have a more consistent behavior. 

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios-sync-engine/pull/665
- [ ] https://github.com/wireapp/wire-ios/pull/1600

## Notes

Issue linked to the ticket 8936.