### PR TITLE
Ensure service users are not reported as guests

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -60,7 +60,8 @@ public extension ZMUser {
             return conversation.team == nil
                 && conversation.teamRemoteIdentifier != nil
         } else {
-            return ZMUser.selfUser(in: managedObjectContext!).hasTeam // There can't be guests in a team that doesn't exist
+            return !isServiceUser // Bots are never guests
+                && ZMUser.selfUser(in: managedObjectContext!).hasTeam // There can't be guests in a team that doesn't exist
                 && conversation.otherActiveParticipants.contains(self)
                 && membership == nil
         }

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -78,6 +78,27 @@ class TeamTests: BaseTeamTests {
         XCTAssertTrue(guest.isGuest(in: conversation))
         XCTAssertFalse(guest.isTeamMember)
     }
+    
+    func testThatItDoesNotReturnABotAsGuestOfATeam() throws {
+        // given
+        let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
+        
+        // we add an actual team member as well
+        createUserAndAddMember(to: team)
+        
+        // when
+        let guest = ZMUser.insertNewObject(in: uiMOC)
+        let bot = ZMUser.insertNewObject(in: uiMOC)
+        bot.serviceIdentifier = UUID.create().transportString()
+        bot.providerIdentifier = UUID.create().transportString()
+        XCTAssert(bot.isServiceUser)
+        let conversation = try team.addConversation(with: [guest, bot])!
+        
+        // then
+        XCTAssert(guest.isGuest(in: conversation))
+        XCTAssertFalse(bot.isGuest(in: conversation))
+        XCTAssertFalse(bot.isTeamMember)
+    }
 
     func testThatItDoesNotReturnUsersAsGuestsIfThereIsNoTeam() {
         // given


### PR DESCRIPTION
## What's new in this PR?

Service users were returning `true` from `isGuest(in:)`and thus appear as guests in conversations.