### PR TITLE
Add method to import local store from backup

### DIFF
--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -94,4 +94,62 @@ extension StorageStack {
             }
         }
     }
+    
+    public enum BackupImportError: Error {
+        case incompatibleBackup(error: Error)
+        case failedToCopy
+    }
+    
+    /// Will import a backup for a given account
+    ///
+    /// - Parameters:
+    ///   - accountIdentifier: account for which to import the backup
+    ///   - backupDirectory: root directory of the decrypted and uncompressed backup
+    ///   - applicationContainer: shared application container
+    ///   - dispatchGroup: group for testing
+    ///   - completion: called on main thread when done. Result will contain the folder where all data was written to.
+    public static func importLocalStorage(accountIdentifier: UUID, from backupDirectory: URL, applicationContainer: URL, dispatchGroup: ZMSDispatchGroup? = nil, completion: @escaping ((Result<URL>) -> Void)) {
+        func fail(_ error: BackupImportError) {
+            DispatchQueue.main.async {
+                completion(.failure(error))
+                dispatchGroup?.leave()
+            }
+        }
+        
+        let queue = DispatchQueue(label: "Database import", qos: .userInitiated)
+        
+        dispatchGroup?.enter()
+        
+        let accountDirectory = accountFolder(accountIdentifier: accountIdentifier, applicationContainer: applicationContainer)
+        let accountStoreFile = accountDirectory.appendingPersistentStoreLocation()
+        let backupStoreFile = backupDirectory.appendingPathComponent(databaseDirectoryName).appendingPersistentStoreLocation()
+        let metadataURL = backupDirectory.appendingPathComponent(metadataFilename)
+        
+        queue.async() {
+            do {
+                let metadata = try BackupMetadata(url: metadataURL)
+                
+                if let verificationError = metadata.verify(using: accountIdentifier) {
+                    fail(.incompatibleBackup(error: verificationError))
+                }
+                
+                let model = NSManagedObjectModel.loadModel()
+                let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+                
+                // Create target directory
+                try FileManager.default.createDirectory(at: accountStoreFile.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
+                
+                // Import the persistent store to the account data directory
+                try coordinator.replacePersistentStore(at: accountStoreFile, destinationOptions: options, withPersistentStoreFrom: backupStoreFile, sourceOptions: options, ofType: NSSQLiteStoreType)
+                
+                DispatchQueue.main.async {
+                    completion(.success(accountDirectory))
+                    dispatchGroup?.leave()
+                }
+            } catch {
+                fail(.failedToCopy)
+            }
+        }
+    }
 }

--- a/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
@@ -31,7 +31,7 @@ class StorageStackBackupTests: DatabaseBaseTest {
         try? FileManager.default.removeItem(at: StorageStack.backupsDirectory)
         super.tearDown()
     }
-
+    
     func createBackup(accountIdentifier: UUID, file: StaticString =
         #file, line: UInt = #line) -> Result<URL>? {
 
@@ -42,6 +42,35 @@ class StorageStackBackupTests: DatabaseBaseTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
         return result
     }
+    
+    func importBackup(accountIdentifier: UUID, backup: URL, file: StaticString = #file, line: UInt = #line) -> Result<URL>? {
+        
+        var result: Result<URL>?
+        StorageStack.importLocalStorage(accountIdentifier: accountIdentifier, from: backup, applicationContainer: applicationContainer, dispatchGroup: dispatchGroup) {
+             result = $0
+        }
+        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+        return result
+    }
+    
+    func createBackupAndDeleteOriginalAccount(accountIdentifier: UUID, file: StaticString = #file, line: UInt = #line) -> URL? {
+        // create populated account database
+        let directory = createStorageStackAndWaitForCompletion(userID: accountIdentifier)
+        _ = ZMConversation.insertGroupConversation(into: directory.uiContext, withParticipants: [])
+        directory.uiContext.saveOrRollback()
+        
+        guard let result = createBackup(accountIdentifier: accountIdentifier) else { return nil }
+        guard case .success(let url) = result else { return nil }
+        
+        // Delete account
+        StorageStack.reset()
+        clearStorageFolder()
+        
+        return url
+    }
+    
+    // MARK: - Export
 
     func testThatItFailsWithWrongAccountIdentifier() throws {
         // given
@@ -125,5 +154,55 @@ class StorageStackBackupTests: DatabaseBaseTest {
         let anotherDirectory = createStorageStackAndWaitForCompletion(userID: uuid)
         let fetchConversations = ZMConversation.sortedFetchRequest()!
         XCTAssertEqual(try anotherDirectory.uiContext.count(for: fetchConversations), 1)
+    }
+    
+    // MARK: - Import
+    
+    func testThatItCanOpenAnImportedBackup() {
+        // given
+        let uuid = UUID()
+        guard let backup = createBackupAndDeleteOriginalAccount(accountIdentifier: uuid) else { return XCTFail() }
+        
+        // when
+        guard let result = importBackup(accountIdentifier: uuid, backup: backup) else { return XCTFail() }
+        
+        // then
+        guard case .success = result else { return XCTFail() }
+        let directory = createStorageStackAndWaitForCompletion(userID: uuid)
+        let fetchConversations = ZMConversation.sortedFetchRequest()!
+        XCTAssertEqual(try directory.uiContext.count(for: fetchConversations), 1)
+    }
+    
+    func testThatItFailsWhenImportingBackupIntoWrongAccount() {
+        // given
+        let uuid = UUID()
+        guard let backup = createBackupAndDeleteOriginalAccount(accountIdentifier: uuid) else { return XCTFail() }
+        
+        // when
+        let differentUUID = UUID()
+        guard let result = importBackup(accountIdentifier: differentUUID, backup: backup) else { return XCTFail() }
+    
+        // then
+        guard case let .failure(error) = result else { return XCTFail() }
+        switch error as? StorageStack.BackupImportError {
+        case .incompatibleBackup?: break
+        default: XCTFail()
+        }
+    }
+    
+    func testThatItFailsWhenImportingNonExistantBackup() {
+        // given
+        let uuid = UUID()
+        let backup = applicationContainer.appendingPathComponent("non-existing-backup")
+        
+        // when
+        guard let result = importBackup(accountIdentifier: uuid, backup: backup) else { return XCTFail() }
+        
+        // then
+        guard case let .failure(error) = result else { return XCTFail() }
+        switch error as? StorageStack.BackupImportError {
+        case .failedToCopy?: break
+        default: XCTFail()
+        }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Adds a method to StorageStack for importing a database from a backup.
## Notes

This method assumes the backup directory passed in contains a uncompressed and decrypted backup.