### PR TITLE
Test improvements

### DIFF
--- a/Source/ManagedObjectContext/StorageStack.swift
+++ b/Source/ManagedObjectContext/StorageStack.swift
@@ -186,6 +186,7 @@ import UIKit
     /// Using a ManagedObjectContextDirectory created by a stack after the stack has been
     /// reset will cause a crash
     public static func reset() {
+        StorageStack.currentStack?.managedObjectContextDirectory?.tearDown()
         StorageStack.currentStack = nil
     }
 }

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -352,6 +352,14 @@ public extension UserClient {
         guard self.fingerprint == .none,
             let syncMOC = self.managedObjectContext?.zm_sync
             else { return }
+
+        if self.objectID.isTemporaryID {
+            do {
+                try syncMOC.obtainPermanentIDs(for: [self])
+            } catch {
+                fatal("Error obtaining permanent id for client")
+            }
+        }
         
         let selfObjectID = self.objectID
         

--- a/Tests/Source/Model/ZMTestSession.m
+++ b/Tests/Source/Model/ZMTestSession.m
@@ -52,6 +52,7 @@
         self.accountIdentifier = identifier;
         self.containerURL = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
         self.storeURL = [[StorageStack accountFolderWithAccountIdentifier:self.accountIdentifier applicationContainer:self.containerURL] URLAppendingPersistentStoreLocation];
+        self.shouldUseInMemoryStore = YES;
     }
 
     return self;


### PR DESCRIPTION
## What's new in this PR?

### Issues

* Tests using ZMTestSession were defaulting to on-disk storage, but it should be in memory. Initialising this flag got lost during a refactoring ~1 year ago.
* In tests a situation can happen that UserClient is not committed to the database and doesn't have permanentID yet, so all consecutive calls to `syncMOC.existingObject(with:)` will fail to return anything.
* Tearing down context directory a bit earlier.