### PR TITLE
Use data model schema version to verify metadata instead of app version

### DIFF
--- a/Source/ManagedObjectContext/BackupMetadata.swift
+++ b/Source/ManagedObjectContext/BackupMetadata.swift
@@ -97,11 +97,11 @@ public extension BackupMetadata {
     
     func verify(
         using userIdentifier: UUID,
-        appVersionProvider: VersionProvider = Bundle.main
+        modelVersionProvider: VersionProvider = NSManagedObjectModel.loadModel()
         ) -> VerificationError? {
         guard self.userIdentifier == userIdentifier else { return .userMismatch }
-        let current = Version(string: appVersionProvider.version)
-        let backup = Version(string: appVersion)
+        let current = Version(string: modelVersionProvider.version)
+        let backup = Version(string: modelVersion)
 
         // Backup has been created on a newer app version.
         guard current >= backup else { return .backupFromNewerAppVersion }

--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -171,11 +171,11 @@ extension StorageStack {
             do {
                 let metadata = try BackupMetadata(url: metadataURL)
                 
-                if let verificationError = metadata.verify(using: accountIdentifier) {
+                let model = NSManagedObjectModel.loadModel()
+                if let verificationError = metadata.verify(using: accountIdentifier, modelVersionProvider: model) {
                     return fail(.incompatibleBackup(verificationError))
                 }
                 
-                let model = NSManagedObjectModel.loadModel()
                 let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
                 
                 // Create target directory

--- a/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
+++ b/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
@@ -80,14 +80,14 @@ class BackupMetadataTests: XCTestCase {
         
         let sut = BackupMetadata(
             appVersion: "3",
-            modelVersion: "24.2.8",
+            modelVersion: "3.212",
             userIdentifier: userIdentifier,
             clientIdentifier: UUID.create().transportString()
         )
         
         // When & Then
         let provider = MockProvider(version: "4.1.23")
-        XCTAssertNil(sut.verify(using: userIdentifier, appVersionProvider: provider))
+        XCTAssertNil(sut.verify(using: userIdentifier, modelVersionProvider: provider))
     }
     
     func testThatItReturnsAnErrorForNewerAppVersionBackupVerification() {
@@ -103,7 +103,7 @@ class BackupMetadataTests: XCTestCase {
         
         // When
         let provider = MockProvider(version: "2.9.12")
-        let error = sut.verify(using: userIdentifier, appVersionProvider: provider)
+        let error = sut.verify(using: userIdentifier, modelVersionProvider: provider)
         
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.backupFromNewerAppVersion)
@@ -122,7 +122,7 @@ class BackupMetadataTests: XCTestCase {
         
         // When
         let provider = MockProvider(version: "3.1.0")
-        let error = sut.verify(using: .create(), appVersionProvider: provider)
+        let error = sut.verify(using: .create(), modelVersionProvider: provider)
         
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.userMismatch)


### PR DESCRIPTION
## What's new in this PR?

* Use data model schema version to verify metadata instead of app version.