### PR TITLE
Fix memory leak caused by not taking ownership of object when expected

### DIFF
--- a/Source/Utilis/UTType+MIMEType.swift
+++ b/Source/Utilis/UTType+MIMEType.swift
@@ -24,7 +24,7 @@ import MobileCoreServices
 struct UTType: CustomStringConvertible {
     let value: CFString
     init?(mimeType: String) {
-        guard let UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType as CFString, nil)?.takeUnretainedValue() else { return nil }
+        guard let UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType as CFString, nil)?.takeRetainedValue() else { return nil }
         value = UTI
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are leaking the return value from `UTTypeCreatePreferredIdentifierForTag`

### Causes

the `Create` in `UTTypeCreatePreferredIdentifierForTag` indicate that this function will create an object which the caller is responsible for releasing.

### Solutions

 Take ownership of the return value by calling `takeRetainedValue`.