### PR TITLE
Do not put the private info into fatal()

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -185,7 +185,7 @@ extension ZMGenericMessage {
         if self.hasConfirmation() || self.hasEphemeral() {
             guard let recipients = recipientForConfirmationMessage() ?? recipientForOtherUsers() else {
                 let confirmationInfo = hasConfirmation() ? ", original message: \(self.confirmation.firstMessageId)" : ""
-                fatal("confirmation need a recipient\n ConvID: \(String(describing: conversation.remoteIdentifier)) ConvType: \(conversation.conversationType.rawValue), connection: \(String(describing: conversation.connection))\(confirmationInfo)")
+                fatal("confirmation need a recipient\n ConvID: \(String(describing: conversation.remoteIdentifier)) ConvType: \(conversation.conversationType.rawValue) \(confirmationInfo)")
             }
             recipientUsers = recipients
         }

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -305,3 +305,15 @@ extension ZMUser {
         return nameGenerator.displayName(for: self, in: conversation)
     }
 }
+
+protocol PrivateStringConvertible {
+    var privateDescription: String { get }
+}
+
+extension NSManagedObject: PrivateStringConvertible {
+    var privateDescription: String {
+        let moc: String = self.managedObjectContext?.description ?? "nil"
+        
+        return "\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque()): moc=\(moc) objectID=\(self.objectID)"
+    }
+}

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -140,7 +140,7 @@ public class UserClient: ZMManagedObject, UserClientType {
         precondition(!createIfNeeded || user.managedObjectContext!.zm_isSyncContext, "clients can only be created on the syncContext")
         
         guard let context = user.managedObjectContext else {
-            fatal("User \(user) is not a member of a managed object context (deleted object).")
+            fatal("User \(user.privateDescription) is not a member of a managed object context (deleted object).")
         }
         
         let relationClients = user.clients.filter({$0.remoteIdentifier == remoteIdentifier})
@@ -334,7 +334,7 @@ public extension UserClient {
         }
         let selfUser = ZMUser.selfUser(in: context)
         guard self.user == selfUser else {
-            fatal("The method 'markForDeletion()' can only be called for clients that belong to the selfUser (self user is \(selfUser))")
+            fatal("The method 'markForDeletion()' can only be called for clients that belong to the selfUser (self user is \(selfUser.privateDescription))")
         }
         guard selfUser.selfClient() != self else {
             fatal("Attempt to delete the self client. This should never happen!")

--- a/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -23,7 +23,7 @@ extension NSOrderedSet {
     
     public func toOrderedSetState<T: Hashable>() -> OrderedSetState<T> {
         guard let objects = array as? [T] else {
-            fatal("Could not cast contents of NSOrderedSet \(self) to expected type \(T.self)")
+            fatal("Could not cast contents of NSOrderedSet \(type(of: self)) to expected type \(T.self)")
         }
         return OrderedSetState(array: objects)
     }

--- a/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
@@ -69,7 +69,7 @@ public struct KeySet : Sequence {
             if let ss = s as? String {
                 a.append(KeyPath.keyPathForString(ss))
             } else {
-                fatal("\(s) is not a string")
+                fatal("\(type(of: s)) is not a string")
             }
         }
         backing = Set(a)


### PR DESCRIPTION
- Added protocol `PrivateStringConvertible` to generate the object description that can be put into the log or the crash report.
- Use `privateDescription` when necessary.