### PR TITLE
Check if a user is wireless in `-canBeConnected`

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -271,7 +271,7 @@ static NSString *const ExpiresAtKey = @"expiresAt";
 
 - (BOOL)canBeConnected;
 {
-    if (self.isServiceUser) {
+    if (self.isServiceUser || self.isWirelessUser) {
         return NO;
     }
     return ! self.isConnected && ! self.isPendingApprovalByOtherUser;

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1219,6 +1219,23 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertFalse(user.canBeConnected);
 }
 
+- (void)testThatAWirelessUserCanNotBeConnectedTo
+{
+    // given
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.expiresAt = [NSDate date];
+    
+    // then
+    XCTAssertFalse(user.isPendingApprovalBySelfUser);
+    XCTAssertFalse(user.isConnected);
+    XCTAssertFalse(user.isBlocked);
+    XCTAssertFalse(user.isIgnored);
+    XCTAssertFalse(user.isPendingApprovalByOtherUser);
+    
+    XCTAssertFalse(user.canBeConnected);
+    XCTAssertTrue(user.isWirelessUser);
+}
+
 - (void)testThatConnectionsValuesAreFalseWhenThereIsNotAConnectionToTheSelfUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

* Check if a user is wireless in `-canBeConnected` to ensure elements on the UI side checking this flag are updated correctly.