### PR TITLE
Fix: backup import fails to create new client

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
@@ -22,6 +22,7 @@ extension NSManagedObjectContext {
     
     /// Prepare a backed up database for being imported, deleting self client, push token etc.
     func prepareToImportBackup() {
+        require(self.zm_isSyncContext, "Needs to be run on Sync Context to avoid race conditions")
         setPersistentStoreMetadata(nil as Data?, key: ZMPersistedClientIdKey)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.importedFromBackup.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.pushToken.rawValue)

--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -172,9 +172,9 @@ import UIKit
                 dispatchGroup: dispatchGroup)
             MemoryReferenceDebugger.register(directory)
 
-            directory.uiContext.performAndWait {
-                if let imported = directory.uiContext.persistentStoreMetadata(forKey: PersistentMetadataKey.importedFromBackup.rawValue) as? NSNumber, imported.boolValue {
-                    directory.uiContext.prepareToImportBackup()
+            directory.syncContext.performAndWait {
+                if let imported = directory.syncContext.persistentStoreMetadata(forKey: PersistentMetadataKey.importedFromBackup.rawValue) as? NSNumber, imported.boolValue {
+                    directory.syncContext.prepareToImportBackup()
                 }
             }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When importing backup a new client doesn't get created which leads to decryption errors.

### Causes

After import we need to do some preprocessing. One of the steps is removing the self client identifier. It was all done on UI context and could lead to race conditions because on the sync context the login could continue as if you have an existing client.

### Solutions

Do all of it on sync context.
