### PR TITLE
Added test for CoreData model identifier matching

### DIFF
--- a/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
@@ -364,6 +364,8 @@ class DatabaseMigrationTests: DatabaseBaseTest {
         
         let regex = try NSRegularExpression(pattern: "[0-9\\.]+[0-9]+")
         
+        var processedVersions = Set<String>()
+        
         try fm.contentsOfDirectory(atPath: source.path).filter { URL(fileURLWithPath: $0).pathExtension == "mom" } .forEach { modelFileName in
             
             let nameMatches = regex.matches(in: modelFileName, range: NSRange(modelFileName.startIndex..., in: modelFileName)).map {
@@ -374,13 +376,16 @@ class DatabaseMigrationTests: DatabaseBaseTest {
                 return
             }
             
-            guard let version = nameMatches.first else {
+            guard let version = nameMatches.first! else {
                 fatal("Wrong name format: \(modelFileName)")
             }
             
+            XCTAssertFalse(processedVersions.contains(version))
+            
             let store = NSManagedObjectModel(contentsOf: source.appendingPathComponent(modelFileName))!
             // then
-            XCTAssertTrue(store.versionIdentifiers.contains(version!))
+            XCTAssertTrue(store.versionIdentifiers.contains(version))
+            processedVersions.insert(version)
         }
     }
 }

--- a/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
@@ -352,6 +352,37 @@ class DatabaseMigrationTests: DatabaseBaseTest {
             self.clearStorageFolder()
         }
     }
+    
+    func testThatTheVersionIdentifiersMatchModelNameAndDoNotDuplicate() throws {
+        // given
+        guard let source = Bundle(for: ZMMessage.self).url(forResource: "zmessaging", withExtension: "momd") else {
+            fatalError("missing resource")
+        }
+        let fm = FileManager.default
+    
+        let excludedModels = Set(["zmessaging.mom", "zmessaging2.9.mom", "zmessaging2.10.mom", "zmessaging2.11.mom"])
+        
+        let regex = try NSRegularExpression(pattern: "[0-9\\.]+[0-9]+")
+        
+        try fm.contentsOfDirectory(atPath: source.path).filter { URL(fileURLWithPath: $0).pathExtension == "mom" } .forEach { modelFileName in
+            
+            let nameMatches = regex.matches(in: modelFileName, range: NSRange(modelFileName.startIndex..., in: modelFileName)).map {
+                String(modelFileName[Range($0.range, in: modelFileName)!])
+            }
+            
+            if excludedModels.contains(modelFileName) { // first version
+                return
+            }
+            
+            guard let version = nameMatches.first else {
+                fatal("Wrong name format: \(modelFileName)")
+            }
+            
+            let store = NSManagedObjectModel(contentsOf: source.appendingPathComponent(modelFileName))!
+            // then
+            XCTAssertTrue(store.versionIdentifiers.contains(version!))
+        }
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## What's new in this PR?

### Issues

The CoreData requires the version's identifier to be updated when the new version is created.

