### PR TITLE
Open service conversation: skipping conversations with a name

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -27,7 +27,8 @@ extension ZMConversation {
         let selfIsActiveMember = NSPredicate(format: "%K == YES", #keyPath(ZMConversation.isSelfAnActiveMember))
         let onlyOneOtherParticipant = NSPredicate(format: "%K.@count == 1", ZMConversationLastServerSyncedActiveParticipantsKey)
         let hasParticipantWithServiceIdentifier = NSPredicate(format: "ANY %K.%K == %@", ZMConversationLastServerSyncedActiveParticipantsKey, #keyPath(ZMUser.serviceIdentifier), serviceID)
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier])
+        let noUserDefinedName = NSPredicate(format: "%K == nil", #keyPath(ZMConversation.userDefinedName))
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier, noUserDefinedName])
 
         let fetchRequest = sortedFetchRequest(with: predicate)
         fetchRequest?.fetchLimit = 1

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Services.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Services.swift
@@ -100,6 +100,19 @@ class ZMConversationTests_Services : BaseZMMessageTests {
         XCTAssertNil(conversation)
     }
 
+    func testThatItChecksOnlyConversationsWithNoUserDefinedName() {
+        // given
+        let existingConversation = createConversation(with: service)
+
+        // when
+        existingConversation.userDefinedName = "First"
+        let conversation = ZMConversation.existingConversation(in: uiMOC, service: service, team: team)
+
+        // then
+        XCTAssertNil(conversation)
+    }
+
+
     func testThatItFindsConversationWithCorrectService() {
         // given
         let existingConversation = createConversation(with: service)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The existing logic of opening conversation with a service was not skipping conversations with custom defined name which made it easy to have multiple conversations with a service. "Open conversation" button would then open the most recent of all conversations with a service.

### Solutions

We filter out conversations with user defined name, so guestrooms and regular conversations created from UI are excluded. This (in most circumstances) leaves only a single conversation that we can open.
