### PR TITLE
Update handling of missing participants

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_END
 
 /// Checks if the security level changed as the result of the participants change.
 /// Appends or moves the security level system message.
-- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(nonnull ZMSystemMessage *)participantsChange;
+//- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(nonnull ZMSystemMessage *)participantsChange;
 
 @end
 

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -195,10 +195,6 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic) BOOL isSelfAnActiveMember; ///< whether the self user is an active member (as opposed to a past member)
 @property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *lastServerSyncedActiveParticipants;
 
-/// Checks if the security level changed as the result of the participants change.
-/// Appends or moves the security level system message.
-//- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(nonnull ZMSystemMessage *)participantsChange;
-
 @end
 
 

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -144,7 +144,7 @@ extension ZMConversation {
     }
     
     /// Adds the user to the list of participants if not already present and inserts a .participantsAdded system message
-    @objc(appendParticipantIfMissing:date:)
+    @objc(addParticipantIfMissing:date:)
     public func addParticipantIfMissing(_ user: ZMUser, at date: Date = Date()) {
         guard !activeParticipants.contains(user) else { return }
         

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -151,7 +151,6 @@ extension ZMConversation {
         case .group:
             appendSystemMessage(type: .participantsAdded, sender: user, users: Set(arrayLiteral: user), clients: nil, timestamp: date)
             internalAddParticipants(Set(arrayLiteral: user))
-            break
         case .oneOnOne, .connection:
             if user.connection == nil {
                 user.connection = connection ?? ZMConnection.insertNewObject(in: managedObjectContext!)
@@ -160,7 +159,6 @@ extension ZMConversation {
             }
             
             user.connection?.needsToBeUpdatedFromBackend = true
-            break
         default:
             break
         }

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -50,9 +50,7 @@ extension ZMConversation {
     public func decreaseSecurityLevelIfNeededAfterDiscovering(clients: Set<UserClient>, causedBy message: ZMOTRMessage?) {
         guard self.decreaseSecurityLevelIfNeeded() else { return }
         self.appendNewAddedClientSystemMessage(added: clients, causedBy: DiscoveryCause.message(message))
-        if let message = message {
-            self.expireAllPendingMessagesBecauseOfSecurityLevelDegradation(staringFrom: message)
-        }
+        self.expireAllPendingMessagesBecauseOfSecurityLevelDegradation()
     }
     
     /// Should be called when a new user is added to the conversation
@@ -60,6 +58,7 @@ extension ZMConversation {
     public func decreaseSecurityLevelIfNeededAfterDiscovering(clients: Set<UserClient>, causedBy users: Set<ZMUser>) {
         guard self.decreaseSecurityLevelIfNeeded() else { return }
         self.appendNewAddedClientSystemMessage(added: clients, causedBy: DiscoveryCause.addedUsers(users))
+        self.expireAllPendingMessagesBecauseOfSecurityLevelDegradation()
     }
 
     /// Should be called when a client is ignored
@@ -214,27 +213,44 @@ extension ZMConversation {
         }
     }
     
-    /// Expire all pending message after the given message, including the given message
-    fileprivate func expireAllPendingMessagesBecauseOfSecurityLevelDegradation(staringFrom startingMessage: ZMMessage) {
-        self.messages.enumerateObjects(options: .reverse) { (msg, idx, stop) in
-            guard let message = msg as? ZMOTRMessage else { return }
-            if message.deliveryState != .delivered && message.deliveryState != .sent {
-                if let clientMessage = message as? ZMClientMessage,
-                    let genericMessage = clientMessage.genericMessage,
-                    genericMessage.hasConfirmation() {
-                    // Delivery receipt: just expire it
-                    clientMessage.expire()
-                } else {
-                    // All other messages: expire and mark that it caused security degradation
-                    message.expire()
-                    message.causedSecurityLevelDegradation = true
-                }
-            }
-            if startingMessage == message {
-                stop.initialize(to: true)
+    /// Expire all pending messages
+    fileprivate func expireAllPendingMessagesBecauseOfSecurityLevelDegradation() {
+        for message in undeliveredMessages {
+            if let clientMessage = message as? ZMClientMessage, let genericMessage = clientMessage.genericMessage, genericMessage.hasConfirmation() {
+                // Delivery receipt: just expire it
+                message.expire()
+            } else {
+                // All other messages: expire and mark that it caused security degradation
+                message.expire()
+                message.causedSecurityLevelDegradation = true
             }
         }
     }
+    
+    fileprivate var undeliveredMessages: [ZMOTRMessage] {
+        guard let managedObjectContext = managedObjectContext else { return [] }
+        
+        let timeoutLimit = Date().addingTimeInterval(-ZMMessage.defaultExpirationTime())
+        let selfUser = ZMUser.selfUser(in: managedObjectContext)
+        let undeliveredMessagesPredicate = NSPredicate(format: "%K == %@ AND %K == %@ AND %K == NO AND %K > %@",
+                                                       ZMMessageConversationKey, self,
+                                                       ZMMessageSenderKey, selfUser,
+                                                       DeliveredKey,
+                                                       ZMMessageServerTimestampKey, timeoutLimit as NSDate)
+        
+        let fetchRequest = NSFetchRequest<ZMClientMessage>(entityName: ZMClientMessage.entityName())
+        fetchRequest.predicate = undeliveredMessagesPredicate
+        
+        let assetFetchRequest = NSFetchRequest<ZMAssetClientMessage>(entityName: ZMAssetClientMessage.entityName())
+        assetFetchRequest.predicate = undeliveredMessagesPredicate
+        
+        var undeliveredMessages: [ZMOTRMessage] = []
+        undeliveredMessages += managedObjectContext.fetchOrAssert(request: fetchRequest) as [ZMOTRMessage]
+        undeliveredMessages += managedObjectContext.fetchOrAssert(request: assetFetchRequest) as [ZMOTRMessage]
+        
+        return undeliveredMessages
+    }
+    
 }
 
 // MARK: - HotFix

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1361,64 +1361,64 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic isSelfAnActiveMember;
 @dynamic lastServerSyncedActiveParticipants;
 
-- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(ZMSystemMessage *)participantsChange
-{
-    NSUInteger messageIndex = [self.messages indexOfObject:participantsChange];
-    if (messageIndex == 0) {
-        return;
-    }
-    ZMMessage *previousMessage = [self.messages objectAtIndex:messageIndex - 1];
-    
-    BOOL (^isAppropriateVerificationSystemMessage)(ZMMessage *message) = ^BOOL(ZMMessage *message) {
-        if (![previousMessage isKindOfClass:[ZMSystemMessage class]]) {
-            return NO;
-        }
-        
-        ZMSystemMessage *systemMessage = (ZMSystemMessage *)message;
-        
-        if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded &&
-            systemMessage.systemMessageType == ZMSystemMessageTypeNewClient) {
-            return ([systemMessage.addedUsers isEqualToSet:participantsChange.users]);
-        }
-        else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved &&
-                 systemMessage.systemMessageType == ZMSystemMessageTypeConversationIsSecure) {
-            return ([systemMessage.users isEqualToSet:participantsChange.users]);
-        }
-        
-        return NO;
-    };
-    
-    if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded) {
-        // Check if the previous system message about the conversation degradation must be now moved or inserted
-        // The message needs to be moved when the action (adding the participant) was local
-        // The message needs to be inserted when the action was remote
-        
-        if (isAppropriateVerificationSystemMessage(previousMessage)) {
-            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
-            
-            previousMessage.serverTimestamp = newDate;
-            [self resortMessagesWithUpdatedMessage:previousMessage];
-        }
-        else {
-            [self decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet set] causedByAddedUsers:participantsChange.users];
-        }
-    }
-    else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved) {
-        // Check if the previous system message about the conversation is secured must be now moved or inserted
-        // The message needs to be moved when the action (removing the participant) was local
-        // The message needs to be inserted when the action was remote
-        
-        if (isAppropriateVerificationSystemMessage(previousMessage)) {
-            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
-            
-            previousMessage.serverTimestamp = newDate;
-            [self resortMessagesWithUpdatedMessage:previousMessage];
-        }
-        else {
-            [self increaseSecurityLevelIfNeededAfterRemovingClientForUsers:participantsChange.users];
-        }
-    }
-}
+//- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(ZMSystemMessage *)participantsChange
+//{
+//    NSUInteger messageIndex = [self.messages indexOfObject:participantsChange];
+//    if (messageIndex == 0) {
+//        return;
+//    }
+//    ZMMessage *previousMessage = [self.messages objectAtIndex:messageIndex - 1];
+//    
+//    BOOL (^isAppropriateVerificationSystemMessage)(ZMMessage *message) = ^BOOL(ZMMessage *message) {
+//        if (![previousMessage isKindOfClass:[ZMSystemMessage class]]) {
+//            return NO;
+//        }
+//        
+//        ZMSystemMessage *systemMessage = (ZMSystemMessage *)message;
+//        
+//        if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded &&
+//            systemMessage.systemMessageType == ZMSystemMessageTypeNewClient) {
+//            return ([systemMessage.addedUsers isEqualToSet:participantsChange.users]);
+//        }
+//        else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved &&
+//                 systemMessage.systemMessageType == ZMSystemMessageTypeConversationIsSecure) {
+//            return ([systemMessage.users isEqualToSet:participantsChange.users]);
+//        }
+//        
+//        return NO;
+//    };
+//    
+//    if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded) {
+//        // Check if the previous system message about the conversation degradation must be now moved or inserted
+//        // The message needs to be moved when the action (adding the participant) was local
+//        // The message needs to be inserted when the action was remote
+//        
+//        if (isAppropriateVerificationSystemMessage(previousMessage)) {
+//            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
+//            
+//            previousMessage.serverTimestamp = newDate;
+//            [self resortMessagesWithUpdatedMessage:previousMessage];
+//        }
+//        else {
+//            [self decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet set] causedByAddedUsers:participantsChange.users];
+//        }
+//    }
+//    else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved) {
+//        // Check if the previous system message about the conversation is secured must be now moved or inserted
+//        // The message needs to be moved when the action (removing the participant) was local
+//        // The message needs to be inserted when the action was remote
+//        
+//        if (isAppropriateVerificationSystemMessage(previousMessage)) {
+//            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
+//            
+//            previousMessage.serverTimestamp = newDate;
+//            [self resortMessagesWithUpdatedMessage:previousMessage];
+//        }
+//        else {
+//            [self increaseSecurityLevelIfNeededAfterRemovingClientForUsers:participantsChange.users];
+//        }
+//    }
+//}
 
 @end
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1361,65 +1361,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic isSelfAnActiveMember;
 @dynamic lastServerSyncedActiveParticipants;
 
-//- (void)insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:(ZMSystemMessage *)participantsChange
-//{
-//    NSUInteger messageIndex = [self.messages indexOfObject:participantsChange];
-//    if (messageIndex == 0) {
-//        return;
-//    }
-//    ZMMessage *previousMessage = [self.messages objectAtIndex:messageIndex - 1];
-//    
-//    BOOL (^isAppropriateVerificationSystemMessage)(ZMMessage *message) = ^BOOL(ZMMessage *message) {
-//        if (![previousMessage isKindOfClass:[ZMSystemMessage class]]) {
-//            return NO;
-//        }
-//        
-//        ZMSystemMessage *systemMessage = (ZMSystemMessage *)message;
-//        
-//        if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded &&
-//            systemMessage.systemMessageType == ZMSystemMessageTypeNewClient) {
-//            return ([systemMessage.addedUsers isEqualToSet:participantsChange.users]);
-//        }
-//        else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved &&
-//                 systemMessage.systemMessageType == ZMSystemMessageTypeConversationIsSecure) {
-//            return ([systemMessage.users isEqualToSet:participantsChange.users]);
-//        }
-//        
-//        return NO;
-//    };
-//    
-//    if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsAdded) {
-//        // Check if the previous system message about the conversation degradation must be now moved or inserted
-//        // The message needs to be moved when the action (adding the participant) was local
-//        // The message needs to be inserted when the action was remote
-//        
-//        if (isAppropriateVerificationSystemMessage(previousMessage)) {
-//            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
-//            
-//            previousMessage.serverTimestamp = newDate;
-//            [self resortMessagesWithUpdatedMessage:previousMessage];
-//        }
-//        else {
-//            [self decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet set] causedByAddedUsers:participantsChange.users];
-//        }
-//    }
-//    else if (participantsChange.systemMessageType == ZMSystemMessageTypeParticipantsRemoved) {
-//        // Check if the previous system message about the conversation is secured must be now moved or inserted
-//        // The message needs to be moved when the action (removing the participant) was local
-//        // The message needs to be inserted when the action was remote
-//        
-//        if (isAppropriateVerificationSystemMessage(previousMessage)) {
-//            NSDate *newDate = [participantsChange.serverTimestamp dateByAddingTimeInterval:0.01];
-//            
-//            previousMessage.serverTimestamp = newDate;
-//            [self resortMessagesWithUpdatedMessage:previousMessage];
-//        }
-//        else {
-//            [self increaseSecurityLevelIfNeededAfterRemovingClientForUsers:participantsChange.users];
-//        }
-//    }
-//}
-
 @end
 
 

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1530,11 +1530,11 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
         NSUInteger currentIndex = length-1;
         const NSUInteger keepUntilIndex = (length-1 >= NumberOfMessagesToKeep) // avoid overflow
         ? (length-1 - NumberOfMessagesToKeep)
-        : length-1;
+        : 0;
         
         while(YES) { // not using a for loop because when hitting 0, --i would make it overflow and wrap
             [messagesToKeep addObject:self.messages[currentIndex]];
-            if(currentIndex == keepUntilIndex) {
+            if (currentIndex == keepUntilIndex) {
                 break;
             }
             --currentIndex;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1462,24 +1462,19 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     
     const static NSUInteger NumberOfMessagesToKeep = 3;
     
-    if(![self hasFaultForRelationshipNamed:ZMConversationMessagesKey])
-    {
+    if (![self hasFaultForRelationshipNamed:ZMConversationMessagesKey]) {
         const NSUInteger length = self.messages.count;
-        if(length == 0) {
+        
+        if (length == 0) {
             return [NSSet set];
         }
-        NSUInteger currentIndex = length-1;
-        const NSUInteger keepUntilIndex = (length-1 >= NumberOfMessagesToKeep) // avoid overflow
-        ? (length-1 - NumberOfMessagesToKeep)
-        : 0;
         
-        while(YES) { // not using a for loop because when hitting 0, --i would make it overflow and wrap
-            [messagesToKeep addObject:self.messages[currentIndex]];
-            if (currentIndex == keepUntilIndex) {
-                break;
-            }
-            --currentIndex;
-        };
+        const NSUInteger startIndex = length > NumberOfMessagesToKeep ? length - NumberOfMessagesToKeep : 0;
+        const NSUInteger endIndex = length - 1;
+        
+        for (NSUInteger index = startIndex; index <= endIndex; index++) {
+            [messagesToKeep addObject:self.messages[index]];
+        }
     }
     
     return messagesToKeep;

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -891,9 +891,9 @@ NSString * const ZMSystemMessageNumberOfGuestsAddedKey = @"numberOfGuestsAdded";
                                                          context:moc
                                                     conversation:conversation];
     
-    if (type == ZMSystemMessageTypeParticipantsAdded || type == ZMSystemMessageTypeParticipantsRemoved) {
-        [conversation insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:message];
-    }
+//    if (type == ZMSystemMessageTypeParticipantsAdded || type == ZMSystemMessageTypeParticipantsRemoved) {
+//        [conversation insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:message];
+//    }
     
     [conversation updateTimestampsAfterUpdatingMessage:message];
     

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -890,11 +890,7 @@ NSString * const ZMSystemMessageNumberOfGuestsAddedKey = @"numberOfGuestsAdded";
     [message updateNewConversationSystemMessageIfNeededWithUsers:usersSet
                                                          context:moc
                                                     conversation:conversation];
-    
-//    if (type == ZMSystemMessageTypeParticipantsAdded || type == ZMSystemMessageTypeParticipantsRemoved) {
-//        [conversation insertOrUpdateSecurityVerificationMessageAfterParticipantsChange:message];
-//    }
-    
+        
     [conversation updateTimestampsAfterUpdatingMessage:message];
     
     return message;

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -154,6 +154,9 @@ NSString * const DeliveredKey = @"delivered";
         ZMSystemMessage *systemMessage = [conversation appendInvalidSystemMessageAt:updateEvent.timeStamp sender:sender];
         return [[MessageUpdateResult alloc] initWithMessage:systemMessage needsConfirmation:NO wasInserted:YES];
     }
+    
+    // Verify sender is part of conversation
+    [conversation appendParticipantIfMissing:[ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc] date: [updateEvent.timeStamp dateByAddingTimeInterval:-0.01]];
 
     // Insert the message
 

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -156,7 +156,7 @@ NSString * const DeliveredKey = @"delivered";
     }
     
     // Verify sender is part of conversation
-    [conversation appendParticipantIfMissing:[ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc] date: [updateEvent.timeStamp dateByAddingTimeInterval:-0.01]];
+    [conversation addParticipantIfMissing:[ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc] date: [updateEvent.timeStamp dateByAddingTimeInterval:-0.01]];
 
     // Insert the message
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -744,7 +744,7 @@
     }];
 }
 
-- (void)testIMarksConversationAsNotSecureAfterResendMessages
+- (void)testItMarksConversationAsNotSecureAfterResendMessages
 {
     __block ZMConversation *conversation;
     [self.syncMOC performGroupedBlockAndWait:^{

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -616,6 +616,40 @@
 #pragma mark - Resending / cancelling messages in degraded conversation
 @implementation ZMConversationSecurityTests (ResendingMessages)
 
+- (void)testItExpiresAllMessagesAfterTheCurrentOneWhenAUserCausesDegradation
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // GIVEN
+        [self createSelfClient];
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.conversationType = ZMConversationTypeGroup;
+        conversation.securityLevel = ZMConversationSecurityLevelSecure;
+        
+        ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
+        [[conversation mutableLastServerSyncedActiveParticipants] addObject:user];
+
+        ZMOTRMessage *message1 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"aabbccdd";
+        client.user = user;
+        
+        // WHEN
+        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByAddedUsers:[NSSet setWithObject:user]];
+        
+        // THEN
+        XCTAssertTrue(message1.isExpired);
+        XCTAssertTrue(message1.causedSecurityLevelDegradation);
+        XCTAssertTrue(message2.isExpired);
+        XCTAssertTrue(message2.causedSecurityLevelDegradation);
+        XCTAssertFalse(conversation.allUsersTrusted);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+    }];
+}
+
 - (void)testItExpiresAllMessagesAfterTheCurrentOneWhenAMessageCausesDegradation
 {
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -626,7 +660,7 @@
         conversation.conversationType = ZMConversationTypeGroup;
         ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
         conversation.securityLevel = ZMConversationSecurityLevelSecure;
-
+        
         ZMOTRMessage *message1 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
         [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
         ZMOTRMessage *message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
@@ -646,16 +680,65 @@
         [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message3];
         
         // THEN
-        XCTAssertFalse(message1.isExpired);
-        XCTAssertFalse(message1.causedSecurityLevelDegradation);
-        XCTAssertFalse(message2.isExpired);
-        XCTAssertFalse(message2.causedSecurityLevelDegradation);
+        XCTAssertTrue(message1.isExpired);
+        XCTAssertTrue(message1.causedSecurityLevelDegradation);
+        XCTAssertTrue(message2.isExpired);
+        XCTAssertTrue(message2.causedSecurityLevelDegradation);
         XCTAssertTrue(message3.isExpired);
         XCTAssertTrue(message3.causedSecurityLevelDegradation);
         XCTAssertTrue(message4.isExpired);
         XCTAssertTrue(message4.causedSecurityLevelDegradation);
         XCTAssertTrue(message5.isExpired);
         XCTAssertTrue(message5.causedSecurityLevelDegradation);
+        XCTAssertFalse(conversation.allUsersTrusted);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+    }];
+}
+
+- (void)testItCancelsAllMessagesThatCausedDegradation
+{
+    __block ZMConversation *conversation;
+    __block ZMOTRMessage *message1;
+    __block ZMOTRMessage *message2;
+    __block ZMOTRMessage *message3;
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // GIVEN
+        [self createSelfClient];
+        conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        conversation.conversationType = ZMConversationTypeGroup;
+        ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
+        conversation.securityLevel = ZMConversationSecurityLevelSecure;
+        
+        message1 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
+        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
+        message3 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
+        
+        
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"aabbccdd";
+        client.user = user;
+        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message2];
+        [self.syncMOC saveOrRollback];
+    }];
+    
+    // WHEN
+    ZMConversation *uiConversation = (ZMConversation *)[self.uiMOC existingObjectWithID:conversation.objectID error:nil];
+    [uiConversation doNotResendMessagesThatCausedDegradation];
+    
+    [self.syncMOC performGroupedBlockAndWait:^{
+        
+        // THEN
+        XCTAssertTrue(message1.isExpired);
+        XCTAssertFalse(message1.causedSecurityLevelDegradation);
+        XCTAssertTrue(message2.isExpired);
+        XCTAssertFalse(message2.causedSecurityLevelDegradation);
+        XCTAssertEqual(message2.deliveryState, ZMDeliveryStateFailedToSend);
+        XCTAssertTrue(message3.isExpired);
+        XCTAssertFalse(message3.causedSecurityLevelDegradation);
+        XCTAssertEqual(message3.deliveryState, ZMDeliveryStateFailedToSend);
         XCTAssertFalse(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
     }];
@@ -712,8 +795,8 @@
         [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message2];
         [self.syncMOC saveOrRollback];
         
-        XCTAssertFalse(message1.isExpired);
-        XCTAssertFalse(message1.causedSecurityLevelDegradation);
+        XCTAssertTrue(message1.isExpired);
+        XCTAssertTrue(message1.causedSecurityLevelDegradation);
         XCTAssertTrue(message2.isExpired);
         XCTAssertTrue(message2.causedSecurityLevelDegradation);
         XCTAssertTrue(message3.isExpired);
@@ -737,55 +820,6 @@
         XCTAssertEqual(message3.deliveryState, ZMDeliveryStatePending);
         XCTAssertFalse(conversation.allUsersTrusted);
         XCTAssertNotEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);
-    }];
-}
-
-- (void)testItCancelsAllMessagesThatCausedDegradation
-{
-    __block ZMConversation *conversation;
-    __block ZMOTRMessage *message1;
-    __block ZMOTRMessage *message2;
-    __block ZMOTRMessage *message3;
-    [self.syncMOC performGroupedBlockAndWait:^{
-        
-        // GIVEN
-        [self createSelfClient];
-        conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
-        conversation.conversationType = ZMConversationTypeGroup;
-        ZMUser *user = [self insertUserInConversation:conversation userIsTrusted:YES managedObjectContext:self.syncMOC];
-        conversation.securityLevel = ZMConversationSecurityLevelSecure;
-        
-        message1 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 2" fetchLinkPreview:NO];
-        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
-        message2 = (ZMOTRMessage *)[conversation appendMessageWithText:@"foo 3" fetchLinkPreview:NO];
-        [NSThread sleepForTimeInterval:0.05]; // cause system time to advance
-        message3 = (ZMOTRMessage *)[conversation appendMessageWithImageData:[self verySmallJPEGData]];
-        
-        
-        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-        client.remoteIdentifier = @"aabbccdd";
-        client.user = user;
-        [conversation decreaseSecurityLevelIfNeededAfterDiscoveringClients:[NSSet setWithObject:client] causedByMessage:message2];
-        [self.syncMOC saveOrRollback];
-    }];
-    
-    // WHEN
-    ZMConversation *uiConversation = (ZMConversation *)[self.uiMOC existingObjectWithID:conversation.objectID error:nil];
-    [uiConversation doNotResendMessagesThatCausedDegradation];
-    
-    [self.syncMOC performGroupedBlockAndWait:^{
-        
-        // THEN
-        XCTAssertFalse(message1.isExpired);
-        XCTAssertFalse(message1.causedSecurityLevelDegradation);
-        XCTAssertTrue(message2.isExpired);
-        XCTAssertFalse(message2.causedSecurityLevelDegradation);
-        XCTAssertEqual(message2.deliveryState, ZMDeliveryStateFailedToSend);
-        XCTAssertTrue(message3.isExpired);
-        XCTAssertFalse(message3.causedSecurityLevelDegradation);
-        XCTAssertEqual(message3.deliveryState, ZMDeliveryStateFailedToSend);
-        XCTAssertFalse(conversation.allUsersTrusted);
-        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
     }];
 }
 
@@ -916,125 +950,6 @@
     return result;
 }
 
-- (void)testThatItMovesExistingDegradedMessageWhenLocalParticpantsAdd
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    [conversation internalAddParticipants:unverifiedUsers];
-
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)2);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    // WHEN
-    ZMSystemMessage *addingSystemMessage = [self simulateAdding:unverifiedUsers to:conversation by:selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsAdded);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], addingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-}
-
-- (void)testThatItMovesExistingDegradedMessageWhenLocalParticpantsAdd_Multiple
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:5];
-    [conversation internalAddParticipants:unverifiedUsers];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)2);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    // WHEN
-    ZMSystemMessage *addingSystemMessage = [self simulateAdding:unverifiedUsers to:conversation by:selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsAdded);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], addingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-}
-
-- (void)testThatItMovesExistingDegradedMessageWhenRemoteParticpantsAdd
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *verifiedUser = [conversation.activeParticipants filteredOrderedSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMUser *  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings __unused) {
-        return !evaluatedObject.isSelfUser;
-    }]].firstObject;
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)1);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    
-    // WHEN
-    ZMSystemMessage *addingSystemMessage = [self simulateAdding:unverifiedUsers to:conversation by:verifiedUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsAdded);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], addingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-}
-
-- (void)testThatItMovesExistingDegradedMessageWhenRemoteParticpantsAdd_Multiple
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *verifiedUser = [conversation.activeParticipants filteredOrderedSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMUser *  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings __unused) {
-        return !evaluatedObject.isSelfUser;
-    }]].firstObject;
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:5];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)1);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    
-    // WHEN
-    ZMSystemMessage *addingSystemMessage = [self simulateAdding:unverifiedUsers to:conversation by:verifiedUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeNewClient);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsAdded);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], addingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).addedUsers isEqualToSet:unverifiedUsers]);
-}
-
-
 - (void)testThatItDoesNotInsertDegradedMessageWhenAddingVerifiedUsers
 {
     // GIVEN
@@ -1093,102 +1008,6 @@
     XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
     XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
     XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeParticipantsAdded);
-}
-
-// Removing participants
-
-- (void)testThatItMovesExistingVerifiedMessageWhenLocalParticpantsRemove
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    [conversation internalAddParticipants:unverifiedUsers];
-    [self simulateAdding:unverifiedUsers to:conversation by:selfUser];
-
-    [conversation internalRemoveParticipants:unverifiedUsers sender:self.selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)4);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeConversationIsSecure);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-    
-    // WHEN
-    
-    ZMSystemMessage *removingSystemMessage = [self simulateRemoving:unverifiedUsers from:conversation by:selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)5);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeConversationIsSecure);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsRemoved);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], removingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-}
-
-- (void)testThatItMovesExistindVerifiedMessageWhenLocalParticpantsRemove_Multiple
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    [conversation internalAddParticipants:unverifiedUsers];
-    [self simulateAdding:unverifiedUsers to:conversation by:selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    
-    // WHEN
-    
-    ZMSystemMessage *removingSystemMessage = [self simulateRemoving:unverifiedUsers from:conversation by:selfUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)5);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeConversationIsSecure);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsRemoved);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], removingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-}
-
-- (void)testThatItMovesExistingVerifiedMessageWhenRemoteParticpantsRemove
-{
-    // GIVEN
-    ZMConversation *conversation = [self setupVerifiedConversation];
-    ZMUser *verifiedUser = [conversation.activeParticipants filteredOrderedSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(ZMUser *  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings __unused) {
-        return !evaluatedObject.isSelfUser;
-    }]].firstObject;
-    
-    // WHEN
-    NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    [conversation internalAddParticipants:unverifiedUsers];
-    [self simulateAdding:unverifiedUsers to:conversation by:verifiedUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)3);
-    
-    // WHEN
-    
-    ZMSystemMessage *removingSystemMessage = [self simulateRemoving:unverifiedUsers from:conversation by:verifiedUser];
-    
-    // THEN
-    XCTAssertEqual(conversation.messages.count, (NSUInteger)5);
-    XCTAssertTrue([conversation.messages.lastObject isKindOfClass:[ZMSystemMessage class]]);
-    XCTAssertEqual(((ZMSystemMessage *)conversation.messages.lastObject).systemMessageType, ZMSystemMessageTypeConversationIsSecure);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
-    
-    XCTAssertEqual(((ZMSystemMessage *)[conversation.messages objectAtIndex:conversation.messages.count - 2]).systemMessageType, ZMSystemMessageTypeParticipantsRemoved);
-    XCTAssertEqual([conversation.messages objectAtIndex:conversation.messages.count - 2], removingSystemMessage);
-    XCTAssertTrue([((ZMSystemMessage *)conversation.messages.lastObject).users isEqualToSet:unverifiedUsers]);
 }
 
 - (void)testThatAddingABlockedUserThatAlreadyIsMemberOfTheConversationDoesNotDegradeTheConversation

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -24,24 +24,26 @@ class ZMMessageTests_Confirmation: BaseZMClientMessageTests {
 // MARK: - Adding confirmation locally
 extension ZMMessageTests_Confirmation {
     
-    func checkThatItInsertsAConfirmationMessageWhenItReceivesAMessage(
-        _ conversationType: ZMConversationType,
-        shouldSendConfirmation: Bool,
-        timestamp: Date = .init(),
-        file: StaticString = #file,
-        line: UInt = #line
-        ) {
+    func checkThatItInsertsAConfirmationMessageWhenItReceivesAMessage(_ conversationType: ZMConversationType,
+                                                                      shouldSendConfirmation: Bool,
+                                                                      timestamp: Date = .init(),
+                                                                      file: StaticString = #file,
+                                                                      line: UInt = #line ) {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.remoteIdentifier = UUID.create()
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         conversation.conversationType = conversationType
+        conversation.mutableLastServerSyncedActiveParticipants.add(user)
         
         let lastModified = Date(timeIntervalSince1970: 1234567890)
         conversation.lastModifiedDate = lastModified
         
         // when
         // other user sends confirmation
-        let sut = insertMessage(conversation, timestamp: timestamp)
+        let sut = insertMessage(conversation, fromSender: user, timestamp: timestamp)
         XCTAssertTrue(uiMOC.saveOrRollback(), file: file, line: line)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
         


### PR DESCRIPTION
## What's new in this PR?

Add method for verifying that a user is part of conversation.

## Note

Deleted some code for moving security level messages which is obsolete since we support adding/removing participants locally anymore.