### PR TITLE
Feature/mentions open notification

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -296,6 +296,7 @@ extension ZMConversation {
         return unreadMessagesIncludingInvisible.lazy.map(replaceChildWithParent).filter({ $0.visibleInConversation != nil }).first(where: { $0.shouldGenerateUnreadCount() })
     }
     
+    // Returns first unread message mentioning the self user
     public var firstUnreadMessageMentioningSelf: ZMConversationMessage? {
         return unreadMessages.first(where: { $0.textMessageData?.isMentioningSelf ?? false })
     }

--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -296,6 +296,10 @@ extension ZMConversation {
         return unreadMessagesIncludingInvisible.lazy.map(replaceChildWithParent).filter({ $0.visibleInConversation != nil }).first(where: { $0.shouldGenerateUnreadCount() })
     }
     
+    public var firstUnreadMessageMentioningSelf: ZMConversationMessage? {
+        return unreadMessages.first(where: { $0.textMessageData?.isMentioningSelf ?? false })
+    }
+    
     /// Returns all unread messages. This may contain unread child messages of a system message which aren't directly visible in the conversation.
     @objc
     public var unreadMessages: [ZMConversationMessage] {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
@@ -218,6 +218,26 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         XCTAssertEqual(conversation.firstUnreadMessage as? ZMClientMessage, message)
     }
     
+    func testThatItReturnsTheFirstUnreadMessageMentioningSelfIfWeHaveItLocally() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        
+        // when
+        let message1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
+        message1.visibleInConversation = conversation
+        message1.serverTimestamp = Date(timeIntervalSinceNow: -2)
+        
+        let nonce = UUID()
+        let message2 = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
+        let mention = Mention(range: NSRange(location: 0, length: 4), user: selfUser)
+        message2.add(ZMGenericMessage.message(content: ZMText.text(with: "@joe hello", mentions: [mention]), nonce: nonce).data())
+        message2.visibleInConversation = conversation
+        message1.serverTimestamp = Date(timeIntervalSinceNow: -1)
+        
+        // then
+        XCTAssertEqual(conversation.firstUnreadMessageMentioningSelf as? ZMClientMessage, message2)
+    }
+    
     func testThatItReturnsNilIfTheLastReadServerTimestampIsMoreRecent() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)


### PR DESCRIPTION
## What's new in this PR?

Add `firstUnreadMessageMentioningSelf`  property on `ZMConversation` which will be used to find the scroll position when opening notification containing a mention.