### PR TITLE
Getter and setter to keep only mentions only for team users

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests+Mute.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Mute.swift
@@ -55,6 +55,14 @@ class ZMConversationTests_Mute : ZMConversationTestsBase {
         XCTAssertEqual(conversation.mutedMessageTypes, .none)
     }
 
+    func testThatItReturnsMutedAllViaGetterForNonTeam() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.mutedMessageTypes = [.nonMentions]
+        
+        // then
+        XCTAssertEqual(conversation.mutedMessageTypes, .all)
+    }
 }
 
 extension ZMConversationTests_Mute {
@@ -111,8 +119,11 @@ extension ZMConversationTests_Mute {
     
     func testMessageShouldCreateNotification_MentionSilenced_HasMention() {
         // GIVEN
+        selfUser.teamIdentifier = UUID()
+        
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.mutedMessageTypes = .nonMentions
+        selfUser.teamIdentifier = UUID()
         let message = conversation.append(text: "@you", mentions: [Mention(range: NSRange(location: 0, length: 4), user: selfUser)], fetchLinkPreview: false, nonce: UUID())!
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         (message as! ZMClientMessage).sender = user

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -57,7 +57,7 @@
                                        archivedRef:nil
                                         isSilenced:NO
                                        silencedRef:nil
-                                    silencedStatus:@(3)
+                                    silencedStatus:@(MutedMessageOptionValueMentions)
                                             teamID:nil
                                         accessMode:@[]
                                         accessRole:@"non_activated"];
@@ -110,6 +110,7 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
+        [ZMUser selfUserInContext:self.syncMOC].teamIdentifier = [NSUUID UUID];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
@@ -161,7 +162,7 @@
                                                            archivedRef:archivedDate
                                                             isSilenced:YES
                                                            silencedRef:silencedDate
-                                                        silencedStatus:@(3)];
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)];
         
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -226,6 +227,7 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
+        [ZMUser selfUserInContext:self.syncMOC].teamIdentifier = [NSUUID UUID];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
@@ -264,6 +266,7 @@
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
+        [ZMUser selfUserInContext:self.syncMOC].teamIdentifier = [NSUUID UUID];
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
@@ -317,7 +320,7 @@
                                                            archivedRef:archivedDate
                                                             isSilenced:YES
                                                            silencedRef:silencedDate
-                                                        silencedStatus:@(3)];
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)];
         
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -384,7 +387,7 @@
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
         
-        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:1 isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil silencedStatus:@(3)];
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation conversationType:1 isArchived:NO archivedRef:nil isSilenced:NO silencedRef:nil silencedStatus:@(MutedMessageOptionValueMentions)];
 
         // when
         NSDate *serverTimeStamp = [NSDate date];
@@ -419,7 +422,7 @@
                                                            archivedRef:nil
                                                             isSilenced:NO
                                                            silencedRef:nil
-                                                        silencedStatus:@(3)
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)
                                                                 teamID:teamID
                                                             accessMode:@[]
                                                             accessRole:@"non_activated"];
@@ -471,7 +474,7 @@
                                                            archivedRef:nil
                                                             isSilenced:NO
                                                            silencedRef:nil
-                                                        silencedStatus:@(3)
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)
                                                                 teamID:team.remoteIdentifier
                                                             accessMode:@[]
                                                             accessRole:@"non_activated"];
@@ -524,7 +527,7 @@
                                                            archivedRef:nil
                                                             isSilenced:NO
                                                            silencedRef:nil
-                                                        silencedStatus:@(3)
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)
                                                                 teamID:nil
                                                             accessMode:@[]
                                                             accessRole:@"non_activated"];
@@ -571,7 +574,7 @@
                                                            archivedRef:nil
                                                             isSilenced:NO
                                                            silencedRef:nil
-                                                        silencedStatus:@(3)
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)
                                                                 teamID:nil
                                                             accessMode:@[@"invite", @"code"]
                                                             accessRole:@"non_activated"];
@@ -605,7 +608,7 @@
                                                            archivedRef:nil
                                                             isSilenced:NO
                                                            silencedRef:nil
-                                                        silencedStatus:@(3)
+                                                        silencedStatus:@(MutedMessageOptionValueMentions)
                                                                 teamID:nil
                                                             accessMode:@[]
                                                             accessRole:@"team"];


### PR DESCRIPTION
## What's new in this PR?

### Issues

The getter would make sure that the new value is only set and correct after the migration for the team users.