### PR TITLE
Using only user identifier to decide if accounts are equal

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -73,11 +73,7 @@ public final class Account: NSObject {
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Account else { return false }
-        return userName == other.userName
-            && teamName == other.teamName
-            && userIdentifier == other.userIdentifier
-            && imageData == other.imageData
-            && teamImageData == other.teamImageData
+        return userIdentifier == other.userIdentifier
     }
 
     public override var hash: Int {

--- a/Tests/Source/Model/AccountTests.swift
+++ b/Tests/Source/Model/AccountTests.swift
@@ -71,4 +71,25 @@ final class AccountTests: ZMConversationTestsBase {
         XCTAssertEqual(account.unreadConversationCount, count)
     }
 
+    func testThatAccountsAreEqualWhenNotImportantPropertiesAreDifferent() {
+        // given
+        let userName = "Bruno", team = "Wire", id = UUID.create(), image = verySmallJPEGData(), count = 14
+
+        let account = Account(userName: userName,
+                              userIdentifier: id,
+                              teamName: team,
+                              imageData: image,
+                              teamImageData: image,
+                              unreadConversationCount: count)
+
+        let sameAccount = Account(userName: "",
+                                  userIdentifier: id,
+                                  teamName: "",
+                                  imageData: nil,
+                                  teamImageData: nil,
+                                  unreadConversationCount: 0)
+
+        XCTAssertEqual(account, sameAccount)
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

To decide if two `Account` objects are equal we compare all properties. We really care only about user identifier, because if team image changes it's still same account.

