### PR TITLE
Add option to filter modified keys

### DIFF
--- a/Source/Model/ZMManagedObject+Internal.h
+++ b/Source/Model/ZMManagedObject+Internal.h
@@ -101,8 +101,8 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedKeysKey;
 - (BOOL)hasLocalModificationsForKeys:(nonnull NSSet *)keys;
 - (BOOL)hasLocalModificationsForKey:(nonnull NSString *)key;
 
-
 - (nonnull NSSet <NSString *> *)keysTrackedForLocalModifications ZM_REQUIRES_SUPER;
+- (nonnull NSSet <NSString *> *)filterUpdatedLocallyModifiedKeys:(nonnull NSSet<NSString *> *)updatedKeys ZM_REQUIRES_SUPER;
 - (void)updateKeysThatHaveLocalModifications ZM_REQUIRES_SUPER;
 
 @end

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -539,9 +539,16 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     NSSet *oldKeys = self.keysThatHaveLocalModifications;
     NSMutableSet *newKeys = [oldKeys mutableCopy];
     [newKeys addObjectsFromArray:self.filteredChangedValues.allKeys ?: @[]];
-    if (! [oldKeys isEqualToSet:newKeys]) {
-        [self setKeysThatHaveLocalModifications:newKeys];
+    NSSet *filteredKeys = [self filterUpdatedLocallyModifiedKeys:newKeys];
+    if (! [oldKeys isEqualToSet:filteredKeys]) {
+        [self setKeysThatHaveLocalModifications:filteredKeys];
     }
+}
+
+// Subclasses should override to conditionally exclude modified keys.
+- (NSSet<NSString *> *)filterUpdatedLocallyModifiedKeys:(NSSet<NSString *> *)updatedKeys
+{
+    return updatedKeys;
 }
 
 @end

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -183,6 +183,35 @@
     XCTAssertNotNil(entity.attributesByName[@"modifiedKeys"]);
 }
 
+- (void)testThatItIgnoresModifiedDisplayNameWhenInserting
+{
+    // Given
+    ZMConversation *sut = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    sut.userDefinedName = @"Name";
+    
+    // When
+    XCTAssert(sut.isInserted);
+    XCTAssert([self.uiMOC saveOrRollback]);
+    
+    // Then
+    XCTAssertFalse([sut.keysThatHaveLocalModifications containsObject:ZMConversationUserDefinedNameKey]);
+}
+
+- (void)testThatItDoesNotIgnoreAModifiedDisplayNameWhenNotInserting
+{
+    // Given
+    ZMConversation *sut = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    XCTAssert([self.uiMOC saveOrRollback]);
+    XCTAssertFalse(sut.isInserted);
+    
+    // When
+    sut.userDefinedName = @"Name";
+    XCTAssert([self.uiMOC saveOrRollback]);
+    
+    // Then
+    XCTAssert([sut.keysThatHaveLocalModifications containsObject:ZMConversationUserDefinedNameKey]);
+}
+
 - (void)testThatWeCanSetAttributesOnConversation
 {
     [self checkConversationAttributeForKey:@"draftMessageText" value:@"It’s cold outside."];


### PR DESCRIPTION
## What's new in this PR?

* Add method to filter modified keys while ensuring they are only set once in the super class.
* Before it was not possible to remove keys that have been added by `ZMManagedObject` in `updateKeysThatHaveLocalModifications`, as setting them would result in a save, which in turn would result in a recalculation which will trigger `updateKeysThatHaveLocalModifications` being called again, leaving the object in a dirty state.
* This PR adds a separate method that subclasses can override to filter the modified keys to be set by the super class, this way the object will not be changed again.
