### PR TITLE
Add missing conversation message window initializer

### DIFF
--- a/Source/Model/Conversation/ZMConversationMessageWindow.swift
+++ b/Source/Model/Conversation/ZMConversationMessageWindow.swift
@@ -32,7 +32,7 @@ public final class ZMConversationMessageWindow: NSObject {
         return mutableMessages.reversed
     }
 
-    init(conversation: ZMConversation, size: UInt) {
+    @objc public init(conversation: ZMConversation, size: UInt) {
         self.conversation = conversation
         self.size = size
         mutableMessages = NSMutableOrderedSet()


### PR DESCRIPTION
## What's new in this PR?

### Issues

An initializer previously available in the Objective-C implementation of `ZMConversationMessageWindow` was not made public in the Swift rewrite. This caused UI tests to fail.