### PR TITLE
Don't update last modified date for message timer update system messages

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -996,6 +996,7 @@ NSString * const ZMSystemMessageMessageTimerKey = @"messageTimer";
     switch (self.systemMessageType) {
         case ZMSystemMessageTypeParticipantsRemoved:
         case ZMSystemMessageTypeConversationNameChanged:
+        case ZMSystemMessageTypeMessageTimerUpdate:
             return NO;
 
         default:

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -87,8 +87,10 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
     {
         let types = [
             ZMSystemMessageType.teamMemberLeave,
-            ZMSystemMessageType.conversationNameChanged
+            ZMSystemMessageType.conversationNameChanged,
+            ZMSystemMessageType.messageTimerUpdate
         ]
+
         for type in types {
             // given
             let conversation = ZMConversation.insertNewObject(in: self.uiMOC)


### PR DESCRIPTION
## What's new in this PR?

* Don't update last modified date for message timer update system messages.