### PR TITLE
Parse and return the summary of the integration

### DIFF
--- a/Source/Model/User/ServiceUser.swift
+++ b/Source/Model/User/ServiceUser.swift
@@ -22,3 +22,7 @@ import Foundation
     var providerIdentifier: String? { get }
     var serviceIdentifier: String? { get }
 }
+
+@objc public protocol SearchServiceUser: ServiceUser {
+    var summary: String? { get }
+}

--- a/Source/Model/User/ZMSearchUser+Internal.h
+++ b/Source/Model/User/ZMSearchUser+Internal.h
@@ -62,7 +62,9 @@ FOUNDATION_EXPORT NSString *const ZMSearchUserTotalMutualFriendsKey;
 @property (nonatomic) NSString *completeAssetKey;
 
 @property (nonatomic, readwrite) NSUInteger totalCommonConnections;
-@property (nonatomic, readwrite, copy) NSString * _providerIdentifier;
+@property (nonatomic, readwrite, copy) NSString *providerIdentifier;
+
+@property (nonatomic, readwrite, copy) NSString *summary;
 
 + (NSCache *)searchUserToSmallProfileImageCache;
 + (NSCache *)searchUserToMediumImageCache;

--- a/Source/Model/User/ZMSearchUser+ServiceUser.swift
+++ b/Source/Model/User/ZMSearchUser+ServiceUser.swift
@@ -18,16 +18,7 @@
 
 import Foundation
 
-extension ZMSearchUser: ServiceUser {
-    public var providerIdentifier: String? {
-        get {
-            return _providerIdentifier
-        }
-        set {
-            _providerIdentifier = newValue
-        }
-    }
-
+extension ZMSearchUser: SearchServiceUser {
     public var serviceIdentifier: String? {
         return self.remoteIdentifier?.transportString()
     }

--- a/Source/Model/User/ZMSearchUser.m
+++ b/Source/Model/User/ZMSearchUser.m
@@ -170,6 +170,10 @@ NSString *const ZMSearchUserTotalMutualFriendsKey = @"total_mutual_friends";
         self.providerIdentifier = payload[@"provider"];
     }
     
+    if (nil != payload[@"summary"]) {
+        self.summary = payload[@"summary"];
+    }
+    
     NSArray *assets = payload[@"assets"];
     if (nil != assets && [assets isKindOfClass:[NSArray class]]) {
         for (NSDictionary *asset in assets) {

--- a/Source/Public/ZMSearchUser.h
+++ b/Source/Public/ZMSearchUser.h
@@ -23,7 +23,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ZMUser, ZMAddressBookContact;
-@protocol ServiceUser;
 
 @interface ZMSearchUser : NSObject <ZMBareUser>
 

--- a/Tests/Source/Model/User/ZMSearchUserPayloadParsingTests.swift
+++ b/Tests/Source/Model/User/ZMSearchUserPayloadParsingTests.swift
@@ -47,6 +47,7 @@ class ZMSearchUserPayloadParsingTests: ZMBaseManagedObjectTest {
                                       "handle": "@user",
                                       "accent_id": 5,
                                       "id": uuid.transportString(),
+                                      "summary": "Short summary",
                                       "provider": provider.transportString()]
         
         // when
@@ -54,6 +55,7 @@ class ZMSearchUserPayloadParsingTests: ZMBaseManagedObjectTest {
         
         // then
         XCTAssertTrue(user.isServiceUser)
+        XCTAssertEqual(user.summary, "Short summary")
         XCTAssertEqual(user.providerIdentifier, provider.transportString())
         XCTAssertEqual(user.serviceIdentifier, uuid.transportString())
         XCTAssertFalse(user.canBeConnected)


### PR DESCRIPTION
## What's new in this PR?

The backend introduced the new property of the integration: summary. It is a string that summarizes the functionality of the service.
