### PR TITLE
[WIP] (DM) ZIOS-10377 - Assets sending is being constantly retried if sent in bad network conditions	

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1044,6 +1044,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 
     message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
     
+    [message setExpirationDate];
     [self sortedAppendMessage:message];
     [self unarchiveIfNeeded];
     [self.managedObjectContext.zm_fileAssetCache storeAssetData:message format:ZMImageFormatOriginal encrypted:NO data:imageData];


### PR DESCRIPTION
## What's new in this PR?

### Issues

The text message sending expires in 20-30 seconds and Retry label appears underneath, but the image is still in Sending state and never gets the Retry option

### Causes

This is because images don't get expired after the deadline of 30 seconds.

### Solutions

I've added a cal to `setExpirationDate()` when appending the message.

## Notes

See [`request-strategy`](url) PR.