### PR TITLE
Fix some link previews not being rendered

### DIFF
--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -48,11 +48,9 @@ import WireLinkPreview
         guard let linkPreview = self.firstZMLinkPreview else { return nil }
         if linkPreview.hasTweet() {
             return TwitterStatus(protocolBuffer: linkPreview)
-        } else if linkPreview.hasArticle() {
+        } else {
             return Article(protocolBuffer: linkPreview)
         }
-        return nil
-        
     }
     
     var firstZMLinkPreview: ZMLinkPreview? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some Link previews were not rendered when containing a valid link preview

### Causes

We were expecting a link preview protobuf to either to contain a tweet or an article but this is no longer required. A link preview is by default an article and can be extended with more meta data (tweet).

### Solutions

Don't verify that the link preview contains an article.