### PR TITLE
Consider wireless user verification

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -375,8 +375,11 @@ extension ZMConversation {
             if $0.isConnected {
                 return false
             }
+            else if $0.isWirelessUser {
+                return false
+            }
             else {
-                return $0.team != selfUser.team
+                return selfUser.team == nil || $0.team != selfUser.team
             }
         } != nil
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We show the devices of wireless users (unlikely to regular non-connected users), therefore it is possible to verify the fingerprints of those users. However the fingerprint verification does not make the conversation verified.

### Causes

In the code we where discarding the non-connected users, since it was not possible to verify their fingerprints.

### Solutions

I've added an extra case for the wireless users in the conversation verification.
