### PR TITLE
Added default values for the conversation creation options

### DIFF
--- a/Source/Model/Conversation/ConversationCreationOptions.swift
+++ b/Source/Model/Conversation/ConversationCreationOptions.swift
@@ -19,10 +19,10 @@
 import Foundation
 
 public struct ConversationCreationOptions {
-    var participants: [ZMUser]
-    var name: String?
-    var team: Team?
-    var allowGuests: Bool
+    var participants: [ZMUser] = []
+    var name: String? = nil
+    var team: Team? = nil
+    var allowGuests: Bool = true
     
     public init(participants: [ZMUser], name: String?, team: Team?, allowGuests: Bool) {
         self.participants = participants

--- a/Source/Model/Conversation/ConversationCreationOptions.swift
+++ b/Source/Model/Conversation/ConversationCreationOptions.swift
@@ -24,7 +24,7 @@ public struct ConversationCreationOptions {
     var team: Team? = nil
     var allowGuests: Bool = true
     
-    public init(participants: [ZMUser], name: String?, team: Team?, allowGuests: Bool) {
+    public init(participants: [ZMUser] = [], name: String? = nil, team: Team? = nil, allowGuests: Bool = true) {
         self.participants = participants
         self.name = name
         self.team = team


### PR DESCRIPTION
## What's new in this PR?

### Issues

Using the new Swift API is not that simple, since all the values for the conversation creation options should be passed in.

### Solutions

Set the default values and let user change them.
