### PR TITLE
Expose user instead of userId on Mention

### DIFF
--- a/Source/Model/Message/Mention.swift
+++ b/Source/Model/Message/Mention.swift
@@ -22,19 +22,20 @@ import Foundation
 public class Mention: NSObject {
     
     public let range: NSRange
-    public let userId: UUID
+    public let user: UserType
     
-    init?(_ protobuf: ZMMention) {
-        guard protobuf.hasUserId(), let userId = UUID(uuidString: protobuf.userId) else { return nil }
+    init?(_ protobuf: ZMMention, context: NSManagedObjectContext) {
+        guard protobuf.hasUserId(), let userId = UUID(uuidString: protobuf.userId),
+              let user = ZMUser(remoteID: userId, createIfNeeded:  true, in: context) else { return nil }
         
         let length = protobuf.end - protobuf.start
-        self.userId = userId
+        self.user = user
         self.range = NSRange(location: Int(protobuf.start), length: max(Int(length), 0))
     }
     
-    public init(range: NSRange, userId: UUID) {
+    public init(range: NSRange, user: UserType) {
         self.range = range
-        self.userId = userId
+        self.user = user
     }
         
 }

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -26,9 +26,10 @@ extension ZMClientMessage: ZMTextMessageData {
     }
     
     public var mentions: [Mention] {
-        guard let protoBuffers = genericMessage?.text.mention else { return [] }
+        guard let protoBuffers = genericMessage?.text.mention,
+              let managedObjectContext = managedObjectContext else { return [] }
         
-        return protoBuffers.compactMap(Mention.init)
+        return protoBuffers.compactMap({ Mention($0, context: managedObjectContext) })
     }
     
 }

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -577,10 +577,12 @@ public extension ZMAvailability {
 @objc
 extension ZMMention {
     
-    public static func mention(_ mention: Mention) -> ZMMention {
+    public static func mention(_ mention: Mention) -> ZMMention? {
+        guard let userId = (mention.user as? ZMUser)?.remoteIdentifier else { return nil }
+        
         let builder = ZMMentionBuilder()
         
-        builder.setUserId(mention.userId.transportString())
+        builder.setUserId(userId.transportString())
         builder.setStart(Int32(mention.range.lowerBound))
         builder.setEnd(Int32(mention.range.upperBound))
     


### PR DESCRIPTION
## What's new in this PR?

 Expose user object instead of the `userId` which isn't very useful in the UI.