### PR TITLE
Fix backup export

### DIFF
--- a/Tests/Source/ManagedObjectContext/StorageStackTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackTests.swift
@@ -575,6 +575,7 @@ extension StorageStackTests {
         contextDirectory.uiContext.setPersistentStoreMetadata(metadata, key: PersistentMetadataKey.lastUpdateEventID.rawValue)
         contextDirectory.uiContext.forceSaveOrRollback()
         contextDirectory = nil
+        StorageStack.reset()
 
         // WHEN
         let importExpectation = self.expectation(description: "Callback invoked")
@@ -620,7 +621,8 @@ extension StorageStackTests {
         contextDirectory.uiContext.setPersistentStoreMetadata("1234567890", key: PersistentMetadataKey.lastUpdateEventID.rawValue)
         contextDirectory.uiContext.forceSaveOrRollback()
         contextDirectory = nil
-        
+        StorageStack.reset()
+
         // WHEN
         let importExpectation = self.expectation(description: "Callback invoked")
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When exporting the backup we set a flag on the store metadata showing that this is an exported database. It was not correctly set.

### Causes

We have a bit of abstraction around `NSManagedContext` to work with persistent metadata and it gets saved only when using our `saveOrRollback` method. 

### Solutions

Updated the code to directly set metadata on the store.
