### PR TITLE
Allow marking message as unread, improved conversation unread

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1011,23 +1011,23 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         return NO;
     }
     
-    if (nil == [self lastMessageCanBeConsideredUnread]) {
+    if (nil == [self lastMessageCanBeMarkedUnread]) {
         return NO;
     }
     
     return YES;
 }
 
-- (ZMMessage *)lastMessageCanBeConsideredUnread
+- (ZMMessage *)lastMessageCanBeMarkedUnread
 {
-    NSUInteger lastMessageIndexCanBeConsideredUnread = [self.messages.reversedOrderedSet indexOfObjectPassingTest:^BOOL(id<ZMConversationMessage> message, NSUInteger idx, BOOL *stop) {
+    NSUInteger lastMessageIndexCanBeMarkedUnread = [self.messages.reversedOrderedSet indexOfObjectPassingTest:^BOOL(id<ZMConversationMessage> message, NSUInteger idx, BOOL *stop) {
         NOT_USED(idx);
         NOT_USED(stop);
-        return message.canBeConsideredUnread;
+        return message.canBeMarkedUnread;
     }];
     
-    if (lastMessageIndexCanBeConsideredUnread != NSNotFound) {
-        return self.messages[self.messages.count - lastMessageIndexCanBeConsideredUnread - 1];
+    if (lastMessageIndexCanBeMarkedUnread != NSNotFound) {
+        return self.messages[self.messages.count - lastMessageIndexCanBeMarkedUnread - 1];
     }
     else {
         return nil;
@@ -1036,14 +1036,14 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
 - (void)markAsUnread
 {
-    ZMMessage *lastMessageCanBeConsideredUnread = [self lastMessageCanBeConsideredUnread];
+    ZMMessage *lastMessageCanBeMarkedUnread = [self lastMessageCanBeMarkedUnread];
     
-    if (lastMessageCanBeConsideredUnread == nil) {
+    if (lastMessageCanBeMarkedUnread == nil) {
         ZMLogError(@"Cannot mark as read: no message to mark in %@", self);
         return;
     }
     
-    [lastMessageCanBeConsideredUnread markAsUnread];
+    [lastMessageCanBeMarkedUnread markAsUnread];
 }
 
 @end

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1023,7 +1023,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     NSUInteger lastMessageIndexCanBeConsideredUnread = [self.messages.reversedOrderedSet indexOfObjectPassingTest:^BOOL(id<ZMConversationMessage> message, NSUInteger idx, BOOL *stop) {
         NOT_USED(idx);
         NOT_USED(stop);
-        return [Message isNormalMessage:message];
+        return message.canBeConsideredUnread;
     }];
     
     if (lastMessageIndexCanBeConsideredUnread != NSNotFound) {

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -118,6 +118,9 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     /// Marks the message as the last unread message in the conversation, moving the unread mark exactly before this
     /// message.
     func markAsUnread()
+    
+    /// Checks if the message can be marked unread
+    var canBeConsideredUnread: Bool { get }
 }
 
 // MARK:- Conversation managed properties
@@ -139,8 +142,21 @@ extension ZMMessage : ZMConversationMessage {
         return false
     }
     
+    public var canBeConsideredUnread: Bool {
+        guard self.isNormal,
+                let _ = self.serverTimestamp,
+                let _ = self.conversation,
+                let sender = self.sender,
+                !sender.isSelfUser else {
+                return false
+        }
+        
+        return true
+    }
+    
     public func markAsUnread() {
-        guard let serverTimestamp = self.serverTimestamp,
+        guard canBeConsideredUnread,
+              let serverTimestamp = self.serverTimestamp,
               let conversation = self.conversation,
               let managedObjectContext = self.managedObjectContext,
               let syncContext = managedObjectContext.zm_sync else {

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -120,7 +120,7 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     func markAsUnread()
     
     /// Checks if the message can be marked unread
-    var canBeConsideredUnread: Bool { get }
+    var canBeMarkedUnread: Bool { get }
 }
 
 // MARK:- Conversation managed properties
@@ -142,7 +142,7 @@ extension ZMMessage : ZMConversationMessage {
         return false
     }
     
-    public var canBeConsideredUnread: Bool {
+    public var canBeMarkedUnread: Bool {
         guard self.isNormal,
                 let _ = self.serverTimestamp,
                 let _ = self.conversation,
@@ -155,7 +155,7 @@ extension ZMMessage : ZMConversationMessage {
     }
     
     public func markAsUnread() {
-        guard canBeConsideredUnread,
+        guard canBeMarkedUnread,
               let serverTimestamp = self.serverTimestamp,
               let conversation = self.conversation,
               let managedObjectContext = self.managedObjectContext,

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1931,7 +1931,8 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeConnection;
     conversation.remoteIdentifier = NSUUID.createUUID;
-    [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
+    ZMMessage *message = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
+    message.sender = self.createUser;
     [conversation markAsRead];
     // WHEN & THEN
     XCTAssertTrue([conversation canMarkAsUnread]);
@@ -1947,7 +1948,7 @@
     [self.uiMOC saveOrRollback];
     
     ZMMessage* unreadMessage = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
-
+    unreadMessage.sender = self.createUser;
     [conversation markAsRead];
     XCTAssertEqual(conversation.lastReadMessage, unreadMessage);
     

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -1816,6 +1816,18 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertTrue([message.ignoredKeys containsObject:@"reactions"]);
 }
 
+- (void)testThatItKnowsThatItCannotUnreadTheMessage_selfMessage {
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+    
+    // when
+    ZMMessage *message = (id)[conversation appendMessageWithText:self.name];
+    
+    // then
+    XCTAssertFalse([message canBeConsideredUnread]);
+}
+
 @end
 
 

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -1825,7 +1825,7 @@ NSString * const ReactionsKey = @"reactions";
     ZMMessage *message = (id)[conversation appendMessageWithText:self.name];
     
     // then
-    XCTAssertFalse([message canBeConsideredUnread]);
+    XCTAssertFalse([message canBeMarkedUnread]);
 }
 
 @end


### PR DESCRIPTION
- Added the method to check if the message can be considered unread. The messages sent by the current user cannot be marked as read.