### PR TITLE
Treat the group conversation with bot as group

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -470,7 +470,16 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     ZMConversationType conversationType = [self internalConversationType];
     
-    if (conversationType == ZMConversationTypeGroup && self.teamRemoteIdentifier != nil && self.otherActiveParticipants.count == 1 && self.userDefinedName.length == 0) {
+    // Exception: the group conversation is considered a 1-1 if:
+    // 1. Belongs to the team.
+    // 2. Has no name given.
+    // 3. Conversation has only one other participant.
+    // 4. This participant is not a service user (bot).
+    if (conversationType == ZMConversationTypeGroup &&
+        self.teamRemoteIdentifier != nil &&
+        self.otherActiveParticipants.count == 1 &&
+        !self.otherActiveParticipants.firstObject.isServiceUser &&
+        self.userDefinedName.length == 0) {
         conversationType = ZMConversationTypeOneOnOne;
     }
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -879,6 +879,21 @@
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
 }
 
+- (void)testThatGroupConversationInTeamWithOnlyBotIsConsideredGroup
+{
+    // given
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user1.providerIdentifier = [[NSUUID createUUID] transportString];
+    user1.serviceIdentifier = [[NSUUID createUUID] transportString];
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    [conversation addParticipant:user1];
+    
+    // then
+    XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
+}
+
 - (void)testThatGroupConversationWithNameInTeamWithOnlyTwoParticipantsIsNotConsideredOneToOne
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

The group conversation with the bot in the team appears as 1-1.

### Causes

Currently Wire sees the group conversation with 1 user without the name in the team as a 1-1 conversation. This mode is suboptimal for the conversations with bots, since then it is not possible to add the new member to the group with only a bot. This is useful when user would like to pre-configure the bot.

### Solutions

The exception case was added.
