### PR TITLE
Resort messages immediately after insertion to avoid saves in between

### DIFF
--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -241,6 +241,7 @@ NSString * const DeliveredKey = @"delivered";
     [clientMessage updateWithUpdateEvent:updateEvent forConversation:conversation];
     [clientMessage unarchiveConversationIfNeeded:conversation];
     [clientMessage updateCategoryCache];
+    [conversation resortMessagesWithUpdatedMessage:clientMessage];
     
     BOOL needsConfirmation = NO;
     if (isNewMessage && !clientMessage.sender.isSelfUser && conversation.conversationType == ZMConversationTypeOneOnOne) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The integration test `[SendAndReceiveMessages testThatItAppendsClientMessages]` was failing randomly.

### Causes

In this test two messages are received and then verified to be in the correct order. The messages were sometimes in the wrong order because the the conversation observer fired too early before the the messages had been sorted. This could happen since the SE context was saved in between that the new message was inserted and that the messages were sorted.

### Solutions

Sort messages immediately after inserting the message.