### PR TITLE
Updated nullability annotations

### DIFF
--- a/Source/Model/User/ZMSearchUser+Internal.h
+++ b/Source/Model/User/ZMSearchUser+Internal.h
@@ -53,7 +53,7 @@ FOUNDATION_EXPORT NSString *const ZMSearchUserTotalMutualFriendsKey;
 
 + (NSArray <ZMSearchUser *> *)usersWithPayloadArray:(NSArray <NSDictionary *> *)payloadArray userSession:(id<ZMManagedObjectContextProvider> )userSession;
 
-- (instancetype)initWithContact:(ZMAddressBookContact *)contact user:(nullable ZMUser *)user userSession:(id<ZMManagedObjectContextProvider> )userSession;
+- (instancetype)initWithContact:(nullable ZMAddressBookContact *)contact user:(nullable ZMUser *)user userSession:(id<ZMManagedObjectContextProvider> )userSession;
 
 @property (nullable, nonatomic) NSUUID *remoteIdentifier;
 /// Returns @c YES if the receiver has a local user or cached profile image data.

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -34,7 +34,7 @@ extern NSString * __nonnull const AvailabilityKey;
 
 @interface ZMUser (Internal)
 
-@property (nullable, nonatomic) NSUUID *remoteIdentifier;
+@property (null_unspecified, nonatomic) NSUUID *remoteIdentifier;
 @property (nullable, nonatomic) ZMConnection *connection;
 
 @property (nullable, nonatomic) NSUUID *teamIdentifier;


### PR DESCRIPTION
## What's new in this PR?

### Issues

After integrating with SE it seems that some of the nullability annotations were not added correctly. 
`ZMUser.remoteIdentiefier` had to be left as `null_unspecified`, because in lots of places it's either force-unrwrapped or conditionally unwrapped. Will have to update in other PRs as the current priority is to finish Xcode 9.3 migration

