### PR TITLE
Conversation creation with name

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -74,23 +74,6 @@ public class Team: ZMManagedObject, TeamType {
     }
 }
 
-
-public enum TeamError: Error {
-    case insufficientPermissions
-}
-
-extension Team {
-
-    public func addConversation(with participants: Set<ZMUser>) throws -> ZMConversation? {
-        guard ZMUser.selfUser(in: managedObjectContext!).canCreateConversation else { throw TeamError.insufficientPermissions }
-        switch participants.count {
-        case 1: return ZMConversation.fetchOrCreateTeamConversation(in: managedObjectContext!, withParticipant: participants.first!, team: self)
-        default: return ZMConversation.insertGroupConversation(into: managedObjectContext!, withParticipants: Array(participants), in: self)
-        }
-    }
-
-}
-
 extension Team {
     
     public func members(matchingQuery query: String) -> [Member] {

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -90,6 +90,7 @@ NS_ASSUME_NONNULL_END
 + (nullable instancetype)conversationWithRemoteID:(nonnull NSUUID *)UUID createIfNeeded:(BOOL)create inContext:(nonnull NSManagedObjectContext *)moc created:(nullable BOOL *)created;
 + (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray *)participants;
 + (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants inTeam:(nullable Team *)team;
++ (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants name:(nullable NSString *)name inTeam:(nullable Team *)team;
 + (nullable instancetype)fetchOrCreateTeamConversationInManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipant:(nonnull ZMUser *)participant team:(nonnull Team *)team;
 
 + (nonnull ZMConversationList *)conversationsIncludingArchivedInContext:(nonnull NSManagedObjectContext *)moc;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -400,8 +400,17 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
                                               withParticipants:(nonnull NSArray<ZMUser *> *)participants
                                                         inTeam:(nullable Team *)team;
 {
+
+    return [self insertGroupConversationIntoUserSession:session withParticipants:participants name:nil inTeam:team];
+}
+
++ (nonnull instancetype)insertGroupConversationIntoUserSession:(nonnull id<ZMManagedObjectContextProvider> )session
+                                              withParticipants:(nonnull NSArray<ZMUser *> *)participants
+                                                          name:(nullable NSString*)name
+                                                        inTeam:(nullable Team *)team
+{
     VerifyReturnNil(session != nil);
-    return [self insertGroupConversationIntoManagedObjectContext:session.managedObjectContext withParticipants:participants inTeam:team];
+    return [self insertGroupConversationIntoManagedObjectContext:session.managedObjectContext withParticipants:participants name:name inTeam:team];
 }
 
 + (instancetype)existingOneOnOneConversationWithUser:(ZMUser *)otherUser inUserSession:(id<ZMManagedObjectContextProvider>)session;
@@ -1215,7 +1224,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return [self insertGroupConversationIntoManagedObjectContext:moc withParticipants:participants inTeam:nil];
 }
 
-+ (instancetype)insertGroupConversationIntoManagedObjectContext:(NSManagedObjectContext *)moc withParticipants:(NSArray *)participants inTeam:(nullable Team *)team;
++ (instancetype)insertGroupConversationIntoManagedObjectContext:(NSManagedObjectContext *)moc withParticipants:(NSArray *)participants inTeam:(nullable Team *)team
+{
+    return [self insertGroupConversationIntoManagedObjectContext:moc withParticipants:participants name:nil inTeam:team];
+}
+
++ (instancetype)insertGroupConversationIntoManagedObjectContext:(NSManagedObjectContext *)moc withParticipants:(NSArray *)participants name:(NSString *)name inTeam:(nullable Team *)team
 {
     ZMUser *selfUser = [ZMUser selfUserInContext:moc];
 
@@ -1223,13 +1237,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         return nil;
     }
 
-    RequireString((participants.count >= 2u), "Not enough users to create group conversations");
-
     ZMConversation *conversation = (ZMConversation *)[super insertNewObjectInManagedObjectContext:moc];
     conversation.lastModifiedDate = [NSDate date];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.creator = selfUser;
     conversation.team = team;
+    conversation.userDefinedName = name;
 
     for (ZMUser *participant in participants) {
         Require([participant isKindOfClass:[ZMUser class]]);

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1448,6 +1448,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     systemMessage.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     systemMessage.nonce = [NSUUID new];
     systemMessage.sender = self.creator;
+    systemMessage.text = self.userDefinedName;
     systemMessage.users = self.activeParticipants.set;
     // the new conversation message should be displayed first,
     // additionally the use of reference date is to ensure proper transition for older clients so the message is the very

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -116,10 +116,15 @@ extern NSString * _Null_unspecified const ZMIsDimmedKey; ///< Specifies that a r
 
 - (nonnull id<ZMConversationMessage>)appendKnock;
 
-/// Insert a new group conversation into the user session
-/// If a team is specified, exsiting conversations will be returned if there are any.
+///// Insert a new group conversation into the user session
 + (nonnull instancetype)insertGroupConversationIntoUserSession:(nonnull id<ZMManagedObjectContextProvider> )session
                                               withParticipants:(nonnull NSArray<ZMUser *> *)participants
+                                                        inTeam:(nullable Team *)team;
+
+/// Insert a new group conversation with name into the user session
++ (nonnull instancetype)insertGroupConversationIntoUserSession:(nonnull id<ZMManagedObjectContextProvider> )session
+                                              withParticipants:(nonnull NSArray<ZMUser *> *)participants
+                                                          name:(nullable NSString*)name
                                                         inTeam:(nullable Team *)team;
 
 /// If that conversation exists, it is returned, @c nil otherwise.

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
@@ -1,0 +1,94 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@testable import WireDataModel
+
+class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testSystemMessageWhenCreatingConversationWithNoName() {
+        syncMOC.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            let alice = self.createUser(onMoc: self.syncMOC)!
+            alice.name = "alice"
+            let bob = self.createUser(onMoc: self.syncMOC)!
+            bob.name = "bob"
+
+            let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [alice, bob], name: nil, in: nil)
+
+            XCTAssertEqual(conversation?.messages.count, 1)
+            let systemMessage = conversation?.messages.firstObject as? ZMSystemMessage
+
+            XCTAssertNotNil(systemMessage)
+            XCTAssertEqual(systemMessage?.systemMessageType, .newConversation)
+            XCTAssertNil(systemMessage?.text)
+            XCTAssertEqual(systemMessage?.users, [selfUser, alice, bob])
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+    }
+
+    func testSystemMessageWhenCreatingConversationWithName() {
+        syncMOC.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            let alice = self.createUser(onMoc: self.syncMOC)!
+            alice.name = "alice"
+            let bob = self.createUser(onMoc: self.syncMOC)!
+            bob.name = "bob"
+
+            let name = "Crypto"
+
+            let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [alice, bob], name: name, in: nil)
+
+            XCTAssertEqual(conversation?.messages.count, 1)
+
+            let systemMessage = conversation?.messages.lastObject as? ZMSystemMessage
+
+            XCTAssertNotNil(systemMessage)
+            XCTAssertEqual(systemMessage?.systemMessageType, .newConversation)
+            XCTAssertEqual(systemMessage?.text, name)
+            XCTAssertEqual(systemMessage?.users, [selfUser, alice, bob])
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+    }
+
+    func testSystemMessageWhenCreatingEmptyConversationWithName() {
+        syncMOC.performGroupedBlock {
+            let name = "Crypto"
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+
+            let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [], name: name, in: nil)
+
+            XCTAssertEqual(conversation?.messages.count, 1)
+
+            let nameMessage = conversation?.messages.firstObject as? ZMSystemMessage
+            XCTAssertNotNil(nameMessage)
+            XCTAssertEqual(nameMessage?.systemMessageType, .newConversation)
+            XCTAssertEqual(nameMessage?.text, name)
+            XCTAssertEqual(nameMessage?.users, [selfUser])
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+    }
+}

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -21,7 +21,7 @@ import WireTesting
 @testable import WireDataModel
 
 
-class Conversationtests_Teams: BaseTeamTests {
+class ConversationTests_Teams: BaseTeamTests {
 
     var team: Team!
     var user: ZMUser!
@@ -179,33 +179,18 @@ class Conversationtests_Teams: BaseTeamTests {
         XCTAssertEqual(conversation?.team, team)
     }
 
-    func testThatUIMethodThrowsWhenPermissionsAreInsuficcient() {
-        do {
-            // given
-            member.permissions = Permissions(rawValue: 0)
-            let otherUser = ZMUser.insertNewObject(in: uiMOC)
-
-            // when
-            _ = try team.addConversation(with: [otherUser])
-            XCTFail("Should not be executed")
-        } catch {
-            // then
-            XCTAssertEqual(error as! TeamError, TeamError.insufficientPermissions)
-        }
-    }
-
-    func testThatItCreatesAConversationWithOnlyAGuest() throws {
+    func testThatItCreatesAConversationWithOnlyAGuest() {
         // given
         let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
         let guest = ZMUser.insertNewObject(in: uiMOC)
 
         // when
-        let conversation = try team.addConversation(with: [guest])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [guest], in: team)
         XCTAssertNotNil(conversation)
     }
 
 
-    func testThatItCreatesAConversationWithAnotherMember() throws {
+    func testThatItCreatesAConversationWithAnotherMember() {
         // given
         let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
         let otherUser = ZMUser.insertNewObject(in: uiMOC)
@@ -214,7 +199,7 @@ class Conversationtests_Teams: BaseTeamTests {
         otherMember.user = otherUser
 
         // when
-        let conversation = try team.addConversation(with: [otherUser])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser], in: team)
         XCTAssertNotNil(conversation)
         XCTAssertEqual(conversation?.otherActiveParticipants, [otherUser])
         XCTAssertTrue(otherUser.isTeamMember)
@@ -224,15 +209,15 @@ class Conversationtests_Teams: BaseTeamTests {
 }
 
 // MARK: - System messages
-extension Conversationtests_Teams {
-    func testThatItCreatesSystemMessageWithTeamMemberLeave() throws {
+extension ConversationTests_Teams {
+    func testThatItCreatesSystemMessageWithTeamMemberLeave() {
         // given
         let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
         let otherUser = ZMUser.insertNewObject(in: uiMOC)
         let otherMember = Member.insertNewObject(in: uiMOC)
         otherMember.team = team
         otherMember.user = otherUser
-        let conversation = try team.addConversation(with: [otherUser])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser], in: team)
         conversation?.lastModifiedDate = Date(timeIntervalSinceNow: -100)
         let timestamp = Date(timeIntervalSinceNow: -20)
         

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -72,7 +72,7 @@ class TeamTests: BaseTeamTests {
 
         // when
         let guest = ZMUser.insertNewObject(in: uiMOC)
-        let conversation = try team.addConversation(with: [guest])!
+        guard let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [guest], in: team) else { XCTFail(); return }
 
         // then
         XCTAssertTrue(guest.isGuest(in: conversation))
@@ -92,7 +92,7 @@ class TeamTests: BaseTeamTests {
         bot.serviceIdentifier = UUID.create().transportString()
         bot.providerIdentifier = UUID.create().transportString()
         XCTAssert(bot.isServiceUser)
-        let conversation = try team.addConversation(with: [guest, bot])!
+        guard let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [guest, bot], in: team) else { XCTFail(); return }
         
         // then
         XCTAssert(guest.isGuest(in: conversation))
@@ -130,8 +130,8 @@ class TeamTests: BaseTeamTests {
             let guest = ZMUser.insertNewObject(in: uiMOC)
 
             // when
-            let conversation1 = try team1.addConversation(with: [guest])!
-            let conversation2 = try team2.addConversation(with: [otherUser])!
+        guard let conversation1 = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [guest], in: team1) else { XCTFail(); return }
+        guard let conversation2 = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser], in: team2) else { XCTFail(); return }
 
             // then
             XCTAssertTrue(guest.isGuest(in: conversation1))

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		F189988B1E7AF80500E579A2 /* store2-28-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = F189988A1E7AF80500E579A2 /* store2-28-0.wiredatabase */; };
 		F18998A61E7BE03800E579A2 /* zmessaging.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F189988C1E7BE03800E579A2 /* zmessaging.xcdatamodeld */; };
 		F1B025621E53500400900C65 /* ZMConversationTests+PrepareToSend.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B025601E534CF900900C65 /* ZMConversationTests+PrepareToSend.swift */; };
+		F1B58928202DCF0C002BB59B /* ZMConversationTests+CreationSystemMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B58926202DCEF9002BB59B /* ZMConversationTests+CreationSystemMessages.swift */; };
 		F1C867701FA9CCB5001505E8 /* DuplicateMerging.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C8676F1FA9CCB5001505E8 /* DuplicateMerging.swift */; };
 		F1C867851FAA0D48001505E8 /* ZMUser+Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C867841FAA0D48001505E8 /* ZMUser+Create.swift */; };
 		F90D99A51E02DC6B00034070 /* AssetCollectionBatched.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90D99A41E02DC6B00034070 /* AssetCollectionBatched.swift */; };
@@ -673,6 +674,7 @@
 		F18998A41E7BE03800E579A2 /* zmessaging2.8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.8.xcdatamodel; sourceTree = "<group>"; };
 		F18998A51E7BE03800E579A2 /* zmessaging2.9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.9.xcdatamodel; sourceTree = "<group>"; };
 		F1B025601E534CF900900C65 /* ZMConversationTests+PrepareToSend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+PrepareToSend.swift"; sourceTree = "<group>"; };
+		F1B58926202DCEF9002BB59B /* ZMConversationTests+CreationSystemMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+CreationSystemMessages.swift"; sourceTree = "<group>"; };
 		F1C8676F1FA9CCB5001505E8 /* DuplicateMerging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateMerging.swift; sourceTree = "<group>"; };
 		F1C867841FAA0D48001505E8 /* ZMUser+Create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Create.swift"; sourceTree = "<group>"; };
 		F90D99A41E02DC6B00034070 /* AssetCollectionBatched.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetCollectionBatched.swift; sourceTree = "<group>"; };
@@ -1588,6 +1590,7 @@
 				F1B025601E534CF900900C65 /* ZMConversationTests+PrepareToSend.swift */,
 				BF735CFB1E7050D0003BC61F /* ZMConversationTests+CallSystemMessages.swift */,
 				16F6BB3B1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift */,
+				F1B58926202DCEF9002BB59B /* ZMConversationTests+CreationSystemMessages.swift */,
 				F9B71F571CB2BC85001DB03F /* ZMConversationTests.h */,
 				F9B71F581CB2BC85001DB03F /* ZMConversationTests.m */,
 				F9C8770A1E015AAF00792613 /* AssetColletionTests.swift */,
@@ -2493,6 +2496,7 @@
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */,
 				BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */,
+				F1B58928202DCF0C002BB59B /* ZMConversationTests+CreationSystemMessages.swift in Sources */,
 				F9DBA5251E28EE1500BE23C0 /* ConversationObserverTests.swift in Sources */,
 				BFE3A96C1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift in Sources */,
 				54F84D031F995B0200ABD7D5 /* DuplicatedEntityRemovalTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the new conversation creation flow we have name at the point of creation. We need an API for this.

### Solutions

Added conversation creation method that takes a name parameter. It is currently optional, bet at a later point we should clean up the API and remove the ability to create conversation without name.
