### PR TITLE
Add database backup methods

### DIFF
--- a/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
+++ b/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
@@ -178,7 +178,7 @@ extension NSPersistentStoreCoordinator {
     }
  
     /// Returns the set of options that need to be passed to the persistent sotre
-    fileprivate static func persistentStoreOptions(supportsMigration: Bool) -> [String: Any] {
+    static func persistentStoreOptions(supportsMigration: Bool) -> [String: Any] {
         return [
             // https://www.sqlite.org/pragma.html
             NSSQLitePragmasOption: [

--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -1,0 +1,81 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireUtilities
+
+extension StorageStack {
+
+    // Each backup for any account will be created in a unique subdirectory inside.
+    // Clearing this should remove all
+    public static var backupsDirectory: URL {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        return tempURL.appendingPathComponent("backups")
+    }
+
+    public enum BackupError: Error {
+        case error
+    }
+
+    /// Will make a copy of account storage and place in a unique directory
+    ///
+    /// - Parameters:
+    ///   - accountIdentifier: identifier of account being backed up
+    ///   - applicationContainer: shared application container
+    ///   - dispatchGroup: group for testing
+    ///   - completion: called on main thread when done. Result will contain the folder where all data was written to.
+    public static func backupLocalStorage(accountIdentifier: UUID, applicationContainer: URL, dispatchGroup: ZMSDispatchGroup? = nil, completion: @escaping ((Result<URL>) -> Void)) {
+
+        let accountDirectory = StorageStack.accountFolder(accountIdentifier: accountIdentifier, applicationContainer: applicationContainer)
+        let storeFile = accountDirectory.appendingPersistentStoreLocation()
+        let queue = DispatchQueue(label: "Database export", qos: .userInitiated)
+
+        let target = backupsDirectory.appendingPathComponent(UUID().uuidString)
+
+        dispatchGroup?.enter()
+        queue.async() {
+            let model = NSManagedObjectModel.loadModel()
+            let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+            do {
+                var readOptions = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
+                // We don't want to change anything in there
+                readOptions[NSReadOnlyPersistentStoreOption] = true
+
+                // Create persistent store from what we have on disk
+                let persistentStore = try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeFile, options: readOptions)
+
+                // Create target directory
+                try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true, attributes: nil)
+                let storeLocation = target.appendingStoreFile()
+
+                let writeOptions = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
+                // Recreate the persistent store inside a new location
+                try coordinator.migratePersistentStore(persistentStore, to: storeLocation, options: writeOptions, withType: NSSQLiteStoreType)
+                DispatchQueue.main.async {
+                    completion(.success(target))
+                }
+                dispatchGroup?.leave()
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(BackupError.error))
+                }
+                dispatchGroup?.leave()
+            }
+        }
+    }
+}

--- a/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
@@ -1,0 +1,89 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class StorageStackBackupTests: DatabaseBaseTest {
+
+    override func setUp() {
+        super.setUp()
+        StorageStack.shared.createStorageAsInMemory = false
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: StorageStack.backupsDirectory)
+        super.tearDown()
+    }
+
+    func createBackup(accountIdentifier: UUID, file: StaticString =
+        #file, line: UInt = #line) -> Result<URL>? {
+
+        var result: Result<URL>?
+        StorageStack.backupLocalStorage(accountIdentifier:accountIdentifier, applicationContainer: applicationContainer, dispatchGroup: self.dispatchGroup) {
+            result = $0
+        }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+        return result
+    }
+
+    func testThatItFailsWithWrongAccountIdentifier() throws {
+        // given
+        let uuid = UUID()
+        _ = createStorageStackAndWaitForCompletion(userID: uuid)
+
+        // when
+        guard let result = createBackup(accountIdentifier: UUID()) else { return XCTFail() }
+
+        guard case let .failure(error) = result else { return XCTFail() }
+
+        XCTAssertEqual(error as? StorageStack.BackupError, .failedToRead)
+    }
+
+    func testThatItFindsTheStorageWithCorrectAccountIdentifier() throws {
+        // given
+        let uuid = UUID()
+        _ = createStorageStackAndWaitForCompletion(userID: uuid)
+
+        // when
+        guard let result = createBackup(accountIdentifier: uuid) else { return XCTFail() }
+
+        // then
+        guard case let .success(url) = result else { return XCTFail() }
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: url.path))
+        XCTAssertTrue(try fm.contentsOfDirectory(atPath: url.path).count > 1)
+    }
+
+    func testThatItFailsWhenItCannotCreateTargetDirectory() throws {
+        // given
+        let uuid = UUID()
+        _ = createStorageStackAndWaitForCompletion(userID: uuid)
+        // create empty file where backup needs to be saved to
+        try Data().write(to: StorageStack.backupsDirectory)
+
+        // when
+        guard let result = createBackup(accountIdentifier: uuid) else { return XCTFail() }
+
+        guard case let .failure(error) = result else { return XCTFail() }
+
+        XCTAssertEqual(error as? StorageStack.BackupError, .failedToWrite)
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		F1549D4A1FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */; };
 		F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */; };
 		F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */; };
+		F16F8EBF2063E9CC009A9D6F /* StorageStackBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16F8EBE2063E9CC009A9D6F /* StorageStackBackupTests.swift */; };
 		F179B5DA2062B77300C13DFD /* StorageStack+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F179B5D92062B77300C13DFD /* StorageStack+Backup.swift */; };
 		F18998831E7AC6D900E579A2 /* ZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998821E7AC6D900E579A2 /* ZMUser.swift */; };
 		F18998861E7AEECF00E579A2 /* ZMUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998841E7AEEC900E579A2 /* ZMUserTests.swift */; };
@@ -668,6 +669,7 @@
 		F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserFetchAndMergeTests.swift; sourceTree = "<group>"; };
 		F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Patches.swift"; sourceTree = "<group>"; };
 		F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMConversationSecurityLevel.swift; sourceTree = "<group>"; };
+		F16F8EBE2063E9CC009A9D6F /* StorageStackBackupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageStackBackupTests.swift; sourceTree = "<group>"; };
 		F179B5D92062B77300C13DFD /* StorageStack+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageStack+Backup.swift"; sourceTree = "<group>"; };
 		F18998821E7AC6D900E579A2 /* ZMUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUser.swift; sourceTree = "<group>"; };
 		F18998841E7AEEC900E579A2 /* ZMUserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUserTests.swift; sourceTree = "<group>"; };
@@ -1534,6 +1536,7 @@
 				5473CC741E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift */,
 				BF103FA01F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift */,
 				54F581FD1F2F70CE0051ACE8 /* StorageStackTests.swift */,
+				F16F8EBE2063E9CC009A9D6F /* StorageStackBackupTests.swift */,
 				543ABF5A1F34A13000DBE28B /* DatabaseBaseTest.swift */,
 				54ED3A9C1F38CB6A0066AD47 /* DatabaseMigrationTests.swift */,
 			);
@@ -2430,6 +2433,7 @@
 				BF0D07FB1E4C7B7A00B934EB /* TextSearchQueryTests.swift in Sources */,
 				F9C348841E2CC08E0015D69D /* UserClientObserverTests.swift in Sources */,
 				1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */,
+				F16F8EBF2063E9CC009A9D6F /* StorageStackBackupTests.swift in Sources */,
 				F929C17B1E423B620018ADA4 /* SnapshotCenterTests.swift in Sources */,
 				F9A708521CAEEB7500C2F5FE /* ZMFetchRequestBatchTests.m in Sources */,
 				F964700A1D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		F1549D4A1FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */; };
 		F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */; };
 		F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */; };
+		F179B5DA2062B77300C13DFD /* StorageStack+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F179B5D92062B77300C13DFD /* StorageStack+Backup.swift */; };
 		F18998831E7AC6D900E579A2 /* ZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998821E7AC6D900E579A2 /* ZMUser.swift */; };
 		F18998861E7AEECF00E579A2 /* ZMUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998841E7AEEC900E579A2 /* ZMUserTests.swift */; };
 		F189988B1E7AF80500E579A2 /* store2-28-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = F189988A1E7AF80500E579A2 /* store2-28-0.wiredatabase */; };
@@ -667,6 +668,7 @@
 		F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserFetchAndMergeTests.swift; sourceTree = "<group>"; };
 		F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Patches.swift"; sourceTree = "<group>"; };
 		F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMConversationSecurityLevel.swift; sourceTree = "<group>"; };
+		F179B5D92062B77300C13DFD /* StorageStack+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageStack+Backup.swift"; sourceTree = "<group>"; };
 		F18998821E7AC6D900E579A2 /* ZMUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUser.swift; sourceTree = "<group>"; };
 		F18998841E7AEEC900E579A2 /* ZMUserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUserTests.swift; sourceTree = "<group>"; };
 		F18998871E7AF0BE00E579A2 /* ZMUserTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMUserTests.h; sourceTree = "<group>"; };
@@ -1189,6 +1191,7 @@
 			children = (
 				F9A705CA1CAEE01D00C2F5FE /* NSManagedObjectContext+tests.h */,
 				541D1B321F1F8D660078C1F2 /* StorageStack.swift */,
+				F179B5D92062B77300C13DFD /* StorageStack+Backup.swift */,
 				EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */,
 				541D1B361F1FBECE0078C1F2 /* NSPersistentStoreCoordinator+Wire.swift */,
 				541D1B341F1FAE3C0078C1F2 /* ManagedObjectContextDirectory.swift */,
@@ -2297,6 +2300,7 @@
 				F9A706B01CAEE01D00C2F5FE /* MessageChangeInfo.swift in Sources */,
 				F9A706A71CAEE01D00C2F5FE /* AnyClassTuple.swift in Sources */,
 				5451DE351F5FFF8B00C82E75 /* NotificationInContext.swift in Sources */,
+				F179B5DA2062B77300C13DFD /* StorageStack+Backup.swift in Sources */,
 				F9A706A41CAEE01D00C2F5FE /* ConversationChangeInfo.swift in Sources */,
 				F9B71F0D1CB264DF001DB03F /* ZMConversationListDirectory.m in Sources */,
 				F920AE2A1E3A5FDD001BC14F /* Dictionary+Mapping.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would like to implement backing up the information inside CoreData database.

### Solutions

To minimize disruption and potentially corrupting the backup by simply copying file we try to work on CoreData layer:

1. Create a fresh `NSPersistentStore` that points to the database that we want to export
2. Try to migrate the persistent store to another location inside temporary directory. This will dump all data to a new location and invalidate the store created in step 1. We don't care about it because it's created for this purpose, all other persistent stores should not be affected.
