### PR TITLE
Stop inserting connection request system message

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -978,8 +978,7 @@ NSString * const ZMMessageParentMessageKey = @"parentMessage";
     return @{
              @(ZMUpdateEventTypeConversationMemberJoin) : @(ZMSystemMessageTypeParticipantsAdded),
              @(ZMUpdateEventTypeConversationMemberLeave) : @(ZMSystemMessageTypeParticipantsRemoved),
-             @(ZMUpdateEventTypeConversationRename) : @(ZMSystemMessageTypeConversationNameChanged),
-             @(ZMUpdateEventTypeConversationConnectRequest) : @(ZMSystemMessageTypeConnectionRequest)
+             @(ZMUpdateEventTypeConversationRename) : @(ZMSystemMessageTypeConversationNameChanged)
              };
 }
 


### PR DESCRIPTION
## What's new in this PR?

We were still inserting system messages of type `.connectionRequest` into conversation although we moved the connection views into the `UITableView`s headerView.

There also was a bug in which we ended up with cells with non-zero height in a conversation and in the case the user cancelled and resent a connection request end up with multiple connection request cells.