### PR TITLE
ZIOS-9535: Received ephemeral message with link is shown without preview

### DIFF
--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -194,7 +194,9 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 
 - (void)updateWithGenericMessage:(ZMGenericMessage *)message updateEvent:(ZMUpdateEvent *__unused)updateEvent initialUpdate:(BOOL)initialUpdate
 {
-    if (!initialUpdate && (message.text.linkPreview.count == 0 || ![self.messageText isEqualToString:message.text.content])) {
+    if (!initialUpdate
+        && (message.text != nil && (message.text.linkPreview.count == 0 || ![self.messageText isEqualToString:message.text.content]))
+        && (message.ephemeral.text != nil && (message.ephemeral.text.linkPreview.count == 0 || ![self.messageText isEqualToString:message.ephemeral.text.content]))) {
         return; // We only update client messages if the update contains a link preview and the content didn't change
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Received ephemeral messages were shown without link previews, even if the preview was visible on other platforms.

### Causes

This was caused by a condition during the update of the message that was considering only "normal" messages, and not ephemeral ones. 

### Solutions

I've added conditions for the ephemeral messages + a test.
