### PR TITLE
Sanitize generic messages for sensitive information when writing internal debug logs

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -704,7 +704,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
                                          object:self
                                        userInfo:nil
      ] post];
-    ZMLogWithLevelAndTag(ZMLogLevelInfo, @"Network", @"appendMessageWithText message: %@", message);
 
     return message;
 }

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -72,7 +72,9 @@ extension ZMClientMessage: EncryptedPayloadGenerator {
     }
 
     public var debugInfo: String {
-        var info = "\(String(describing: genericMessage))"
+        
+        var info = genericMessage?.sanitizedDebugDescription ?? "genericMessage is nil"
+                
         if let genericMessage = genericMessage, genericMessage.hasExternal() {
             info = "External message: " + info
         }
@@ -90,7 +92,7 @@ extension ZMAssetClientMessage: EncryptedPayloadGenerator {
     }
 
     public var debugInfo: String {
-        return "\(String(describing: genericAssetMessage))"
+        return genericAssetMessage?.sanitizedDebugDescription ?? "genericMessage is nil"
     }
     
 }

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -72,9 +72,7 @@ extension ZMClientMessage: EncryptedPayloadGenerator {
     }
 
     public var debugInfo: String {
-        
-        var info = genericMessage?.sanitizedDebugDescription ?? "genericMessage is nil"
-                
+        var info = "\(String(describing: genericMessage))"
         if let genericMessage = genericMessage, genericMessage.hasExternal() {
             info = "External message: " + info
         }
@@ -92,7 +90,7 @@ extension ZMAssetClientMessage: EncryptedPayloadGenerator {
     }
 
     public var debugInfo: String {
-        return genericAssetMessage?.sanitizedDebugDescription ?? "genericMessage is nil"
+        return "\(String(describing: genericAssetMessage))"
     }
     
 }

--- a/Source/Model/Message/ZMGenericMessage+Debug.swift
+++ b/Source/Model/Message/ZMGenericMessage+Debug.swift
@@ -68,7 +68,7 @@ fileprivate extension ZMArticle {
 
 extension ZMGenericMessage {
     
-    public var sanitizedDebugDescription: String {
+    open override var debugDescription: String {
         
         guard let builder = self.toBuilder() else { return "" }
         
@@ -80,9 +80,10 @@ extension ZMGenericMessage {
             builder.setEdited(editedBuilder.setText(editedBuilder.text().sanitize()))
         }
         
-        return builder.build().debugDescription
+        let message = builder.build()!
+        
+        let description = NSMutableString()
+        message.writeDescription(to: description, withIndent: "")
+        return description as String
     }
-    
-    
-
 }

--- a/Source/Model/Message/ZMGenericMessage+Debug.swift
+++ b/Source/Model/Message/ZMGenericMessage+Debug.swift
@@ -18,13 +18,13 @@
 
 import Foundation
 
-fileprivate let retractedValue = "<retracted>"
+fileprivate let redactedValue = "<redacted>"
 
 fileprivate extension ZMText {
     
     func sanitize() -> ZMText {
         let builder = toBuilder()!
-        _ = builder.setContent(retractedValue)
+        _ = builder.setContent(redactedValue)
         
         if let linkPreviews = builder.linkPreview() as? [ZMLinkPreview] {
             builder.setLinkPreviewArray(linkPreviews.map({ $0.sanitize() }))
@@ -39,10 +39,10 @@ fileprivate extension ZMLinkPreview {
     
     func sanitize() -> ZMLinkPreview {
         let builder = toBuilder()!
-        builder.setUrl(retractedValue)
-        builder.setPermanentUrl(retractedValue)
-        builder.setTitle(retractedValue)
-        builder.setSummary(retractedValue)
+        builder.setUrl(redactedValue)
+        builder.setPermanentUrl(redactedValue)
+        builder.setTitle(redactedValue)
+        builder.setSummary(redactedValue)
         builder.clearTweet()
         
         if builder.hasArticle() {
@@ -58,9 +58,9 @@ fileprivate extension ZMArticle {
     
     func sanitize() -> ZMArticle {
         let builder = toBuilder()!
-        builder.setTitle(retractedValue)
-        builder.setPermanentUrl(retractedValue)
-        builder.setSummary(retractedValue)
+        builder.setTitle(redactedValue)
+        builder.setPermanentUrl(redactedValue)
+        builder.setSummary(redactedValue)
         return builder.build()
     }
     

--- a/Source/Model/Message/ZMGenericMessage+Debug.swift
+++ b/Source/Model/Message/ZMGenericMessage+Debug.swift
@@ -1,0 +1,88 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+fileprivate let retractedValue = "<retracted>"
+
+fileprivate extension ZMText {
+    
+    func sanitize() -> ZMText {
+        let builder = toBuilder()!
+        _ = builder.setContent(retractedValue)
+        
+        if let linkPreviews = builder.linkPreview() as? [ZMLinkPreview] {
+            builder.setLinkPreviewArray(linkPreviews.map({ $0.sanitize() }))
+        }
+        
+        return builder.build()
+    }
+    
+}
+
+fileprivate extension ZMLinkPreview {
+    
+    func sanitize() -> ZMLinkPreview {
+        let builder = toBuilder()!
+        builder.setUrl(retractedValue)
+        builder.setPermanentUrl(retractedValue)
+        builder.setTitle(retractedValue)
+        builder.setSummary(retractedValue)
+        builder.clearTweet()
+        
+        if builder.hasArticle() {
+            builder.setArticle(builder.article().sanitize())
+        }
+        
+        return builder.build()
+    }
+    
+}
+
+fileprivate extension ZMArticle {
+    
+    func sanitize() -> ZMArticle {
+        let builder = toBuilder()!
+        builder.setTitle(retractedValue)
+        builder.setPermanentUrl(retractedValue)
+        builder.setSummary(retractedValue)
+        return builder.build()
+    }
+    
+}
+
+extension ZMGenericMessage {
+    
+    public var sanitizedDebugDescription: String {
+        
+        guard let builder = self.toBuilder() else { return "" }
+        
+        if builder.hasText() {
+            builder.setText(builder.text().sanitize())
+        }
+        
+        if builder.hasEdited(), let editedBuilder = builder.edited().toBuilder(), editedBuilder.hasText() {
+            builder.setEdited(editedBuilder.setText(editedBuilder.text().sanitize()))
+        }
+        
+        return builder.build().debugDescription
+    }
+    
+    
+
+}

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -55,7 +55,8 @@ import WireTesting
         
         StorageStack.shared.createManagedObjectContextDirectory(
             accountIdentifier: userID,
-            applicationContainer: self.applicationContainer
+            applicationContainer: self.applicationContainer,
+            dispatchGroup: dispatchGroup
         ) { directory in
             contextDirectory = directory
         }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
 		16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */; };
+		168913DC2085066800F1E98A /* ZMGenericMessage+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */; };
 		16AD86BA1F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */; };
 		16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */; };
 		16D95A421FCEF87B00C96069 /* ZMUser+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D95A411FCEF87B00C96069 /* ZMUser+Availability.swift */; };
@@ -499,6 +500,7 @@
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
 		16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ZMImageOwner.swift"; sourceTree = "<group>"; };
+		168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessage+Debug.swift"; sourceTree = "<group>"; };
 		16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+NotificationContext.swift"; sourceTree = "<group>"; };
 		16D68E961CEF2EC4003AB9E0 /* ZMFileMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMFileMetadata.swift; sourceTree = "<group>"; };
 		16D95A411FCEF87B00C96069 /* ZMUser+Availability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Availability.swift"; sourceTree = "<group>"; };
@@ -1347,6 +1349,7 @@
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
 				F9A705F91CAEE01D00C2F5FE /* ZMGenericMessage+External.m */,
+				168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */,
 				F9A705FC1CAEE01D00C2F5FE /* ZMGenericMessageData.h */,
 				F9A705FD1CAEE01D00C2F5FE /* ZMGenericMessageData.m */,
 				F9A705FE1CAEE01D00C2F5FE /* ZMImageMessage.m */,
@@ -2401,6 +2404,7 @@
 				EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */,
 				54363A031D787D0E0048FD7D /* ZMAssetClientMessage+Encryption.swift in Sources */,
 				F9A706781CAEE01D00C2F5FE /* ZMClientMessage.m in Sources */,
+				168913DC2085066800F1E98A /* ZMGenericMessage+Debug.swift in Sources */,
 				F9A7069C1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm in Sources */,
 				54E3EE3F1F6169A800A261E3 /* ZMAssetClientMessage+FileMessageData.swift in Sources */,
 				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,


### PR DESCRIPTION
### Issues

For internal builds we allow users to send debug logs which may contain sensitive information.

### Solutions

Sanitize all messages from user generated content before writing them to the internal debug log.