### PR TITLE
Fix/ephemeral deletion

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -167,6 +167,13 @@ extension ZMGenericMessage {
                 zmLog.error("sender of deleted ephemeral message \(self.deleted.messageId) is already cleared \n ConvID: \(String(describing: conversation.remoteIdentifier)) ConvType: \(conversation.conversationType.rawValue)")
                 return Set(arrayLiteral: selfUser)
             }
+            
+            // if self deletes their own message, we want to send delete msg
+            // for everyone, so return nil.
+            guard !sender.isSelfUser else { return nil }
+            
+            // otherwise we delete only for self and the sender, all other
+            // recipients are unaffected.
             return Set(arrayLiteral: sender, selfUser)
         }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

An ephemeral message sent in a group conversation is not deleted on the clients of all recipients when the original sender deletes for everyone.

### Causes

When an ephemeral message is deleted, we decide who the recipients should be for the `ZMMessageDelete` message. The logic is to only send this deletion message to the self user and the sender of the ephemeral message, which I believe is to ensure that the message is still available for other users in the conversation. However, this logic fails to check if the sender and self user are one and the same, in which case no one else will delete the ephemeral.

### Solutions

If the sender and self user are the same, include all authorized users in the conversation as recipients of the deletion message.