### PR TITLE
Fix crash on accessing not existing delivered key on SystemMessage

### DIFF
--- a/Source/Model/Conversation/ZMConversationMessageWindow.m
+++ b/Source/Model/Conversation/ZMConversationMessageWindow.m
@@ -84,11 +84,9 @@
     const NSRange range = NSMakeRange(messages.count - numberOfMessages, numberOfMessages);
     NSMutableOrderedSet *newMessages = [NSMutableOrderedSet orderedSetWithOrderedSet:messages range:range copyItems:NO];
     if (self.conversation.clearedTimeStamp != nil) {
-        [newMessages filterUsingPredicate:[NSPredicate predicateWithFormat:@"%K == FALSE OR %K > conversation.%K",
-                                           DeliveredKey, ZMMessageServerTimestampKey, ZMConversationClearedTimeStampKey]];
-        
-        [newMessages filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMManagedObject *  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable __unused bindings) {
-            return !evaluatedObject.isZombieObject;
+        [newMessages filterUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMMessage * _Nullable message, NSDictionary<NSString *,id> * _Nullable __unused bindings) {
+            return !message.isZombieObject &&
+                   (message.deliveryState == ZMDeliveryStatePending || [message.serverTimestamp compare:self.conversation.clearedTimeStamp] == NSOrderedDescending);
         }]];
     }
     


### PR DESCRIPTION
### Issues

App enters a crash loop after clearing/deleting a conversation.

### Causes

When filtering out the visible messages in a conversation after clearing it we query the `delivered` property to show any pending messages. This was previously only done for `ClientMessage` since we also checked if the message was encrypted. After removing the `isEncrypted` flag we also query this on `SystemMessage` which doesn't have `delivered` property in core data, this results in a crash.

### Solutions

Do the filter with a block instead where we can access the `deliveryStatus` property.