### PR TITLE
Reset both timer values when setting a nil timer value without having a previous one

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -94,7 +94,7 @@ public extension MessageDestructionTimeoutValue {
 
 }
 
-public enum MessageDestructionTimeout {
+public enum MessageDestructionTimeout: Equatable {
     case local(MessageDestructionTimeoutValue)
     case synced(MessageDestructionTimeoutValue)
 }
@@ -144,6 +144,13 @@ public extension MessageDestructionTimeoutValue {
     
 }
 
+public func ==(lhs: MessageDestructionTimeout, rhs: MessageDestructionTimeout) -> Bool {
+    switch (rhs, lhs) {
+    case let (.local(lhsValue), .local(rhsValue)): return lhsValue == rhsValue
+    case let (.synced(lhsValue), .synced(rhsValue)): return lhsValue == rhsValue
+    default: return false
+    }
+}
 
 public extension ZMConversation {
 
@@ -190,6 +197,7 @@ public extension ZMConversation {
                 case .synced?:
                     syncedMessageDestructionTimeout = 0
                 case nil:
+                    syncedMessageDestructionTimeout = 0
                     localMessageDestructionTimeout = 0
                 }
             }

--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -144,14 +144,6 @@ public extension MessageDestructionTimeoutValue {
     
 }
 
-public func ==(lhs: MessageDestructionTimeout, rhs: MessageDestructionTimeout) -> Bool {
-    switch (rhs, lhs) {
-    case let (.local(lhsValue), .local(rhsValue)): return lhsValue == rhsValue
-    case let (.synced(lhsValue), .synced(rhsValue)): return lhsValue == rhsValue
-    default: return false
-    }
-}
-
 public extension ZMConversation {
 
     /// Defines the time interval until an inserted messages is deleted / "self-destructs" on all clients.
@@ -206,11 +198,11 @@ public extension ZMConversation {
     
     @objc var messageDestructionTimeoutValue: TimeInterval {
         switch messageDestructionTimeout {
-        case .some(.local(let value)):
+        case .local(let value)?:
             return value.rawValue
-        case .some(.synced(let value)):
+        case .synced(let value)?:
             return value.rawValue
-        case .none:
+        case nil:
             return 0
         }
     }


### PR DESCRIPTION
## What's new in this PR?

Reset both timer values when setting a nil timer value without having a previous one. Otherwise it's not possible to set a synced value, and then reset it to nil because we didn't reset the synced value in that case.