### PR TITLE
Added user is sender flag

### DIFF
--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -159,6 +159,8 @@ inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 @property (nonatomic) id <ZMSystemMessageData> _Nullable parentMessage; // Only filled for .performedCall & .missedCall
 @property (nonatomic, readonly) NSDate * _Nonnull lastChildMessageDate; // Equals the serverTimestamp, if no childMessages are present
 
+@property (nonatomic, readonly) BOOL userIsTheSender; // Set to true if sender is the only user in users array. E.g. when a wireless user joins conversation
+
 + (ZMSystemMessage * _Nullable)fetchLatestPotentialGapSystemMessageInConversation:(ZMConversation * _Nonnull)conversation;
 - (void)updateNeedsUpdatingUsersIfNeeded;
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -648,7 +648,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     NSSet *noncesData = [nonces mapWithBlock:^NSData*(NSUUID *uuid) {
         return uuid.data;
     }];
-    NSPredicate *noncePredicate = [NSPredicate predicateWithFormat:@"%K IN %@", noncesData]; // FIXME? How can this work at all?
+    NSPredicate *noncePredicate = [NSPredicate predicateWithFormat:@"%K IN %@", noncesData];
     return [NSCompoundPredicate andPredicateWithSubpredicates:@[conversationPredicate, noncePredicate]];
 }
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -1011,6 +1011,12 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     return date;
 }
 
+- (BOOL)userIsTheSender
+{
+    BOOL onlyOneUser = self.users.count == 1;
+    BOOL isSender = [self.users containsObject:self.sender];
+    return onlyOneUser && isSender;
+}
 
 @end
 

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -103,6 +103,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic) NSTimeInterval duration;
 @property (nonatomic) NSSet<id <ZMSystemMessageData>>  *childMessages;
 @property (nonatomic) id <ZMSystemMessageData> parentMessage;
+@property (nonatomic, readonly) BOOL userIsTheSender;
 
 @end
 

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -32,7 +32,7 @@ class ManagedObjectContextChangeObserverTests : ZMBaseManagedObjectTest {
 
         // when
         uiMOC.perform {
-            ZMMessage(nonce: UUID(), managedObjectContext: self.uiMOC)
+            _ = ZMMessage(nonce: UUID(), managedObjectContext: self.uiMOC)
         }
 
         // then
@@ -91,7 +91,7 @@ class ManagedObjectContextChangeObserverTests : ZMBaseManagedObjectTest {
         _ = sut
         sut = nil
         uiMOC.perform {
-            ZMMessage(nonce: UUID(), managedObjectContext: self.uiMOC)
+            _ = ZMMessage(nonce: UUID(), managedObjectContext: self.uiMOC)
         }
 
         // then

--- a/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
+++ b/Tests/Source/Model/Utils/MessageCountTrackerTests.swift
@@ -185,10 +185,10 @@ class MessageCountTrackerTests: BaseZMMessageTests {
 
         syncMOC.performGroupedBlockAndWait {
             self.syncMOC.analytics = mockAnalytics
-            101.times { ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
-            4.times { ZMImageMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
-            3.times { ZMAssetClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
-            2.times { ZMTextMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
+            101.times { _ = ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
+            4.times { _ = ZMImageMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
+            3.times { _ = ZMAssetClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
+            2.times { _ = ZMTextMessage(nonce: UUID(), managedObjectContext: self.syncMOC) }
         }
 
         // When


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some system messages have sender and users array containing the same user. We need to easily check for this in UI.

### Solutions

Add a property to ZMSystemMessage that is true when users array contains only single user and it's the same as sender

