### PR TITLE
ZIOS-8814: Fix asset ID verification

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Invalid.swift
+++ b/Source/Model/Conversation/ZMConversation+Invalid.swift
@@ -18,25 +18,15 @@
 
 import Foundation
 
-extension ZMMentionBuilder {
+extension ZMConversation {
 
-    public static func build(_ users: [ZMUser]) -> [ZMMention] {
-        var mentions: [ZMMention] = []
+    /// Appends a "message invalid" system message
+    public func appendInvalidSystemMessage(at date: Date, sender: ZMUser) -> ZMSystemMessage {
+        return self.appendSystemMessage(type: .invalid,
+                                 sender: sender,
+                                 users: nil,
+                                 clients: nil,
+                                 timestamp: date).message
 
-        for user in users {
-            let builder = ZMMention.builder()!
-            builder.setUser(user)
-            if let user = builder.buildAndValidate() {
-                mentions.append(user)
-            }
-        }
-
-        return mentions
     }
-
-    public func setUser(_ user: ZMUser) {
-        setUserId(user.remoteIdentifier!.transportString())
-        setUserName(user.name!)
-    }
-
 }

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -309,8 +309,7 @@ extension ZMConversation {
                                          addedUsers: Set<ZMUser> = Set(),
                                          clients: Set<UserClient>?,
                                          timestamp: Date?,
-                                         duration: TimeInterval? = nil
-                                         ) -> (message: ZMSystemMessage, insertionIndex: UInt) {
+                                         duration: TimeInterval? = nil) -> (message: ZMSystemMessage, insertionIndex: UInt) {
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: managedObjectContext!)
         systemMessage.systemMessageType = type
         systemMessage.sender = sender

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1363,7 +1363,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
 
-    ZMGenericMessage *genericMessage = [ZMGenericMessage genericMessageWithLocation:locationData.zmLocation messageID:nonce.transportString expiresAfter:@(self.messageDestructionTimeout)];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage genericMessageWithLocation:locationData.zmLocation messageID:nonce expiresAfter:@(self.messageDestructionTimeout)];
     ZMClientMessage *message = [self appendClientMessageWithGenericMessage:genericMessage];
     return message;
 }
@@ -1372,7 +1372,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     VerifyReturnNil(!self.destructionEnabled || self.canSendEphemeral);
 
-    ZMGenericMessage *genericMessage = [ZMGenericMessage knockWithNonce:nonce.transportString expiresAfter:@(self.messageDestructionTimeout)];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage knockWithNonce:nonce expiresAfter:@(self.messageDestructionTimeout)];
     ZMClientMessage *message = [self appendClientMessageWithGenericMessage:genericMessage];
     return message;
 }
@@ -1386,7 +1386,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
     ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithText:normalizedText.stringByRemovingExtremeCombiningCharacters
                                                              linkPreview:nil
-                                                                   nonce:nonce.transportString
+                                                                   nonce:nonce
                                                             expiresAfter:@(self.messageDestructionTimeout)
                                                                 mentions: mentions];
     ZMClientMessage *message = [self appendClientMessageWithGenericMessage:genericMessage];
@@ -1534,7 +1534,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
 
     NSUUID *nonce = [NSUUID UUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithLastRead:lastRead ofConversationWithID:convID.transportString nonce:nonce.transportString];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithLastRead:lastRead ofConversationWithID:convID nonce:nonce];
     VerifyReturnNil(message != nil);
     
     return [self appendSelfConversationWithGenericMessage:message managedObjectContext:conversation.managedObjectContext];
@@ -1563,7 +1563,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     }
     
     NSUUID *nonce = [NSUUID UUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithClearedTimestamp:cleared ofConversationWithID:convID.transportString nonce:nonce.transportString];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithClearedTimestamp:cleared ofConversationWithID:convID nonce:nonce];
     VerifyReturnNil(message != nil);
     
     return [self appendSelfConversationWithGenericMessage:message managedObjectContext:conversation.managedObjectContext];

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -26,9 +26,8 @@ extension ZMConversation {
               let conversation = message.conversation,
               let convID = conversation.remoteIdentifier
         else { return }
-        
-        let nonce = NSUUID()
-        let genericMessage = ZMGenericMessage(hideMessage: messageNonce.transportString(), inConversation: convID.transportString(), nonce: nonce.transportString())
+
+        let genericMessage = ZMGenericMessage(hideMessage: messageNonce, inConversation: convID, nonce: UUID())
         ZMConversation.appendSelfConversation(with: genericMessage, managedObjectContext: message.managedObjectContext!)
     }
 }
@@ -60,7 +59,7 @@ extension ZMMessage {
         guard let conversation = conversation, let messageNonce = nonce else { return nil}
         
         // We insert a message of type `ZMMessageDelete` containing the nonce of the message that should be deleted
-        let deletedMessage = ZMGenericMessage(deleteMessage: messageNonce.transportString(), nonce: NSUUID().transportString())
+        let deletedMessage = ZMGenericMessage(deleteMessage: messageNonce, nonce: UUID())
         let delete = conversation.appendClientMessage(with: deletedMessage, expires: false, hidden: true)
         removeClearingSender(false)
         updateCategoryCache()
@@ -88,7 +87,7 @@ extension ZMMessage {
         let mentions = conversation.mentions(in: newText)
         let normalizedNewText = conversation.normalize(text: newText, for: mentions)
 
-        let edited = ZMGenericMessage(editMessage: messageNonce.transportString(), newText: normalizedNewText, nonce: NSUUID().transportString(), mentions: mentions)
+        let edited = ZMGenericMessage(editMessage: messageNonce, newText: normalizedNewText, nonce: UUID(), mentions: mentions)
         
         guard let newMessage = conversation.appendClientMessage(with: edited, expires: true, hidden: false) else { return nil }
         newMessage.updatedTimestamp = newMessage.serverTimestamp

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -38,8 +38,8 @@ extension ZMMessage {
         
         let genericMessage = ZMGenericMessage(
             emojiString: emoji,
-            messageID: messageID.transportString(),
-            nonce: NSUUID().transportString()
+            messageID: messageID,
+            nonce: UUID()
         )
     
         let clientMessage = message.conversation?.appendClientMessage(with: genericMessage, expires: false, hidden: true)

--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -171,7 +171,7 @@ extension V2Asset: AssetProxyType {
     }
 
     func processAddedMediumImage(properties: ZMIImageProperties, keys: ZMImageAssetEncryptionKeys) {
-        let messageID = assetClientMessage.nonce!.transportString()
+        let messageID = assetClientMessage.nonce!
 
         let mediumMessage = ZMGenericMessage.genericMessage(
             mediumImageProperties: properties,
@@ -203,7 +203,7 @@ extension V2Asset: AssetProxyType {
             mediumImageProperties: medium.map(imageProperties),
             processedImageProperties: properties,
             encryptionKeys: keys,
-            nonce: assetClientMessage.nonce!.transportString(),
+            nonce: assetClientMessage.nonce!,
             format: .preview,
             expiresAfter: NSNumber(value: assetClientMessage.deletionTimeout)
         )

--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -167,19 +167,17 @@ extension V3Asset: AssetProxyType {
         guard format == .medium, let sha256 = keys.sha256 else { return zmLog.error("Tried to process non-medium v3 image for \(assetClientMessage)") }
         guard let nonce = assetClientMessage.nonce else { return zmLog.error("Tried to process image message without nonce: \(assetClientMessage)") }
         
-        let messageID = nonce.transportString()
-
         let original = ZMGenericMessage.genericMessage(
             withImageSize: properties.size,
             mimeType: properties.mimeType,
             size: UInt64(properties.length),
-            nonce: messageID,
+            nonce: nonce,
             expiresAfter: NSNumber(value: assetClientMessage.deletionTimeout)
         )
         let uploaded = ZMGenericMessage.genericMessage(
             withUploadedOTRKey: keys.otrKey,
             sha256: sha256,
-            messageID: messageID,
+            messageID: nonce,
             expiresAfter: NSNumber(value: assetClientMessage.deletionTimeout)
         )
 

--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -41,7 +41,7 @@ import Foundation
     var fileURL: URL? { get }
     
     /// The asset ID of the thumbnail, if any
-    var thumbnailAssetID: UUID? { get set }
+    var thumbnailAssetID: String? { get set }
     
     /// Duration of the media in milliseconds
     var durationMilliseconds: UInt64 { get }
@@ -144,7 +144,7 @@ extension ZMAssetClientMessage: ZMFileMessageData {
         return self.genericAssetMessage?.assetData?.original.name.removingExtremeCombiningCharacters
     }
     
-    public var thumbnailAssetID: UUID? {
+    public var thumbnailAssetID: String? {
         
         get {
             guard self.fileMessageData != nil else { return nil }
@@ -153,7 +153,7 @@ extension ZMAssetClientMessage: ZMFileMessageData {
                 let assetId = assetData.preview.remote.assetId,
                 !assetId.isEmpty
             else { return nil }
-            return UUID(uuidString:assetId)
+            return assetId
         }
         
         set {
@@ -180,9 +180,9 @@ extension ZMAssetClientMessage: ZMFileMessageData {
                 assetBuilder.merge(from: assetData)
             }
             messageBuilder.merge(from: thumbnailMessage)
-            remoteBuilder.setAssetId(newValue?.transportString())
+            remoteBuilder.setAssetId(newValue)
 
-            previewBuilder.setRemote(remoteBuilder.buildAndValidate())
+            previewBuilder.setRemote(remoteBuilder.build())
             assetBuilder.setPreview(previewBuilder.build())
             let asset = assetBuilder.build()!
             

--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -205,7 +205,7 @@ extension ZMAssetClientMessage {
             
             if !assetData.preview.remote.hasAssetId() {
                 if let thumbnailId = eventData["id"] as? String {
-                    self.fileMessageData?.thumbnailAssetID = UUID(uuidString: thumbnailId)
+                    self.fileMessageData?.thumbnailAssetID = thumbnailId
                 }
             } else {
                 self.version = 3

--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -23,7 +23,7 @@ extension ZMAssetClientMessage {
     func genericMessageDataFromDataSet(for format: ZMImageFormat) -> ZMGenericMessageData? {
         return self.dataSet.array
             .flatMap { $0 as? ZMGenericMessageData }
-            .filter { $0.genericMessage.imageAssetData?.imageFormat() == format }
+            .filter { $0.genericMessage?.imageAssetData?.imageFormat() == format }
             .first
     }
     
@@ -67,11 +67,13 @@ extension ZMAssetClientMessage {
         }
     }
     
-    func mergeWithExistingData(data: Data) -> ZMGenericMessageData {
+    func mergeWithExistingData(data: Data) -> ZMGenericMessageData? {
         self.cachedGenericAssetMessage = nil
         
-        let genericMessage = ZMGenericMessageBuilder().merge(from: data).build()! as! ZMGenericMessage
-        
+        guard let genericMessage = ZMGenericMessageBuilder().merge(from: data).build() as? ZMGenericMessage else {
+            return nil
+        }
+
         if let imageFormat = genericMessage.imageAssetData?.imageFormat(),
             let existingMessageData = self.genericMessageDataFromDataSet(for: imageFormat)
         {
@@ -203,7 +205,7 @@ extension ZMAssetClientMessage {
             
             if !assetData.preview.remote.hasAssetId() {
                 if let thumbnailId = eventData["id"] as? String {
-                    self.fileMessageData?.thumbnailAssetID = thumbnailId
+                    self.fileMessageData?.thumbnailAssetID = UUID(uuidString: thumbnailId)
                 }
             } else {
                 self.version = 3

--- a/Source/Model/Message/ZMAssetClientMessage+ImageAssetStorage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+ImageAssetStorage.swift
@@ -98,7 +98,7 @@ extension ZMAssetClientMessage: ImageAssetStorage {
         let asset = builder.build()!
         
         let filePreviewMessage = ZMGenericMessage.genericMessage(asset: asset,
-                                                                 messageID: self.nonce!.transportString(),
+                                                                 messageID: self.nonce!,
                                                                  expiresAfter: self.deletionTimeout as NSNumber)
         self.add(filePreviewMessage)
     }

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -40,7 +40,7 @@ import Foundation
         let assetMessage = ZMGenericMessage.genericMessage(withImageSize: CGSize.zero,
                                                            mimeType: mimeType,
                                                            size: UInt64(imageData.count),
-                                                           nonce: nonce.transportString(),
+                                                           nonce: nonce,
                                                            expiresAfter: timeout as NSNumber)
         add(assetMessage)
         preprocessedSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData)
@@ -64,7 +64,7 @@ import Foundation
         delivered = false
         version = 3
         
-        add(ZMGenericMessage.genericMessage(fileMetadata: metadata, messageID: nonce.transportString(), expiresAfter: timeout as NSNumber))
+        add(ZMGenericMessage.genericMessage(fileMetadata: metadata, messageID: nonce, expiresAfter: timeout as NSNumber))
     }
     
     public override func prepareForDeletion() {
@@ -246,7 +246,7 @@ import Foundation
     
     private func removeNotUploaded() {
         for data in self.dataSet.array.map({ $0 as! ZMGenericMessageData }) {
-            if let assetData = data.genericMessage.assetData,
+            if let assetData = data.genericMessage?.assetData,
                 assetData.hasNotUploaded() {
                 data.asset = nil
                 self.managedObjectContext?.delete(data)

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -293,7 +293,7 @@ extension ZMGenericMessage {
         guard let encryptedDataWithKeys = ZMGenericMessage.encryptedDataWithKeys(from: self)
         else {return nil}
         
-        let externalGenericMessage = ZMGenericMessage.genericMessage(withKeyWithChecksum: encryptedDataWithKeys.keys, messageID: NSUUID().transportString())
+        let externalGenericMessage = ZMGenericMessage.genericMessage(withKeyWithChecksum: encryptedDataWithKeys.keys, messageID: UUID())
         return externalGenericMessage.encryptedMessagePayloadData(conversation, externalData: encryptedDataWithKeys.data)
     }
     
@@ -302,7 +302,7 @@ extension ZMGenericMessage {
         guard let encryptedDataWithKeys = ZMGenericMessage.encryptedDataWithKeys(from: self)
             else {return nil}
         
-        let externalGenericMessage = ZMGenericMessage.genericMessage(withKeyWithChecksum: encryptedDataWithKeys.keys, messageID: NSUUID().transportString())
+        let externalGenericMessage = ZMGenericMessage.genericMessage(withKeyWithChecksum: encryptedDataWithKeys.keys, messageID: UUID())
         return externalGenericMessage.encryptedMessagePayloadData(for: recipients, externalData: encryptedDataWithKeys.data, context: context)
     }
 }

--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -171,17 +171,22 @@ extension ZMClientMessage: ZMImageOwner {
 
                 let newMessage = ZMGenericMessage.message(text: self.textMessageData?.messageText ?? "",
                                                           linkPreview: updatedPreview,
-                                                          nonce: self.nonce!.transportString(),
+                                                          nonce: self.nonce!,
                                                           expiresAfter: self.deletionTimeout as NSNumber,
                                                           mentions: mentions)
                 self.add(newMessage.data())
             } else if genericMessage.hasEdited() {
 
-                let newMessage = ZMGenericMessage(editMessage: genericMessage.edited.replacingMessageId,
+                guard let replacingMessageID = UUID(uuidString: genericMessage.edited.replacingMessageId) else {
+                    return
+                }
+
+                let newMessage = ZMGenericMessage(editMessage: replacingMessageID,
                                                   newText: self.textMessageData?.messageText ?? "",
                                                   linkPreview: updatedPreview,
-                                                  nonce: self.nonce!.transportString(),
+                                                  nonce: self.nonce!,
                                                   mentions: mentions)
+
                 self.add(newMessage.data())
             }
         }

--- a/Source/Model/Message/ZMGenericMessage+UpdateEvent.m
+++ b/Source/Model/Message/ZMGenericMessage+UpdateEvent.m
@@ -33,13 +33,11 @@
         case ZMUpdateEventTypeConversationClientMessageAdd: {
             NSString *base64Content = [updateEvent.payload stringForKey:@"data"];
             message = [self genericMessageWithBase64String:base64Content updateEvent:updateEvent];
-            VerifyReturnNil(message != nil);
         }
             break;
         case ZMUpdateEventTypeConversationOtrMessageAdd: {
             NSString *base64Content = [[updateEvent.payload dictionaryForKey:@"data"] stringForKey:@"text"];
             message = [self genericMessageWithBase64String:base64Content updateEvent:updateEvent];
-            VerifyReturnNil(message != nil);
         }
             break;
             
@@ -50,17 +48,15 @@
                 message = [ZMGenericMessage messageWithBase64String:base64Content];
             }
             @catch(NSException *e) {
-                ZMLogError(@"Cannot create message from protobuffer: %@ event: %@", e, updateEvent);
-                return nil;
+                message = nil;
             }
-            VerifyReturnNil(message != nil);
         }
             break;
             
         default:
             break;
     }
-    
+
     if (message.hasExternal) {
         return [self genericMessageFromUpdateEventWithExternal:updateEvent external:message.external];
     }

--- a/Source/Model/Message/ZMGenericMessageData.h
+++ b/Source/Model/Message/ZMGenericMessageData.h
@@ -24,17 +24,20 @@
 @class ZMClientMessage;
 @class ZMAssetClientMessage;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const ZMGenericMessageDataMessageKey;
 extern NSString * const ZMGenericMessageDataAssetKey;
 
+NS_ASSUME_NONNULL_END
+
 @interface ZMGenericMessageData: ZMManagedObject
 
-@property (nonatomic) NSData *data;
-@property (nonatomic, readonly) ZMGenericMessage *genericMessage;
-@property (nonatomic) ZMClientMessage *message;
-@property (nonatomic) ZMAssetClientMessage *asset;
+@property (nonatomic, nonnull) NSData *data;
+@property (nonatomic, readonly, nullable) ZMGenericMessage *genericMessage;
+@property (nonatomic, nullable) ZMClientMessage *message;
+@property (nonatomic, nullable) ZMAssetClientMessage *asset;
 
-+ (NSString *)entityName;
++ (NSString * _Nonnull)entityName;
 
 @end
-

--- a/Source/Model/Message/ZMGenericMessageData.m
+++ b/Source/Model/Message/ZMGenericMessageData.m
@@ -21,6 +21,7 @@
 @import WireUtilities;
 
 #import "ZMGenericMessageData.h"
+#import <WireDataModel/WireDataModel-Swift.h>
 
 static NSString * const ZMGenericMessageDataDataKey = @"data";
 
@@ -40,7 +41,8 @@ NSString * const ZMGenericMessageDataAssetKey = @"asset";
 
 - (ZMGenericMessage *)genericMessage
 {
-    return (ZMGenericMessage *)[[[ZMGenericMessage builder] mergeFromData:self.data] build];
+    ZMGenericMessageBuilder *builder = (ZMGenericMessageBuilder *)[[ZMGenericMessage builder] mergeFromData:self.data];
+    return [builder build];
 }
 
 - (NSSet *)modifiedKeys

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -242,7 +242,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
 
 - (ZMClientMessage *)confirmReception
 {
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithConfirmation:self.nonce.transportString type:ZMConfirmationTypeDELIVERED nonce:[NSUUID UUID].transportString];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithConfirmation:self.nonce type:ZMConfirmationTypeDELIVERED nonce:[NSUUID UUID]];
     return [self.conversation appendClientMessageWithGenericMessage:genericMessage expires:NO hidden:YES];
 }
 

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -131,22 +131,32 @@ NSString * const DeliveredKey = @"delivered";
     }
     @catch(NSException *e) {
         ZMLogError(@"Cannot create message from protobuffer: %@", e);
-        return nil;
+        message = nil;
     }
-    VerifyReturnNil(message != nil);
-    
-    if (!message.knownMessage) {
-        [UnknownMessageAnalyticsTracker tagUnknownMessageWithAnalytics:moc.analytics];
-    }
-    
+
     ZMConversation *conversation = [self.class conversationForUpdateEvent:updateEvent inContext:moc prefetchResult:prefetchResult];
     VerifyReturnNil(conversation != nil);
     ZMUser *selfUser = [ZMUser selfUserInContext:moc];
-    
+
     if (conversation.conversationType == ZMConversationTypeSelf && ![updateEvent.senderUUID isEqual:selfUser.remoteIdentifier]) {
         return nil; // don't process messages in the self conversation not sent from the self user
     }
-    
+
+    if (!message.knownMessage) {
+        [UnknownMessageAnalyticsTracker tagUnknownMessageWithAnalytics:moc.analytics];
+    }
+
+    // Check if the message is valid
+
+    if (message == nil) {
+        ZMUser *sender = [ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:NO inContext:moc];
+        VerifyReturnNil(sender);
+        ZMSystemMessage *systemMessage = [conversation appendInvalidSystemMessageAt:updateEvent.timeStamp sender:sender];
+        return [[MessageUpdateResult alloc] initWithMessage:systemMessage needsConfirmation:NO wasInserted:YES];
+    }
+
+    // Insert the message
+
     if (message.hasLastRead && conversation.conversationType == ZMConversationTypeSelf) {
         [ZMConversation updateConversationWithZMLastReadFromSelfConversation:message.lastRead inContext:moc];
     }

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -235,7 +235,7 @@ public class UserClient: ZMManagedObject, UserClientType {
                 guard
                     let user = (try? uiMOC.existingObject(with: userID)) as? ZMUser,
                     let conversation = self.conversation(for: user) else { return }
-                let message = ZMGenericMessage.sessionReset(withNonce: UUID().transportString())
+                let message = ZMGenericMessage.sessionReset(withNonce: UUID())
                 GenericMessageScheduleNotification.post(message: message, conversation: conversation)
             }
         }

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -1,0 +1,295 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireProtos
+
+extension UUID {
+
+    fileprivate static func isValid(object: Any?) -> Bool {
+        guard let string = object as? String else { return false }
+        return UUID(uuidString: string) != nil
+    }
+
+    fileprivate static func isValid(bytes: Data?) -> Bool {
+        return bytes?.count == 16
+    }
+
+    fileprivate static func isValid(array: [Any]?) -> Bool {
+        return array?.map(UUID.isValid).contains(false) == false
+    }
+
+}
+
+// MARK: - Specific Validation
+
+// MARK: Generic Message
+
+extension ZMGenericMessage {
+    @objc public func validatingFields() -> ZMGenericMessage? {
+        // Validate the message itself
+        guard UUID.isValid(object: messageId) else { return nil }
+
+        // Validate the mentions in the text
+        if self.hasText() {
+            guard self.text!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the last read
+        if self.hasLastRead() {
+            guard self.lastRead!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the cleared
+        if self.hasCleared() {
+            guard self.cleared!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the hide
+        if self.hasHidden() {
+            guard self.hidden!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the delete
+        if self.hasDeleted() {
+            guard self.deleted!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the edit
+        if self.hasEdited() {
+            guard self.edited!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the confirmation
+        if self.hasConfirmation() {
+            guard self.confirmation!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the reaction
+        if self.hasReaction() {
+            guard self.reaction!.validatingFields() != nil else { return nil }
+        }
+
+        // Validate the reaction
+        if self.hasAsset() {
+            guard self.asset!.validatingFields() != nil else { return nil }
+        }
+
+        return self
+    }
+}
+
+extension ZMGenericMessageBuilder {
+    @objc public func buildAndValidate() -> ZMGenericMessage? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: - Text
+
+extension ZMText {
+    @objc public func validatingFields() -> ZMText? {
+
+        if let mentions = self.mention {
+            let validMentions = mentions.flatMap { $0.validatingFields() }
+            guard validMentions.count == mentions.count else { return nil }
+        }
+
+        return self
+
+    }
+}
+
+extension ZMTextBuilder {
+    @objc public func buildAndValidate() -> ZMText? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Mention
+
+extension ZMMention {
+    @objc public func validatingFields() -> ZMMention? {
+        guard UUID.isValid(object: userId) else { return nil }
+        return self
+    }
+}
+
+extension ZMMentionBuilder {
+    @objc public func buildAndValidate() -> ZMMention? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Last Read
+
+extension ZMLastRead {
+    @objc public func validatingFields() -> ZMLastRead? {
+        guard UUID.isValid(object: conversationId) else { return nil }
+        return self
+    }
+}
+
+extension ZMLastReadBuilder {
+    @objc public func buildAndValidate() -> ZMLastRead? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Cleared
+
+extension ZMCleared {
+    @objc public func validatingFields() -> ZMCleared? {
+        guard UUID.isValid(object: conversationId) else { return nil }
+        return self
+    }
+}
+
+extension ZMClearedBuilder {
+    @objc public func buildAndValidate() -> ZMCleared? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Message Hide
+
+extension ZMMessageHide {
+    @objc public func validatingFields() -> ZMMessageHide? {
+        guard UUID.isValid(object: conversationId) else { return nil }
+        guard UUID.isValid(object: messageId) else { return nil }
+        return self
+    }
+}
+
+extension ZMMessageHideBuilder {
+    @objc public func buildAndValidate() -> ZMMessageHide? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Message Delete
+
+extension ZMMessageDelete {
+    @objc public func validatingFields() -> ZMMessageDelete? {
+        guard UUID.isValid(object: messageId) else { return nil }
+        return self
+    }
+}
+
+extension ZMMessageDeleteBuilder {
+    @objc public func buildAndValidate() -> ZMMessageDelete? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Message Edit
+
+extension ZMMessageEdit {
+    @objc public func validatingFields() -> ZMMessageEdit? {
+        guard UUID.isValid(object: replacingMessageId) else { return nil }
+        return self
+    }
+}
+
+extension ZMMessageEditBuilder {
+    @objc public func buildAndValidate() -> ZMMessageEdit? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Message Confirmation
+
+extension ZMConfirmation {
+    @objc public func validatingFields() -> ZMConfirmation? {
+        guard UUID.isValid(object: firstMessageId) else { return nil }
+
+        if self.moreMessageIds != nil {
+            guard UUID.isValid(array: moreMessageIds) else { return nil }
+        }
+
+        return self
+    }
+}
+
+extension ZMConfirmationBuilder {
+    @objc public func buildAndValidate() -> ZMConfirmation? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: - Asset
+
+extension ZMAsset {
+    @objc public func validatingFields() -> ZMAsset? {
+        if self.hasUploaded() {
+            guard self.uploaded!.validatingFields() != nil else { return nil }
+        }
+        return self
+    }
+}
+
+extension ZMAssetBuilder {
+    @objc public func buildAndValidate() -> ZMAsset? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Asset Remote Data
+
+extension ZMAssetRemoteData {
+    @objc public func validatingFields() -> ZMAssetRemoteData? {
+        guard UUID.isValid(object: assetId) else { return nil }
+        return self
+    }
+}
+
+extension ZMAssetRemoteDataBuilder {
+    @objc public func buildAndValidate() -> ZMAssetRemoteData? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: Reaction
+
+extension ZMReaction {
+    @objc public func validatingFields() -> ZMReaction? {
+        guard UUID.isValid(object: messageId) else { return nil }
+        return self
+    }
+}
+
+extension ZMReactionBuilder {
+    @objc public func buildAndValidate() -> ZMReaction? {
+        return self.build()?.validatingFields()
+    }
+}
+
+// MARK: User ID
+
+extension ZMUserId {
+    @objc public func validatingFields() -> ZMUserId? {
+        guard UUID.isValid(bytes: uuid) else { return nil }
+        return self
+    }
+}
+
+extension ZMUserIdBuilder {
+    @objc public func buildAndValidate() -> ZMUserId? {
+        return self.build()?.validatingFields()
+    }
+}

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -85,11 +85,6 @@ extension ZMGenericMessage {
             guard self.reaction!.validatingFields() != nil else { return nil }
         }
 
-        // Validate the reaction
-        if self.hasAsset() {
-            guard self.asset!.validatingFields() != nil else { return nil }
-        }
-
         return self
     }
 }
@@ -228,38 +223,6 @@ extension ZMConfirmation {
 
 extension ZMConfirmationBuilder {
     @objc public func buildAndValidate() -> ZMConfirmation? {
-        return self.build()?.validatingFields()
-    }
-}
-
-// MARK: - Asset
-
-extension ZMAsset {
-    @objc public func validatingFields() -> ZMAsset? {
-        if self.hasUploaded() {
-            guard self.uploaded!.validatingFields() != nil else { return nil }
-        }
-        return self
-    }
-}
-
-extension ZMAssetBuilder {
-    @objc public func buildAndValidate() -> ZMAsset? {
-        return self.build()?.validatingFields()
-    }
-}
-
-// MARK: Asset Remote Data
-
-extension ZMAssetRemoteData {
-    @objc public func validatingFields() -> ZMAssetRemoteData? {
-        guard UUID.isValid(object: assetId) else { return nil }
-        return self
-    }
-}
-
-extension ZMAssetRemoteDataBuilder {
-    @objc public func buildAndValidate() -> ZMAssetRemoteData? {
         return self.build()?.validatingFields()
     }
 }

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -110,24 +110,12 @@ extension ZMText {
     }
 }
 
-extension ZMTextBuilder {
-    @objc public func buildAndValidate() -> ZMText? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: Mention
 
 extension ZMMention {
     @objc public func validatingFields() -> ZMMention? {
         guard UUID.isValid(object: userId) else { return nil }
         return self
-    }
-}
-
-extension ZMMentionBuilder {
-    @objc public func buildAndValidate() -> ZMMention? {
-        return self.build()?.validatingFields()
     }
 }
 
@@ -140,24 +128,12 @@ extension ZMLastRead {
     }
 }
 
-extension ZMLastReadBuilder {
-    @objc public func buildAndValidate() -> ZMLastRead? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: Cleared
 
 extension ZMCleared {
     @objc public func validatingFields() -> ZMCleared? {
         guard UUID.isValid(object: conversationId) else { return nil }
         return self
-    }
-}
-
-extension ZMClearedBuilder {
-    @objc public func buildAndValidate() -> ZMCleared? {
-        return self.build()?.validatingFields()
     }
 }
 
@@ -171,12 +147,6 @@ extension ZMMessageHide {
     }
 }
 
-extension ZMMessageHideBuilder {
-    @objc public func buildAndValidate() -> ZMMessageHide? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: Message Delete
 
 extension ZMMessageDelete {
@@ -186,24 +156,12 @@ extension ZMMessageDelete {
     }
 }
 
-extension ZMMessageDeleteBuilder {
-    @objc public func buildAndValidate() -> ZMMessageDelete? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: Message Edit
 
 extension ZMMessageEdit {
     @objc public func validatingFields() -> ZMMessageEdit? {
         guard UUID.isValid(object: replacingMessageId) else { return nil }
         return self
-    }
-}
-
-extension ZMMessageEditBuilder {
-    @objc public func buildAndValidate() -> ZMMessageEdit? {
-        return self.build()?.validatingFields()
     }
 }
 
@@ -221,12 +179,6 @@ extension ZMConfirmation {
     }
 }
 
-extension ZMConfirmationBuilder {
-    @objc public func buildAndValidate() -> ZMConfirmation? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: Reaction
 
 extension ZMReaction {
@@ -236,23 +188,11 @@ extension ZMReaction {
     }
 }
 
-extension ZMReactionBuilder {
-    @objc public func buildAndValidate() -> ZMReaction? {
-        return self.build()?.validatingFields()
-    }
-}
-
 // MARK: User ID
 
 extension ZMUserId {
     @objc public func validatingFields() -> ZMUserId? {
         guard UUID.isValid(bytes: uuid) else { return nil }
         return self
-    }
-}
-
-extension ZMUserIdBuilder {
-    @objc public func buildAndValidate() -> ZMUserId? {
-        return self.build()?.validatingFields()
     }
 }

--- a/Source/Utilis/Protos/ZMGenericMessage+Assets.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Assets.swift
@@ -136,15 +136,15 @@ public extension ZMAssetImageMetaData {
 
 public extension ZMAssetRemoteData {
     
-    public static func remoteData(withOTRKey otrKey: Data, sha256: Data, assetId: UUID? = nil, assetToken: UUID? = nil) -> ZMAssetRemoteData {
+    public static func remoteData(withOTRKey otrKey: Data, sha256: Data, assetId: String? = nil, assetToken: String? = nil) -> ZMAssetRemoteData {
         let builder = ZMAssetRemoteData.builder()!
         builder.setOtrKey(otrKey)
         builder.setSha256(sha256)
         if let identifier = assetId {
-            builder.setAssetId(identifier.transportString())
+            builder.setAssetId(identifier)
         }
         if let token = assetToken {
-            builder.setAssetToken(token.transportString())
+            builder.setAssetToken(token)
         }
         return builder.build()
     }
@@ -152,11 +152,11 @@ public extension ZMAssetRemoteData {
 
 
 extension ZMAssetRemoteData {
-    func builder(withAssetID assetID: UUID, token: UUID?) -> ZMAssetRemoteDataBuilder {
+    func builder(withAssetID assetID: String, token: String?) -> ZMAssetRemoteDataBuilder {
         let builder = toBuilder()!
-        builder.setAssetId(assetID.transportString())
+        builder.setAssetId(assetID)
         if let token = token {
-            builder.setAssetToken(token.transportString())
+            builder.setAssetToken(token)
         }
         return builder
     }

--- a/Source/Utilis/Protos/ZMGenericMessage+Assets.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Assets.swift
@@ -136,15 +136,15 @@ public extension ZMAssetImageMetaData {
 
 public extension ZMAssetRemoteData {
     
-    public static func remoteData(withOTRKey otrKey: Data, sha256: Data, assetId: String? = nil, assetToken: String? = nil) -> ZMAssetRemoteData {
+    public static func remoteData(withOTRKey otrKey: Data, sha256: Data, assetId: UUID? = nil, assetToken: UUID? = nil) -> ZMAssetRemoteData {
         let builder = ZMAssetRemoteData.builder()!
         builder.setOtrKey(otrKey)
         builder.setSha256(sha256)
         if let identifier = assetId {
-            builder.setAssetId(identifier)
+            builder.setAssetId(identifier.transportString())
         }
         if let token = assetToken {
-            builder.setAssetToken(token)
+            builder.setAssetToken(token.transportString())
         }
         return builder.build()
     }
@@ -152,11 +152,11 @@ public extension ZMAssetRemoteData {
 
 
 extension ZMAssetRemoteData {
-    func builder(withAssetID assetID: String, token: String?) -> ZMAssetRemoteDataBuilder {
+    func builder(withAssetID assetID: UUID, token: UUID?) -> ZMAssetRemoteDataBuilder {
         let builder = toBuilder()!
-        builder.setAssetId(assetID)
+        builder.setAssetId(assetID.transportString())
         if let token = token {
-            builder.setAssetToken(token)
+            builder.setAssetToken(token.transportString())
         }
         return builder
     }

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -55,9 +55,9 @@ extension ZMGenericMessageBuilder {
 
 public extension ZMGenericMessage {
     
-    @objc public static func genericMessage(pbMessage: PBGeneratedMessage, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    @objc public static func genericMessage(pbMessage: PBGeneratedMessage, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         let builder = ZMGenericMessage.builder()!
-        builder.setMessageId(messageID)
+        builder.setMessageId(messageID.transportString())
         if let timeout = timeout, timeout.compare(0) == .orderedDescending  {
             builder.setEphemeral(ZMEphemeral.ephemeral(pbMessage: pbMessage, expiresAfter: timeout))
         } else {
@@ -87,61 +87,61 @@ public extension ZMGenericMessage {
 
 public extension ZMGenericMessage {
 
-    public static func genericMessage(external: ZMExternal, messageID: String) -> ZMGenericMessage {
+    public static func genericMessage(external: ZMExternal, messageID: UUID) -> ZMGenericMessage {
         return genericMessage(pbMessage: external, messageID: messageID)
     }
     
-    public static func genericMessage(withKeyWithChecksum keys: ZMEncryptionKeyWithChecksum, messageID: String) -> ZMGenericMessage {
+    public static func genericMessage(withKeyWithChecksum keys: ZMEncryptionKeyWithChecksum, messageID: UUID) -> ZMGenericMessage {
         let external = ZMExternal.external(withKeyWithChecksum: keys)
         return ZMGenericMessage.genericMessage(external: external, messageID: messageID)
     }
     
     // MARK: ZMLocationMessageData
     
-    public static func genericMessage(location: ZMLocation, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(location: ZMLocation, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return genericMessage(pbMessage: location, messageID: messageID, expiresAfter: timeout)
 
     }
     
     // MARK: ZMAssetClientMessage
     
-    public static func genericMessage(asset: ZMAsset, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(asset: ZMAsset, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return genericMessage(pbMessage: asset, messageID: messageID, expiresAfter: timeout)
     }
     
     public static func genericMessage(withAssetSize size: UInt64,
                                                     mimeType: String,
                                                     name: String,
-                                                    messageID: String,
+                                                    messageID: UUID,
                                        expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         
         let asset = ZMAsset.asset(withOriginal: .original(withSize: size, mimeType: mimeType, name: name))
         return ZMGenericMessage.genericMessage(asset: asset, messageID: messageID, expiresAfter: timeout)
     }
     
-    public static func genericMessage(fileMetadata: ZMFileMetadata, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(fileMetadata: ZMFileMetadata, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return ZMGenericMessage.genericMessage(asset: fileMetadata.asset, messageID: messageID, expiresAfter: timeout)
     }
     
-    public static func genericMessage(withUploadedOTRKey otrKey: Data, sha256: Data, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(withUploadedOTRKey otrKey: Data, sha256: Data, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return ZMGenericMessage.genericMessage(asset: .asset(withUploadedOTRKey: otrKey, sha256: sha256), messageID: messageID, expiresAfter: timeout)
     }
     
-    public static func genericMessage(notUploaded: ZMAssetNotUploaded, messageID: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(notUploaded: ZMAssetNotUploaded, messageID: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return ZMGenericMessage.genericMessage(asset: .asset(withNotUploaded: notUploaded), messageID: messageID, expiresAfter: timeout)
     }
     
-    public static func genericMessage(imageData: Data, format:ZMImageFormat, nonce: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(imageData: Data, format:ZMImageFormat, nonce: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         let asset = ZMImageAsset(data: imageData, format: format)!
         return genericMessage(pbMessage: asset, messageID: nonce, expiresAfter: timeout)
     }
     
-    public static func genericMessage(mediumImageProperties: ZMIImageProperties?, processedImageProperties:ZMIImageProperties?, encryptionKeys: ZMImageAssetEncryptionKeys?, nonce: String, format:ZMImageFormat, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(mediumImageProperties: ZMIImageProperties?, processedImageProperties:ZMIImageProperties?, encryptionKeys: ZMImageAssetEncryptionKeys?, nonce: UUID, format:ZMImageFormat, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         let asset = ZMImageAsset(mediumProperties: mediumImageProperties, processedProperties: processedImageProperties, encryptionKeys: encryptionKeys, format: format)
         return genericMessage(pbMessage: asset, messageID: nonce, expiresAfter: timeout)
     }
 
-    public static func genericMessage(withImageSize imageSize: CGSize, mimeType: String, size: UInt64, nonce: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func genericMessage(withImageSize imageSize: CGSize, mimeType: String, size: UInt64, nonce: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         let imageMeta = ZMAssetImageMetaData.imageMetaData(withWidth: Int32(imageSize.width), height: Int32(imageSize.height))
         let original = ZMAssetOriginal.original(withSize: size, mimeType: mimeType, name: nil, imageMetaData: imageMeta)
         let asset = ZMAsset.asset(withOriginal: original, preview: nil)
@@ -157,29 +157,29 @@ public extension ZMGenericMessage {
     
     // MARK: Text
 
-    public static func message(text: String, nonce: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func message(text: String, nonce: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return message(text:text, linkPreview:nil, nonce:nonce, expiresAfter: timeout)
     }
     
-    public static func message(text: String, linkPreview: ZMLinkPreview?, nonce: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func message(text: String, linkPreview: ZMLinkPreview?, nonce: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         return message(text:text, linkPreview:linkPreview, nonce:nonce, expiresAfter: timeout, mentions: [])
     }
 
-    public static func message(text: String, linkPreview: ZMLinkPreview?, nonce: String, expiresAfter timeout: NSNumber? = nil, mentions: [ZMMention]) -> ZMGenericMessage {
+    public static func message(text: String, linkPreview: ZMLinkPreview?, nonce: UUID, expiresAfter timeout: NSNumber? = nil, mentions: [ZMMention]) -> ZMGenericMessage {
         let zmtext = ZMText(message:text, linkPreview:linkPreview, mentions: mentions)!
         return genericMessage(pbMessage: zmtext, messageID: nonce, expiresAfter: timeout)
     }
 
     // MARK: Knock
 
-    public static func knock(nonce: String, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
+    public static func knock(nonce: UUID, expiresAfter timeout: NSNumber? = nil) -> ZMGenericMessage {
         let knockBuilder = ZMKnock.builder()!
         knockBuilder.setHotKnock(false)
         return genericMessage(pbMessage: knockBuilder.build(), messageID: nonce, expiresAfter: timeout)
     }
 
     // MARK: Updating assets with asset ID and token
-    public func updatedUploaded(withAssetId assetId: String, token: String?) -> ZMGenericMessage? {
+    public func updatedUploaded(withAssetId assetId: UUID, token: UUID?) -> ZMGenericMessage? {
         guard let asset = assetData, let remote = asset.uploaded, asset.hasUploaded() else { return nil }
         let newRemote = remote.updated(withId: assetId, token: token)
         let builder = toBuilder()!
@@ -197,10 +197,10 @@ public extension ZMGenericMessage {
             return nil
         }
 
-        return builder.build()
+        return builder.buildAndValidate()
     }
 
-    public func updatedPreview(withAssetId assetId: String, token: String?) -> ZMGenericMessage? {
+    public func updatedPreview(withAssetId assetId: UUID, token: UUID?) -> ZMGenericMessage? {
         guard let asset = assetData, let preview = asset.preview, let remote = preview.remote, preview.hasRemote() else { return nil }
         let newRemote = remote.updated(withId: assetId, token: token)
         let previewBuilder = preview.toBuilder()
@@ -220,18 +220,18 @@ public extension ZMGenericMessage {
             return nil
         }
 
-        return builder.build()
+        return builder.buildAndValidate()
     }
 
 }
 
 extension ZMAssetRemoteData {
 
-    public func updated(withId assetId: String, token: String?) -> ZMAssetRemoteData {
+    public func updated(withId assetId: UUID, token: UUID?) -> ZMAssetRemoteData {
         let builder = toBuilder()!
-        builder.setAssetId(assetId)
+        builder.setAssetId(assetId.transportString())
         if let token = token {
-            builder.setAssetToken(token)
+            builder.setAssetToken(token.transportString())
         }
         return builder.build()
     }
@@ -500,7 +500,7 @@ public extension ZMLinkPreview {
         return linkPreviewbuilder.build()
     }
     
-    func update(withAssetKey assetKey: String, assetToken: String?) -> ZMLinkPreview {
+    func update(withAssetKey assetKey: UUID, assetToken: UUID?) -> ZMLinkPreview {
         
         let linkPreviewbuilder = toBuilder()!
         

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -179,7 +179,7 @@ public extension ZMGenericMessage {
     }
 
     // MARK: Updating assets with asset ID and token
-    public func updatedUploaded(withAssetId assetId: UUID, token: UUID?) -> ZMGenericMessage? {
+    public func updatedUploaded(withAssetId assetId: String, token: String?) -> ZMGenericMessage? {
         guard let asset = assetData, let remote = asset.uploaded, asset.hasUploaded() else { return nil }
         let newRemote = remote.updated(withId: assetId, token: token)
         let builder = toBuilder()!
@@ -200,7 +200,7 @@ public extension ZMGenericMessage {
         return builder.buildAndValidate()
     }
 
-    public func updatedPreview(withAssetId assetId: UUID, token: UUID?) -> ZMGenericMessage? {
+    public func updatedPreview(withAssetId assetId: String, token: String?) -> ZMGenericMessage? {
         guard let asset = assetData, let preview = asset.preview, let remote = preview.remote, preview.hasRemote() else { return nil }
         let newRemote = remote.updated(withId: assetId, token: token)
         let previewBuilder = preview.toBuilder()
@@ -227,11 +227,11 @@ public extension ZMGenericMessage {
 
 extension ZMAssetRemoteData {
 
-    public func updated(withId assetId: UUID, token: UUID?) -> ZMAssetRemoteData {
+    public func updated(withId assetId: String, token: String?) -> ZMAssetRemoteData {
         let builder = toBuilder()!
-        builder.setAssetId(assetId.transportString())
+        builder.setAssetId(assetId)
         if let token = token {
-            builder.setAssetToken(token.transportString())
+            builder.setAssetToken(token)
         }
         return builder.build()
     }
@@ -500,7 +500,7 @@ public extension ZMLinkPreview {
         return linkPreviewbuilder.build()
     }
     
-    func update(withAssetKey assetKey: UUID, assetToken: UUID?) -> ZMLinkPreview {
+    func update(withAssetKey assetKey: String, assetToken: String?) -> ZMLinkPreview {
         
         let linkPreviewbuilder = toBuilder()!
         

--- a/Source/Utilis/Protos/ZMGenericMessage+Obfuscation.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Obfuscation.swift
@@ -47,6 +47,7 @@ public extension String {
 public extension ZMGenericMessage {
 
     public func obfuscatedMessage() -> ZMGenericMessage? {
+        guard let messageID = (messageId as String?).flatMap(UUID.init) else { return nil }
         guard hasEphemeral() else { return nil }
         
         if let someText = textData {
@@ -59,20 +60,20 @@ public extension ZMGenericMessage {
                     let originalURL = obfuscatedContent[offsetIndex...]
                     obfuscatedLinkPreviews = linkPreviews.map{$0.obfuscated(originalURL: String(originalURL))}
                 }
-                return ZMGenericMessage.message(text: obfuscatedContent, linkPreview:obfuscatedLinkPreviews.first, nonce: messageId, mentions: [])
+                return ZMGenericMessage.message(text: obfuscatedContent, linkPreview:obfuscatedLinkPreviews.first, nonce: messageID, mentions: [])
             }
         }
         if let someAsset = assetData {
             let obfuscatedAsset = someAsset.obfuscated()
-            return ZMGenericMessage.genericMessage(asset: obfuscatedAsset, messageID: messageId)
+            return ZMGenericMessage.genericMessage(asset: obfuscatedAsset, messageID: messageID)
         }
         if locationData != nil {
             let obfuscatedLocation = ZMLocation.location(withLatitude: 0.0, longitude: 0.0)
-            return ZMGenericMessage.genericMessage(location: obfuscatedLocation, messageID: messageId)
+            return ZMGenericMessage.genericMessage(location: obfuscatedLocation, messageID: messageID)
         }
         if let imageAsset = imageAssetData {
             let obfuscatedImage = imageAsset.obfuscated()
-            return ZMGenericMessage.genericMessage(pbMessage: obfuscatedImage, messageID: messageId)
+            return ZMGenericMessage.genericMessage(pbMessage: obfuscatedImage, messageID: messageID)
         }
         return nil
     }

--- a/Source/Utilis/Protos/ZMGenericMessage+PropertyUtils.h
+++ b/Source/Utilis/Protos/ZMGenericMessage+PropertyUtils.h
@@ -31,7 +31,7 @@
 @interface ZMLastRead (Utils)
 
 + (ZMLastRead *)lastReadWithTimestamp:(NSDate *)timeStamp
-                  conversationRemoteIDString:(NSString *)conversationIDString;
+                  conversationRemoteID:(NSUUID *)conversationID;
 
 @end
 
@@ -40,7 +40,7 @@
 @interface ZMCleared (Utils)
 
 + (instancetype)clearedWithTimestamp:(NSDate *)timeStamp
-          conversationRemoteIDString:(NSString *)conversationIDString;
+          conversationRemoteID:(NSUUID *)conversationID;
 
 @end
 
@@ -49,8 +49,8 @@
 
 @interface ZMMessageHide (Utils)
 
-+ (instancetype)messageHideWithMessageID:(NSString *)messageID
-                          conversationID:(NSString *)conversationID;
++ (instancetype)messageHideWithMessageID:(NSUUID *)messageID
+                          conversationID:(NSUUID *)conversationID;
 
 @end
 
@@ -59,7 +59,7 @@
 
 @interface ZMMessageDelete (Utils)
 
-+ (instancetype)messageDeleteWithMessageID:(NSString *)messageID;
++ (instancetype)messageDeleteWithMessageID:(NSUUID *)messageID;
 
 @end
 
@@ -68,22 +68,22 @@
 
 @interface ZMMessageEdit (Utils)
 
-+ (instancetype)messageEditWithMessageID:(NSString *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview;
++ (instancetype)messageEditWithMessageID:(NSUUID *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview;
 
-+ (instancetype)messageEditWithMessageID:(NSString *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview mentions:(NSArray<ZMMention *> *)mentions;
++ (instancetype)messageEditWithMessageID:(NSUUID *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview mentions:(NSArray<ZMMention *> *)mentions;
 
 @end
 
 
 @interface ZMReaction (Utils)
 
-+ (instancetype)reactionWithEmoji:(NSString *)emoji messageID:(NSString *)messageID;
++ (instancetype)reactionWithEmoji:(NSString *)emoji messageID:(NSUUID *)messageID;
 
 @end
 
 @interface ZMConfirmation (Utils)
 
-+ (instancetype)messageWithMessageID:(NSString *)messageID confirmationType:(ZMConfirmationType)confirmationType;
++ (instancetype)messageWithMessageID:(NSUUID *)messageID confirmationType:(ZMConfirmationType)confirmationType;
 
 @end
 

--- a/Source/Utilis/Protos/ZMGenericMessage+PropertyUtils.m
+++ b/Source/Utilis/Protos/ZMGenericMessage+PropertyUtils.m
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
+@import WireTransport;
 
 #import "ZMGenericMessage+PropertyUtils.h"
 
@@ -46,10 +47,10 @@
 
 @implementation ZMLastRead (Utils)
 
-+ (instancetype)lastReadWithTimestamp:(NSDate *)timeStamp conversationRemoteIDString:(NSString *)conversationIDString;
++ (instancetype)lastReadWithTimestamp:(NSDate *)timeStamp conversationRemoteID:(NSUUID *)conversationID;
 {
     ZMLastReadBuilder *builder = [ZMLastRead builder];
-    builder.conversationId = conversationIDString;
+    builder.conversationId = conversationID.transportString;
     builder.lastReadTimestamp = (long long) ([timeStamp timeIntervalSince1970] * 1000); // timestamps are stored in milliseconds
     return [builder build];
 }
@@ -61,10 +62,10 @@
 
 @implementation ZMCleared (Utils)
 
-+ (instancetype)clearedWithTimestamp:(NSDate *)timeStamp conversationRemoteIDString:(NSString *)conversationIDString;
++ (instancetype)clearedWithTimestamp:(NSDate *)timeStamp conversationRemoteID:(NSUUID *)conversationID;
 {
     ZMClearedBuilder *builder = [ZMCleared builder];
-    builder.conversationId = conversationIDString;
+    builder.conversationId = conversationID.transportString;
     builder.clearedTimestamp = (long long) ([timeStamp timeIntervalSince1970] * 1000); // timestamps are stored in milliseconds
     return [builder build];
 }
@@ -73,12 +74,12 @@
 
 @implementation ZMMessageHide (Utils)
 
-+ (instancetype)messageHideWithMessageID:(NSString *)messageID
-                          conversationID:(NSString *)conversationID;
++ (instancetype)messageHideWithMessageID:(NSUUID *)messageID
+                          conversationID:(NSUUID *)conversationID;
 {
     ZMMessageHideBuilder *builder = [ZMMessageHide builder];
-    builder.conversationId = conversationID;
-    builder.messageId = messageID;
+    builder.conversationId = conversationID.transportString;
+    builder.messageId = messageID.transportString;
     return [builder build];
 }
 
@@ -86,10 +87,10 @@
 
 @implementation ZMMessageDelete (Utils)
 
-+ (instancetype)messageDeleteWithMessageID:(NSString *)messageID;
++ (instancetype)messageDeleteWithMessageID:(NSUUID *)messageID;
 {
     ZMMessageDeleteBuilder *builder = [ZMMessageDelete builder];
-    builder.messageId = messageID;
+    builder.messageId = messageID.transportString;
     return [builder build];
 }
 
@@ -98,15 +99,15 @@
 
 @implementation ZMMessageEdit (Utils)
 
-+ (instancetype)messageEditWithMessageID:(NSString *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview
++ (instancetype)messageEditWithMessageID:(NSUUID *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview
 {
     return [self messageEditWithMessageID:messageID newText:newText linkPreview:linkPreview mentions:@[]];
 }
 
-+ (instancetype)messageEditWithMessageID:(NSString *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview mentions:(NSArray<ZMMention *> *)mentions
++ (instancetype)messageEditWithMessageID:(NSUUID *)messageID newText:(NSString *)newText linkPreview:(ZMLinkPreview*)linkPreview mentions:(NSArray<ZMMention *> *)mentions
 {
     ZMMessageEditBuilder *builder = [ZMMessageEdit builder];
-    builder.replacingMessageId = messageID;
+    builder.replacingMessageId = messageID.transportString;
     builder.text = [ZMText textWithMessage:newText linkPreview:linkPreview mentions: mentions];
     return [builder build];
 }
@@ -115,11 +116,11 @@
 
 @implementation ZMReaction (Utils)
 
-+ (instancetype)reactionWithEmoji:(NSString *)emoji messageID:(NSString *)messageID;
++ (instancetype)reactionWithEmoji:(NSString *)emoji messageID:(NSUUID *)messageID;
 {
     ZMReactionBuilder *builder = [ZMReaction builder];
     builder.emoji = emoji;
-    builder.messageId = messageID;
+    builder.messageId = messageID.transportString;
     return [builder build];
 }
 
@@ -128,10 +129,10 @@
 
 @implementation ZMConfirmation (Utils)
 
-+ (instancetype)messageWithMessageID:(NSString *)messageID confirmationType:(ZMConfirmationType)confirmationType;
++ (instancetype)messageWithMessageID:(NSUUID *)messageID confirmationType:(ZMConfirmationType)confirmationType;
 {
     ZMConfirmationBuilder *builder = [ZMConfirmation builder];
-    builder.firstMessageId = messageID;
+    builder.firstMessageId = messageID.transportString;
     builder.type = confirmationType;
     return [builder build];
 }

--- a/Source/Utilis/Protos/ZMGenericMessage+Utils.h
+++ b/Source/Utilis/Protos/ZMGenericMessage+Utils.h
@@ -52,52 +52,52 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ZMGenericMessage (Utils)
 
 + (ZMGenericMessage *)messageWithBase64String:(NSString *)string;
-+ (ZMGenericMessage *)sessionResetWithNonce:(NSString *)nonce;
-+ (ZMGenericMessage *)messageWithConfirmation:(NSString *)messageID type:(ZMConfirmationType)type nonce:(NSString *)nonce;
++ (ZMGenericMessage *)sessionResetWithNonce:(NSUUID *)nonce;
++ (ZMGenericMessage *)messageWithConfirmation:(NSUUID *)messageID type:(ZMConfirmationType)type nonce:(NSUUID *)nonce;
 
 
 + (ZMGenericMessage *)messageWithLastRead:(NSDate *)timestamp
-                     ofConversationWithID:(NSString *)conversationIDString
-                                    nonce:(NSString *)nonce;
+                     ofConversationWithID:(NSUUID *)conversationID
+                                    nonce:(NSUUID *)nonce;
 
 + (ZMGenericMessage *)messageWithClearedTimestamp:(NSDate *)timestamp
-                     ofConversationWithID:(NSString *)conversationIDString
-                                    nonce:(NSString *)nonce;
+                     ofConversationWithID:(NSUUID *)conversationID
+                                    nonce:(NSUUID *)nonce;
 
-+ (ZMGenericMessage *)messageWithHideMessage:(NSString *)messageID
-                              inConversation:(NSString *)conversationID
-                                       nonce:(NSString *)nonce;
++ (ZMGenericMessage *)messageWithHideMessage:(NSUUID *)messageID
+                              inConversation:(NSUUID *)conversationID
+                                       nonce:(NSUUID *)nonce;
 
-+ (ZMGenericMessage *)messageWithDeleteMessage:(NSString *)messageID
-                                         nonce:(NSString *)nonce;
++ (ZMGenericMessage *)messageWithDeleteMessage:(NSUUID *)messageID
+                                         nonce:(NSUUID *)nonce;
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
-                                       nonce:(NSString *)nonce;
+                                       nonce:(NSUUID *)nonce;
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
                                  linkPreview:(ZMLinkPreview *)linkPreview
-                                       nonce:(NSString *)nonce;
+                                       nonce:(NSUUID *)nonce;
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
                                     mentions:(NSArray<ZMMention *> *)mentions;
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
                                  linkPreview:(ZMLinkPreview *)linkPreview
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
                                     mentions:(NSArray<ZMMention *> *)mentions;
 
 
 + (ZMGenericMessage *)messageWithEmojiString:(NSString *)emojiString
-                                   messageID:(NSString *)messageID
-                                       nonce:(NSString *)nonce;
+                                   messageID:(NSUUID *)messageID
+                                       nonce:(NSUUID *)nonce;
 
 + (ZMGenericMessage *)messageWithCallingContent:(NSString *)content
-                                          nonce:(NSString *)nonce;
+                                          nonce:(NSUUID *)nonce;
 
 - (BOOL)knownMessage;
 

--- a/Source/Utilis/Protos/ZMGenericMessage+Utils.m
+++ b/Source/Utilis/Protos/ZMGenericMessage+Utils.m
@@ -101,77 +101,77 @@
     NSData *data = [[NSData alloc] initWithBase64EncodedString:string options:0];
     ZMGenericMessageBuilder *builder = [ZMGenericMessage builder];
     [builder mergeFromData:data];
-    ZMGenericMessage *message = [builder build];
+    ZMGenericMessage *message = [builder buildAndValidate];
     return message;
 }
 
-+ (ZMGenericMessage *)sessionResetWithNonce:(NSString *)nonce
++ (ZMGenericMessage *)sessionResetWithNonce:(NSUUID *)nonce
 {
     ZMGenericMessageBuilder *builder = [ZMGenericMessage builder];
     builder.clientAction = ZMClientActionRESETSESSION;
-    builder.messageId = nonce;
-    return [builder build];
+    builder.messageId = nonce.transportString;
+    return [builder buildAndValidate];
 }
 
 + (ZMGenericMessage *)messageWithLastRead:(NSDate *)timestamp
-                     ofConversationWithID:(NSString *)conversationIDString
-                                    nonce:(NSString *)nonce;
+                     ofConversationWithID:(NSUUID *)conversationID
+                                    nonce:(NSUUID *)nonce;
 {
-    ZMLastRead *lastRead = [ZMLastRead lastReadWithTimestamp:timestamp conversationRemoteIDString:conversationIDString];
+    ZMLastRead *lastRead = [ZMLastRead lastReadWithTimestamp:timestamp conversationRemoteID:conversationID];
     return [ZMGenericMessage genericMessageWithPbMessage:lastRead messageID:nonce expiresAfter:nil];
 }
 
 + (ZMGenericMessage *)messageWithClearedTimestamp:(NSDate *)timestamp
-                             ofConversationWithID:(NSString *)conversationIDString
-                                            nonce:(NSString *)nonce;
+                             ofConversationWithID:(NSUUID *)conversationID
+                                            nonce:(NSUUID *)nonce;
 {
-    ZMCleared *cleared = [ZMCleared clearedWithTimestamp:timestamp conversationRemoteIDString:conversationIDString];
+    ZMCleared *cleared = [ZMCleared clearedWithTimestamp:timestamp conversationRemoteID:conversationID];
     return [ZMGenericMessage genericMessageWithPbMessage:cleared messageID:nonce expiresAfter:nil];
 }
 
-+ (ZMGenericMessage *)messageWithHideMessage:(NSString *)messageID
-                              inConversation:(NSString *)conversationID
-                                       nonce:(NSString *)nonce;
++ (ZMGenericMessage *)messageWithHideMessage:(NSUUID *)messageID
+                              inConversation:(NSUUID *)conversationID
+                                       nonce:(NSUUID *)nonce;
 {
     ZMMessageHide *hide = [ZMMessageHide messageHideWithMessageID:messageID conversationID:conversationID];
     return [ZMGenericMessage genericMessageWithPbMessage:hide messageID:nonce expiresAfter:nil];
 }
 
-+ (ZMGenericMessage *)messageWithDeleteMessage:(NSString *)messageID
-                                         nonce:(NSString *)nonce;
++ (ZMGenericMessage *)messageWithDeleteMessage:(NSUUID *)messageID
+                                         nonce:(NSUUID *)nonce;
 {
     ZMMessageDelete *deleted = [ZMMessageDelete messageDeleteWithMessageID:messageID];
     return [ZMGenericMessage genericMessageWithPbMessage:deleted messageID:nonce expiresAfter:nil];
 }
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
 {
     return [ZMGenericMessage messageWithEditMessage:messageID newText:newText nonce:nonce mentions:@[]];
 }
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
                                  linkPreview:(ZMLinkPreview *)linkPreview
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
 {
     return [ZMGenericMessage messageWithEditMessage:messageID newText:newText linkPreview:linkPreview nonce:nonce mentions:@[]];
 }
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
                                     mentions:(NSArray<ZMMention *> *)mentions;
 {
     ZMMessageEdit *edited = [ZMMessageEdit messageEditWithMessageID:messageID newText:newText linkPreview:nil mentions:mentions];
     return [ZMGenericMessage genericMessageWithPbMessage:edited messageID:nonce expiresAfter:nil];
 }
 
-+ (ZMGenericMessage *)messageWithEditMessage:(NSString *)messageID
++ (ZMGenericMessage *)messageWithEditMessage:(NSUUID *)messageID
                                      newText:(NSString *)newText
                                  linkPreview:(ZMLinkPreview *)linkPreview
-                                       nonce:(NSString *)nonce
+                                       nonce:(NSUUID *)nonce
                                     mentions:(NSArray<ZMMention *> *)mentions;
 {
     ZMMessageEdit *edited = [ZMMessageEdit messageEditWithMessageID:messageID newText:newText linkPreview:linkPreview mentions:mentions];
@@ -179,28 +179,28 @@
 }
 
 + (ZMGenericMessage *)messageWithEmojiString:(NSString *)emojiString
-                                   messageID:(NSString *)messageID
-                                       nonce:(NSString *)nonce;
+                                   messageID:(NSUUID *)messageID
+                                       nonce:(NSUUID *)nonce;
 {
     ZMReaction *reaction = [ZMReaction reactionWithEmoji:emojiString messageID:messageID];
     return [ZMGenericMessage genericMessageWithPbMessage:reaction messageID:nonce expiresAfter:nil];
 }
 
-+ (ZMGenericMessage *)messageWithConfirmation:(NSString *)messageID type:(ZMConfirmationType)type nonce:(NSString *)nonce;
++ (ZMGenericMessage *)messageWithConfirmation:(NSUUID *)messageID type:(ZMConfirmationType)type nonce:(NSUUID *)nonce;
 {
     ZMConfirmation *confirmation = [ZMConfirmation messageWithMessageID:messageID confirmationType:type];
     return [ZMGenericMessage genericMessageWithPbMessage:confirmation messageID:nonce expiresAfter:nil];
 }
 
 + (ZMGenericMessage *)messageWithCallingContent:(NSString *)content
-                                          nonce:(NSString *)nonce;
+                                          nonce:(NSUUID *)nonce;
 {
     ZMCallingBuilder *callingBuilder = [ZMCalling builder];
     callingBuilder.content = content;
     
     ZMGenericMessageBuilder *builder = [ZMGenericMessage builder];
     builder.calling = [callingBuilder build];
-    builder.messageId = nonce;
+    builder.messageId = [nonce transportString];
     return [builder build];
 }
 

--- a/Source/Utilis/Protos/ZMMention+Helper.swift
+++ b/Source/Utilis/Protos/ZMMention+Helper.swift
@@ -21,17 +21,11 @@ import Foundation
 extension ZMMentionBuilder {
 
     public static func build(_ users: [ZMUser]) -> [ZMMention] {
-        var mentions: [ZMMention] = []
-
-        for user in users {
+        return users.map {
             let builder = ZMMention.builder()!
-            builder.setUser(user)
-            if let user = builder.buildAndValidate() {
-                mentions.append(user)
-            }
+            builder.setUser($0)
+            return builder.build()
         }
-
-        return mentions
     }
 
     public func setUser(_ user: ZMUser) {

--- a/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
+++ b/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
@@ -142,7 +142,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         NSUUID *nonce = [NSUUID createUUID];
         ZMClientMessage *m = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
-        [m addData:[ZMGenericMessage messageWithText:@"X" nonce:nonce.transportString expiresAfter:nil].data];
+        [m addData:[ZMGenericMessage messageWithText:@"X" nonce:[NSUUID createUUID] expiresAfter:nil].data];
         m.serverTimestamp = [self nextDate];
         [self.syncConversation.mutableMessages addObject:m];
         XCTAssert([self.syncMOC saveOrRollback]);
@@ -281,7 +281,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         NSUUID *nonce = NSUUID.createUUID;
         ZMClientMessage *m = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
-        [m addData:[ZMGenericMessage messageWithText:@"X" nonce:nonce.transportString expiresAfter:nil].data];
+        [m addData:[ZMGenericMessage messageWithText:@"X" nonce:[NSUUID createUUID] expiresAfter:nil].data];
         m.serverTimestamp = [self nextDate];
         [self.syncConversation.mutableMessages addObject:m];
     }];

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2042,7 +2042,7 @@
     message.sender = sender;
     [message markAsSent];
 
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithEditMessage:message.nonce.transportString newText:@"Edited Test Message" nonce:NSUUID.createUUID.transportString];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithEditMessage:message.nonce newText:@"Edited Test Message" nonce:[NSUUID createUUID]];
     NSDictionary *payload = @{
                               @"conversation": conversation.remoteIdentifier.transportString,
                               @"from": message.sender.remoteIdentifier.transportString,
@@ -3584,7 +3584,7 @@
         updatedConversation.remoteIdentifier = [NSUUID createUUID];
         updatedConversation.lastReadServerTimeStamp = oldLastRead;
         
-        ZMGenericMessage *message = [ZMGenericMessage messageWithLastRead:newLastRead ofConversationWithID:updatedConversation.remoteIdentifier.transportString nonce:[NSUUID UUID].transportString];
+        ZMGenericMessage *message = [ZMGenericMessage messageWithLastRead:newLastRead ofConversationWithID:updatedConversation.remoteIdentifier nonce:[NSUUID UUID]];
         NSData *contentData = message.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3620,7 +3620,7 @@
         conversation.remoteIdentifier = [NSUUID createUUID];
         [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         
-        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = message.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3665,7 +3665,7 @@
         [self.syncMOC.zm_fileAssetCache storeAssetData:message format:ZMImageFormatMedium encrypted:YES data:imageData];
         
         // delete
-        ZMGenericMessage *deleteMessage = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *deleteMessage = [ZMGenericMessage messageWithHideMessage:messageID inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = deleteMessage.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3717,7 +3717,7 @@
         [self.syncMOC.zm_fileAssetCache storeAssetData:message encrypted:YES data:fileData];
         
         // delete
-        ZMGenericMessage *deleteMessage = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *deleteMessage = [ZMGenericMessage messageWithHideMessage:messageID inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = deleteMessage.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3756,7 +3756,7 @@
         [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:[NSUUID createUUID] fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
-        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:[NSUUID createUUID].transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:[NSUUID createUUID] inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = message.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3792,7 +3792,7 @@
         [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
-        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = message.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         
@@ -3828,7 +3828,7 @@
         [conversation appendOTRMessageWithText:@"Le fromage c'est delicieux" nonce:messageID fetchLinkPreview:YES];
         NSUInteger previusMessagesCount = conversation.messages.count;
         
-        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID.transportString inConversation:conversation.remoteIdentifier.transportString nonce:[NSUUID createUUID].transportString];
+        ZMGenericMessage *message = [ZMGenericMessage messageWithHideMessage:messageID inConversation:conversation.remoteIdentifier nonce:[NSUUID createUUID]];
         NSData *contentData = message.data;
         NSString *data = [contentData base64EncodedStringWithOptions:0];
         

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -201,7 +201,7 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
             return ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: nonce)!
         default:
             let streamPayload = ["payload" : [payload],
-                                 "id" : UUID.create().transportString()] as [String : Any]
+                                 "id" : UUID.create()] as [String : Any]
             let event = ZMUpdateEvent.eventsArray(from: streamPayload as ZMTransportData,
                                                                    source: eventSource)!.first!
             XCTAssertNotNil(event)

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTest+Encryption.swift
@@ -88,7 +88,7 @@ class ZMAssetClientMessageTests_Encryption : BaseZMAssetClientMessageTests {
             
             // when
             let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!.transportString()))
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!))
             
             // then
             guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
@@ -130,7 +130,7 @@ class ZMAssetClientMessageTests_Encryption : BaseZMAssetClientMessageTests {
             
             // when
             let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!.transportString()))
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!))
             
             // then
             guard let (encryptedData, _) = sut.encryptedMessagePayloadForDataType(.fullAsset) else { return XCTFail() }
@@ -198,7 +198,7 @@ extension ZMAssetClientMessageTests_Encryption {
     func insertFileMessage() -> ZMAssetClientMessage{
         let sut = syncConversation.appendOTRMessage(with: addFile(), nonce: UUID.create())!
         let (otrKey, sha256) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!.transportString(), expiresAfter: NSNumber(value: sut.deletionTimeout)))
+        sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!, expiresAfter: NSNumber(value: sut.deletionTimeout)))
         return sut
     }
     

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -71,7 +71,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
     
     func assetWithImage() -> ZMAsset {
         let original = ZMAssetOriginal.original(withSize: 1000, mimeType: "image", name: "foo")
-        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: UUID.create(), assetToken: UUID.create())
+        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: "id", assetToken: "token")
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 30, height: 40)
         let imageMetaDataBuilder = imageMetaData.toBuilder()!
         imageMetaDataBuilder.setTag("bar")

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -71,7 +71,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
     
     func assetWithImage() -> ZMAsset {
         let original = ZMAssetOriginal.original(withSize: 1000, mimeType: "image", name: "foo")
-        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: "assetID", assetToken: "assetToken")
+        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: UUID.create(), assetToken: UUID.create())
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 30, height: 40)
         let imageMetaDataBuilder = imageMetaData.toBuilder()!
         imageMetaDataBuilder.setTag("bar")
@@ -83,7 +83,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
     
     func thumbnailEvent(for message: ZMAssetClientMessage) -> ZMUpdateEvent {
         let payload : [String : Any] = [
-            "id": UUID.create().transportString(),
+            "id": UUID.create(),
             "conversation": conversation.remoteIdentifier!.transportString(),
             "from": selfUser.remoteIdentifier!.transportString(),
             "time": Date().transportString(),
@@ -103,7 +103,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         // when
         let message = conversation.appendMessage(with: fileMetadata) as! ZMAssetClientMessage
         
-        let remoteMessage = ZMGenericMessage.genericMessage(pbMessage: assetWithImage(), messageID: message.nonce!.transportString())
+        let remoteMessage = ZMGenericMessage.genericMessage(pbMessage: assetWithImage(), messageID: message.nonce!)
         
         let event = thumbnailEvent(for: message)
         message.update(with: remoteMessage, updateEvent: event, initialUpdate: true)
@@ -230,7 +230,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.addFile()
         let message = conversation.appendMessage(with: fileMetadata) as! ZMAssetClientMessage
         message.sender = sender
-        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!.transportString()))
+        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!))
         XCTAssertTrue(message.genericAssetMessage!.assetData!.hasUploaded())
         
         // when
@@ -254,10 +254,10 @@ extension ZMAssetClientMessageTests_Ephemeral {
         message.visibleInConversation = conversation
         
         let imageData = verySmallJPEGData()
-        let assetMessage = ZMGenericMessage.genericMessage(withImageSize: CGSize.zero, mimeType: "", size: UInt64(imageData.count), nonce: nonce.transportString(), expiresAfter: 10)
+        let assetMessage = ZMGenericMessage.genericMessage(withImageSize: CGSize.zero, mimeType: "", size: UInt64(imageData.count), nonce: nonce, expiresAfter: 10)
         message.add(assetMessage)
         
-        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key(), messageID: message.nonce!.transportString(), expiresAfter: NSNumber(value: conversation.messageDestructionTimeout))
+        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key(), messageID: message.nonce!, expiresAfter: NSNumber(value: conversation.messageDestructionTimeout))
         message.add(uploaded)
         message.setImageData(imageData, for: .medium, properties: nil)
         
@@ -283,7 +283,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let imageMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties,
                                                            processedImageProperties: properties,
                                                            encryptionKeys: keys,
-                                                           nonce: UUID.create().transportString(),
+                                                           nonce: UUID.create(),
                                                            format: .preview)
         message.add(imageMessage)
         return message
@@ -339,7 +339,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.addFile()
         let message = conversation.appendMessage(with: fileMetadata) as! ZMAssetClientMessage
         message.sender = sender
-        message.add(ZMGenericMessage.genericMessage(notUploaded: ZMAssetNotUploaded.CANCELLED, messageID: message.nonce!.transportString()))
+        message.add(ZMGenericMessage.genericMessage(notUploaded: ZMAssetNotUploaded.CANCELLED, messageID: message.nonce!))
         XCTAssertTrue(message.genericAssetMessage!.assetData!.hasNotUploaded())
         
         // when
@@ -356,7 +356,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         conversation.messageDestructionTimeout = timeout
         let fileMetadata = self.addFile()
         let message = conversation.appendMessage(with: fileMetadata) as! ZMAssetClientMessage
-        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!.transportString()))
+        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!))
         XCTAssertTrue(message.genericAssetMessage!.assetData!.hasUploaded())
         
         // when
@@ -376,7 +376,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         conversation.conversationType = .oneOnOne
         message.sender = ZMUser.insertNewObject(in: uiMOC)
         message.sender?.remoteIdentifier = UUID.create()
-        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!.transportString()))
+        message.add(ZMGenericMessage.genericMessage(withUploadedOTRKey: Data(), sha256: Data(), messageID: message.nonce!))
         XCTAssertTrue(message.genericAssetMessage!.assetData!.hasUploaded())
         
         // when

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -56,10 +56,10 @@ class BaseZMAssetClientMessageTests : BaseZMClientMessageTests {
         
         let keys = ZMImageAssetEncryptionKeys(otrKey: Data.randomEncryptionKey(), macKey: Data.zmRandomSHA256Key(), mac: Data.zmRandomSHA256Key())
         
-        let mediumMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce.transportString(), format: .medium)
+        let mediumMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce, format: .medium)
         message.add(mediumMessage)
         
-        let previewMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce.transportString(), format: .preview)
+        let previewMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce, format: .preview)
         message.add(previewMessage)
     }
     
@@ -71,7 +71,7 @@ class BaseZMAssetClientMessageTests : BaseZMClientMessageTests {
         let uploaded = ZMGenericMessage.genericMessage(
             withUploadedOTRKey: .randomEncryptionKey(),
             sha256: .zmRandomSHA256Key(),
-            messageID: nonce.transportString()
+            messageID: nonce
         )
 
         message.add(uploaded)
@@ -162,7 +162,7 @@ class ZMAssetClientMessageTests : BaseZMAssetClientMessageTests {
         self.uiMOC.zm_fileAssetCache.deleteAssetData(message, format: ZMImageFormat.medium, encrypted: false)
         
         let imageProperties = ZMIImageProperties(size: ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData), length: UInt(imageData.count), mimeType: "image/jpeg")
-        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!.transportString(), format: ZMImageFormat.medium))
+        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!, format: ZMImageFormat.medium))
         
         // when
         XCTAssertNotNil(message.imageAssetStorage.updateMessage(imageData: encryptedImageData, for: ZMImageFormat.medium))
@@ -190,7 +190,7 @@ class ZMAssetClientMessageTests : BaseZMAssetClientMessageTests {
 
         
         let imageProperties = ZMIImageProperties(size: ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData), length: UInt(imageData.count), mimeType: "image/jpeg")
-        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!.transportString(), format: ZMImageFormat.medium))
+        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!, format: ZMImageFormat.medium))
         
         // when
         //pass in some wrong data (i.e. plain data instead of encrypted)
@@ -216,7 +216,7 @@ class ZMAssetClientMessageTests : BaseZMAssetClientMessageTests {
         self.uiMOC.zm_fileAssetCache.deleteAssetData(message, format: ZMImageFormat.medium, encrypted: false)
         
         let imageProperties = ZMIImageProperties(size: ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData), length: UInt(imageData.count), mimeType: "image/jpeg")
-        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!.transportString(), format: ZMImageFormat.medium))
+        message.add(ZMGenericMessage.genericMessage(mediumImageProperties: imageProperties, processedImageProperties: imageProperties, encryptionKeys: keys, nonce: message.nonce!, format: ZMImageFormat.medium))
         
         // when
         XCTAssertNotNil(message.imageAssetStorage.updateMessage(imageData: encryptedImageData, for: ZMImageFormat.medium))
@@ -420,7 +420,7 @@ extension ZMAssetClientMessageTests {
             remoteData: ZMAssetRemoteData.remoteData(withOTRKey: otrKey, sha256: sha256),
             imageMetaData: builder.build()!)
         let previewAsset = ZMAsset.asset(preview: preview)
-        let previewMessage = ZMGenericMessage.genericMessage(asset: previewAsset, messageID: nonce.transportString())
+        let previewMessage = ZMGenericMessage.genericMessage(asset: previewAsset, messageID: nonce)
 
         
         // when
@@ -453,7 +453,7 @@ extension ZMAssetClientMessageTests {
         // when
         let originalMessage = ZMGenericMessage.genericMessage(
             asset: .asset(withOriginal: .original(withSize: 256, mimeType: mimeType, name: name)),
-            messageID: nonce.transportString()
+            messageID: nonce
         )
         sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
@@ -474,8 +474,8 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
-        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: UUID.create(), token: UUID.create())
         sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -492,7 +492,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
         sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -509,7 +509,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce.transportString())
+        let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce)
         sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -527,10 +527,10 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
-        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "123456789", token: "token")
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: UUID.create(), token: UUID.create())
         sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
-        let canceledMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce.transportString())
+        let canceledMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce)
         sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -547,7 +547,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertNotNil(sut)
         
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .FAILED, messageID: nonce.transportString())
+        let originalMessage = ZMGenericMessage.genericMessage(notUploaded: .FAILED, messageID: nonce)
         sut.update(with: originalMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -573,7 +573,7 @@ extension ZMAssetClientMessageTests {
         let payload = self.payloadForMessage(in: conversation, type: EventConversationAddOTRAsset, data: dataPayload)
         let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload!, uuid: UUID.create())
         // when
-        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce.transportString())
+        let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
         sut.update(with: originalMessage, updateEvent: updateEvent, initialUpdate: true)
         
         // then
@@ -600,7 +600,7 @@ extension ZMAssetClientMessageTests {
             // when
             let otrKey = Data.randomEncryptionKey()
             let sha256 = Data.zmRandomSHA256Key()
-            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!.transportString()))
+            sut.add(.genericMessage(withUploadedOTRKey: otrKey, sha256: sha256, messageID: sut.nonce!))
             
             // then
             XCTAssertNotNil(sut)
@@ -637,7 +637,7 @@ extension ZMAssetClientMessageTests {
             sut.add(ZMGenericMessage.genericMessage(
                 withUploadedOTRKey: .randomEncryptionKey(),
                 sha256: .zmRandomSHA256Key(),
-                messageID: sut.nonce!.transportString()
+                messageID: sut.nonce!
                 )
             )
             
@@ -654,7 +654,7 @@ extension ZMAssetClientMessageTests {
         // given
         let sut = ZMAssetClientMessage(nonce: .create(), managedObjectContext: uiMOC)
         sut.sender = selfUser
-        let original = ZMGenericMessage.genericMessage(asset: .asset(withOriginal: .original(withSize: 256, mimeType: "text/plain", name: name)), messageID: sut.nonce!.transportString())
+        let original = ZMGenericMessage.genericMessage(asset: .asset(withOriginal: .original(withSize: 256, mimeType: "text/plain", name: name)), messageID: sut.nonce!)
         sut.add(original)
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertNotNil(sut.fileMessageData)
@@ -789,7 +789,7 @@ extension ZMAssetClientMessageTests {
             let sut = ZMAssetClientMessage(nonce: .create(), managedObjectContext: syncMOC)
             sut.sender = ZMUser.selfUser(in: syncMOC)
             sut.visibleInConversation = syncConversation
-            let original = ZMGenericMessage.genericMessage(asset: .asset(withOriginal: .original(withSize: 256, mimeType: "text/plain", name: self.name)), messageID: sut.nonce!.transportString())
+            let original = ZMGenericMessage.genericMessage(asset: .asset(withOriginal: .original(withSize: 256, mimeType: "text/plain", name: self.name)), messageID: sut.nonce!)
             sut.add(original)
             XCTAssertNotNil(sut.fileMessageData)
             XCTAssertTrue(self.syncMOC.saveOrRollback())
@@ -881,11 +881,11 @@ extension ZMAssetClientMessageTests {
             let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
             let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
             
-            let uuid = UUID.create().transportString()
+            let uuid = UUID.create()
             let sut = appendFileMessage(to: syncConversation)!
             
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))
-            sut.add(ZMGenericMessage.genericMessage(asset: asset, messageID: "\(sut.nonce!)"))
+            sut.add(ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!))
             
             XCTAssertNil(sut.fileMessageData?.thumbnailAssetID)
             
@@ -911,15 +911,15 @@ extension ZMAssetClientMessageTests {
             let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
             let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
             
-            let uuid = UUID.create().transportString()
+            let uuid = UUID.create()
             let sut = appendFileMessage(to: syncConversation)!
             
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))
-            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "\(sut.nonce!)")
+            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!)
             let payload : [String : AnyObject] = [
                 "type" : "conversation.otr-asset-add" as AnyObject,
                 "data" : [
-                    "id" : uuid
+                    "id" : uuid.transportString()
                 ] as AnyObject
             ]
             let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID.create())
@@ -955,11 +955,11 @@ extension ZMAssetClientMessageTests {
             builder.mergePreview(assetWithPreview.preview)
             let asset = builder.build()!
             
-            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "\(sut.nonce!)")
+            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!)
             let payload : [String : AnyObject] = [
                 "type" : "conversation.otr-asset-add" as AnyObject,
                 "data" : [
-                    "id" : UUID.create().transportString()
+                    "id" : UUID.create().uuidString
                 ] as AnyObject
             ]
             let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID.create())
@@ -986,7 +986,7 @@ extension ZMAssetClientMessageTests {
         let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
         
-        let uuid = UUID.create().transportString()
+        let uuid = UUID.create()
         let sut = appendFileMessage(to: conversation)!
         
         XCTAssertFalse(sut.genericAssetMessage!.asset.hasPreview())
@@ -999,7 +999,7 @@ extension ZMAssetClientMessageTests {
         self.syncMOC.performAndWait {
             let sutInSyncContext = self.syncMOC.object(with: sut.objectID) as! ZMAssetClientMessage
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))
-            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "\(sut.nonce!)")
+            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!)
             let payload : [String : AnyObject] = [
                 "type" : "conversation.otr-asset-add" as AnyObject,
                 "data" : [
@@ -1188,7 +1188,7 @@ extension ZMAssetClientMessageTests {
                 mediumImageProperties: storeProcessed ? self.sampleImageProperties(.medium) : nil,
                 processedImageProperties: storeProcessed ? self.sampleImageProperties(format) : nil,
                 encryptionKeys: storeEncrypted ? encryptionKeys : nil,
-                nonce: nonce.transportString(),
+                nonce: nonce,
                 format: format)
             
             if (storeProcessed) {
@@ -1599,7 +1599,7 @@ extension ZMAssetClientMessageTests {
             let nonce = UUID.create()
             let imageData = self.verySmallJPEGData()
             let assetId = format == .medium ? mediumAssetId : previewAssetId
-            let genericMessage = ZMGenericMessage.genericMessage(imageData: imageData, format: format, nonce: nonce.transportString())
+            let genericMessage = ZMGenericMessage.genericMessage(imageData: imageData, format: format, nonce: nonce)
             let dataPayload = [
                 "info" : genericMessage.data().base64String(),
                 "id" : assetId.transportString()
@@ -1636,7 +1636,7 @@ extension ZMAssetClientMessageTests {
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
         let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: 256, mimeType: "video/mp4", remoteData: remoteData, imageMetaData: imageMetaData))
         
-        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce.transportString())
+        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce)
         
         let dataPayload = [
             "info" : genericMessage.data().base64String(),
@@ -1658,7 +1658,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.conversation?.remoteIdentifier, conversation.remoteIdentifier)
         XCTAssertEqual(sut.sender?.remoteIdentifier!.transportString(), payload["from"] as? String)
         XCTAssertEqual(sut.serverTimestamp?.transportString(), payload["time"] as? String)
-        XCTAssertEqual(sut.fileMessageData?.thumbnailAssetID, thumbnailId.transportString())
+        XCTAssertEqual(sut.fileMessageData?.thumbnailAssetID, thumbnailId)
         XCTAssertEqual(sut.nonce, nonce)
         XCTAssertNotNil(sut.fileMessageData)
     }
@@ -1676,7 +1676,7 @@ extension ZMAssetClientMessageTests {
             let firstDate = Date(timeIntervalSince1970: 12334)
             let secondDate = firstDate.addingTimeInterval(234444)
             
-            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce.transportString())
+            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce)
             
             let dataPayload = [
                 "info" : genericMessage.data().base64String(),
@@ -1712,7 +1712,7 @@ extension ZMAssetClientMessageTests {
             let firstDate = Date(timeIntervalSince1970: 12334)
             let secondDate = firstDate.addingTimeInterval(234444)
             
-            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce.transportString())
+            let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: nonce)
             
             let dataPayload = [
                 "info" : genericMessage.data().base64String(),
@@ -1854,7 +1854,7 @@ extension ZMAssetClientMessageTests {
             message.expire()
         }
         if state == .delivered {
-            let genericMessage = ZMGenericMessage(confirmation: message.nonce!.transportString(), type: .DELIVERED, nonce: UUID.create().transportString())
+            let genericMessage = ZMGenericMessage(confirmation: message.nonce!, type: .DELIVERED, nonce: UUID.create())
             _ = ZMMessageConfirmation.createOrUpdateMessageConfirmation(genericMessage, conversation: message.conversation!, sender: message.sender!)
             message.managedObjectContext?.saveOrRollback()
         }
@@ -1870,14 +1870,14 @@ extension ZMAssetClientMessageTests {
 
 extension ZMAssetClientMessageTests {
 
-    typealias PreviewMeta = (otr: Data, sha: Data, assetId: String?, token: String?)
+    typealias PreviewMeta = (otr: Data, sha: Data, assetId: UUID?, token: UUID?)
 
-    private func originalGenericMessage(nonce: String, image: ZMAssetImageMetaData? = nil, preview: ZMAssetPreview? = nil, mimeType: String = "image/jpg", name: String? = nil) -> ZMGenericMessage {
+    private func originalGenericMessage(nonce: UUID, image: ZMAssetImageMetaData? = nil, preview: ZMAssetPreview? = nil, mimeType: String = "image/jpg", name: String? = nil) -> ZMGenericMessage {
         let asset = ZMAsset.asset(withOriginal: .original(withSize: 128, mimeType: mimeType, name: name, imageMetaData: image), preview: preview)
         return ZMGenericMessage.genericMessage(asset: asset, messageID: nonce)
     }
 
-    private func uploadedGenericMessage(nonce: String, otr: Data = .randomEncryptionKey(), sha: Data = .zmRandomSHA256Key(), assetId: String? = UUID.create().transportString(), token: String? = UUID.create().transportString()) -> ZMGenericMessage {
+    private func uploadedGenericMessage(nonce: UUID, otr: Data = .randomEncryptionKey(), sha: Data = .zmRandomSHA256Key(), assetId: UUID? = UUID.create(), token: UUID? = UUID.create()) -> ZMGenericMessage {
 
         let assetBuilder = ZMAsset.builder()!
         let remoteBuilder = ZMAssetRemoteData.builder()!
@@ -1885,17 +1885,17 @@ extension ZMAssetClientMessageTests {
         _ = remoteBuilder.setOtrKey(otr)
         _ = remoteBuilder.setSha256(sha)
         if let assetId = assetId {
-            _ = remoteBuilder.setAssetId(assetId)
+            _ = remoteBuilder.setAssetId(assetId.transportString())
         }
         if let token = token {
-            _ = remoteBuilder.setAssetToken(token)
+            _ = remoteBuilder.setAssetToken(token.transportString())
         }
 
         assetBuilder.setUploaded(remoteBuilder)
         return ZMGenericMessage.genericMessage(asset: assetBuilder.build(), messageID: nonce)
     }
 
-    func previewGenericMessage(with nonce: String, assetId: String? = UUID.create().transportString(), token: String? = UUID.create().transportString(), otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
+    func previewGenericMessage(with nonce: UUID, assetId: UUID? = UUID.create(), token: UUID? = UUID.create(), otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
         let assetBuilder = ZMAsset.builder()
         let previewBuilder = ZMAssetPreview.builder()
         let remoteBuilder = ZMAssetRemoteData.builder()
@@ -1903,10 +1903,10 @@ extension ZMAssetClientMessageTests {
         _ = remoteBuilder?.setOtrKey(otr)
         _ = remoteBuilder?.setSha256(sha)
         if let assetId = assetId {
-            _ = remoteBuilder?.setAssetId(assetId)
+            _ = remoteBuilder?.setAssetId(assetId.transportString())
         }
         if let token = token {
-            _ = remoteBuilder?.setAssetToken(token)
+            _ = remoteBuilder?.setAssetToken(token.transportString())
         }
         _ = previewBuilder?.setSize(512)
         _ = previewBuilder?.setMimeType("image/jpg")
@@ -1932,7 +1932,7 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
+        let uploaded = uploadedGenericMessage(nonce: nonce)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
@@ -1944,7 +1944,7 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let (preview, _) = previewGenericMessage(with: nonce.transportString())
+        let (preview, _) = previewGenericMessage(with: nonce)
         sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
@@ -1956,7 +1956,7 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString(), assetId: nil, token: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce, assetId: nil, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
@@ -1968,7 +1968,7 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let (preview, _) = previewGenericMessage(with: nonce.transportString(), assetId: nil, token: nil)
+        let (preview, _) = previewGenericMessage(with: nonce, assetId: nil, token: nil)
         sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: true)
 
         // then
@@ -1980,11 +1980,11 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let assetId = UUID.create().transportString()
+        let assetId = UUID.create()
         let assetData = Data.secureRandomData(length: 512)
 
-        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), name: "document.pdf"), updateEvent: ZMUpdateEvent(), initialUpdate: true)
-        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: originalGenericMessage(nonce: nonce, name: "document.pdf"), updateEvent: ZMUpdateEvent(), initialUpdate: true)
+        sut.update(with: uploadedGenericMessage(nonce: nonce, assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_fileAssetCache.storeAssetData(sut, encrypted: false, data: assetData)
 
 
@@ -1999,11 +1999,11 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let assetId = UUID.create().transportString()
+        let assetId = UUID.create()
         let assetData = Data.secureRandomData(length: 512)
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        sut.update(with: originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil), updateEvent: ZMUpdateEvent(), initialUpdate: false)
-        sut.update(with: uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: originalGenericMessage(nonce: nonce, image: image, preview: nil), updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploadedGenericMessage(nonce: nonce, assetId: assetId), updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_fileAssetCache.storeAssetData(sut, format: .medium, encrypted: false, data: assetData)
 
         // then
@@ -2017,8 +2017,8 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        let original = originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil)
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
+        let original = originalGenericMessage(nonce: nonce, image: image, preview: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce)
 
         // when
         sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
@@ -2035,11 +2035,11 @@ extension ZMAssetClientMessageTests {
     func testThatItReturnsAValidImageDataIdentifierEqualToTheCacheKeyOfTheAsset() {
         // given
         let (sut, nonce) = createMessageWithNonce()
-        let assetId = UUID.create().transportString()
+        let assetId = UUID.create()
 
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        let original = originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil)
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString(), assetId: assetId)
+        let original = originalGenericMessage(nonce: nonce, image: image, preview: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce, assetId: assetId)
 
         // when
         sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
@@ -2054,7 +2054,7 @@ extension ZMAssetClientMessageTests {
         let (sut, nonce) = createMessageWithNonce()
 
         // when
-        let (preview, previewMeta) = previewGenericMessage(with: nonce.transportString())
+        let (preview, previewMeta) = previewGenericMessage(with: nonce)
         sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: false)
 
         // then
@@ -2067,7 +2067,7 @@ extension ZMAssetClientMessageTests {
 
         // when
         let previewData = Data.secureRandomData(length: 512)
-        let (preview, _) = previewGenericMessage(with: nonce.transportString())
+        let (preview, _) = previewGenericMessage(with: nonce)
         sut.update(with: preview, updateEvent: ZMUpdateEvent(), initialUpdate: false)
         uiMOC.zm_fileAssetCache.storeAssetData(sut, format: .medium, encrypted: false, data: previewData)
 
@@ -2084,8 +2084,8 @@ extension ZMAssetClientMessageTests {
 
         let data = verySmallJPEGData()
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        let original = originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil)
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
+        let original = originalGenericMessage(nonce: nonce, image: image, preview: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce)
 
         // when
         sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
@@ -2105,8 +2105,8 @@ extension ZMAssetClientMessageTests {
         // given
         let (sut, nonce) = createMessageWithNonce()
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
-        let original = originalGenericMessage(nonce: nonce.transportString(), image: image, preview: nil)
-        let uploaded = uploadedGenericMessage(nonce: nonce.transportString())
+        let original = originalGenericMessage(nonce: nonce, image: image, preview: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce)
 
         // when
         sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -475,7 +475,7 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
-        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: UUID.create(), token: UUID.create())
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "id", token: "token")
         sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         // then
@@ -528,7 +528,7 @@ extension ZMAssetClientMessageTests {
         
         // when
         let originalMessage = ZMGenericMessage.genericMessage(withUploadedOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key(), messageID: nonce)
-        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: UUID.create(), token: UUID.create())
+        let uploadedMessage = originalMessage.updatedUploaded(withAssetId: "id", token: "token")
         sut.update(with: uploadedMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         let canceledMessage = ZMGenericMessage.genericMessage(notUploaded: .CANCELLED, messageID: nonce)
         sut.update(with: canceledMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
@@ -881,7 +881,7 @@ extension ZMAssetClientMessageTests {
             let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
             let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
             
-            let uuid = UUID.create()
+            let uuid = "asset_id"
             let sut = appendFileMessage(to: syncConversation)!
             
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))
@@ -911,7 +911,7 @@ extension ZMAssetClientMessageTests {
             let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
             let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
             
-            let uuid = UUID.create()
+            let uuid = "uuid"
             let sut = appendFileMessage(to: syncConversation)!
             
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))
@@ -919,7 +919,7 @@ extension ZMAssetClientMessageTests {
             let payload : [String : AnyObject] = [
                 "type" : "conversation.otr-asset-add" as AnyObject,
                 "data" : [
-                    "id" : uuid.transportString()
+                    "id" : uuid
                 ] as AnyObject
             ]
             let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID.create())
@@ -1631,7 +1631,7 @@ extension ZMAssetClientMessageTests {
         let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let nonce = UUID.create()
-        let thumbnailId = UUID.create()
+        let thumbnailId = "uuid"
         let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
         let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: 256, mimeType: "video/mp4", remoteData: remoteData, imageMetaData: imageMetaData))
@@ -1640,7 +1640,7 @@ extension ZMAssetClientMessageTests {
         
         let dataPayload = [
             "info" : genericMessage.data().base64String(),
-            "id" : thumbnailId.transportString()
+            "id" : thumbnailId
         ] as [String : Any]
         
         let payload = self.payloadForMessage(in: conversation, type: EventConversationAddOTRAsset, data: dataPayload)!
@@ -1870,7 +1870,7 @@ extension ZMAssetClientMessageTests {
 
 extension ZMAssetClientMessageTests {
 
-    typealias PreviewMeta = (otr: Data, sha: Data, assetId: UUID?, token: UUID?)
+    typealias PreviewMeta = (otr: Data, sha: Data, assetId: String?, token: String?)
 
     private func originalGenericMessage(nonce: UUID, image: ZMAssetImageMetaData? = nil, preview: ZMAssetPreview? = nil, mimeType: String = "image/jpg", name: String? = nil) -> ZMGenericMessage {
         let asset = ZMAsset.asset(withOriginal: .original(withSize: 128, mimeType: mimeType, name: name, imageMetaData: image), preview: preview)
@@ -1895,7 +1895,7 @@ extension ZMAssetClientMessageTests {
         return ZMGenericMessage.genericMessage(asset: assetBuilder.build(), messageID: nonce)
     }
 
-    func previewGenericMessage(with nonce: UUID, assetId: UUID? = UUID.create(), token: UUID? = UUID.create(), otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
+    func previewGenericMessage(with nonce: UUID, assetId: String? = UUID.create().transportString(), token: String? = UUID.create().transportString(), otr: Data = .randomEncryptionKey(), sha: Data = .randomEncryptionKey()) -> (ZMGenericMessage, PreviewMeta) {
         let assetBuilder = ZMAsset.builder()
         let previewBuilder = ZMAssetPreview.builder()
         let remoteBuilder = ZMAssetRemoteData.builder()
@@ -1903,10 +1903,10 @@ extension ZMAssetClientMessageTests {
         _ = remoteBuilder?.setOtrKey(otr)
         _ = remoteBuilder?.setSha256(sha)
         if let assetId = assetId {
-            _ = remoteBuilder?.setAssetId(assetId.transportString())
+            _ = remoteBuilder?.setAssetId(assetId)
         }
         if let token = token {
-            _ = remoteBuilder?.setAssetToken(token.transportString())
+            _ = remoteBuilder?.setAssetToken(token)
         }
         _ = previewBuilder?.setSize(512)
         _ = previewBuilder?.setMimeType("image/jpg")

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -881,7 +881,7 @@ extension ZMAssetClientMessageTests {
             let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data.zmRandomSHA256Key(), sha256: Data.zmRandomSHA256Key())
             let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 4235, height: 324)
             
-            let uuid = "asset_id"
+            let uuid = "asset-id"
             let sut = appendFileMessage(to: syncConversation)!
             
             let asset = ZMAsset.asset(withOriginal: nil, preview: ZMAssetPreview.preview(withSize: previewSize, mimeType: previewMimeType, remoteData: remoteData, imageMetaData: imageMetaData))

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -75,7 +75,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         cache.storeAssetData(sut, format: .medium, encrypted: true, data: mediumJPEGData())
         
         // expect
-        let assetId = UUID.create()
+        let assetId = "asset_id"
         let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         let observer = AssetDeletionNotificationObserver()
@@ -91,7 +91,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         
         // then
         assertDeletedContent(ofMessage: sut, inConversation: conversation)
-        XCTAssertEqual(observer.deletedIdentifiers, [assetId.transportString()])
+        XCTAssertEqual(observer.deletedIdentifiers, [assetId])
         wipeCaches()
     }
     
@@ -116,11 +116,11 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         XCTAssertNotNil(cache.assetData(sut, encrypted: false))
         
         // expect
-        let assetId = UUID.create()
+        let assetId = "asset_id"
         let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
-        let previewAssetId = UUID.create()
+        let previewAssetId = "preview_assetId"
         let remote = ZMAssetRemoteData.remoteData(withOTRKey: .init(), sha256: .init(), assetId: previewAssetId, assetToken: nil)
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 1024, height: 1024)
         let preview = ZMAssetPreview.preview(withSize: 256, mimeType: "image/png", remoteData: remote, imageMetaData: image)
@@ -142,8 +142,8 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         // then
         assertDeletedContent(ofMessage: sut, inConversation: conversation, fileName: "file.dat")
         XCTAssertEqual(observer.deletedIdentifiers.count, 2)
-        XCTAssert(observer.deletedIdentifiers.contains(assetId.transportString()))
-        XCTAssert(observer.deletedIdentifiers.contains(previewAssetId.transportString()))
+        XCTAssert(observer.deletedIdentifiers.contains(assetId))
+        XCTAssert(observer.deletedIdentifiers.contains(previewAssetId))
         wipeCaches()
     }
     

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -75,7 +75,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         cache.storeAssetData(sut, format: .medium, encrypted: true, data: mediumJPEGData())
         
         // expect
-        let assetId = "asset_id"
+        let assetId = "asset-id"
         let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         let observer = AssetDeletionNotificationObserver()
@@ -116,7 +116,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         XCTAssertNotNil(cache.assetData(sut, encrypted: false))
         
         // expect
-        let assetId = "asset_id"
+        let assetId = "asset-id"
         let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -75,8 +75,8 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         cache.storeAssetData(sut, format: .medium, encrypted: true, data: mediumJPEGData())
         
         // expect
-        let assetId = UUID.create().transportString()
-        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!.transportString()).updatedUploaded(withAssetId: assetId, token: nil)
+        let assetId = UUID.create()
+        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         let observer = AssetDeletionNotificationObserver()
         
@@ -91,7 +91,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         
         // then
         assertDeletedContent(ofMessage: sut, inConversation: conversation)
-        XCTAssertEqual(observer.deletedIdentifiers, [assetId])
+        XCTAssertEqual(observer.deletedIdentifiers, [assetId.transportString()])
         wipeCaches()
     }
     
@@ -116,16 +116,16 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         XCTAssertNotNil(cache.assetData(sut, encrypted: false))
         
         // expect
-        let assetId = UUID.create().transportString()
-        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!.transportString()).updatedUploaded(withAssetId: assetId, token: nil)
+        let assetId = UUID.create()
+        let uploaded = ZMGenericMessage.genericMessage(withUploadedOTRKey: .init(), sha256: .init(), messageID: sut.nonce!).updatedUploaded(withAssetId: assetId, token: nil)
         sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
-        let previewAssetId = UUID.create().transportString()
+        let previewAssetId = UUID.create()
         let remote = ZMAssetRemoteData.remoteData(withOTRKey: .init(), sha256: .init(), assetId: previewAssetId, assetToken: nil)
         let image = ZMAssetImageMetaData.imageMetaData(withWidth: 1024, height: 1024)
         let preview = ZMAssetPreview.preview(withSize: 256, mimeType: "image/png", remoteData: remote, imageMetaData: image)
         let asset = ZMAsset.asset(withOriginal: nil, preview: preview)
-        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!.transportString())
+        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: sut.nonce!)
         sut.update(with: genericMessage, updateEvent: ZMUpdateEvent(), initialUpdate: true)
         
         let observer = AssetDeletionNotificationObserver()
@@ -142,8 +142,8 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         // then
         assertDeletedContent(ofMessage: sut, inConversation: conversation, fileName: "file.dat")
         XCTAssertEqual(observer.deletedIdentifiers.count, 2)
-        XCTAssert(observer.deletedIdentifiers.contains(assetId))
-        XCTAssert(observer.deletedIdentifiers.contains(previewAssetId))
+        XCTAssert(observer.deletedIdentifiers.contains(assetId.transportString()))
+        XCTAssert(observer.deletedIdentifiers.contains(previewAssetId.transportString()))
         wipeCaches()
     }
     
@@ -260,7 +260,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         // given
         let conversation = ZMConversation.insertNewObject(in:uiMOC)
         let nonce = UUID.create()
-        let deletedMessage = ZMGenericMessage(deleteMessage: nonce.transportString(), nonce: UUID().transportString())
+        let deletedMessage = ZMGenericMessage(deleteMessage: nonce, nonce: UUID())
         
         // when
         let sut = conversation.appendClientMessage(with: deletedMessage, expires: false, hidden: true)!
@@ -446,7 +446,7 @@ extension ZMClientMessageTests_Deletion {
         assertDeletedContent(ofMessage: sut as! ZMOTRMessage, inConversation: conversation)
 
         //when
-        let genericMessage = ZMGenericMessage.message(text: name!, nonce: nonce.transportString())
+        let genericMessage = ZMGenericMessage.message(text: name!, nonce: nonce)
         let nextEvent = createUpdateEvent(nonce, conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.messageUpdateResult(from: nextEvent, in: self.uiMOC, prefetchResult: nil)
@@ -501,7 +501,7 @@ extension ZMClientMessageTests_Deletion {
 extension ZMClientMessageTests_Deletion {
 
     func createMessageDeletedUpdateEvent(_ nonce: UUID, conversationID: UUID, senderID: UUID = .create()) -> ZMUpdateEvent {
-        let genericMessage = ZMGenericMessage(deleteMessage: nonce.transportString(), nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage(deleteMessage: nonce, nonce: UUID.create())
         return createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: senderID)
     }
     

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -380,7 +380,7 @@
 
 - (ZMUpdateEvent *)createMessageEditUpdateEventWithOldNonce:(NSUUID *)oldNonce newNonce:(NSUUID *)newNonce conversationID:(NSUUID*)conversationID senderID:(NSUUID *)senderID newText:(NSString *)newText
 {
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithEditMessage:oldNonce.transportString newText:newText nonce:newNonce.transportString];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithEditMessage:oldNonce newText:newText nonce:newNonce];
     
     NSDictionary *payload = @{
                    @"conversation": conversationID.transportString,
@@ -397,7 +397,7 @@
 
 - (ZMUpdateEvent *)createTextAddedEventWithNonce:(NSUUID *)nonce conversationID:(NSUUID*)conversationID senderID:(NSUUID *)senderID
 {
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithText:@"Yeah!" nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithText:@"Yeah!" nonce:nonce expiresAfter:nil];
     
     NSDictionary *payload = @{
                               @"conversation": conversationID.transportString,

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
@@ -155,7 +155,7 @@ extension ZMClientMessageTests_Ephemeral {
             article.title = "title"
             article.summary = "summary"
             let linkPreview = article.protocolBuffer.update(withOtrKey: Data(), sha256: Data())
-            let genericMessage = ZMGenericMessage.message(text: "foo", linkPreview: linkPreview, nonce: UUID.create().transportString(), expiresAfter: NSNumber(value: timeout))
+            let genericMessage = ZMGenericMessage.message(text: "foo", linkPreview: linkPreview, nonce: UUID.create(), expiresAfter: NSNumber(value: timeout))
             let message = self.syncConversation.appendClientMessage(with: genericMessage)!
             message.linkPreviewState = .processed
             XCTAssertEqual(message.linkPreviewState, .processed)
@@ -244,7 +244,7 @@ extension ZMClientMessageTests_Ephemeral {
             XCTAssertNil(message.destructionDate)
 
             // when
-            let delete = ZMGenericMessage(deleteMessage: message.nonce!.transportString(), nonce: UUID.create().transportString())
+            let delete = ZMGenericMessage(deleteMessage: message.nonce!, nonce: UUID.create())
             let event = self.createUpdateEvent(UUID.create(), conversationID: self.syncConversation.remoteIdentifier!, genericMessage: delete, senderID: self.syncUser1.remoteIdentifier!, eventSource: .download)
             _ = ZMOTRMessage.messageUpdateResult(from: event, in: self.syncMOC, prefetchResult: nil)
             
@@ -269,7 +269,7 @@ extension ZMClientMessageTests_Ephemeral {
         
         self.syncMOC.performGroupedBlockAndWait {
             // when
-            let delete = ZMGenericMessage(deleteMessage: message.nonce!.transportString(), nonce: UUID.create().transportString())
+            let delete = ZMGenericMessage(deleteMessage: message.nonce!, nonce: UUID.create())
             let event = self.createUpdateEvent(UUID.create(), conversationID: self.syncConversation.remoteIdentifier!, genericMessage: delete, senderID: self.selfUser.remoteIdentifier!, eventSource: .download)
             _ = ZMOTRMessage.messageUpdateResult(from: event, in: self.syncMOC, prefetchResult: nil)
             

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
@@ -33,7 +33,7 @@ class ClientMessageTests_Location: BaseZMMessageTests {
                 longitude: longitude,
                 name: name,
                 zoomLevel: zoom),
-            messageID: UUID.create().transportString()
+            messageID: UUID.create()
         )
         
         // when

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -465,7 +465,7 @@ extension ClientMessageTests_OTR {
             connection.status = .accepted
             conversation.connection = connection
             
-            let genericMessage = ZMGenericMessage.message(text: "yo", nonce: UUID().transportString())
+            let genericMessage = ZMGenericMessage.message(text: "yo", nonce: UUID.create())
             let clientmessage = ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC)
             clientmessage.add(genericMessage.data())
             clientmessage.visibleInConversation = conversation
@@ -488,7 +488,7 @@ extension ClientMessageTests_OTR {
             conversation.remoteIdentifier = UUID.create()
             conversation.mutableLastServerSyncedActiveParticipants.add(self.syncUser1)
             
-            let genericMessage = ZMGenericMessage.message(text: "yo", nonce: UUID().transportString())
+            let genericMessage = ZMGenericMessage.message(text: "yo", nonce: UUID.create())
             let clientmessage = ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC)
             clientmessage.add(genericMessage.data())
             clientmessage.visibleInConversation = conversation

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -42,7 +42,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         )
         article.title = "title"
         article.summary = "summary"
-        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer.update(withOtrKey: Data(), sha256: Data()), nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer.update(withOtrKey: Data(), sha256: Data()), nonce: nonce).data())
         
         // when
         let willHaveAnImage = clientMessage.textMessageData!.hasImageData
@@ -65,7 +65,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         )
         article.title = "title"
         article.summary = "summary"
-        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer, nonce: nonce).data())
         
         // when
         let willHaveAnImage = clientMessage.textMessageData!.hasImageData
@@ -90,7 +90,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         preview.message = name
 
         let updated = preview.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key())
-        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: updated, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: updated, nonce: nonce).data())
         
         // when
         let willHaveAnImage = clientMessage.textMessageData!.hasImageData
@@ -114,7 +114,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         
         preview.author = "Author"
         preview.message = name
-        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: preview.protocolBuffer, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: preview.protocolBuffer, nonce: nonce).data())
         
         // when
         let willHaveAnImage = clientMessage.textMessageData!.hasImageData
@@ -137,16 +137,16 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
 
         article.title = "title"
         article.summary = "summary"
-        let assetKey = "123"
+        let assetKey = UUID.create()
 
         let linkPreview = article.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key()).update(withAssetKey: assetKey, assetToken: nil)
-        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: linkPreview, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: linkPreview, nonce: nonce).data())
         
         // when
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
         
         // then
-        XCTAssertEqual(imageDataIdentifier, assetKey)
+        XCTAssertEqual(imageDataIdentifier, assetKey.transportString())
     }
     
     func testThatItDoesntReturnsImageDataIdentifier_whenArticleHasNoImage() {
@@ -162,7 +162,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         
         article.title = "title"
         article.summary = "summary"
-        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: article.protocolBuffer, nonce: nonce).data())
         
         // when
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
@@ -176,7 +176,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let nonce = UUID.create()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
 
-        let assetKey = "123"
+        let assetKey = UUID.create()
         let twitterStatus = TwitterStatus(
             originalURLString: "example.com/tweet",
             permanentURLString: "http://www.example.com/tweet/1",
@@ -188,14 +188,14 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         twitterStatus.message = name
         
         let linkPreview = twitterStatus.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key()).update(withAssetKey: assetKey, assetToken: nil)
-        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: linkPreview, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: linkPreview, nonce: nonce).data())
         clientMessage.nonce = nonce
         
         // when
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
         
         // then
-        XCTAssertEqual(imageDataIdentifier, assetKey)
+        XCTAssertEqual(imageDataIdentifier, assetKey.transportString())
     }
     
     func testThatItDoesntReturnsImageDataIdentifier_whenTwitterStatusHasNoImage() {
@@ -212,7 +212,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         
         preview.author = "Author"
         preview.message = name
-        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: preview.protocolBuffer, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: preview.protocolBuffer, nonce: nonce).data())
         
         // when
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
@@ -262,8 +262,8 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
         
         let updated = preview.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key())
-        let withID = updated.update(withAssetKey: "ID", assetToken: nil)
-        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: withID, nonce: nonce.transportString()).data())
+        let withID = updated.update(withAssetKey: UUID.create(), assetToken: nil)
+        clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: withID, nonce: nonce).data())
         try! uiMOC.obtainPermanentIDs(for: [clientMessage])
 
         

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -137,7 +137,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
 
         article.title = "title"
         article.summary = "summary"
-        let assetKey = UUID.create()
+        let assetKey = "asset_key"
 
         let linkPreview = article.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key()).update(withAssetKey: assetKey, assetToken: nil)
         clientMessage.add(ZMGenericMessage.message(text: "sample text", linkPreview: linkPreview, nonce: nonce).data())
@@ -146,7 +146,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
         
         // then
-        XCTAssertEqual(imageDataIdentifier, assetKey.transportString())
+        XCTAssertEqual(imageDataIdentifier, assetKey)
     }
     
     func testThatItDoesntReturnsImageDataIdentifier_whenArticleHasNoImage() {
@@ -176,7 +176,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let nonce = UUID.create()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
 
-        let assetKey = UUID.create()
+        let assetKey = "asset_key"
         let twitterStatus = TwitterStatus(
             originalURLString: "example.com/tweet",
             permanentURLString: "http://www.example.com/tweet/1",
@@ -195,7 +195,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let imageDataIdentifier = clientMessage.textMessageData!.imageDataIdentifier
         
         // then
-        XCTAssertEqual(imageDataIdentifier, assetKey.transportString())
+        XCTAssertEqual(imageDataIdentifier, assetKey)
     }
     
     func testThatItDoesntReturnsImageDataIdentifier_whenTwitterStatusHasNoImage() {
@@ -262,7 +262,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
         
         let updated = preview.protocolBuffer.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key())
-        let withID = updated.update(withAssetKey: UUID.create(), assetToken: nil)
+        let withID = updated.update(withAssetKey: "id", assetToken: nil)
         clientMessage.add(ZMGenericMessage.message(text: "Text", linkPreview: withID, nonce: nonce).data())
         try! uiMOC.obtainPermanentIDs(for: [clientMessage])
 

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
@@ -28,7 +28,7 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         conversation.remoteIdentifier = UUID.create()
         conversation.isArchived = true
         
-        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
 
         // when
@@ -48,7 +48,7 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         conversation.isArchived = true
         conversation.isSilenced = true
 
-        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
         
         // when
@@ -73,7 +73,7 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         conversation.lastServerTimeStamp = lastMessage.serverTimestamp!
         conversation.clearMessageHistory()
         
-        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
         XCTAssertNotNil(event)
         
@@ -101,7 +101,7 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         conversation.lastServerTimeStamp = lastMessage.serverTimestamp!
         conversation.clearMessageHistory()
 
-        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage.message(text: "bar", nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
         
         XCTAssertLessThan(conversation.clearedTimeStamp!.timeIntervalSince1970, event.timeStamp()!.timeIntervalSince1970)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
@@ -43,9 +43,9 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         var genericMessage : ZMGenericMessage!
         switch contentType{
         case .textMessage:
-            genericMessage = ZMGenericMessage.message(text: text, linkPreview: article.protocolBuffer, nonce: nonce.transportString())
+            genericMessage = ZMGenericMessage.message(text: text, linkPreview: article.protocolBuffer, nonce: nonce)
         case .editMessage:
-            genericMessage = ZMGenericMessage(editMessage: UUID.create().transportString(), newText: text, linkPreview: article.protocolBuffer, nonce: nonce.transportString())
+            genericMessage = ZMGenericMessage(editMessage: UUID.create(), newText: text, linkPreview: article.protocolBuffer, nonce: nonce)
         }
         clientMessage.add(genericMessage.data())
         clientMessage.visibleInConversation = conversation

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.m
@@ -169,7 +169,7 @@
     conversation.remoteIdentifier = [NSUUID createUUID];
     
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
     NSData *contentData = message.data;
     
     NSString *data = [contentData base64EncodedStringWithOptions:0];
@@ -203,7 +203,7 @@
     
     NSString *senderClientID = [NSString createAlphanumericalString];
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
     NSData *contentData = message.data;
     
     NSDictionary *data = @{ @"sender": senderClientID, @"text" : [contentData base64EncodedStringWithOptions:0] };
@@ -229,6 +229,40 @@
     AssertEqualData(sut.genericMessage.data, contentData);
 }
 
+- (void)testThatItDoesNotCreateOTRMessageIfItsIdentifierIsInvalid
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+
+    NSString *senderClientID = [NSString createAlphanumericalString];
+    NSUUID *nonce = [NSUUID createUUID];
+    ZMGenericMessage *prototype = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
+    ZMGenericMessageBuilder *builder = [ZMGenericMessage builderWithPrototype:prototype];
+    [builder setMessageId:@"please-fail"];
+
+    ZMGenericMessage *message = [builder build];
+    NSData *contentData = message.data;
+
+    NSDictionary *data = @{ @"sender": senderClientID, @"text" : [contentData base64EncodedStringWithOptions:0] };
+    NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data];
+
+    ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
+    XCTAssertNotNil(event);
+
+    // when
+    __block ZMClientMessage *sut;
+    [self performPretendingUiMocIsSyncMoc:^{
+        sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
+    }];
+
+    // then
+    XCTAssertNotNil(sut);
+    XCTAssertEqualObjects(sut.conversation, conversation);
+    XCTAssertTrue([sut isKindOfClass:[ZMSystemMessage class]]);
+    XCTAssertEqualObjects(sut.serverTimestamp.transportString, payload[@"time"]);
+}
+
 - (void)testThatItDoesNotCreateKnockMessagesIfThereIsAlreadyOtrKnockWithTheSameNonce
 {
     // given
@@ -237,7 +271,7 @@
     conversation.remoteIdentifier = [NSUUID createUUID];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage knockWithNonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage knockWithNonce:[NSUUID createUUID] expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     
@@ -266,8 +300,8 @@
     NSUUID *nonce = [NSUUID createUUID];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = [NSUUID createUUID];
-    
-    NSDictionary *data = @{ @"sender": senderClientID, @"text" : [ZMGenericMessage sessionResetWithNonce:nonce.transportString].data.base64String };
+
+    NSDictionary *data = @{ @"sender": senderClientID, @"text" : [ZMGenericMessage sessionResetWithNonce:nonce].data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data];
     ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
     XCTAssertNotNil(event);
@@ -319,12 +353,12 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:nonce expiresAfter:nil];
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -356,13 +390,13 @@
     NSString *unknownSender = [NSString createAlphanumericalString];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:nonce expiresAfter:nil];
     NSDictionary *data = @{ @"sender" : unknownSender, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -393,13 +427,13 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:[NSUUID createUUID] expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText nonce:[NSUUID createUUID] expiresAfter:nil];
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -430,14 +464,14 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:[NSUUID createUUID] expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
     ZMLinkPreview *linkPreview = [ZMLinkPreview linkPreviewWithOriginalURL:@"http://www.sunet.se" permanentURL:@"http://www.sunet.se" offset:0 title:@"Test" summary:nil imageAsset:nil];
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText linkPreview:linkPreview nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:modifiedText linkPreview:linkPreview nonce:[NSUUID createUUID] expiresAfter:nil];
     
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
@@ -468,14 +502,14 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:initialText nonce:nonce expiresAfter:nil];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
     ZMLinkPreview *linkPreview = [ZMLinkPreview linkPreviewWithOriginalURL:@"http://www.sunet.se" permanentURL:@"http://www.sunet.se" offset:0 title:@"Test" summary:nil imageAsset:nil];
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:initialText linkPreview:linkPreview nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithText:initialText linkPreview:linkPreview nonce:nonce expiresAfter:nil];
     
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
@@ -495,32 +529,6 @@
     XCTAssertEqualObjects(existingMessage.textMessageData.messageText, initialText);
 }
 
-- (void)testThatItReturnsNilIfTheClientMessageContentIsInvalid
-{
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    
-    NSString *data = @"123";
-    
-    NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAdd data:data];
-    
-    ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:payload uuid:nil];
-    XCTAssertNotNil(event);
-    
-    // when
-    __block ZMClientMessage *sut;
-    [self performPretendingUiMocIsSyncMoc:^{
-        [self performIgnoringZMLogError:^{
-            sut = (id)[ZMClientMessage messageUpdateResultFromUpdateEvent:event inManagedObjectContext:self.uiMOC prefetchResult:nil].message;
-        }];
-    }];
-    
-    // then
-    XCTAssertNil(sut);
-    
-}
-
 - (void)testThatItReturnsNilIfTheClientMessageIsZombie
 {
     // given
@@ -532,7 +540,7 @@
     existingMessage.nonce = nonce;
     existingMessage.visibleInConversation = conversation;
     
-    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
     NSData *contentData = message.data;
     
     NSString *data = [contentData base64EncodedStringWithOptions:0];

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
@@ -37,14 +37,14 @@ extension ZMClientMessageTests_Reaction {
     
     func updateEventForAddingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
-        let genericMessage = ZMGenericMessage(emojiString: "❤️", messageID: message.nonce!.transportString(), nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage(emojiString: "❤️", messageID: message.nonce!, nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
     
     func updateEventForRemovingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
-        let genericMessage = ZMGenericMessage(emojiString: "", messageID: message.nonce!.transportString(), nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage(emojiString: "", messageID: message.nonce!, nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
@@ -88,7 +88,7 @@ extension ZMClientMessageTests_Reaction {
         
         let message = insertMessage()
         
-        let genericMessage = ZMGenericMessage(emojiString: "TROP BIEN", messageID: message.nonce!.transportString(), nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage(emojiString: "TROP BIEN", messageID: message.nonce!, nonce: UUID.create())
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier!)
         
         // when

--- a/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
@@ -24,15 +24,15 @@ class GenericMessageTests_NativePush: BaseZMMessageTests {
 
     func testThatItSetsNativePushToFalseWhenSendingAConfirmationMessage() {
         let message = ZMGenericMessage(
-            confirmation: UUID.create().transportString(),
+            confirmation: UUID.create(),
             type: .DELIVERED,
-            nonce: UUID.create().transportString()
+            nonce: UUID.create()
         )
         assertThatItSetsNativePush(to: false, for: message)
     }
 
     func testThatItSetsNativePushToTrueWhenSendingATextMessage() {
-        let message = ZMGenericMessage.message(text: "Text", nonce: UUID.create().transportString())
+        let message = ZMGenericMessage.message(text: "Text", nonce: UUID.create())
         assertThatItSetsNativePush(to: true, for: message)
     }
 

--- a/Tests/Source/Model/Messages/ZMGenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageTests.swift
@@ -24,19 +24,19 @@ class GenericMessageTests: ZMTBaseTest {
     func testThatItChecksTheCommonMessageTypesAsKnownMessage() {
         let generators: [()->(ZMGenericMessage)] = [
             {
-                return ZMGenericMessage.message(text: "hello", nonce: NSUUID().transportString())
+                return ZMGenericMessage.message(text: "hello", nonce: UUID())
             },
             {
-                return ZMGenericMessage.genericMessage(imageData: self.verySmallJPEGData(), format: .medium, nonce: NSUUID().transportString())
+                return ZMGenericMessage.genericMessage(imageData: self.verySmallJPEGData(), format: .medium, nonce: UUID.create())
             },
             {
-                return ZMGenericMessage.knock(nonce: NSUUID().transportString())
+                return ZMGenericMessage.knock(nonce: UUID.create())
             },
             {
-                return ZMGenericMessage(lastRead: Date(), ofConversationWithID: NSUUID().transportString(), nonce: NSUUID().transportString())
+                return ZMGenericMessage(lastRead: Date(), ofConversationWith: UUID.create(), nonce: UUID.create())
             },
             {
-                return ZMGenericMessage(clearedTimestamp: Date(), ofConversationWithID: NSUUID().transportString(), nonce: NSUUID().transportString())
+                return ZMGenericMessage(clearedTimestamp: Date(), ofConversationWith: UUID.create(), nonce: UUID.create())
             },
             {
                 var externalBuilder = ZMExternal.builder()!
@@ -47,35 +47,35 @@ class GenericMessageTests: ZMTBaseTest {
                 
                 let messageBuilder = ZMGenericMessageBuilder()
                 messageBuilder.setExternal(externalBuilder.build()!)
-                messageBuilder.setMessageId("MESSAGE ID")
+                messageBuilder.setMessageId(UUID.create().transportString())
                 return messageBuilder.build()!
             },
             {
-                return ZMGenericMessage.sessionReset(withNonce: NSUUID().transportString())
+                return ZMGenericMessage.sessionReset(withNonce: UUID.create())
             },
             {
-                return ZMGenericMessage(callingContent: "Calling", nonce: NSUUID().transportString())
+                return ZMGenericMessage(callingContent: "Calling", nonce: UUID.create())
             },
             {
-                return ZMGenericMessage.genericMessage(withAssetSize: 0, mimeType: "image/jpeg", name: "test", messageID: NSUUID().transportString())
+                return ZMGenericMessage.genericMessage(withAssetSize: 0, mimeType: "image/jpeg", name: "test", messageID: UUID.create())
             },
             {
-                return ZMGenericMessage(hideMessage: "test", inConversation: NSUUID().transportString(), nonce: NSUUID().transportString())
+                return ZMGenericMessage(hideMessage: UUID.create(), inConversation: UUID.create(), nonce: UUID.create())
             },
             {
-                return ZMGenericMessage.genericMessage(location: ZMLocation.location(withLatitude: 0, longitude: 0, name: "name", zoomLevel: 1), messageID: NSUUID().transportString())
+                return ZMGenericMessage.genericMessage(location: ZMLocation.location(withLatitude: 0, longitude: 0, name: "name", zoomLevel: 1), messageID: UUID.create())
             },
             {
-                return ZMGenericMessage(deleteMessage: "Delete", nonce: NSUUID().transportString())
+                return ZMGenericMessage(deleteMessage: UUID.create(), nonce: UUID.create())
             },
             {
-                return ZMGenericMessage(editMessage: "Test", newText: "Test", nonce: NSUUID().transportString())
+                return ZMGenericMessage(editMessage: UUID.create(), newText: "Test", nonce: UUID.create())
             },
             {
-                return ZMGenericMessage(emojiString: "test", messageID: NSUUID().transportString(), nonce: NSUUID().transportString())
+                return ZMGenericMessage(emojiString: "test", messageID: UUID.create(), nonce: UUID.create())
             },
             {
-                return ZMGenericMessage.knock(nonce: NSUUID().transportString(), expiresAfter: 10)
+                return ZMGenericMessage.knock(nonce: UUID.create(), expiresAfter: 10)
             },
             {
                 return ZMGenericMessage.genericMessage(withAvailability: .away)
@@ -93,7 +93,7 @@ class GenericMessageTests: ZMTBaseTest {
     func testThatGenericMessageHasImage_WhenHandlingImages() {
         // given
         let image = ZMImageAsset(data: verySmallJPEGData(), format: .medium)!
-        let imageMessage = ZMGenericMessage.genericMessage(pbMessage: image, messageID: "foo")
+        let imageMessage = ZMGenericMessage.genericMessage(pbMessage: image, messageID: UUID.create())
         
         // when & then
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -104,7 +104,7 @@ class GenericMessageTests: ZMTBaseTest {
         // given
         let image = ZMImageAsset(data: verySmallJPEGData(), format: .medium)!
         let genericMessage = ZMGenericMessage.genericMessage(pbMessage: image,
-                                                             messageID: "foo",
+                                                             messageID: UUID.create(),
                                                              expiresAfter: NSNumber(value: 3.0))
         
         // when & then
@@ -117,7 +117,7 @@ class GenericMessageTests: ZMTBaseTest {
         let svgMessage = ZMGenericMessage.genericMessage(withAssetSize: 100,
                                                          mimeType: "image/svg+xml",
                                                          name: "test",
-                                                         messageID: NSUUID().transportString())
+                                                         messageID: UUID.create())
         
         //when & then
         XCTAssertTrue(!svgMessage.hasImage())
@@ -128,7 +128,7 @@ class GenericMessageTests: ZMTBaseTest {
         let svgMessage = ZMGenericMessage.genericMessage(withAssetSize: 100,
                                                          mimeType: "image/svg+xml",
                                                          name: "test",
-                                                         messageID: NSUUID().transportString(),
+                                                         messageID: UUID.create(),
                                                          expiresAfter: NSNumber(value: 3.0))
         
         // when & then

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -95,7 +95,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         article.title = "title"
         article.summary = "summary"
         let linkPreview = article.protocolBuffer.update(withOtrKey: Data(), sha256: Data())
-        let genericMessage = ZMGenericMessage.message(text: "foo", linkPreview: linkPreview, nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage.message(text: "foo", linkPreview: linkPreview, nonce: UUID.create())
         let message = self.conversation.appendClientMessage(with: genericMessage)
         message?.linkPreviewState = .processed
         
@@ -121,7 +121,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         let imageSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData)
         let properties = ZMIImageProperties(size:imageSize, length:UInt(imageData.count), mimeType:"image/jpeg")
         let keys = ZMImageAssetEncryptionKeys(otrKey: Data.randomEncryptionKey(), macKey: Data.zmRandomSHA256Key(), mac: Data.zmRandomSHA256Key())
-        let imageMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce.transportString(), format: .preview, expiresAfter: NSNumber(value: message.deletionTimeout))
+        let imageMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties, processedImageProperties: properties, encryptionKeys: keys, nonce: messageNonce, format: .preview, expiresAfter: NSNumber(value: message.deletionTimeout))
         message.add(imageMessage)
         message.updateCategoryCache()
         

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -143,7 +143,7 @@ extension ZMMessageTests_Confirmation {
             return
         }
         
-        XCTAssertTrue(hiddenMessage.genericMessage!.hasConfirmation())
+        XCTAssertTrue(hiddenMessage.genericMessage?.hasConfirmation() == true)
         // when
         
         sut.message!.removePendingDeliveryReceipts()
@@ -245,6 +245,10 @@ extension ZMMessageTests_Confirmation {
     func testThatItSendsOutNotificationsForTheDeliveryStatusChange(){
         // given
         let dispatcher = NotificationDispatcher(managedObjectContext: uiMOC)
+
+        defer {
+            dispatcher.tearDown()
+        }
         
         let conversation = ZMConversation.insertNewObject(in:uiMOC)
         conversation.remoteIdentifier = .create()
@@ -278,7 +282,6 @@ extension ZMMessageTests_Confirmation {
             return XCTFail()
         }
         XCTAssertTrue(messageChangeInfo.deliveryStateChanged)
-        dispatcher.tearDown()
     }
     
     func testThatAMessageConfirmationDoesNotExpire() {
@@ -304,7 +307,7 @@ extension ZMMessageTests_Confirmation {
     
     func insertMessage(_ conversation: ZMConversation, fromSender: ZMUser? = nil, timestamp: Date = .init(), moc: NSManagedObjectContext? = nil, eventSource: ZMUpdateEventSource = .download) -> MessageUpdateResult {
         let nonce = UUID.create()
-        let genericMessage = ZMGenericMessage.message(text: "foo", nonce: nonce.transportString())
+        let genericMessage = ZMGenericMessage.message(text: "foo", nonce: nonce)
         let messageEvent = createUpdateEvent(
             nonce,
             conversationID: conversation.remoteIdentifier!,
@@ -332,7 +335,7 @@ extension ZMMessageTests_Confirmation {
     }
     
     func createMessageConfirmationUpdateEvent(_ nonce: UUID, conversationID: UUID, senderID: UUID = .create()) -> ZMUpdateEvent {
-        let genericMessage = ZMGenericMessage(confirmation: nonce.transportString(), type: .DELIVERED, nonce: UUID.create().transportString())
+        let genericMessage = ZMGenericMessage(confirmation: nonce, type: .DELIVERED, nonce: UUID.create())
         return createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: senderID)
     }
     

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -198,7 +198,7 @@ NSString * const ReactionsKey = @"reactions";
         
         
         NSUUID *nonce = [NSUUID createUUID];
-        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:self.name nonce:nonce.transportString expiresAfter:nil];
+        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
         ZMClientMessage *msg = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
         [msg addData:textMessage.data];
         
@@ -229,7 +229,7 @@ NSString * const ReactionsKey = @"reactions";
         
         
         NSUUID *nonce = [NSUUID createUUID];
-        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:self.name nonce:nonce.transportString expiresAfter:nil];
+        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:self.name nonce:nonce expiresAfter:nil];
         ZMClientMessage *msg = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
         [msg addData:textMessage.data];
         
@@ -1475,7 +1475,7 @@ NSString * const ReactionsKey = @"reactions";
     
     NSString *senderClientID = [NSString createAlphanumericalString];
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *knockMessage = [ZMGenericMessage knockWithNonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *knockMessage = [ZMGenericMessage knockWithNonce:nonce expiresAfter:nil];
 
     NSDictionary *data = @{ @"sender" : senderClientID, @"text" : knockMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate dateWithTimeIntervalSinceReferenceDate:450000000]];
@@ -1512,7 +1512,7 @@ NSString * const ReactionsKey = @"reactions";
 - (void)testThatAClientMessageHasKnockMessageData
 {
     // given
-    ZMGenericMessage *knock = [ZMGenericMessage knockWithNonce:[NSUUID createUUID].transportString expiresAfter:nil];
+    ZMGenericMessage *knock = [ZMGenericMessage knockWithNonce:[NSUUID createUUID] expiresAfter:nil];
     ZMClientMessage *message = [[ZMClientMessage alloc] initWithNonce:NSUUID.createUUID managedObjectContext:self.uiMOC];
     [message addData:knock.data];
     

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
@@ -28,7 +28,7 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let nonce = UUID()
             let clearedDate = Date()
             let selfConversation = ZMConversation.selfConversation(in: self.syncMOC)
-            let message = ZMGenericMessage(clearedTimestamp: clearedDate, ofConversationWithID: self.syncConversation.remoteIdentifier!.transportString(), nonce: nonce.transportString())
+            let message = ZMGenericMessage(clearedTimestamp: clearedDate, ofConversationWith: self.syncConversation.remoteIdentifier!, nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
             
             // when
@@ -47,7 +47,7 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let nonce = UUID()
             let lastReadDate = Date()
             let selfConversation = ZMConversation.selfConversation(in: self.syncMOC)
-            let message = ZMGenericMessage(lastRead: lastReadDate, ofConversationWithID: self.syncConversation.remoteIdentifier!.transportString(), nonce: nonce.transportString())
+            let message = ZMGenericMessage(lastRead: lastReadDate, ofConversationWith: self.syncConversation.remoteIdentifier!, nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
             
             // when
@@ -66,7 +66,7 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let nonce = UUID()
             let selfConversation = ZMConversation.selfConversation(in: self.syncMOC)
             let toBehiddenMessage = self.syncConversation.appendMessage(withText: "hello") as! ZMClientMessage
-            let message = ZMGenericMessage(hideMessage: toBehiddenMessage.nonce!.transportString(), inConversation: self.syncConversation.remoteIdentifier!.transportString(), nonce: nonce.transportString())
+            let message = ZMGenericMessage(hideMessage: toBehiddenMessage.nonce!, inConversation: self.syncConversation.remoteIdentifier!, nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
             
             // when

--- a/Tests/Source/Model/Observer/MessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/MessageObserverTests.swift
@@ -111,7 +111,7 @@ class MessageObserverTests : NotificationDispatcherTestBase {
         let imageMessage = ZMGenericMessage.genericMessage(mediumImageProperties: properties,
                                                            processedImageProperties: properties,
                                                            encryptionKeys: keys,
-                                                           nonce: UUID.create().transportString(),
+                                                           nonce: UUID.create(),
                                                            format: .preview)
 
         // when
@@ -135,7 +135,7 @@ class MessageObserverTests : NotificationDispatcherTestBase {
         // given
         let clientMessage = ZMClientMessage(nonce: UUID.create(), managedObjectContext: uiMOC)
         let nonce = UUID.create()
-        clientMessage.add(ZMGenericMessage.message(text: name!, nonce: nonce.transportString()).data())
+        clientMessage.add(ZMGenericMessage.message(text: name!, nonce: nonce).data())
         let preview = ZMLinkPreview.linkPreview(
             withOriginalURL: "www.example.com",
             permanentURL: "www.example.com/permanent",
@@ -144,7 +144,7 @@ class MessageObserverTests : NotificationDispatcherTestBase {
             summary: "summary",
             imageAsset: nil
         )
-        let updateGenericMessage = ZMGenericMessage.message(text: name!, linkPreview: preview, nonce: nonce.transportString())
+        let updateGenericMessage = ZMGenericMessage.message(text: name!, linkPreview: preview, nonce: nonce)
         uiMOC.saveOrRollback()
         
         // when

--- a/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
@@ -159,7 +159,7 @@ class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
         self.processPendingChangesAndClearNotifications()
         
         // when
-        let genMsg = ZMGenericMessage.knock(nonce: "nonce")
+        let genMsg = ZMGenericMessage.knock(nonce: UUID.create())
         let msg1 = conversation.appendClientMessage(with: genMsg)!
         msg1.serverTimestamp = Date()
         conversation.resortMessages(withUpdatedMessage: msg1)

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -495,7 +495,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
             let genericMessage = ZMGenericMessage.message(
                 text: message.textMessageData!.messageText,
                 linkPreview: preview,
-                nonce: message.nonce!.transportString(),
+                nonce: message.nonce!,
                 expiresAfter: NSNumber(value: message.deletionTimeout)
             )
 

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -248,7 +248,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
     
     func testThatItRefetchesMissingFingerprintForUserWithSession() {
         // given
-        let otherClientId = UUID.create().transportString()
+        let otherClientId = UUID.create()
         
         self.syncMOC.performGroupedBlockAndWait {
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
@@ -259,7 +259,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
             })
             
             let otherClient = UserClient.insertNewObject(in: self.syncMOC)
-            otherClient.remoteIdentifier = otherClientId
+            otherClient.remoteIdentifier = otherClientId.transportString()
             let otherUser = ZMUser.insertNewObject(in:self.syncMOC)
             otherUser.remoteIdentifier = UUID.create()
             otherClient.user = otherUser
@@ -280,7 +280,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
         
         self.syncMOC.performGroupedBlockAndWait {
             let fetchRequest = NSFetchRequest<UserClient>(entityName: UserClient.entityName())
-            fetchRequest.predicate = NSPredicate(format: "%K == %@", "remoteIdentifier", otherClientId)
+            fetchRequest.predicate = NSPredicate(format: "%K == %@", "remoteIdentifier", otherClientId.transportString())
             fetchRequest.fetchLimit = 1
             // when
             do {

--- a/Tests/Source/Model/Utils/GenericMessageTests+Obfuscation.swift
+++ b/Tests/Source/Model/Utils/GenericMessageTests+Obfuscation.swift
@@ -23,7 +23,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     
     func assetWithImage() -> ZMAsset {
         let original = ZMAssetOriginal.original(withSize: 1000, mimeType: "image", name: "foo")
-        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: "assetID", assetToken: "assetToken")
+        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: UUID.create(), assetToken: UUID.create())
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 30, height: 40)
         let imageMetaDataBuilder = imageMetaData.toBuilder()!
         imageMetaDataBuilder.setTag("bar")
@@ -36,7 +36,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesEmojis(){
         // given
         let text = "📲"
-        let message = ZMGenericMessage.message(text: text, nonce: "bar", expiresAfter: NSNumber(value: 1.0))
+        let message = ZMGenericMessage.message(text: text, nonce: UUID.create(), expiresAfter: NSNumber(value: 1.0))
         
         // when
         let obfuscatedMessage = message.obfuscatedMessage()
@@ -48,7 +48,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesCyrillic(){
         // given
         let text = "привет мир!"
-        let message = ZMGenericMessage.message(text: text, nonce: "bar", expiresAfter: NSNumber(value: 1.0))
+        let message = ZMGenericMessage.message(text: text, nonce: UUID.create(), expiresAfter: NSNumber(value: 1.0))
         
         // when
         let obfuscatedMessage = message.obfuscatedMessage()
@@ -61,7 +61,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesTextMessages(){
         // given
         let text = "foo"
-        let message = ZMGenericMessage.message(text: text, nonce: "bar", expiresAfter: NSNumber(value: 1.0))
+        let message = ZMGenericMessage.message(text: text, nonce: UUID.create(), expiresAfter: NSNumber(value: 1.0))
         
         // when
         let obfuscatedMessage = message.obfuscatedMessage()
@@ -74,7 +74,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesTextMessageDifferentlyEachTime() {
         // given
         let text = "foo"
-        let message = ZMGenericMessage.message(text: text, nonce: "bar", expiresAfter: NSNumber(value: 1.0))
+        let message = ZMGenericMessage.message(text: text, nonce: UUID.create(), expiresAfter: NSNumber(value: 1.0))
         
         // when
         let obfuscatedMessage1 = message.obfuscatedMessage()
@@ -91,7 +91,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItDoesNotObfuscateNonEphemeralTextMessages(){
         // given
         let text = "foo"
-        let message = ZMGenericMessage.message(text: text, nonce: "bar")
+        let message = ZMGenericMessage.message(text: text, nonce: UUID.create())
         
         // when
         let obfuscatedMessage = message.obfuscatedMessage()
@@ -110,7 +110,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
         let offset : Int32 = 4
         
         let linkPreview = ZMLinkPreview.linkPreview(withOriginalURL: origURL, permanentURL: permURL, offset: offset, title: title, summary: summary, imageAsset: nil)
-        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: "qwerty", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -144,7 +144,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
         let offset : Int32 = 4
 
         let linkPreview = ZMLinkPreview.linkPreview(withOriginalURL: origURL, permanentURL: permURL, offset: offset, title: title, summary: summary, imageAsset: image)
-        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: "qwerty", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -174,7 +174,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
         let offset : Int32 = 4
         
         let linkPreview = ZMLinkPreview.linkPreview(withOriginalURL: origURL, permanentURL: permURL, offset: offset, title: title, summary: summary, imageAsset: nil, tweet: tweet)
-        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: "qwerty", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.message(text: text, linkPreview: linkPreview, nonce: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -194,7 +194,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesImageAssetContent(){
         // given
         let image = ZMImageAsset(data: verySmallJPEGData(), format: .medium)!
-        let genericMessage = ZMGenericMessage.genericMessage(pbMessage: image, messageID: "foo", expiresAfter: NSNumber(value: 3.0))
+        let genericMessage = ZMGenericMessage.genericMessage(pbMessage: image, messageID: UUID.create(), expiresAfter: NSNumber(value: 3.0))
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertTrue(genericMessage.ephemeral.hasImage())
         XCTAssertEqual(genericMessage.imageAssetData?.mimeType, "image/jpeg")
@@ -221,7 +221,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesAssetsImageContent(){
         // given
         let asset  = assetWithImage()
-        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "sdgfhgjkl", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -246,7 +246,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
         let original = ZMAssetOriginal.original(withSize: 200, mimeType: "video", name: "foo", videoDurationInMillis: 500, videoDimensions: CGSize(width: 305, height: 200))
         
         let asset  = ZMAsset.asset(withOriginal: original, preview: nil)
-        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "sdgfhgjkl", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -270,7 +270,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
         // given
         let original = ZMAssetOriginal.original(withSize: 200, mimeType: "audio", name: "foo", audioDurationInMillis: 300, normalizedLoudness: [2.9])
         let asset  = ZMAsset.asset(withOriginal: original, preview: nil)
-        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: "sdgfhgjkl", expiresAfter: NSNumber(value:20))
+        let genericMessage = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscated =  genericMessage.obfuscatedMessage()
@@ -291,7 +291,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     func testThatItObfuscatesLocationMessages() {
         // given
         let location  = ZMLocation.location(withLatitude: 2.0, longitude: 3.0)
-        let message = ZMGenericMessage.genericMessage(location: location, messageID: "bar", expiresAfter: NSNumber(value:20))
+        let message = ZMGenericMessage.genericMessage(location: location, messageID: UUID.create(), expiresAfter: NSNumber(value:20))
         
         // when
         let obfuscatedMessage = message.obfuscatedMessage()

--- a/Tests/Source/Model/Utils/GenericMessageTests+Obfuscation.swift
+++ b/Tests/Source/Model/Utils/GenericMessageTests+Obfuscation.swift
@@ -23,7 +23,7 @@ class ZMGenericMessageTests_Obfuscation : ZMBaseManagedObjectTest {
     
     func assetWithImage() -> ZMAsset {
         let original = ZMAssetOriginal.original(withSize: 1000, mimeType: "image", name: "foo")
-        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: UUID.create(), assetToken: UUID.create())
+        let remoteData = ZMAssetRemoteData.remoteData(withOTRKey: Data(), sha256: Data(), assetId: "id", assetToken: "token")
         let imageMetaData = ZMAssetImageMetaData.imageMetaData(withWidth: 30, height: 40)
         let imageMetaDataBuilder = imageMetaData.toBuilder()!
         imageMetaDataBuilder.setTag("bar")

--- a/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -54,25 +54,41 @@ class ModelValidationTests: XCTestCase {
 
     // MARK: Mention
 
-    func testThatItCreatesMentionWithValidFields() {
+    func testThatItCreatesTextWithValidMentions() {
 
-        let builder = ZMMention.builder()!
-        builder.setUserName("John Appleseed")
-        builder.setUserId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+        let mentionBuilder = ZMMention.builder()!
+        mentionBuilder.setUserName("John Appleseed")
+        mentionBuilder.setUserId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
 
-        let mention = builder.buildAndValidate()
-        XCTAssertNotNil(mention)
+        let textBuilder = ZMText.builder()!
+        textBuilder.setContent("Hello @John Appleseed")
+        textBuilder.addMention(mentionBuilder.build()!)
+
+        let builder = ZMGenericMessage.builder()!
+        builder.setMessageId(UUID.create().transportString())
+        builder.setText(textBuilder.build()!)
+
+        let message = builder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
-    func testThatItDoesNotCreateMentionWithInvalidFields() {
+    func testThatItDoesNotCreateTextWithInvalidMention() {
 
-        let builder = ZMMention.builder()!
-        builder.setUserName("Jane Appleseed")
-        builder.setUserId("user\u{0}")
+        let mentionBuilder = ZMMention.builder()!
+        mentionBuilder.setUserName("Jane Appleseed")
+        mentionBuilder.setUserId("user\u{0}")
 
-        let mention = builder.buildAndValidate()
-        XCTAssertNil(mention)
+        let textBuilder = ZMText.builder()!
+        textBuilder.setContent("Hello @John Appleseed")
+        textBuilder.addMention(mentionBuilder.build()!)
+
+        let builder = ZMGenericMessage.builder()!
+        builder.setMessageId(UUID.create().transportString())
+        builder.setText(textBuilder.build()!)
+
+        let message = builder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -84,8 +100,11 @@ class ModelValidationTests: XCTestCase {
         builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
         builder.setLastReadTimestamp(25_000)
 
-        let lastRead = builder.buildAndValidate()
-        XCTAssertNotNil(lastRead)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setLastRead(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -95,8 +114,11 @@ class ModelValidationTests: XCTestCase {
         builder.setConversationId("null")
         builder.setLastReadTimestamp(25_000)
 
-        let lastRead = builder.buildAndValidate()
-        XCTAssertNil(lastRead)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setLastRead(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -108,8 +130,11 @@ class ModelValidationTests: XCTestCase {
         builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
         builder.setClearedTimestamp(25_000)
 
-        let cleared = builder.buildAndValidate()
-        XCTAssertNotNil(cleared)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setCleared(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -119,8 +144,11 @@ class ModelValidationTests: XCTestCase {
         builder.setConversationId("wirewire")
         builder.setClearedTimestamp(25_000)
 
-        let cleared = builder.buildAndValidate()
-        XCTAssertNil(cleared)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setCleared(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -132,8 +160,11 @@ class ModelValidationTests: XCTestCase {
         builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
         builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
 
-        let hide = builder.buildAndValidate()
-        XCTAssertNotNil(hide)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setHidden(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -143,21 +174,27 @@ class ModelValidationTests: XCTestCase {
         invalidConversationBuilder.setConversationId("")
         invalidConversationBuilder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
 
-        let invalidConversationHide = invalidConversationBuilder.buildAndValidate()
+        let invalidConversationMessageBuilder = genericMessageBuilder()
+        invalidConversationMessageBuilder.setHidden(invalidConversationBuilder.build())
+        let invalidConversationHide = invalidConversationMessageBuilder.buildAndValidate()
         XCTAssertNil(invalidConversationHide)
 
         let invalidMessageBuilder = ZMMessageHide.builder()!
         invalidMessageBuilder.setConversationId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
         invalidMessageBuilder.setMessageId("")
 
-        let invalidMessageHide = invalidMessageBuilder.buildAndValidate()
+        let invalidMessageMessageBuilder = genericMessageBuilder()
+        invalidMessageMessageBuilder.setHidden(invalidMessageBuilder)
+        let invalidMessageHide = invalidMessageMessageBuilder.buildAndValidate()
         XCTAssertNil(invalidMessageHide)
 
         let invalidHideBuilder = ZMMessageHide.builder()!
         invalidHideBuilder.setConversationId("")
         invalidHideBuilder.setMessageId("")
 
-        let invalidHide = invalidHideBuilder.buildAndValidate()
+        let invalidHideMessageBuilder = genericMessageBuilder()
+        invalidHideMessageBuilder.setHidden(invalidHideBuilder)
+        let invalidHide = invalidHideMessageBuilder.buildAndValidate()
         XCTAssertNil(invalidHide)
 
     }
@@ -169,8 +206,11 @@ class ModelValidationTests: XCTestCase {
         let builder = ZMMessageDelete.builder()!
         builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
 
-        let delete = builder.buildAndValidate()
-        XCTAssertNotNil(delete)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setDeleted(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -179,8 +219,11 @@ class ModelValidationTests: XCTestCase {
         let builder = ZMMessageDelete.builder()!
         builder.setMessageId("invalid")
 
-        let delete = builder.buildAndValidate()
-        XCTAssertNil(delete)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setDeleted(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -195,8 +238,11 @@ class ModelValidationTests: XCTestCase {
         builder.setText(text)
         builder.setReplacingMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
 
-        let edit = builder.buildAndValidate()
-        XCTAssertNotNil(edit)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setEdited(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -209,8 +255,11 @@ class ModelValidationTests: XCTestCase {
         builder.setText(text)
         builder.setReplacingMessageId("N0TAUNIV-ER5A-77YU-NIQU-EID3NTIF1ER!")
 
-        let edit = builder.buildAndValidate()
-        XCTAssertNil(edit)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setEdited(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -223,8 +272,11 @@ class ModelValidationTests: XCTestCase {
         builder.setFirstMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
         builder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229"])
 
-        let confirmation = builder.buildAndValidate()
-        XCTAssertNotNil(confirmation)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setConfirmation(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -235,16 +287,20 @@ class ModelValidationTests: XCTestCase {
         invalidFirstIDBuilder.setFirstMessageId("invalid")
         invalidFirstIDBuilder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229"])
 
-        let invalidFirstID = invalidFirstIDBuilder.buildAndValidate()
-        XCTAssertNil(invalidFirstID)
+        let invalidFirstIDMessageBuilder = genericMessageBuilder()
+        invalidFirstIDMessageBuilder.setConfirmation(invalidFirstIDBuilder.build())
+        let invalidFirstIDMessage = invalidFirstIDMessageBuilder.buildAndValidate()
+        XCTAssertNil(invalidFirstIDMessage)
 
         let invalidArrayBuilder = ZMConfirmation.builder()!
         invalidArrayBuilder.setType(.DELIVERED)
         invalidArrayBuilder.setFirstMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
         invalidArrayBuilder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229", 150])
 
-        let invalidArray = invalidArrayBuilder.buildAndValidate()
-        XCTAssertNil(invalidArray)
+        let invalidArrayMessageBuilder = genericMessageBuilder()
+        invalidArrayMessageBuilder.setConfirmation(invalidArrayBuilder.build())
+        let invalidArrayMessage = invalidArrayMessageBuilder.buildAndValidate()
+        XCTAssertNil(invalidArrayMessage)
 
     }
 
@@ -256,8 +312,11 @@ class ModelValidationTests: XCTestCase {
         builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
         builder.setEmoji("🤩")
 
-        let reaction = builder.buildAndValidate()
-        XCTAssertNotNil(reaction)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setReaction(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNotNil(message)
 
     }
 
@@ -267,8 +326,11 @@ class ModelValidationTests: XCTestCase {
         builder.setMessageId("Not-A-UUID")
         builder.setEmoji("🤩")
 
-        let reaction = builder.buildAndValidate()
-        XCTAssertNil(reaction)
+        let messageBuilder = genericMessageBuilder()
+        messageBuilder.setReaction(builder.build())
+
+        let message = messageBuilder.buildAndValidate()
+        XCTAssertNil(message)
 
     }
 
@@ -279,7 +341,7 @@ class ModelValidationTests: XCTestCase {
         let builder = ZMUserId.builder()!
         builder.setUuid(NSUUID().data())
 
-        let userID = builder.buildAndValidate()
+        let userID = builder.build().validatingFields()
         XCTAssertNotNil(userID)
 
     }
@@ -289,9 +351,17 @@ class ModelValidationTests: XCTestCase {
         let tooSmallBuilder = ZMUserId.builder()!
         tooSmallBuilder.setUuid(Data())
 
-        let tooSmall = tooSmallBuilder.buildAndValidate()
+        let tooSmall = tooSmallBuilder.build().validatingFields()
         XCTAssertNil(tooSmall)
 
+    }
+
+    // MARK: - Utilities
+
+    private func genericMessageBuilder() -> ZMGenericMessageBuilder {
+        let builder = ZMGenericMessage.builder()!
+        builder.setMessageId(UUID.create().uuidString)
+        return builder
     }
 
 }

--- a/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -248,36 +248,6 @@ class ModelValidationTests: XCTestCase {
 
     }
 
-    // MARK: Asset Remote Data
-
-    func testThatItCreatesAssetWithValidFields() {
-
-        let builder = ZMAssetRemoteData.builder()!
-        builder.setAssetId("671F7546-C5CF-434D-95C7-32629780FC08")
-        builder.setOtrKey(Data())
-        builder.setSha256(Data())
-        builder.setAssetToken("token")
-        builder.setEncryption(ZMEncryptionAlgorithm.AESCBC)
-
-        let asset = builder.buildAndValidate()
-        XCTAssertNotNil(asset)
-
-    }
-
-    func testThatItDoesNotCreateAssetWithInvalidFields() {
-
-        let builder = ZMAssetRemoteData.builder()!
-        builder.setAssetId("nil")
-        builder.setOtrKey(Data())
-        builder.setSha256(Data())
-        builder.setAssetToken("token")
-        builder.setEncryption(ZMEncryptionAlgorithm.AESCBC)
-
-        let asset = builder.buildAndValidate()
-        XCTAssertNil(asset)
-
-    }
-
     // MARK: Reaction
 
     func testThatItCreatesReactionWithValidFields() {

--- a/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -1,0 +1,327 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class ModelValidationTests: XCTestCase {
+
+    // MARK: Generic Message
+
+    func testThatItCreatesGenericMessageWithValidFields() {
+
+        let text = ZMText.builder()!
+        text.setContent("Hello hello hello")
+
+        let builder = ZMGenericMessage.builder()!
+        builder.setText(text)
+        builder.setMessageId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+
+        let message = builder.buildAndValidate()
+        XCTAssertNotNil(message)
+
+    }
+
+    func testThatItDoesNotCreateGenericMessageWithInvalidFields() {
+
+        let text = ZMText.builder()!
+        text.setContent("Hieeee!")
+
+        let builder = ZMGenericMessage.builder()!
+        builder.setText(text)
+        builder.setMessageId("nonce")
+
+        let message = builder.buildAndValidate()
+        XCTAssertNil(message)
+
+    }
+
+    // MARK: Mention
+
+    func testThatItCreatesMentionWithValidFields() {
+
+        let builder = ZMMention.builder()!
+        builder.setUserName("John Appleseed")
+        builder.setUserId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+
+        let mention = builder.buildAndValidate()
+        XCTAssertNotNil(mention)
+
+    }
+
+    func testThatItDoesNotCreateMentionWithInvalidFields() {
+
+        let builder = ZMMention.builder()!
+        builder.setUserName("Jane Appleseed")
+        builder.setUserId("user\u{0}")
+
+        let mention = builder.buildAndValidate()
+        XCTAssertNil(mention)
+
+    }
+
+    // MARK: Last Read
+
+    func testThatItCreatesLastReadWithValidFields() {
+
+        let builder = ZMLastRead.builder()!
+        builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+        builder.setLastReadTimestamp(25_000)
+
+        let lastRead = builder.buildAndValidate()
+        XCTAssertNotNil(lastRead)
+
+    }
+
+    func testThatItDoesNotCreateLastReadWithInvalidFields() {
+
+        let builder = ZMLastRead.builder()!
+        builder.setConversationId("null")
+        builder.setLastReadTimestamp(25_000)
+
+        let lastRead = builder.buildAndValidate()
+        XCTAssertNil(lastRead)
+
+    }
+
+    // MARK: Cleared
+
+    func testThatItCreatesClearedWithValidFields() {
+
+        let builder = ZMCleared.builder()!
+        builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+        builder.setClearedTimestamp(25_000)
+
+        let cleared = builder.buildAndValidate()
+        XCTAssertNotNil(cleared)
+
+    }
+
+    func testThatItDoesNotCreateClearedWithInvalidFields() {
+
+        let builder = ZMCleared.builder()!
+        builder.setConversationId("wirewire")
+        builder.setClearedTimestamp(25_000)
+
+        let cleared = builder.buildAndValidate()
+        XCTAssertNil(cleared)
+
+    }
+
+    // MARK: Message Hide
+
+    func testThatItCreatesHideWithValidFields() {
+
+        let builder = ZMMessageHide.builder()!
+        builder.setConversationId("8783C4BD-A5D3-4F6B-8C41-A6E75F12926F")
+        builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+
+        let hide = builder.buildAndValidate()
+        XCTAssertNotNil(hide)
+
+    }
+
+    func testThatItDoesNotCreateHideWithInvalidFields() {
+
+        let invalidConversationBuilder = ZMMessageHide.builder()!
+        invalidConversationBuilder.setConversationId("")
+        invalidConversationBuilder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+
+        let invalidConversationHide = invalidConversationBuilder.buildAndValidate()
+        XCTAssertNil(invalidConversationHide)
+
+        let invalidMessageBuilder = ZMMessageHide.builder()!
+        invalidMessageBuilder.setConversationId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+        invalidMessageBuilder.setMessageId("")
+
+        let invalidMessageHide = invalidMessageBuilder.buildAndValidate()
+        XCTAssertNil(invalidMessageHide)
+
+        let invalidHideBuilder = ZMMessageHide.builder()!
+        invalidHideBuilder.setConversationId("")
+        invalidHideBuilder.setMessageId("")
+
+        let invalidHide = invalidHideBuilder.buildAndValidate()
+        XCTAssertNil(invalidHide)
+
+    }
+
+    // MARK: Message Delete
+
+    func testThatItCreatesMessageDeleteWithValidFields() {
+
+        let builder = ZMMessageDelete.builder()!
+        builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+
+        let delete = builder.buildAndValidate()
+        XCTAssertNotNil(delete)
+
+    }
+
+    func testThatItDoesNotCreateMessageDeleteWithInvalidFields() {
+
+        let builder = ZMMessageDelete.builder()!
+        builder.setMessageId("invalid")
+
+        let delete = builder.buildAndValidate()
+        XCTAssertNil(delete)
+
+    }
+
+    // MARK: Message Edit
+
+    func testThatItCreatesMessageEditWithValidFields() {
+
+        let text = ZMText.builder()!
+        text.setContent("Hello")
+
+        let builder = ZMMessageEdit.builder()!
+        builder.setText(text)
+        builder.setReplacingMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+
+        let edit = builder.buildAndValidate()
+        XCTAssertNotNil(edit)
+
+    }
+
+    func testThatItDoesNotCreateMessageEditWithInvalidFields() {
+
+        let text = ZMText.builder()!
+        text.setContent("Hello")
+
+        let builder = ZMMessageEdit.builder()!
+        builder.setText(text)
+        builder.setReplacingMessageId("N0TAUNIV-ER5A-77YU-NIQU-EID3NTIF1ER!")
+
+        let edit = builder.buildAndValidate()
+        XCTAssertNil(edit)
+
+    }
+
+    // MARK: Message Confirmation
+
+    func testThatItCreatesConfirmationWithValidFields() {
+
+        let builder = ZMConfirmation.builder()!
+        builder.setType(.DELIVERED)
+        builder.setFirstMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+        builder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229"])
+
+        let confirmation = builder.buildAndValidate()
+        XCTAssertNotNil(confirmation)
+
+    }
+
+    func testThatItDoesNotCreateConfirmationWithInvalidFields() {
+
+        let invalidFirstIDBuilder = ZMConfirmation.builder()!
+        invalidFirstIDBuilder.setType(.DELIVERED)
+        invalidFirstIDBuilder.setFirstMessageId("invalid")
+        invalidFirstIDBuilder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229"])
+
+        let invalidFirstID = invalidFirstIDBuilder.buildAndValidate()
+        XCTAssertNil(invalidFirstID)
+
+        let invalidArrayBuilder = ZMConfirmation.builder()!
+        invalidArrayBuilder.setType(.DELIVERED)
+        invalidArrayBuilder.setFirstMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+        invalidArrayBuilder.setMoreMessageIdsArray(["54A6E947-1321-42C6-BA99-F407FDF1A229", 150])
+
+        let invalidArray = invalidArrayBuilder.buildAndValidate()
+        XCTAssertNil(invalidArray)
+
+    }
+
+    // MARK: Asset Remote Data
+
+    func testThatItCreatesAssetWithValidFields() {
+
+        let builder = ZMAssetRemoteData.builder()!
+        builder.setAssetId("671F7546-C5CF-434D-95C7-32629780FC08")
+        builder.setOtrKey(Data())
+        builder.setSha256(Data())
+        builder.setAssetToken("token")
+        builder.setEncryption(ZMEncryptionAlgorithm.AESCBC)
+
+        let asset = builder.buildAndValidate()
+        XCTAssertNotNil(asset)
+
+    }
+
+    func testThatItDoesNotCreateAssetWithInvalidFields() {
+
+        let builder = ZMAssetRemoteData.builder()!
+        builder.setAssetId("nil")
+        builder.setOtrKey(Data())
+        builder.setSha256(Data())
+        builder.setAssetToken("token")
+        builder.setEncryption(ZMEncryptionAlgorithm.AESCBC)
+
+        let asset = builder.buildAndValidate()
+        XCTAssertNil(asset)
+
+    }
+
+    // MARK: Reaction
+
+    func testThatItCreatesReactionWithValidFields() {
+
+        let builder = ZMReaction.builder()!
+        builder.setMessageId("8B496992-E74D-41D2-A2C4-C92EEE777DCE")
+        builder.setEmoji("🤩")
+
+        let reaction = builder.buildAndValidate()
+        XCTAssertNotNil(reaction)
+
+    }
+
+    func testThatItDoesNotCreateReactionWithInvalidFields() {
+
+        let builder = ZMReaction.builder()!
+        builder.setMessageId("Not-A-UUID")
+        builder.setEmoji("🤩")
+
+        let reaction = builder.buildAndValidate()
+        XCTAssertNil(reaction)
+
+    }
+
+    // MARK: User ID
+
+    func testThatItCreatesUserIDWithValidFields() {
+
+        let builder = ZMUserId.builder()!
+        builder.setUuid(NSUUID().data())
+
+        let userID = builder.buildAndValidate()
+        XCTAssertNotNil(userID)
+
+    }
+
+    func testThatItDoesNotCreateUserIDWithInvalidFields() {
+
+        let tooSmallBuilder = ZMUserId.builder()!
+        tooSmallBuilder.setUuid(Data())
+
+        let tooSmall = tooSmallBuilder.buildAndValidate()
+        XCTAssertNil(tooSmall)
+
+    }
+
+}

--- a/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
+++ b/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
@@ -107,7 +107,7 @@ class ProtobufUtilitiesTests: XCTestCase {
         XCTAssertFalse(preview.article.image.uploaded.hasAssetId())
         
         // when
-        let (assetKey, token) = ("Key", "Token")
+        let (assetKey, token) = (UUID.create(), UUID.create())
         let updated = preview.update(withAssetKey: assetKey, assetToken: token)
         
         // then
@@ -117,23 +117,23 @@ class ProtobufUtilitiesTests: XCTestCase {
                 return
             }
             XCTAssertTrue(asset.uploaded.hasAssetId())
-            XCTAssertEqual(asset.uploaded.assetId, assetKey)
-            XCTAssertEqual(asset.uploaded.assetToken, token)
+            XCTAssertEqual(asset.uploaded.assetId, assetKey.transportString())
+            XCTAssertEqual(asset.uploaded.assetToken, token.transportString())
         }
     }
 
     func testThatItUpdatesRemoteAssetDataWIthAssetIdAndAssetToken() {
         // given 
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let (assetId, token) = (UUID.create(), UUID.create())
         let sut = ZMAssetRemoteData.remoteData(withOTRKey: otrKey, sha256: sha)
 
         // when
         let updated = sut.updated(withId: assetId, token: token)
 
         // then
-        XCTAssertEqual(updated.assetId, assetId)
-        XCTAssertEqual(updated.assetToken, token)
+        XCTAssertEqual(updated.assetId, assetId.transportString())
+        XCTAssertEqual(updated.assetToken, token.transportString())
         XCTAssertEqual(updated.otrKey, otrKey)
         XCTAssertEqual(updated.sha256, sha)
     }
@@ -141,9 +141,9 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetUploadedWithAssetIdAndToken() {
         // given
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let (assetId, token) = (UUID.create(), UUID.create())
         let asset = ZMAsset.asset(withUploadedOTRKey: otrKey, sha256: sha)
-        let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create().transportString())
+        let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create())
 
         // when
         guard let updated = sut.updatedUploaded(withAssetId: assetId, token: token) else { return XCTFail() }
@@ -151,8 +151,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertFalse(updated.hasEphemeral())
         XCTAssert(updated.hasAsset())
-        XCTAssertEqual(updated.asset.uploaded.assetId, assetId)
-        XCTAssertEqual(updated.asset.uploaded.assetToken, token)
+        XCTAssertEqual(updated.asset.uploaded.assetId, assetId.transportString())
+        XCTAssertEqual(updated.asset.uploaded.assetToken, token.transportString())
         XCTAssertEqual(updated.asset.uploaded.otrKey, otrKey)
         XCTAssertEqual(updated.asset.uploaded.sha256, sha)
     }
@@ -160,9 +160,9 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetUploadedWithAssetIdAndToken_Ephemeral() {
         // given
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let (assetId, token) = (UUID.create(), UUID.create())
         let asset = ZMAsset.asset(withUploadedOTRKey: otrKey, sha256: sha)
-        let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create().transportString(), expiresAfter: NSNumber(value: 15))
+        let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create(), expiresAfter: NSNumber(value: 15))
 
         // when
         guard let updated = sut.updatedUploaded(withAssetId: assetId, token: token) else { return XCTFail() }
@@ -170,8 +170,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssert(updated.hasEphemeral())
         XCTAssertFalse(updated.hasAsset())
-        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetId, assetId)
-        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetToken, token)
+        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetId, assetId.transportString())
+        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetToken, token.transportString())
         XCTAssertEqual(updated.ephemeral.asset.uploaded.otrKey, otrKey)
         XCTAssertEqual(updated.ephemeral.asset.uploaded.sha256, sha)
     }
@@ -179,7 +179,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetPreviewWithAssetIdAndToken() {
         // given
         let (otr, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let (assetId, token) = (UUID.create(), UUID.create())
         let previewAsset = ZMAssetPreview.preview(
             withSize: 128,
             mimeType: "image/jpg",
@@ -189,7 +189,7 @@ class ProtobufUtilitiesTests: XCTestCase {
 
         let sut = ZMGenericMessage.genericMessage(
             asset: .asset(withOriginal: nil, preview: previewAsset),
-            messageID: UUID.create().transportString(),
+            messageID: UUID.create(),
             expiresAfter: NSNumber(value: 0)
         )
 
@@ -199,8 +199,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertFalse(updated.hasEphemeral())
         XCTAssert(updated.hasAsset())
-        XCTAssertEqual(updated.asset.preview.remote.assetId, assetId)
-        XCTAssertEqual(updated.asset.preview.remote.assetToken, token)
+        XCTAssertEqual(updated.asset.preview.remote.assetId, assetId.transportString())
+        XCTAssertEqual(updated.asset.preview.remote.assetToken, token.transportString())
         XCTAssertEqual(updated.asset.preview.remote.otrKey, otr)
         XCTAssertEqual(updated.asset.preview.remote.sha256, sha)
     }
@@ -208,7 +208,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetPreviewWithAssetIdAndToken_Ephemeral() {
         // given
         let (otr, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create().transportString(), UUID.create().transportString())
+        let (assetId, token) = (UUID.create(), UUID.create())
         let previewAsset = ZMAssetPreview.preview(
             withSize: 128,
             mimeType: "image/jpg",
@@ -218,7 +218,7 @@ class ProtobufUtilitiesTests: XCTestCase {
 
         let sut = ZMGenericMessage.genericMessage(
             asset: .asset(withOriginal: nil, preview: previewAsset),
-            messageID: UUID.create().transportString(),
+            messageID: UUID.create(),
             expiresAfter: NSNumber(value: 15)
         )
 
@@ -228,8 +228,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertTrue(updated.hasEphemeral())
         XCTAssert(updated.ephemeral.hasAsset())
-        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetId, assetId)
-        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetToken, token)
+        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetId, assetId.transportString())
+        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetToken, token.transportString())
         XCTAssertEqual(updated.ephemeral.asset.preview.remote.otrKey, otr)
         XCTAssertEqual(updated.ephemeral.asset.preview.remote.sha256, sha)
     }

--- a/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
+++ b/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
@@ -107,7 +107,7 @@ class ProtobufUtilitiesTests: XCTestCase {
         XCTAssertFalse(preview.article.image.uploaded.hasAssetId())
         
         // when
-        let (assetKey, token) = (UUID.create(), UUID.create())
+        let (assetKey, token) = ("key", "token")
         let updated = preview.update(withAssetKey: assetKey, assetToken: token)
         
         // then
@@ -117,23 +117,23 @@ class ProtobufUtilitiesTests: XCTestCase {
                 return
             }
             XCTAssertTrue(asset.uploaded.hasAssetId())
-            XCTAssertEqual(asset.uploaded.assetId, assetKey.transportString())
-            XCTAssertEqual(asset.uploaded.assetToken, token.transportString())
+            XCTAssertEqual(asset.uploaded.assetId, assetKey)
+            XCTAssertEqual(asset.uploaded.assetToken, token)
         }
     }
 
     func testThatItUpdatesRemoteAssetDataWIthAssetIdAndAssetToken() {
         // given 
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create(), UUID.create())
+        let (assetId, token) = ("id", "token")
         let sut = ZMAssetRemoteData.remoteData(withOTRKey: otrKey, sha256: sha)
 
         // when
         let updated = sut.updated(withId: assetId, token: token)
 
         // then
-        XCTAssertEqual(updated.assetId, assetId.transportString())
-        XCTAssertEqual(updated.assetToken, token.transportString())
+        XCTAssertEqual(updated.assetId, assetId)
+        XCTAssertEqual(updated.assetToken, token)
         XCTAssertEqual(updated.otrKey, otrKey)
         XCTAssertEqual(updated.sha256, sha)
     }
@@ -141,7 +141,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetUploadedWithAssetIdAndToken() {
         // given
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create(), UUID.create())
+        let (assetId, token) = ("id", "token")
         let asset = ZMAsset.asset(withUploadedOTRKey: otrKey, sha256: sha)
         let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create())
 
@@ -151,8 +151,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertFalse(updated.hasEphemeral())
         XCTAssert(updated.hasAsset())
-        XCTAssertEqual(updated.asset.uploaded.assetId, assetId.transportString())
-        XCTAssertEqual(updated.asset.uploaded.assetToken, token.transportString())
+        XCTAssertEqual(updated.asset.uploaded.assetId, assetId)
+        XCTAssertEqual(updated.asset.uploaded.assetToken, token)
         XCTAssertEqual(updated.asset.uploaded.otrKey, otrKey)
         XCTAssertEqual(updated.asset.uploaded.sha256, sha)
     }
@@ -160,7 +160,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetUploadedWithAssetIdAndToken_Ephemeral() {
         // given
         let (otrKey, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create(), UUID.create())
+        let (assetId, token) = ("id", "token")
         let asset = ZMAsset.asset(withUploadedOTRKey: otrKey, sha256: sha)
         let sut = ZMGenericMessage.genericMessage(asset: asset, messageID: UUID.create(), expiresAfter: NSNumber(value: 15))
 
@@ -170,8 +170,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssert(updated.hasEphemeral())
         XCTAssertFalse(updated.hasAsset())
-        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetId, assetId.transportString())
-        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetToken, token.transportString())
+        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetId, assetId)
+        XCTAssertEqual(updated.ephemeral.asset.uploaded.assetToken, token)
         XCTAssertEqual(updated.ephemeral.asset.uploaded.otrKey, otrKey)
         XCTAssertEqual(updated.ephemeral.asset.uploaded.sha256, sha)
     }
@@ -179,7 +179,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetPreviewWithAssetIdAndToken() {
         // given
         let (otr, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create(), UUID.create())
+        let (assetId, token) = ("id", "token")
         let previewAsset = ZMAssetPreview.preview(
             withSize: 128,
             mimeType: "image/jpg",
@@ -199,8 +199,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertFalse(updated.hasEphemeral())
         XCTAssert(updated.hasAsset())
-        XCTAssertEqual(updated.asset.preview.remote.assetId, assetId.transportString())
-        XCTAssertEqual(updated.asset.preview.remote.assetToken, token.transportString())
+        XCTAssertEqual(updated.asset.preview.remote.assetId, assetId)
+        XCTAssertEqual(updated.asset.preview.remote.assetToken, token)
         XCTAssertEqual(updated.asset.preview.remote.otrKey, otr)
         XCTAssertEqual(updated.asset.preview.remote.sha256, sha)
     }
@@ -208,7 +208,7 @@ class ProtobufUtilitiesTests: XCTestCase {
     func testThatItUpdatesAGenericMessageWithAssetPreviewWithAssetIdAndToken_Ephemeral() {
         // given
         let (otr, sha) = (Data.randomEncryptionKey(), Data.zmRandomSHA256Key())
-        let (assetId, token) = (UUID.create(), UUID.create())
+        let (assetId, token) = ("id", "token")
         let previewAsset = ZMAssetPreview.preview(
             withSize: 128,
             mimeType: "image/jpg",
@@ -228,8 +228,8 @@ class ProtobufUtilitiesTests: XCTestCase {
         // then
         XCTAssertTrue(updated.hasEphemeral())
         XCTAssert(updated.ephemeral.hasAsset())
-        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetId, assetId.transportString())
-        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetToken, token.transportString())
+        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetId, assetId)
+        XCTAssertEqual(updated.ephemeral.asset.preview.remote.assetToken, token)
         XCTAssertEqual(updated.ephemeral.asset.preview.remote.otrKey, otr)
         XCTAssertEqual(updated.ephemeral.asset.preview.remote.sha256, sha)
     }

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.m
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.m
@@ -204,7 +204,7 @@
     NSUUID *nonce = [NSUUID createUUID];
     ZMClientMessage *message = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
     
-    ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:text nonce:nonce.transportString expiresAfter:nil];
+    ZMGenericMessage *textMessage = [ZMGenericMessage messageWithText:text nonce:nonce expiresAfter:nil];
     [message addData:textMessage.data];
     return message;
 }

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -181,7 +181,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
             "name": NSNull(),
             "type": NSNumber(value: ZMBackendConversationType.convTypeGroup.rawValue),
             "id": conversation.remoteIdentifier!.transportString(),
-            "creator": UUID.create().transportString(),
+            "creator": UUID.create(),
             "members": [
                 "others": activeUsers.map { ["id": $0.remoteIdentifier!.transportString()] },
                 "self": [

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -98,6 +98,9 @@
 		5E0FB2012051493700FD9867 /* Set+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB2002051493700FD9867 /* Set+Filter.swift */; };
 		5E0FB2042051574300FD9867 /* ZMConversationTests+Mentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB202205156E900FD9867 /* ZMConversationTests+Mentions.swift */; };
 		5E0FB215205176B400FD9867 /* Set+ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */; };
+		5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E771F372080BB0000575629 /* PBMessage+Validation.swift */; };
+		5E771F3B2080C42300575629 /* PBMessageValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E771F392080C40B00575629 /* PBMessageValidationTests.swift */; };
+		5EDDC7A62088CE3B00B24850 /* ZMConversation+Invalid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC7A52088CE3B00B24850 /* ZMConversation+Invalid.swift */; };
 		7C7AF812201892FA00D0A3BE /* UTType+MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7AF811201892FA00D0A3BE /* UTType+MIMEType.swift */; };
 		7CBC3FC120177C3C008D06E4 /* RasterImages+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC3FC020177C3C008D06E4 /* RasterImages+Protobuf.swift */; };
 		871DD79F2084A316006B1C56 /* BatchDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871DD79E2084A316006B1C56 /* BatchDeleteTests.swift */; };
@@ -583,6 +586,9 @@
 		5E0FB2002051493700FD9867 /* Set+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Filter.swift"; sourceTree = "<group>"; };
 		5E0FB202205156E900FD9867 /* ZMConversationTests+Mentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Mentions.swift"; sourceTree = "<group>"; };
 		5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+ServiceUser.swift"; sourceTree = "<group>"; };
+		5E771F372080BB0000575629 /* PBMessage+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBMessage+Validation.swift"; sourceTree = "<group>"; };
+		5E771F392080C40B00575629 /* PBMessageValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBMessageValidationTests.swift; sourceTree = "<group>"; };
+		5EDDC7A52088CE3B00B24850 /* ZMConversation+Invalid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Invalid.swift"; sourceTree = "<group>"; };
 		7C7AF811201892FA00D0A3BE /* UTType+MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UTType+MIMEType.swift"; sourceTree = "<group>"; };
 		7CBC3FC020177C3C008D06E4 /* RasterImages+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RasterImages+Protobuf.swift"; sourceTree = "<group>"; };
 		8702B0EA20527F47006B60B9 /* zmessaging2.44.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.44.0.xcdatamodel; sourceTree = "<group>"; };
@@ -1079,6 +1085,7 @@
 			isa = PBXGroup;
 			children = (
 				F963E9721D9BF9E300098AD3 /* ProtosTests.swift */,
+				5E771F392080C40B00575629 /* PBMessageValidationTests.swift */,
 				BF707C501EB9F9CC00108D4E /* ClusterizerTests.swift */,
 				546D3DE81CE5D24C00A6047F /* MimeTypeTests.swift */,
 				54DE05DC1CF8711F00C35253 /* ProtobufUtilitiesTests.swift */,
@@ -1105,6 +1112,14 @@
 			name = Utils;
 			path = Tests/Source/Utils;
 			sourceTree = SOURCE_ROOT;
+		};
+		5E771F362080BAB200575629 /* Validation */ = {
+			isa = PBXGroup;
+			children = (
+				5E771F372080BB0000575629 /* PBMessage+Validation.swift */,
+			);
+			path = Validation;
+			sourceTree = "<group>";
 		};
 		BF10B5941E64591600E7036E /* Analytics */ = {
 			isa = PBXGroup;
@@ -1249,6 +1264,7 @@
 		F9A705D41CAEE01D00C2F5FE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5E771F362080BAB200575629 /* Validation */,
 				CE4EDC071D6D9A04002A20AA /* Reaction */,
 				F93A30281D6EFB66005CCB1D /* Confirmation */,
 				F9A705D51CAEE01D00C2F5FE /* Connection */,
@@ -1313,6 +1329,7 @@
 				F9C877081E000C9D00792613 /* AssetCollection.swift */,
 				F90D99A41E02DC6B00034070 /* AssetCollectionBatched.swift */,
 				5E0FB1FC2051396300FD9867 /* ZMConversation+Mentions.swift */,
+				5EDDC7A52088CE3B00B24850 /* ZMConversation+Invalid.swift */,
 			);
 			path = Conversation;
 			sourceTree = "<group>";
@@ -1830,7 +1847,6 @@
 				F9C9A6A01CAD7C7F0039E10C /* Public */,
 			);
 			name = Source;
-			path = WireDataModel;
 			sourceTree = "<group>";
 		};
 		F9C9A50A1CAD5DF10039E10C /* Tests */ = {
@@ -2304,6 +2320,7 @@
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
 				F9A706941CAEE01D00C2F5FE /* UserClient+Protobuf.swift in Sources */,
 				BF8F3A831E4B61C70079E9E7 /* TextSearchQuery.swift in Sources */,
+				5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */,
 				BF10B5971E64591600E7036E /* AnalyticsType.swift in Sources */,
 				16313D621D227DC1001B2AB3 /* LinkPreview+ProtocolBuffer.swift in Sources */,
 				F9A706A11CAEE01D00C2F5FE /* ZMOrderedSetState.mm in Sources */,
@@ -2341,6 +2358,7 @@
 				5451DE371F604CD500C82E75 /* ZMMoveIndex.swift in Sources */,
 				54E3EE451F61A53C00A261E3 /* ZMAssetClientMessage+Ephemeral.swift in Sources */,
 				F9B71F2E1CB264EF001DB03F /* ZMConversationMessageWindow.m in Sources */,
+				5EDDC7A62088CE3B00B24850 /* ZMConversation+Invalid.swift in Sources */,
 				F9A706B01CAEE01D00C2F5FE /* MessageChangeInfo.swift in Sources */,
 				F9A706A71CAEE01D00C2F5FE /* AnyClassTuple.swift in Sources */,
 				5451DE351F5FFF8B00C82E75 /* NotificationInContext.swift in Sources */,
@@ -2569,6 +2587,7 @@
 				F963E9741D9BF9ED00098AD3 /* ProtosTests.swift in Sources */,
 				16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */,
 				873B88FE2040470900FBE254 /* ConversationCreationOptionsTests.swift in Sources */,
+				5E771F3B2080C42300575629 /* PBMessageValidationTests.swift in Sources */,
 				F9FD757B1E2FB60E00B4558B /* SearchUserObserverTests.swift in Sources */,
 				F9B71F9A1CB2BF0E001DB03F /* ZMUserTests.m in Sources */,
 				F9331C581CB3BE5300139ECC /* ZMConversationTests+SecurityLevel.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

#479 introduced a bug that caused all messages with an asset to fail verification and be replaced by a system message.

### Causes

We mistakenly validated the asset key and token as a UUID, but these fields are never sent as UUIDs by the server. This caused the validation to fail all the time, even when the asset can be used.

### Solutions

We reverted the changes and made sure that the asset keys and tokens are never validated as UUIDs.