### PR TITLE
Remove client identifier from backup metadata

### DIFF
--- a/Source/ManagedObjectContext/BackupMetadata.swift
+++ b/Source/ManagedObjectContext/BackupMetadata.swift
@@ -25,29 +25,34 @@ public struct BackupMetadata: Codable {
     public let appVersion, modelVersion: String
     public let creationTime: Date
     public let userIdentifier: UUID
+    public let clientIdentifier: String
     
     public init(
         appVersion: String,
         modelVersion: String,
         creationTime: Date = .init(),
-        userIdentifier: UUID
+        userIdentifier: UUID,
+        clientIdentifier: String
         ) {
         platform = .iOS
         self.appVersion = appVersion
         self.modelVersion = modelVersion
         self.creationTime = creationTime
         self.userIdentifier = userIdentifier
+        self.clientIdentifier = clientIdentifier
     }
     
     public init(
         userIdentifier: UUID,
+        clientIdentifier: String,
         appVersionProvider: VersionProvider = Bundle.main,
         modelVersionProvider: VersionProvider = NSManagedObjectModel.loadModel()
         ) {
         self.init(
             appVersion: appVersionProvider.version,
             modelVersion: modelVersionProvider.version,
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: clientIdentifier
         )
     }
 }
@@ -62,6 +67,7 @@ public func ==(lhs: BackupMetadata, rhs: BackupMetadata) -> Bool {
         && lhs.modelVersion == rhs.modelVersion
         && lhs.creationTime == rhs.creationTime
         && lhs.userIdentifier == rhs.userIdentifier
+        && lhs.clientIdentifier == rhs.clientIdentifier
 }
 
 // MARK: - Serialization Helper
@@ -90,10 +96,10 @@ public extension BackupMetadata {
     }
     
     func verify(
-        using remoteIdentifierProvider: RemoteIdentifierProvider,
+        using userIdentifier: UUID,
         appVersionProvider: VersionProvider = Bundle.main
         ) -> VerificationError? {
-        guard userIdentifier == remoteIdentifierProvider.remoteIdentifier else { return .userMismatch }
+        guard self.userIdentifier == userIdentifier else { return .userMismatch }
         let current = Version(string: appVersionProvider.version)
         let backup = Version(string: appVersion)
 
@@ -103,12 +109,6 @@ public extension BackupMetadata {
     }
     
 }
-
-public protocol RemoteIdentifierProvider {
-    var remoteIdentifier: UUID? { get }
-}
-
-extension ZMUser: RemoteIdentifierProvider {}
 
 // MARK: - Version Helper
 

--- a/Source/ManagedObjectContext/BackupMetadata.swift
+++ b/Source/ManagedObjectContext/BackupMetadata.swift
@@ -25,35 +25,29 @@ public struct BackupMetadata: Codable {
     public let appVersion, modelVersion: String
     public let creationTime: Date
     public let userIdentifier: UUID
-    public let clientIdentifier: String
     
     public init(
         appVersion: String,
         modelVersion: String,
         creationTime: Date = .init(),
-        userIdentifier: UUID,
-        clientIdentifier: String
+        userIdentifier: UUID
         ) {
         platform = .iOS
         self.appVersion = appVersion
         self.modelVersion = modelVersion
         self.creationTime = creationTime
         self.userIdentifier = userIdentifier
-        self.clientIdentifier = clientIdentifier
     }
     
-    public init?(
-        client: UserClient,
+    public init(
+        userIdentifier: UUID,
         appVersionProvider: VersionProvider = Bundle.main,
         modelVersionProvider: VersionProvider = NSManagedObjectModel.loadModel()
         ) {
-        guard let clientIdentifier = client.remoteIdentifier,
-            let userIdentifier = client.user?.remoteIdentifier else { return nil }
         self.init(
             appVersion: appVersionProvider.version,
             modelVersion: modelVersionProvider.version,
-            userIdentifier: userIdentifier,
-            clientIdentifier: clientIdentifier
+            userIdentifier: userIdentifier
         )
     }
 }
@@ -68,7 +62,6 @@ public func ==(lhs: BackupMetadata, rhs: BackupMetadata) -> Bool {
         && lhs.modelVersion == rhs.modelVersion
         && lhs.creationTime == rhs.creationTime
         && lhs.userIdentifier == rhs.userIdentifier
-        && lhs.clientIdentifier == rhs.clientIdentifier
 }
 
 // MARK: - Serialization Helper

--- a/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
+++ b/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
@@ -38,11 +38,13 @@ class BackupMetadataTests: XCTestCase {
         // Given
         let date = Date()
         let userIdentifier = UUID.create()
+        let clientIdentifier = UUID.create().transportString()
         let sut = BackupMetadata(
             appVersion: "3.9",
             modelVersion: "24.2.8",
             creationTime: date,
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: clientIdentifier
         )
         
         // When & Then
@@ -54,11 +56,13 @@ class BackupMetadataTests: XCTestCase {
         // Given
         let date = Date()
         let userIdentifier = UUID.create()
+        let clientIdentifier = UUID.create().transportString()
         let sut = BackupMetadata(
             appVersion: "3.9",
             modelVersion: "24.2.8",
             creationTime: date,
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: clientIdentifier
         )
         
         try sut.write(to: url)
@@ -77,12 +81,13 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: UUID.create().transportString()
         )
         
         // When & Then
-        let provider = MockProvider(version: "4.1.23", remoteIdentifier: userIdentifier)
-        XCTAssertNil(sut.verify(using: provider, appVersionProvider: provider))
+        let provider = MockProvider(version: "4.1.23")
+        XCTAssertNil(sut.verify(using: userIdentifier, appVersionProvider: provider))
     }
     
     func testThatItReturnsAnErrorForNewerAppVersionBackupVerification() {
@@ -92,12 +97,13 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: UUID.create().transportString()
         )
         
         // When
-        let provider = MockProvider(version: "2.9.12", remoteIdentifier: userIdentifier)
-        let error = sut.verify(using: provider, appVersionProvider: provider)
+        let provider = MockProvider(version: "2.9.12")
+        let error = sut.verify(using: userIdentifier, appVersionProvider: provider)
         
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.backupFromNewerAppVersion)
@@ -110,12 +116,13 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier
+            userIdentifier: userIdentifier,
+            clientIdentifier: UUID.create().transportString()
         )
         
         // When
-        let provider = MockProvider(version: "3.1.0", remoteIdentifier: .create())
-        let error = sut.verify(using: provider, appVersionProvider: provider)
+        let provider = MockProvider(version: "3.1.0")
+        let error = sut.verify(using: .create(), appVersionProvider: provider)
         
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.userMismatch)
@@ -125,13 +132,11 @@ class BackupMetadataTests: XCTestCase {
 
 // MARK: - Helper
 
-fileprivate class MockProvider: VersionProvider, RemoteIdentifierProvider {
+fileprivate class MockProvider: VersionProvider {
     
-    var remoteIdentifier: UUID?
     var version: String
     
-    init(version: String, remoteIdentifier: UUID) {
+    init(version: String) {
         self.version = version
-        self.remoteIdentifier = remoteIdentifier
     }
 }

--- a/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
+++ b/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
@@ -38,13 +38,11 @@ class BackupMetadataTests: XCTestCase {
         // Given
         let date = Date()
         let userIdentifier = UUID.create()
-        let clientIdentifier = UUID.create().transportString()
         let sut = BackupMetadata(
             appVersion: "3.9",
             modelVersion: "24.2.8",
             creationTime: date,
-            userIdentifier: userIdentifier,
-            clientIdentifier: clientIdentifier
+            userIdentifier: userIdentifier
         )
         
         // When & Then
@@ -56,13 +54,11 @@ class BackupMetadataTests: XCTestCase {
         // Given
         let date = Date()
         let userIdentifier = UUID.create()
-        let clientIdentifier = UUID.create().transportString()
         let sut = BackupMetadata(
             appVersion: "3.9",
             modelVersion: "24.2.8",
             creationTime: date,
-            userIdentifier: userIdentifier,
-            clientIdentifier: clientIdentifier
+            userIdentifier: userIdentifier
         )
         
         try sut.write(to: url)
@@ -81,8 +77,7 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier,
-            clientIdentifier: UUID.create().transportString()
+            userIdentifier: userIdentifier
         )
         
         // When & Then
@@ -97,8 +92,7 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier,
-            clientIdentifier: UUID.create().transportString()
+            userIdentifier: userIdentifier
         )
         
         // When
@@ -116,8 +110,7 @@ class BackupMetadataTests: XCTestCase {
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
-            userIdentifier: userIdentifier,
-            clientIdentifier: UUID.create().transportString()
+            userIdentifier: userIdentifier
         )
         
         // When


### PR DESCRIPTION
## What's new in this PR?

* Remove client identifier from backup metadata.