### PR TITLE
allowGuests now means that either type of guests are allowed

### DIFF
--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -92,11 +92,12 @@ public extension ZMConversation {
     @NSManaged @objc dynamic internal var accessModeStrings: [String]?
     @NSManaged @objc dynamic internal var accessRoleString: String?
     
-    /// If set to true, then any user can join the conversation.
+    /// If set to false, only team member can join the conversation.
+    /// True means that a regular guest OR wireless guests could join
     /// Controls the values of `accessMode` and `accessRole`.
     public var allowGuests: Bool {
         get {
-            return accessMode != .teamOnly && accessRole == .nonActivated
+            return accessMode != .teamOnly && accessRole != .team
         }
         set {
             accessMode = ConversationAccessMode.value(forAllowGuests: newValue)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
@@ -118,14 +118,19 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
     }
     
     func testThatAccessModeStringsChangingAllowGuestsSets() {
-        [(true, ["code", "invite"], ConversationAccessRole.nonActivated.rawValue),
-         (false, [], ConversationAccessRole.team.rawValue),
-         (true, ["invite"], ConversationAccessRole.nonActivated.rawValue)].forEach {
+        let values = [
+            (true, ["code", "invite"], ConversationAccessRole.nonActivated.rawValue),
+            (false, [], ConversationAccessRole.team.rawValue),
+            (true, ["invite"], ConversationAccessRole.nonActivated.rawValue),
+            (true, ["invite"], ConversationAccessRole.activated.rawValue)
+        ]
+
+        for (allowGuests, accessMode, accessRole) in values {
             // when
-            sut.accessModeStrings = $0.1
-            sut.accessRoleString = $0.2
+            sut.accessModeStrings = accessMode
+            sut.accessRoleString = accessRole
             // then
-            XCTAssertEqual(sut.allowGuests, $0.0)
+            XCTAssertEqual(sut.allowGuests, allowGuests)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

The conversations that were created earlier have a `"access": ["invite"]` and were treated as not allowing guests which is not correct.

### Solutions

Relaxed the meaning of the flag to be false when it's team-only conversation and true otherwise.
