### PR TITLE
Add hasUnreadMessagesInOtherConversations

### DIFF
--- a/Source/Model/Conversation/ZMConversation+UnreadCount.h
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.h
@@ -36,8 +36,14 @@
 /// Predicate for conversations that will be considered unread for the purpose of the badge count
 + (NSPredicate *)predicateForConversationConsideredUnread;
 
-/// Count of unread conversation
+/// Predicate for conversations that will be considered unread for the purpose of the back arrow dot
++ ( NSPredicate *)predicateForConversationConsideredUnreadIncludingSilenced;
+
+/// Count of unread conversations (exluding silenced converations)
 + (NSUInteger)unreadConversationCountInContext:(NSManagedObjectContext *)moc;
+
+/// Count of unread conversations (including silenced conversations)
++ (NSUInteger)unreadConversationCountIncludingSilencedInContext:(NSManagedObjectContext *)moc excluding:(ZMConversation *)conversation;
 
 @end
 

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.h
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.h
@@ -30,6 +30,8 @@
 /// and reset when the visible window changes
 @property (nonatomic) BOOL hasUnreadUnsentMessage;
 
+@property (nonatomic, readonly) BOOL hasUnreadMessagesInOtherConversations;
+
 @property (nonatomic, readonly) ZMConversationListIndicator unreadListIndicator;
 + (NSSet *)keyPathsForValuesAffectingUnreadListIndicator;
 

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -155,5 +155,10 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     return [NSSet setWithObjects:ZMConversationLastUnreadMissedCallDateKey, ZMConversationLastUnreadKnockDateKey, ZMConversationInternalEstimatedUnreadCountKey, ZMConversationLastReadServerTimeStampKey, ZMConversationHasUnreadUnsentMessageKey,  nil];
 }
 
+- (BOOL)hasUnreadMessagesInOtherConversations
+{
+    return [ZMConversation unreadConversationCountIncludingSilencedInContext:self.managedObjectContext excluding:self] > 0;
+}
+
 @end
 

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -94,9 +94,15 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ZMConversation entityName]];
     request.predicate = [self predicateForConversationConsideredUnread];
     
-    NSSet *conversations = [[moc registeredObjects] filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"self.class == %@", ZMConversation.class]];
-    ZMConversation *conv = [conversations anyObject];
-    NOT_USED(conv);
+    return [moc countForFetchRequest:request error:nil];
+}
+
++ (NSUInteger)unreadConversationCountIncludingSilencedInContext:(NSManagedObjectContext *)moc excluding:(ZMConversation *)conversation
+{
+    NSPredicate *excludedConversationPredicate = [NSPredicate predicateWithFormat:@"SELF !=  %@", conversation];
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ZMConversation entityName]];
+    request.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[excludedConversationPredicate, [self predicateForConversationConsideredUnreadIncludingSilenced]]];
+    
     return [moc countForFetchRequest:request error:nil];
 }
 
@@ -110,6 +116,15 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     NSPredicate *acceptablePredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[pendingConnection, unreadMessages]];
     
     return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSilencedPredicate, notSelfConversation, notInvalidConversation, acceptablePredicate]];
+}
+
++ (NSPredicate *)predicateForConversationConsideredUnreadIncludingSilenced;
+{
+    NSPredicate *notSelfConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeSelf];
+    NSPredicate *notInvalidConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeInvalid];
+    NSPredicate *unreadMessages = [NSPredicate predicateWithFormat:@"%K > 0", ZMConversationInternalEstimatedUnreadCountKey];
+    
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, unreadMessages]];
 }
 
 - (void)setInternalEstimatedUnreadCount:(int64_t)internalEstimatedUnreadCount


### PR DESCRIPTION
## What's new in this PR?

Adds `ZMConversation.hasUnreadMessagesInOtherConversations` which is used determine if we should show an back arrow dot.

Also expose predicates underlaying this, which is used as a debug tool in UI.