### PR TITLE
Fix/audio message timer

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -82,4 +82,22 @@ extension ZMAssetClientMessage {
         }
         return super.startDestructionIfNeeded()
     }
+    
+    /// Extends the destruction timer to the given date, which must be later
+    /// than the current destruction date. If a timer is already running,
+    /// then it will be stopped and restarted with the new date, otherwise
+    /// a new timer will be created.
+    public func extendDestructionTimer(to date: Date) {
+        let timeout = date.timeIntervalSince(Date())
+        
+        guard let isSelfUser = self.sender?.isSelfUser,
+            let destructionDate = self.destructionDate,
+            date > destructionDate,
+            timeout > 0
+            else { return }
+        
+        let msg = self as ZMMessage
+        if isSelfUser { msg.restartObfuscationTimer(timeout) }
+        else { msg.restartDeletionTimer(timeout) }
+    }
 }

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -297,6 +297,13 @@ extern NSString *  _Nonnull const ZMMessageServerTimestampKey;
 /// Inserts a delete message for the ephemeral and sets the destruction timeout to nil
 - (void)deleteEphemeral;
 
+/// Restarts the deletion timer with the given time interval. If a timer already
+/// exists, it will be stopped first.
+- (void)restartDeletionTimer:(NSTimeInterval)remainingTime;
+
+/// Restarts the deletion timer with the given time interval. If a timer already
+/// exists, it will be stopped first.
+- (void)restartObfuscationTimer:(NSTimeInterval)remainingTime;
 
 /// When we restart, we might still have messages that had a timer, but whose timer did not fire before killing the app
 /// To delete those messages immediately use this method on startup (e.g. in the init of the ZMClientMessageTranscoder) to fetch and delete those messages

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -1096,6 +1096,7 @@ NSString * const ZMSystemMessageMessageTimerKey = @"messageTimer";
         NSError *error;
         ZMMessage *message = [uiContext existingObjectWithID:self.objectID error:&error];
         if (error == nil && message != nil) {
+            [uiContext.zm_messageDeletionTimer stopTimerForMessage:message];
             NOT_USED([uiContext.zm_messageDeletionTimer startDeletionTimerWithMessage:message timeout:remainingTime]);
         }
     }];
@@ -1111,6 +1112,7 @@ NSString * const ZMSystemMessageMessageTimerKey = @"messageTimer";
         NSError *error;
         ZMMessage *message = [syncContext existingObjectWithID:self.objectID error:&error];
         if (error == nil && message != nil) {
+            [syncContext.zm_messageObfuscationTimer stopTimerForMessage:message];
             NOT_USED([syncContext.zm_messageObfuscationTimer startObfuscationTimerWithMessage:message timeout:remainingTime]);
         }
     }];


### PR DESCRIPTION
## What's new in this PR?

This PR introduces a new method to extend a destruction timer of a `ZMAssetClientMessage`.  This will be used in the UI to handle the case when an ephemeral audio message is longer than its timeout (thus making it impossible to hear the entire message).