### PR TITLE
Fix/last read after restore

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -586,28 +586,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         return;
     }
     
-    // If the message is a self system message, then we would not update the
-    // last read server time stamp, even if there are previous unread messages
-    if ([message isKindOfClass:[ZMSystemMessage class]] && senderIsSelfUser) {
-        // find the last message where sender is not self
-        __block ZMMessage *lastReceivedMessage;
-        [self.messages.array enumerateObjectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, idx)] options:NSEnumerationReverse usingBlock:^(ZMMessage *aMessage, NSUInteger anIdx __unused, BOOL *stop) {
-            if (!aMessage.sender.isSelfUser) {
-                lastReceivedMessage = aMessage;
-                *stop = YES;
-            }
-        }];
-        
-        if (lastReceivedMessage == nil ||
-            [lastReceivedMessage.serverTimestamp compare:self.lastReadServerTimeStamp] == NSOrderedAscending)
-        {
-            return;
-        }
-        
-        [self updateLastReadServerTimeStamp:lastReceivedMessage.serverTimestamp senderIsSelfUser:NO];
-        return;
-    }
-    
     if (idx+1  == self.messages.count) {
         timeStamp = self.lastServerTimeStamp;
     }

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -586,6 +586,28 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         return;
     }
     
+    // If the message is a self system message, then we would not update the
+    // last read server time stamp, even if there are previous unread messages
+    if ([message isKindOfClass:[ZMSystemMessage class]] && senderIsSelfUser) {
+        // find the last message where sender is not self
+        __block ZMMessage *lastReceivedMessage;
+        [self.messages.array enumerateObjectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, idx)] options:NSEnumerationReverse usingBlock:^(ZMMessage *aMessage, NSUInteger anIdx __unused, BOOL *stop) {
+            if (!aMessage.sender.isSelfUser) {
+                lastReceivedMessage = aMessage;
+                *stop = YES;
+            }
+        }];
+        
+        if (lastReceivedMessage == nil ||
+            [lastReceivedMessage.serverTimestamp compare:self.lastReadServerTimeStamp] == NSOrderedAscending)
+        {
+            return;
+        }
+        
+        [self updateLastReadServerTimeStamp:lastReceivedMessage.serverTimestamp senderIsSelfUser:NO];
+        return;
+    }
+    
     if (idx+1  == self.messages.count) {
         timeStamp = self.lastServerTimeStamp;
     }

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -568,6 +568,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         timeStamp = [(ZMSystemMessage *)message.systemMessageData lastChildMessageDate];
     }
     BOOL senderIsSelfUser = message.sender.isSelfUser;
+    BOOL isSystemMessage = [message isKindOfClass:[ZMSystemMessage class]];
 
     if( ! self.managedObjectContext.zm_isUserInterfaceContext ) {
         return;
@@ -610,19 +611,21 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             }
             timeStamp = lastDeliveredMessage.serverTimestamp;
             senderIsSelfUser = lastDeliveredMessage.sender.isSelfUser;
+            isSystemMessage = [lastDeliveredMessage isKindOfClass:[ZMSystemMessage class]];
         }
     }
-    [self updateLastReadServerTimeStamp:timeStamp senderIsSelfUser:senderIsSelfUser];
+    [self updateLastReadServerTimeStamp:timeStamp senderIsSelfUser:senderIsSelfUser messageIsSystemMessage:isSystemMessage];
 }
 
-- (void)updateLastReadServerTimeStamp:(NSDate *)serverTimeStamp senderIsSelfUser:(BOOL)senderIsSelfUser
+
+- (void)updateLastReadServerTimeStamp:(NSDate *)serverTimeStamp senderIsSelfUser:(BOOL)senderIsSelfUser messageIsSystemMessage:(BOOL)messageIsSystemMessage
 {
-    if ((self.lastReadServerTimeStamp != nil) &&([serverTimeStamp compare:self.lastReadServerTimeStamp] == NSOrderedAscending)) {
+    if ((self.lastReadServerTimeStamp != nil) && ([serverTimeStamp compare:self.lastReadServerTimeStamp] == NSOrderedAscending)) {
         return;
     }
     
-    if (self.tempMaxLastReadServerTimeStamp == nil ||  [self.tempMaxLastReadServerTimeStamp compare:serverTimeStamp] == NSOrderedAscending) {
-        if (!senderIsSelfUser) {
+    if (self.tempMaxLastReadServerTimeStamp == nil || [self.tempMaxLastReadServerTimeStamp compare:serverTimeStamp] == NSOrderedAscending) {
+        if (!senderIsSelfUser || messageIsSystemMessage) {
             self.tempMaxLastReadServerTimeStamp = serverTimeStamp;
         }
         else {

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1797,7 +1797,7 @@
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, ((ZMMessage *) conversation.messages[4]).serverTimestamp);
 }
 
-- (void)testThatItSetsTheLastReadServerTimeStampToTheLastReadNonSystemMessageInTheVisibleRange;
+- (void)testThatItSetsTheLastReadServerTimeStampToTheLastReadMessageInTheVisibleRangeEvenIfSystemMessage;
 {
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -1808,6 +1808,7 @@
     }
     
     message = [self insertNonUnreadDotGeneratingMessageIntoConversation:conversation];
+    conversation.lastServerTimeStamp = message.serverTimestamp;
     
     // when
     [conversation setVisibleWindowFromMessage:conversation.messages[2] toMessage:conversation.messages[11]];
@@ -1815,7 +1816,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, ((ZMMessage *) conversation.messages[10]).serverTimestamp);
+    XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, ((ZMMessage *) conversation.messages[11]).serverTimestamp);
 }
 
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1797,6 +1797,28 @@
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, ((ZMMessage *) conversation.messages[4]).serverTimestamp);
 }
 
+- (void)testThatItSetsTheLastReadServerTimeStampToTheLastReadNonSystemMessageInTheVisibleRange;
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.lastReadTimestampSaveDelay = 0.1;
+    ZMMessage *message = [self insertDownloadedMessageIntoConversation:conversation];
+    for (int i = 0; i < 10; ++i) {
+        message = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
+    }
+    
+    message = [self insertNonUnreadDotGeneratingMessageIntoConversation:conversation];
+    
+    // when
+    [conversation setVisibleWindowFromMessage:conversation.messages[2] toMessage:conversation.messages[11]];
+    
+    WaitForAllGroupsToBeEmpty(0.5);
+    
+    // then
+    XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, ((ZMMessage *) conversation.messages[10]).serverTimestamp);
+}
+
+
 - (void)testThatItSavesTheLastReadServerTimeStampBeforeDelayedDispatchEnds;
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

After restoring from backup & opening a conversation with unread messages, then immediately returning to the conversation list, the unread badge is not cleared.

### Causes

The timestamp of the last message in the visible message window is used update the last unread server timestamp, but only if it is not from the self user. Since we have restored a backup and are on a new device, a new device system message is appended to the conversation. And since this system message is 'sent' from the self user, the server timestamp is not updated until the user scrolls up, and the pulls the system message offscreen.

### Solutions

When attempting to update the last read server time stamp, we check if the given message (which is the last one when the conversation loads) is a system message from the self user. If so, then we find the last received message and use its timestamp to update the server timestamp.

**EDIT:** Instead of backtracking to the last received unread message, we now use the system message's timestamp. This simplifies the code and rests upon the likelihood that if you see a system message that follows received messages, you have also seen the previous messages.

## Notes

The logic here in this part of the codebase is quite tricky, and I'm not 100% confident that my solution does not introduce unwanted side effects, so if you have any concerns please raise them!
