### PR TITLE
delete for everyone when deleting ephemeral

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -36,7 +36,7 @@ extension ZMMessage {
     
     // NOTE: This is a free function meant to be called from Obj-C because you can't call protocol extension from it
     @objc public static func hideMessage(_ message: ZMConversationMessage) {
-        // when deleteing ephemeral, we must delete for everyone (only self & sender will receieve delete message)
+        // when deleting ephemeral, we must delete for everyone (only self & sender will receive delete message)
         // b/c deleting locally will void the destruction timer completion.
         guard !message.isEphemeral else { deleteForEveryone(message); return }
         guard let castedMessage = message as? ZMMessage else { return }

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -36,6 +36,9 @@ extension ZMMessage {
     
     // NOTE: This is a free function meant to be called from Obj-C because you can't call protocol extension from it
     @objc public static func hideMessage(_ message: ZMConversationMessage) {
+        // when deleteing ephemeral, we must delete for everyone (only self & sender will receieve delete message)
+        // b/c deleting locally will void the destruction timer completion.
+        guard !message.isEphemeral else { deleteForEveryone(message); return }
         guard let castedMessage = message as? ZMMessage else { return }
         castedMessage.hideForSelfUser()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues
If the receiver deletes an ephemeral message, then the message is not deleted on the sender side and they are stuck with the obfuscated message.

### Causes
When the deletion timer fires normally (on the receiver side), a call to `ZMMessage.deleteForEveryone(message:) is eventually invoked, which generates a delete message to be sent to participants in the client. This method name is misleading because in the case of ephemeral messages, we actually only delete for the self user and the original sender. See [here](https://github.com/wireapp/wire-ios-data-model/blob/68d5d5d5f385b15bb3cddbfe7facf12fecf5400a/Source/Model/Message/ZMClientMessage%2BEncryption.swift#L161) for details.

However, when the receiver deletes the ephemeral, they only delete the message locally. This means that when the destruction timer fires, it returns early because it finds that the ephemeral to delete is already deleted. As a result, the original sender never receives the delete message and is stuck with the obfuscated message. 

### Solutions
We simply need to delete the ephemeral message for everyone.