### PR TITLE
Allow sending the messages to bots without mention

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Mentions.swift
+++ b/Source/Model/Conversation/ZMConversation+Mentions.swift
@@ -18,11 +18,15 @@
 
 import Foundation
 
-extension ZMConversation {
 
+extension ZMConversation {
     @objc(normalizeText:forMentions:)
     func normalize(text: String, for mentions: [ZMMention]) -> String {
 
+        guard ZMUser.servicesMustBeMentioned else {
+            return text
+        }
+        
         // If the message is for a bot, remove the mention handle
 
         guard let firstMention = mentions.first else {
@@ -38,9 +42,9 @@ extension ZMConversation {
             return text
         }
 
-        // Remove the ServiceMentionKeyword (while it's here)
+        // Remove the ZMUser.serviceMentionKeyword (while it's here)
 
-        guard let mentionHandleRange = text.range(of: ServiceMentionKeyword + " ") else {
+        guard let mentionHandleRange = text.range(of: ZMUser.serviceMentionKeyword + " ") else {
             return text
         }
 
@@ -53,7 +57,7 @@ extension ZMConversation {
         let serviceUsers = (self.lastServerSyncedActiveParticipants.set as! Set<ZMUser>).serviceUsers
         var mentionedUsers: [ZMUser] = []
 
-        if text.starts(with: ServiceMentionKeyword + " ") {
+        if text.starts(with: ZMUser.serviceMentionKeyword + " ") {
             mentionedUsers.append(contentsOf: serviceUsers)
         }
 

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -173,9 +173,13 @@ extension ZMGenericMessage {
         func allAuthorizedRecipients() -> Set<ZMUser> {
             if let connectedUser = conversation.connectedUser { return Set(arrayLiteral: connectedUser, selfUser) }
 
-            let authorizedServices = services.filtered { service in
-                self.textData?.mention?.contains { $0.userId == service.remoteIdentifier?.transportString() } ?? false
+            func mentionedServices() -> Set<ZMUser> {
+                return services.filtered { service in
+                    self.textData?.mention?.contains { $0.userId == service.remoteIdentifier?.transportString() } ?? false
+                }
             }
+            
+            let authorizedServices = ZMUser.servicesMustBeMentioned ? mentionedServices() : services
 
             return otherUsers.union(authorizedServices).union([selfUser])
         }

--- a/Source/Model/User/ServiceUser.swift
+++ b/Source/Model/User/ServiceUser.swift
@@ -18,8 +18,6 @@
 
 import Foundation
 
-let ServiceMentionKeyword = "@bots"
-
 @objc public protocol ServiceUser: class, ZMBareUser {
     var providerIdentifier: String? { get }
     var serviceIdentifier: String? { get }
@@ -27,4 +25,9 @@ let ServiceMentionKeyword = "@bots"
 
 @objc public protocol SearchServiceUser: ServiceUser {
     var summary: String? { get }
+}
+
+extension ZMUser {
+    static let servicesMustBeMentioned = false
+    static let serviceMentionKeyword = "@bots"
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Mentions.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Mentions.swift
@@ -155,7 +155,12 @@ class ZMConversationMentionsTests: ZMConversationTestsBase {
         // When the first mention is a bot, trim the text
 
         let serviceMentionNormalization = conversation.normalize(text: "@bots @wire Hello", for: serviceMention)
-        XCTAssertEqual(serviceMentionNormalization, "@wire Hello")
+        if ZMUser.servicesMustBeMentioned {
+            XCTAssertEqual(serviceMentionNormalization, "@wire Hello")
+        }
+        else {
+            XCTAssertEqual(serviceMentionNormalization, "@bots @wire Hello")
+        }
 
         // When the first mention is not a bot, do not trim the text
 

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -27,6 +27,7 @@ class ClientMessageTests_OTR: BaseZMClientMessageTests {
 extension ClientMessageTests_OTR {
 
     func testThatItExcludesServicesWhenNotMentioned() {
+
         self.syncMOC.performGroupedBlockAndWait {
             let regularUser1 = ZMUser.insertNewObject(in: self.syncMOC)
             regularUser1.remoteIdentifier = UUID.create()
@@ -70,9 +71,12 @@ extension ClientMessageTests_OTR {
 
             // then
 
-            switch strategy {
-            case .ignoreAllMissingClientsNotFromUsers(let users):
+            switch (ZMUser.servicesMustBeMentioned, strategy) {
+            case (true, .ignoreAllMissingClientsNotFromUsers(let users)):
                 XCTAssertEqual(users, Set([regularUser1, regularUser2, serviceUser2, selfUser]))
+            case (false, .doNotIgnoreAnyMissingClient):
+                // all good
+                break
             default:
                 XCTFail()
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need to temporarily disable the filtering of messages, so they only go to the bots if the bots are mentioned.

### Solutions

Bool flag to control the messages behavior for that particular case is added.