### PR TITLE
Keep mentions when updating text message after setting image data

### DIFF
--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -165,9 +165,9 @@ extension ZMClientMessage: ZMImageOwner {
         
         let updatedPreview = linkPreview.update(withOtrKey: keys.otrKey, sha256: keys.sha256!, original: original)
 
-        if let genericMessage = self.genericMessage {
+        if let genericMessage = self.genericMessage, let textMessageData = textMessageData {
             
-            let text = ZMText.text(with: textMessageData?.messageText ?? "", linkPreviews: [updatedPreview])
+            let text = ZMText.text(with: textMessageData.messageText ?? "", mentions: textMessageData.mentions, linkPreviews: [updatedPreview])
             let messageUpdate: MessageContentType
 
             if genericMessage.hasText() {

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
@@ -35,11 +35,12 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
             originalURLString: "example.com/article/original",
             permanentURLString: "http://www.example.com/article/1",
             resolvedURLString: "http://www.example.com/article/1",
-            offset: 12
+            offset: 5
         )
         article.title = "title"
         article.summary = "tile"
-        let text = ZMText.text(with: "sample text", linkPreviews: [article.protocolBuffer])
+        let mention = Mention(range: NSRange(location: 0, length: 4), user: user1)
+        let text = ZMText.text(with: "@joe example.com/article/original", mentions: [mention], linkPreviews: [article.protocolBuffer])
         var genericMessage : ZMGenericMessage!
         switch contentType{
         case .textMessage:
@@ -51,6 +52,19 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.visibleInConversation = conversation
         clientMessage.sender = selfUser
         return clientMessage
+    }
+    
+    func testThatItKeepsMentionsWhenSettingImageData() {
+        // given
+        let clientMessage = insertMessageWithLinkPreview(contentType: .textMessage)
+        let imageData = mediumJPEGData()
+        
+        // when
+        let properties = ZMIImageProperties(size: CGSize(width: 42, height: 12), length: UInt(imageData.count), mimeType: "image/jpeg")
+        clientMessage.setImageData(imageData, for: .medium, properties: properties)
+        
+        // then
+        XCTAssertEqual(clientMessage.mentions.count, 1)
     }
     
     func testThatItCachesAndEncryptsTheMediumImage_TextMessage() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Mention were disappearing when sending mention together with links

### Causes

We didn't copy the mentions over when setting the downloaded link preview image data on a message.

### Solutions

Copy the mention over.