### PR TITLE
Added a flag to exported database to show that it is a backup

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
@@ -23,6 +23,7 @@ extension NSManagedObjectContext {
     /// Prepare a backed up database for being imported, deleting self client, push token etc.
     func prepareToImportBackup() {
         setPersistentStoreMetadata(nil as Data?, key: ZMPersistedClientIdKey)
+        setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.importedFromBackup.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.pushToken.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.pushKitToken.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.lastUpdateEventID.rawValue)

--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -108,6 +108,25 @@ extension StorageStack {
 
                 // Recreate the persistent store inside a new location
                 try coordinator.replacePersistentStore(at: backupLocation, destinationOptions: options, withPersistentStoreFrom: storeFile, sourceOptions: options, ofType: NSSQLiteStoreType)
+
+                // Add persistent store at the new location to allow creation of NSManagedObjectContext
+                _ = try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: backupLocation, options: options)
+                let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+                context.persistentStoreCoordinator = coordinator
+                var saveError: Error? = nil
+                context.performAndWait {
+                    context.setPersistentStoreMetadata(NSNumber(booleanLiteral: true), key: PersistentMetadataKey.importedFromBackup.rawValue)
+                    // Mark the db as backed up
+                    do {
+                        try context.save()
+                    } catch {
+                        saveError = error
+                    }
+                }
+                if let error = saveError {
+                    return fail(.failedToWrite(error))
+                }
+
                 let metadata = BackupMetadata(userIdentifier: accountIdentifier, clientIdentifier: clientIdentifier, appVersionProvider: Bundle.main, modelVersionProvider: model)
                 try metadata.write(to: metadataURL)
                 log.info("successfully created backup at: \(backupDirectory.path), metadata: \(metadata)")

--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -83,12 +83,11 @@ import UIKit
     /// - parameter completionHandler: this callback is invoked on the main queue.
     /// - parameter accountIdentifier: user identifier that the store should be created for
     /// - parameter container: the shared container for the app
-    @objc(createManagedObjectContextDirectoryForAccountIdentifier:applicationContainer:dispatchGroup:importingFromBackup:startedMigrationCallback:completionHandler:)
+    @objc(createManagedObjectContextDirectoryForAccountIdentifier:applicationContainer:dispatchGroup:startedMigrationCallback:completionHandler:)
     public func createManagedObjectContextDirectory(
         accountIdentifier: UUID,
         applicationContainer: URL,
         dispatchGroup: ZMSDispatchGroup? = nil,
-        importingFromBackup: Bool = false,
         startedMigrationCallback: (() -> Void)? = nil,
         completionHandler: @escaping (ManagedObjectContextDirectory) -> Void
         )
@@ -119,7 +118,6 @@ import UIKit
                     storeFile: storeFile,
                     applicationContainer: applicationContainer,
                     migrateIfNeeded: true,
-                    importingFromBackup: importingFromBackup,
                     startedMigrationCallback: {
                         DispatchQueue.main.async {
                             startedMigrationCallback?()
@@ -154,7 +152,6 @@ import UIKit
         storeFile: URL,
         applicationContainer: URL,
         migrateIfNeeded: Bool,
-        importingFromBackup: Bool,
         startedMigrationCallback: (() -> Void)? = nil,
         completionHandler: @escaping (ManagedObjectContextDirectory) -> Void
         )
@@ -171,13 +168,13 @@ import UIKit
                 accountDirectory: accountDirectory,
                 applicationContainer: applicationContainer)
             MemoryReferenceDebugger.register(directory)
-            
-            if importingFromBackup {
-                directory.uiContext.performAndWait {
+
+            directory.uiContext.performAndWait {
+                if let imported = directory.uiContext.persistentStoreMetadata(forKey: PersistentMetadataKey.importedFromBackup.rawValue) as? NSNumber, imported.boolValue {
                     directory.uiContext.prepareToImportBackup()
                 }
             }
-            
+
             completionHandler(directory)
         }
     }

--- a/Source/Model/PersistentMetadataKeys.swift
+++ b/Source/Model/PersistentMetadataKeys.swift
@@ -23,6 +23,7 @@ public enum PersistentMetadataKey: String {
     case lastUpdateEventID = "LastUpdateEventID"
     case pushToken = "pushToken"
     case pushKitToken = "ZMPushKitToken"
+    case importedFromBackup = "importedFromBackup"
     
 }
 

--- a/Tests/Source/Model/ZMTestSession.m
+++ b/Tests/Source/Model/ZMTestSession.m
@@ -168,7 +168,6 @@
     [[StorageStack shared] createManagedObjectContextDirectoryForAccountIdentifier:self.accountIdentifier
                                                               applicationContainer:self.containerURL
                                                                      dispatchGroup:self.dispatchGroup
-                                                               importingFromBackup:NO
                                                           startedMigrationCallback:nil
                                                                  completionHandler:^(ManagedObjectContextDirectory * directory) {
         self.contextDirectory = directory;


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need to do some pre-processing after we import the database and it is good to be sure that we know when this is the case.

### Solutions

On export add a flag to persistent metadata to show that it is a backup
