### PR TITLE
Do not unarchive conversation if fully muted and mentioned

### DIFF
--- a/Source/Model/Message/ZMOTRMessage+Unarchive.swift
+++ b/Source/Model/Message/ZMOTRMessage+Unarchive.swift
@@ -49,7 +49,7 @@ extension ZMOTRMessage {
             let sender = self.sender,
             !sender.isSelfUser,
             let textMessageData = self.textMessageData,
-            textMessageData.isMentioningSelf {
+            !conversation.mutedMessageTypes.contains(.mentions) && textMessageData.isMentioningSelf {
             conversation.unarchive(with: self)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We had a bug that the conversation was unarchived when self user is mentioned, even if the conversation is fully muted.
