### PR TITLE
Correctly parse milisecond conversation timer

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -114,7 +114,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSNumber *messageTimerNumber = [transportData optionalNumberForKey:ConversationInfoMessageTimer];
     
     if (messageTimerNumber != nil) {
-        self.syncedMessageDestructionTimeout = messageTimerNumber.doubleValue;
+        // Backend is sending the miliseconds, we need to convert to seconds.
+        self.syncedMessageDestructionTimeout = messageTimerNumber.doubleValue / 1000;
     }
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -585,7 +585,7 @@
                                   @"members" : @{
                                           @"others" : @3
                                           },
-                                  @"message_timer": @1000,
+                                  @"message_timer": @31536000000,
                                   @"type" : @1,
                                   @"id" : [uuid UUIDString]
                                   };
@@ -599,7 +599,7 @@
         
         // then
         XCTAssertNotNil(conversation);
-        XCTAssertEqual(conversation.messageDestructionTimeoutValue, 1000);
+        XCTAssertEqual(conversation.messageDestructionTimeoutValue, 31536000);
     }];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We should set and read the timer as milliseconds. Another fix is coming for the SE.