### PR TITLE
Guarantee that the completion handler is always called

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -143,7 +143,7 @@ extension ZMAssetClientMessage: ZMFileMessageData {
     }
     
     public func fetchImagePreviewData(queue: DispatchQueue, completionHandler: @escaping (Data?) -> Void) {
-        guard nil != self.fileMessageData, !isImage else { return }
+        guard nil != self.fileMessageData, !isImage else { return completionHandler(nil) }
         
         self.asset?.fetchImageData(with: queue, completionHandler: completionHandler)
     }


### PR DESCRIPTION
## What's new in this PR?

Always call completion handler.

### Issues

Completion handler for fetching image data wasn't always called which causes issues for the consumer.

