### PR TITLE
Use query generations on UI and search MOC

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
@@ -81,6 +81,9 @@ extension ManagedObjectContextDirectory {
             moc.configure(with: persistentStoreCoordinator)
             ZMUser.selfUser(in: moc)
             dispatchGroup.apply(moc.add)
+            if #available(iOS 10, *) {
+                try? moc.setQueryGenerationFrom(.current)
+            }
         }
         moc.mergePolicy = ZMSyncMergePolicy(merge: .rollbackMergePolicyType)
         return moc
@@ -125,6 +128,9 @@ extension ManagedObjectContextDirectory {
             moc.undoManager = nil
             moc.mergePolicy = ZMSyncMergePolicy(merge: .rollbackMergePolicyType)
             dispatchGroup.apply(moc.add)
+            if #available(iOS 10, *) {
+                try? moc.setQueryGenerationFrom(.current)
+            }
         }
         return moc
     }

--- a/Tests/Source/ManagedObjectContext/StorageStackTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackTests.swift
@@ -471,6 +471,29 @@ class StorageStackTests: DatabaseBaseTest {
         StorageStack.reset()
         
     }
+
+    func testThatItSetsQueryGenerationTokenOnUIAndSerchContext() {
+        // GIVEN
+        let completionExpectation = self.expectation(description: "Callback invoked")
+
+        // WHEN
+        StorageStack.shared.createManagedObjectContextDirectory(
+            accountIdentifier: accountID,
+            applicationContainer: self.applicationContainer,
+            startedMigrationCallback: { XCTFail() }
+        ) { directory in
+            if #available(iOS 10, *) {
+                XCTAssertNotNil(directory.uiContext.queryGenerationToken)
+                XCTAssertNil(directory.syncContext.queryGenerationToken)
+                XCTAssertNotNil(directory.searchContext.queryGenerationToken)
+            }
+            completionExpectation.fulfill()
+        }
+
+        // THEN
+        XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
+
+    }
 }
 
 // MARK: - Legacy User ID


### PR DESCRIPTION
## What's new in this PR?

### Issues

Because we have two MOCs and data can be updated in either one of them it can get out of date quickly. For example we try to display a conversation message in the UI, but before data is loaded the actual message is deleted. There are several known bugs with ephemerals about this.

### Solutions

Starting from iOS 10 there is a new CoreData feature that allows to pin the MOC to data snapshot at certain time. All fetches will then show data as it was at that time, even if it was changed afterwards. On the DB level this is done by keeping the log of all changes (in the .wal file) that allows recreating state of each transaction.
