### PR TITLE
Make message window size public

### DIFF
--- a/Source/Model/Conversation/ZMConversationMessageWindow.swift
+++ b/Source/Model/Conversation/ZMConversationMessageWindow.swift
@@ -19,9 +19,10 @@
 import Foundation
 
 public final class ZMConversationMessageWindow: NSObject {
-    private(set) var size: UInt
-    let mutableMessages: NSMutableOrderedSet
+    @objc public private(set) var size: UInt
     @objc public let conversation: ZMConversation
+
+    let mutableMessages: NSMutableOrderedSet
 
     var activeSize: UInt {
         return min(size, UInt(conversation.messages.count))


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `size` property of the message window was not publicly accessible, which caused compilation problems in SE tests (cf. [Circle CI](https://circleci.com/gh/wireapp/wire-ios-sync-engine/3781?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)).

### Causes

When this class was re-written in Swift, the size property was left with internal access.