### PR TITLE
Fix: copy date formatter updates & move MessageDestructionTimeoutValue's displayString from wire-ios

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Ephemeral.swift
+++ b/Source/Model/Conversation/ZMConversation+Ephemeral.swift
@@ -101,8 +101,10 @@ public enum MessageDestructionTimeout: Equatable {
 
 fileprivate let longStyleFormatter: DateComponentsFormatter = {
     let formatter = DateComponentsFormatter()
+    formatter.includesApproximationPhrase = false
+    formatter.maximumUnitCount = 1
     formatter.unitsStyle = .full
-    formatter.allowedUnits = [.day, .hour, .minute, .second]
+    formatter.allowedUnits = [.weekOfMonth, .day, .hour, .minute, .second]
     formatter.zeroFormattingBehavior = .dropAll
     return formatter
 }()


### PR DESCRIPTION
## What's new in this PR?

1. Move the latest change for longStyleFormatter form wire-ios project to data-model

