### PR TITLE
Move image request methods to data type protocols

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -70,16 +70,6 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     
     var usersReaction : Dictionary<String, [ZMUser]> { get }
     
-    /// Request the download of the file if not already present.
-    /// The download will be executed asynchronously. The caller can be notified by observing the message window.
-    /// This method can safely be called multiple times, even if the content is already available locally
-    func requestFileDownload()
-    
-    /// Request the download of the image if not already present.
-    /// The download will be executed asynchronously. The caller can be notified by observing the message window.
-    /// This method can safely be called multiple times, even if the content is already available locally
-    func requestImageDownload()
-    
     /// In case this message failed to deliver, this will resend it
     func resend()
     
@@ -225,10 +215,6 @@ extension ZMMessage {
         }
         return .pending
     }
-    
-    @objc public func requestFileDownload() {}
-    
-    @objc public func requestImageDownload() {}
     
     @objc public var usersReaction : Dictionary<String, [ZMUser]> {
         var result = Dictionary<String, [ZMUser]>()

--- a/Source/Model/Message/ZMAssetClientMessage+Download.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Download.swift
@@ -19,21 +19,8 @@
 
 import Foundation
 
-
-
 extension ZMAssetClientMessage {
 
     /// Name of notification fired when requesting a download of an image
     public static let imageDownloadNotificationName = NSNotification.Name(rawValue: "ZMAssetClientMessageImageDownloadNotification")
-}
-
-extension ZMImageMessage {
-    
-    public override func requestImageDownload() {
-        // V2
-        // objects with temp ID on the UI must just have been inserted so no need to download
-        guard !self.objectID.isTemporaryID,
-            let moc = self.managedObjectContext?.zm_userInterface else { return }
-        NotificationInContext(name: ZMAssetClientMessage.imageDownloadNotificationName, context: moc.notificationContext, object: self.objectID).post()
-    }
 }

--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -61,6 +61,9 @@ import Foundation
     /// Marks file to be downloaded
     func requestFileDownload()
     
+    /// Marks file image preview to be downloaded
+    func requestImagePreviewDownload()
+    
     /// Video-message related properties
     /// if MIME type is indicating the video content
     var isVideo: Bool { get }
@@ -262,6 +265,14 @@ extension ZMAssetClientMessage: ZMFileMessageData {
             return nil
         }
         return assetData.original.normalizedLoudnessLevels
+    }
+    
+    public func requestFileDownload() {
+        asset?.requestFileDownload()
+    }
+    
+    public func requestImagePreviewDownload() {
+        asset?.requestImageDownload()
     }
 }
 

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -191,15 +191,6 @@ import Foundation
         return Set(arrayLiteral: #keyPath(ZMAssetClientMessage.associatedTaskIdentifier_data))
     }
     
-    /// Marks file to be downloaded
-    override public func requestFileDownload() {
-        self.asset?.requestFileDownload()
-    }
-
-    override public func requestImageDownload() {
-        self.asset?.requestImageDownload()
-    }
-    
     var v2Asset: V2Asset? {
         return V2Asset(with: self)
     }

--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -63,7 +63,7 @@ import WireLinkPreview
         return Set([#keyPath(ZMClientMessage.dataSet), #keyPath(ZMClientMessage.dataSet) + ".data"])
     }
 
-    public override func requestImageDownload() {
+    public func requestLinkPreviewImageDownload() {
         guard !self.objectID.isTemporaryID,
               self.linkPreview != nil,
               let moc = self.managedObjectContext,

--- a/Source/Model/Message/ZMImageMessage.m
+++ b/Source/Model/Message/ZMImageMessage.m
@@ -164,6 +164,25 @@
     }];
 }
 
+- (void)requestImageDownload {
+    // V2
+    
+    // objects with temp ID on the UI must just have been inserted so no need to download
+    if (self.objectID.isTemporaryID) {
+        return;
+    }
+    
+    NSManagedObjectContext *moc = self.managedObjectContext.zm_userInterfaceContext;
+    
+    if (moc != nil) {
+        NotificationInContext * note = [[NotificationInContext alloc] initWithName:ZMAssetClientMessage.imageDownloadNotificationName
+                                                                           context:moc.notificationContext
+                                                                            object:self.objectID
+                                                                          userInfo:nil];
+        [note post];
+    }
+}
+
 - (void)fetchPreviewDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *))completionHandler {
     NSManagedObjectContext *syncContext =  self.managedObjectContext.zm_syncContext;
     

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -765,9 +765,15 @@ NSString * const ZMSystemMessageNumberOfGuestsAddedKey = @"numberOfGuestsAdded";
     return ZMDeliveryStateDelivered;
 }
 
-- (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *))completionHandler {
+- (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *))completionHandler
+{
     NOT_USED(queue);
     NOT_USED(completionHandler);
+}
+
+- (void)requestLinkPreviewImageDownload
+{
+    
 }
 
 @end

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -47,6 +47,11 @@
 
 - (void)fetchImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *imageData))completionHandler;
 
+/// Request the download of the image if not already present.
+/// The download will be executed asynchronously. The caller can be notified by observing the message window.
+/// This method can safely be called multiple times, even if the content is already available locally
+- (void)requestImageDownload;
+
 @end
 
 
@@ -91,6 +96,9 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 
 /// Fetch linkpreview image data from disk on the given queue
 - (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *imageData))completionHandler;
+
+/// Request link preview image to be downloaded
+- (void)requestLinkPreviewImageDownload;
 
 @end
 

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1590,7 +1590,7 @@ extension ZMAssetClientMessageTests {
         }
         
         // when
-        message.requestImageDownload()
+        message.imageMessageData?.requestImageDownload()
 
         // then
         withExtendedLifetime(token) { () -> () in
@@ -2100,7 +2100,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.transferState, .uploaded)
 
         // when
-        sut.requestImageDownload()
+        sut.imageMessageData?.requestImageDownload()
 
         // then
         XCTAssertEqual(sut.transferState, .downloading)
@@ -2119,7 +2119,7 @@ extension ZMAssetClientMessageTests {
         sut.transferState = .unavailable
         
         // when
-        sut.requestImageDownload()
+        sut.imageMessageData?.requestImageDownload()
         
         // then
         XCTAssertEqual(sut.transferState, .unavailable)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -276,7 +276,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
             expectation.fulfill()
         }
         
-        clientMessage.requestImageDownload()
+        clientMessage.textMessageData?.requestLinkPreviewImageDownload()
         
         // then
         withExtendedLifetime(token) { () -> () in


### PR DESCRIPTION
### Issues

Image were not being downloaded.

### Causes

The method for requesting images was living on the base message protocol `ConversationMessage` and most of the time the underlying object is implementing the message data type protocol (image, file, text). But this is not always the case for images which resulted in a cast to fail.

### Solutions

Move image download methods to the relevant data type protocols to avoid having to rely on casting.