### PR TITLE
Feature: Adjust time values presets

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -19,12 +19,12 @@
 
 public enum ZMConversationMessageDestructionTimeout : TimeInterval {
     case none = 0
-    case fiveSeconds = 5
-    case fifteenSeconds = 15
-    case thirtySeconds = 30
-    case oneMinute = 60
+    case tenSeconds = 10
     case fiveMinutes = 300
+    case oneHour = 3600
     case oneDay = 86400
+    case oneWeek = 604800
+    case fourWeeks = 2419200
 }
 
 public extension ZMConversationMessageDestructionTimeout {
@@ -32,12 +32,12 @@ public extension ZMConversationMessageDestructionTimeout {
     static var all: [ZMConversationMessageDestructionTimeout] {
         return [
             .none,
-            .fiveSeconds,
-            .fifteenSeconds,
-            .thirtySeconds,
-            .oneMinute,
+            .tenSeconds,
             .fiveMinutes,
-            .oneDay
+            .oneHour,
+            .oneDay,
+            .oneWeek,
+            .fourWeeks
         ]
     }
 }
@@ -46,8 +46,8 @@ public extension ZMConversationMessageDestructionTimeout {
 
     public static func validTimeout(for timeout: TimeInterval) -> TimeInterval {
         return timeout.clamp(
-            between: ZMConversationMessageDestructionTimeout.fiveSeconds.rawValue,
-            and: ZMConversationMessageDestructionTimeout.oneDay.rawValue
+            between: ZMConversationMessageDestructionTimeout.tenSeconds.rawValue,
+            and: ZMConversationMessageDestructionTimeout.fourWeeks.rawValue
         )
     }
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -65,10 +65,10 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         
         // when
-        conversation.updateMessageDestructionTimeout(timeout: .fiveSeconds)
+        conversation.updateMessageDestructionTimeout(timeout: .tenSeconds)
         
         // then
-        XCTAssertEqual(conversation.messageDestructionTimeout, 5)
+        XCTAssertEqual(conversation.messageDestructionTimeout, 10)
     }
 
     
@@ -78,10 +78,10 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
         conversation.conversationType = .oneOnOne
         
         // when
-        conversation.updateMessageDestructionTimeout(timeout: .fiveSeconds)
+        conversation.updateMessageDestructionTimeout(timeout: .tenSeconds)
         
         // then
-        XCTAssertEqual(conversation.messageDestructionTimeout, 5)
+        XCTAssertEqual(conversation.messageDestructionTimeout, 10)
     }
  
     func testThatSendingEphemeralToEmptyConversationIsNotPossible() {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -31,7 +31,9 @@ class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.fiveMinutes.rawValue, 300)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.oneDay.rawValue, 86400)
     }
-    
+
+    ///TODO: string test
+
     func testThatItReturnsTheClosestTimeOut() {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: -2), 5)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 0), 5)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -19,20 +19,16 @@
 import Foundation
 @testable import WireDataModel
 
-
 class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
 
     func testThatItReturnsTheCorrectTimeouts(){
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.none.rawValue, 0)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.fiveSeconds.rawValue, 5)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.fifteenSeconds.rawValue, 15)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.thirtySeconds.rawValue, 30)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.oneMinute.rawValue, 60)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.tenSeconds.rawValue, 10)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.fiveMinutes.rawValue, 300)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.oneDay.rawValue, 86400)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.oneWeek.rawValue, 604800)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.fourWeeks.rawValue, 2419200)
     }
-
-    ///TODO: string test
 
     func testThatItReturnsTheClosestTimeOut() {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: -2), 5)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -31,11 +31,11 @@ class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
     }
 
     func testThatItReturnsTheClosestTimeOut() {
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: -2), 5)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 0), 5)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 2), 5)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 5), 5)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 6), 6)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: -2), 10)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 0), 10)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 2), 10)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 5), 10)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 6), 10)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 14), 14)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 15), 15)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 16), 16)
@@ -50,8 +50,8 @@ class ZMConversationMessageDestructionTimeoutTests : XCTestCase {
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 301), 301)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 86399), 86399)
         XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 86400), 86400)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 86401), 86400)
-        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 1234567890), 86400)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 86401), 86401)
+        XCTAssertEqual(ZMConversationMessageDestructionTimeout.validTimeout(for: 1234567890), 2419200)
     }
 
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2145,7 +2145,7 @@
     ZMMessage *message = (id)[conversation appendMessageWithText:@"Test Message"];
     message.sender = self.selfUser;
     [message markAsSent];
-    conversation.messageDestructionTimeout = 10;
+    conversation.messageDestructionTimeout = 15;
     ZMMessage *ephemeralMessage = (id)[conversation appendMessageWithText:@"Ephemeral Test Message"];
     ephemeralMessage.sender = self.selfUser;
     [ephemeralMessage markAsSent];

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -67,7 +67,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         otherUser.remoteIdentifier = UUID.create()
         
         self.conversation.mutableLastServerSyncedActiveParticipants.addObjects(from: [otherUser])
-        self.conversation.updateMessageDestructionTimeout(timeout: .thirtySeconds)
+        self.conversation.updateMessageDestructionTimeout(timeout: .fiveMinutes)
         let message = self.conversation.appendMessage(withText: "ramble on!")! as! ZMMessage
         
         // THEN


### PR DESCRIPTION
## What's new in this PR?

Adjust timed messages expiry time to 10 seconds, 5 minutes, 1 hour, 1 day, 1 week or 4 weeks.