### PR TITLE
Do not consider WebM as the video format

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -216,7 +216,7 @@ extension ZMAssetClientMessage: ZMFileMessageData {
     }
 
     public var isVideo: Bool {
-        return self.mimeType?.isVideoMimeType() ?? false
+        return self.mimeType?.isPlayableVideoMimeType() ?? false
     }
     
     public var isAudio: Bool {

--- a/Source/Utilis/MimeType.swift
+++ b/Source/Utilis/MimeType.swift
@@ -20,11 +20,19 @@
 import Foundation
 import MobileCoreServices
 
+// WebM can be considered the video MIME type if the appropriate video player is installed on the operating system.
+fileprivate let unsupportedVideoTypes: Set<String> = ["video/webm"]
+
 extension String {
     
     /// Returns whether the string represents a video mime type
     public func isVideoMimeType() -> Bool {
         return (self as NSString).zm_conforms(to: kUTTypeMovie)
+    }
+    
+    /// Returns whether it is possible to play the file with the given mime type as the video
+    public func isPlayableVideoMimeType() -> Bool {
+        return isVideoMimeType() && !unsupportedVideoTypes.contains(self)
     }
     
     /// Returns whether the string represents an audio mime type

--- a/Tests/Source/Model/Utils/MimeTypeTests.swift
+++ b/Tests/Source/Model/Utils/MimeTypeTests.swift
@@ -24,6 +24,8 @@ class MimeTypeTests: XCTestCase {
     func testThatItParsesVideoMimeTypeCorrectly_Positive() {
         XCTAssertTrue("video/mp4".isVideoMimeType())
         XCTAssertTrue("video/mpeg".isVideoMimeType())
+        // WebM can be considered the video MIME type if the appropriate video player is installed on the operating system.
+        XCTAssertFalse("video/webm".isVideoMimeType())
     }
 
     func testThatItParsesVideoMimeTypeCorrectly_Negative() {
@@ -49,6 +51,10 @@ class MimeTypeTests: XCTestCase {
         XCTAssertFalse(".mp4".isAudioMimeType())
         XCTAssertFalse("video/mp4".isAudioMimeType())
         XCTAssertFalse("video/mpeg".isAudioMimeType())
+    }
+    
+    func testPlayableMimeType() {
+        XCTAssertFalse("video/webm".isPlayableVideoMimeType())
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

WebM is not supported by the iOS and also not known to the MIME type system. If user installs the player for WebM, for example VLC, then the format is recognized as video, but still cannot be played by the iOS integrated video player.

### Solutions

Manually exclude WebM from the list of the video formats.