### PR TITLE
Find conversation with service

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -24,7 +24,7 @@ extension ZMConversation {
         guard let serviceID = service.serviceIdentifier else { return nil }
         let sameTeam = predicateForConversations(in: team)
         let groupConversation = NSPredicate(format: "%K == %d", ZMConversationConversationTypeKey, ZMConversationType.group.rawValue)
-        let selfIsActiveMember = NSPredicate(format: "isSelfAnActiveMember == YES")
+        let selfIsActiveMember = NSPredicate(format: "%K == YES", #keyPath(ZMConversation.isSelfAnActiveMember))
         let onlyOneOtherParticipant = NSPredicate(format: "%K.@count == 1", ZMConversationLastServerSyncedActiveParticipantsKey)
         let hasParticipantWithServiceIdentifier = NSPredicate(format: "ANY %K.%K == %@", ZMConversationLastServerSyncedActiveParticipantsKey, #keyPath(ZMUser.serviceIdentifier), serviceID)
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier])

--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMConversation {
+    public class func existingConversation(in moc: NSManagedObjectContext, with service: ServiceUser, in team: Team?) -> ZMConversation? {
+        guard let team = team else { return nil }
+        guard let serviceID = service.serviceIdentifier else { return nil }
+        let sameTeam = predicateForConversations(in: team)
+        let groupConversation = NSPredicate(format: "%K == %d", ZMConversationConversationTypeKey, ZMConversationType.group.rawValue)
+        let selfIsActiveMember = NSPredicate(format: "isSelfAnActiveMember == YES")
+        let onlyOneOtherParticipant = NSPredicate(format: "%K.@count == 1", ZMConversationLastServerSyncedActiveParticipantsKey)
+        let hasParticipantWithServiceIdentifier = NSPredicate(format: "ANY %K.%K == %@", ZMConversationLastServerSyncedActiveParticipantsKey, #keyPath(ZMUser.serviceIdentifier), serviceID)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier])
+
+        let fetchRequest = sortedFetchRequest(with: predicate)
+        fetchRequest?.fetchLimit = 1
+        let result = moc.executeFetchRequestOrAssert(fetchRequest)
+        return result?.first as? ZMConversation
+    }
+}

--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ZMConversation {
-    public class func existingConversation(in moc: NSManagedObjectContext, with service: ServiceUser, in team: Team?) -> ZMConversation? {
+    public class func existingConversation(in moc: NSManagedObjectContext, service: ServiceUser, team: Team?) -> ZMConversation? {
         guard let team = team else { return nil }
         guard let serviceID = service.serviceIdentifier else { return nil }
         let sameTeam = predicateForConversations(in: team)

--- a/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
+++ b/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
@@ -1,0 +1,62 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMBaseManagedObjectTest {
+
+    func createConversation(in moc: NSManagedObjectContext) -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: moc)
+        conversation.remoteIdentifier = UUID()
+        conversation.conversationType = .group
+        return conversation
+    }
+
+    func createTeam(in moc: NSManagedObjectContext) -> Team {
+        let team = Team.insertNewObject(in: moc)
+        team.remoteIdentifier = UUID()
+        return team
+    }
+
+    func createUser(in moc: NSManagedObjectContext) -> ZMUser {
+        let user = ZMUser.insertNewObject(in: moc)
+        user.remoteIdentifier = UUID()
+        return user
+    }
+
+    @discardableResult func createMembership(in moc: NSManagedObjectContext, user: ZMUser, team: Team) -> Member {
+        let member = Member.insertNewObject(in: moc)
+        member.user = user
+        member.team = team
+        return member
+    }
+
+    @discardableResult func createTeamMember(in moc: NSManagedObjectContext, for team: Team) -> ZMUser {
+        let user = createUser(in: moc)
+        createMembership(in:moc, user: user, team: team)
+        return user
+    }
+
+    func createService(in moc: NSManagedObjectContext, named: String) -> ServiceUser {
+        let serviceUser = createUser(in: moc)
+        serviceUser.serviceIdentifier = UUID.create().transportString()
+        serviceUser.providerIdentifier = UUID.create().transportString()
+        serviceUser.name = named
+        return serviceUser
+    }
+}

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
@@ -95,14 +95,14 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
     func testThatItDoesNotSetAllTeamUsersAddedWhenItIsNotTheCaseForTeamUser() {
         syncMOC.performGroupedBlockAndWait {
             // given
-            let team = self.createTeam()
+            let team = self.createTeam(in: self.syncMOC)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
-            self.createMembership(user: selfUser, team: team)
-            let membership = self.createMembership(user: selfUser, team: team)
+            self.createMembership(in: self.syncMOC, user: selfUser, team: team)
+            let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
             
-            let user1 = self.createTeamMember(for: team)
-            self.createTeamMember(for: team)
+            let user1 = self.createTeamMember(in: self.syncMOC, for: team)
+            self.createTeamMember(in: self.syncMOC, for: team)
             
             // when
             let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [user1], name: self.name, in: team)
@@ -123,13 +123,13 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
     func testThatItDoesSetAllTeamUsersAddedWhenItIsTheCaseForTeamUser() {
         syncMOC.performGroupedBlockAndWait {
             // given
-            let team = self.createTeam()
+            let team = self.createTeam(in: self.syncMOC)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
-            let membership = self.createMembership(user: selfUser, team: team)
+            let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
             
-            let user1 = self.createTeamMember(for: team)
-            let user2 = self.createTeamMember(for: team)
+            let user1 = self.createTeamMember(in: self.syncMOC, for: team)
+            let user2 = self.createTeamMember(in: self.syncMOC, for: team)
             
             // when
             let conversation = ZMConversation.insertGroupConversation(into: self.syncMOC, withParticipants: [user1, user2], name: self.name, in: team)
@@ -150,13 +150,13 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
     func testThatItIncludesNumberOfGuestsAddedInNewConversationSystemMessageWithAllTeamUsers() {
         syncMOC.performGroupedBlockAndWait {
             // given
-            let team = self.createTeam()
+            let team = self.createTeam(in: self.syncMOC)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
-            let membership = self.createMembership(user: selfUser, team: team)
+            let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
             
-            let user1 = self.createTeamMember(for: team)
-            let user2 = self.createTeamMember(for: team)
+            let user1 = self.createTeamMember(in: self.syncMOC, for: team)
+            let user2 = self.createTeamMember(in: self.syncMOC, for: team)
             let guest1 = self.createUser(onMoc: self.syncMOC)!
             let guest2 = self.createUser(onMoc: self.syncMOC)!
             
@@ -179,13 +179,13 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
     func testThatItIncludesNumberOfGuestsAddedInNewConversationSystemMessageWithoutAllTeamUsers() {
         syncMOC.performGroupedBlockAndWait {
             // given
-            let team = self.createTeam()
+            let team = self.createTeam(in: self.syncMOC)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
-            let membership = self.createMembership(user: selfUser, team: team)
+            let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
             
-            let user1 = self.createTeamMember(for: team)
-            self.createTeamMember(for: team)
+            let user1 = self.createTeamMember(in: self.syncMOC, for: team)
+            self.createTeamMember(in: self.syncMOC, for: team)
             let guest1 = self.createUser(onMoc: self.syncMOC)!
             let guest2 = self.createUser(onMoc: self.syncMOC)!
             
@@ -205,35 +205,4 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
         }
     }
 
-}
-
-// MARK: - Helper
-
-extension ZMConversationTestsBase {
-    
-    func createConversation() -> ZMConversation {
-        let conversation = ZMConversation.insertNewObject(in: syncMOC)
-        conversation.remoteIdentifier = UUID()
-        conversation.conversationType = .group
-        return conversation
-    }
-    
-    func createTeam() -> Team {
-        let team = Team.insertNewObject(in: syncMOC)
-        team.remoteIdentifier = UUID()
-        return team
-    }
-    
-    @discardableResult func createMembership(user: ZMUser, team: Team) -> Member {
-        let member = Member.insertNewObject(in: syncMOC)
-        member.user = user
-        member.team = team
-        return member
-    }
-    
-    @discardableResult func createTeamMember(for team: Team) -> ZMUser {
-        let user = createUser(onMoc: syncMOC)!
-        createMembership(user: user, team: team)
-        return user
-    }
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Services.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Services.swift
@@ -1,0 +1,116 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class ZMConversationTests_Services : BaseZMMessageTests {
+
+    var team: Team!
+    var service: ServiceUser!
+    var user: ZMUser!
+
+    override func setUp() {
+        super.setUp()
+        team = createTeam(in: uiMOC)
+        service = createService(in: uiMOC, named: "Botty")
+        user = createUser(in: uiMOC)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        team = nil
+        service = nil
+        user = nil
+    }
+
+    func createConversation(with service: ServiceUser) -> ZMConversation {
+        let conversation = createConversation(in: uiMOC)
+        conversation.team = team
+        conversation.conversationType = .group
+        conversation.isSelfAnActiveMember = true
+        conversation.internalAddParticipants([service as! ZMUser])
+        return conversation
+    }
+
+    func testThatConversationIsNotFoundWhenThereIsNoTeam() {
+        // when
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: nil)
+
+        // then
+        XCTAssertNil(conversation)
+    }
+
+    func testThatConversationIsNotFoundWhenUserIsNotAService() {
+        // when
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: user, team: team)
+
+        // then
+        XCTAssertNil(conversation)
+    }
+
+    func testThatItFindsConversationWithService() {
+        // given
+        let existingConversation = createConversation(with: service)
+
+        // when
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: team)
+
+        // then
+        XCTAssertNotNil(conversation)
+        XCTAssertEqual(existingConversation, conversation)
+    }
+
+    func testThatItDoesNotFindConversationWithMoreMembers() {
+        // given
+        let existingConversation = createConversation(with: service)
+        existingConversation.internalAddParticipants([createUser(in: uiMOC)])
+
+        // when
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: team)
+
+        // then
+        XCTAssertNil(conversation)
+    }
+
+    func testThatItChecksOnlyConversationsWhereIAmPresent() {
+        // given
+        let existingConversation = createConversation(with: service)
+
+        // when
+        existingConversation.isSelfAnActiveMember = false
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: team)
+
+        // then
+        XCTAssertNil(conversation)
+    }
+
+    func testThatItFindsConversationWithCorrectService() {
+        // given
+        let existingConversation = createConversation(with: service)
+        _ = createConversation(with: createService(in: uiMOC, named: "BAD"))
+
+        // when
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: team)
+
+        // then
+        XCTAssertNotNil(conversation)
+        XCTAssertEqual(existingConversation, conversation)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		F11F3E8B1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F3E8A1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift */; };
 		F125BAD71EE9849B0018C2F8 /* ZMConversation+Teams.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125BAD61EE9849B0018C2F8 /* ZMConversation+Teams.swift */; };
 		F12BD0B01E4DCEC40012ADBA /* ZMMessage+Insert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12BD0AF1E4DCEC40012ADBA /* ZMMessage+Insert.swift */; };
+		F137EEBE212C14300043FDEB /* ZMConversation+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */; };
 		F13A89D1210628F700AB40CB /* PushToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13A89D0210628F600AB40CB /* PushToken.swift */; };
 		F1549D4A1FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */; };
 		F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */; };
@@ -721,6 +722,7 @@
 		F11F3E8A1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidClientsRemovalTests.swift; sourceTree = "<group>"; };
 		F125BAD61EE9849B0018C2F8 /* ZMConversation+Teams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Teams.swift"; sourceTree = "<group>"; };
 		F12BD0AF1E4DCEC40012ADBA /* ZMMessage+Insert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Insert.swift"; sourceTree = "<group>"; };
+		F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Services.swift"; sourceTree = "<group>"; };
 		F13A89D0210628F600AB40CB /* PushToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushToken.swift; sourceTree = "<group>"; };
 		F13A89D22106293000AB40CB /* PushTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushTokenTests.swift; sourceTree = "<group>"; };
 		F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserFetchAndMergeTests.swift; sourceTree = "<group>"; };
@@ -1323,6 +1325,7 @@
 				F125BAD61EE9849B0018C2F8 /* ZMConversation+Teams.swift */,
 				161541B91E27EBD400AC2FFB /* ZMConversation+Calling.swift */,
 				1626344A20D935C0000D4063 /* ZMConversation+Timestamps.swift */,
+				F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */,
 				F9B71F181CB264EF001DB03F /* ZMConversation+Transport.h */,
 				F9B71F191CB264EF001DB03F /* ZMConversation+Transport.m */,
 				F9B71F1A1CB264EF001DB03F /* ZMConversation+UnreadCount.h */,
@@ -2387,6 +2390,7 @@
 				54D809FC1F681D6400B2CCB4 /* ZMClientMessage+LinkPreview.swift in Sources */,
 				F93A30251D6EFB47005CCB1D /* ZMMessageConfirmation.swift in Sources */,
 				EFD0B02D21087DC80065EBF3 /* ZMConversation+Language.swift in Sources */,
+				F137EEBE212C14300043FDEB /* ZMConversation+Services.swift in Sources */,
 				BFABEB8C1E647054003BE9F3 /* GenericMessageScheduleNotification.swift in Sources */,
 				54EDE6801CBBF1860044A17E /* PINCache+ZMessaging.swift in Sources */,
 				F963E9811D9C09E700098AD3 /* ZMMessageTimer.m in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -222,6 +222,8 @@
 		F12BD0B01E4DCEC40012ADBA /* ZMMessage+Insert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12BD0AF1E4DCEC40012ADBA /* ZMMessage+Insert.swift */; };
 		F137EEBE212C14300043FDEB /* ZMConversation+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */; };
 		F13A89D1210628F700AB40CB /* PushToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13A89D0210628F600AB40CB /* PushToken.swift */; };
+		F14B9C6F212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B9C6E212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift */; };
+		F1517922212DAE2E00BA3EBD /* ZMConversationTests+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1517921212DAE2E00BA3EBD /* ZMConversationTests+Services.swift */; };
 		F1549D4A1FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */; };
 		F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */; };
 		F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */; };
@@ -725,6 +727,8 @@
 		F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Services.swift"; sourceTree = "<group>"; };
 		F13A89D0210628F600AB40CB /* PushToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushToken.swift; sourceTree = "<group>"; };
 		F13A89D22106293000AB40CB /* PushTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushTokenTests.swift; sourceTree = "<group>"; };
+		F14B9C6E212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMBaseManagedObjectTest+Helpers.swift"; sourceTree = "<group>"; };
+		F1517921212DAE2E00BA3EBD /* ZMConversationTests+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Services.swift"; sourceTree = "<group>"; };
 		F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserFetchAndMergeTests.swift; sourceTree = "<group>"; };
 		F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Patches.swift"; sourceTree = "<group>"; };
 		F16378501E5C805100898F84 /* ZMConversationSecurityLevel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMConversationSecurityLevel.swift; sourceTree = "<group>"; };
@@ -1666,6 +1670,7 @@
 				F9C8622A1D87DC18009AAC33 /* MessagingTest+UUID.swift */,
 				CEE525A81CCA4C97001D06F9 /* NSString+RandomString.h */,
 				CEE525A91CCA4C97001D06F9 /* NSString+RandomString.m */,
+				F14B9C6E212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift */,
 			);
 			name = Helper;
 			path = Tests/Source/Helper;
@@ -1691,6 +1696,7 @@
 				16F6BB3B1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift */,
 				F1B58926202DCEF9002BB59B /* ZMConversationTests+CreationSystemMessages.swift */,
 				EF9A4702210A026600085102 /* ZMConversationTests+Language.swift */,
+				F1517921212DAE2E00BA3EBD /* ZMConversationTests+Services.swift */,
 				F9B71F571CB2BC85001DB03F /* ZMConversationTests.h */,
 				F9B71F581CB2BC85001DB03F /* ZMConversationTests.m */,
 				F9C8770A1E015AAF00792613 /* AssetColletionTests.swift */,
@@ -2523,6 +2529,7 @@
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
+				F14B9C6F212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,
 				F9FD75761E2E79BF00B4558B /* ConversationListObserverTests.swift in Sources */,
 				BF3493EB1EC34C0B00B0C314 /* TeamTests.swift in Sources */,
@@ -2597,6 +2604,7 @@
 				F9B71FA31CB2BF37001DB03F /* ZMConversationTests+gapsAndWindows.m in Sources */,
 				F9A708391CAEEB7500C2F5FE /* CoreDataRelationshipsTests.m in Sources */,
 				54F581FF1F2F716B0051ACE8 /* StorageStackTests.swift in Sources */,
+				F1517922212DAE2E00BA3EBD /* ZMConversationTests+Services.swift in Sources */,
 				BFCF31DB1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift in Sources */,
 				F9B71FF21CB2C4C6001DB03F /* AnyClassTupleTests.swift in Sources */,
 				F9A7083A1CAEEB7500C2F5FE /* MockEntity.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need a way to find an existing conversation with given service so we would not create duplicates.

### Solutions

The predicate for the matching conversation is pretty complicated, but basically is:
* Group conversation in a team
* You are part of it
* There is only one other participant
* The participant is a service with matching identifier
