### PR TITLE
Do not crash when deleting ephemeral

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -400,6 +400,11 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     // We need to cascade delete the pending delivery confirmation messages for the message being deleted
     [message removePendingDeliveryReceipts];
     
+    if (message.hasBeenDeleted) {
+        ZMLogError(@"Attempt to delete the deleted message: %@, existing: %@", deletedMessage, message);
+        return;
+    }
+    
     // Only the sender of the original message can delete it
     if (![senderID isEqual:message.sender.remoteIdentifier] && !message.isEphemeral) {
         return;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Client is crashing when syncing the notification stream.

### Causes

The ephemeral message is already deleted when someone is trying to delete it again with the `delete` message type.

### Solutions

Check if message is already deleted.

