### PR TITLE
Fix: Search results don't contain group conversations where the current user participates

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -66,8 +66,7 @@ extern NSString *const ZMConversationSilencedChangedTimeStampKey;
 
 extern NSString *const ZMNotificationConversationKey;
 extern NSString *const ZMConversationRemoteIdentifierDataKey;
-extern NSString *const TeamRemoteIdentifierKey;
-
+extern NSString *const TeamRemoteIdentifierDataKey;
 
 extern const NSUInteger ZMConversationMaxTextMessageLength;
 extern NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay;

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -41,15 +41,21 @@ extension ZMConversation {
         let userDefinedNamePredicate = NSPredicate(format: "%K == NULL",                                                                      ZMConversationUserDefinedNameKey
         )
 
-        let teamRemoteIdentifierPredicate = NSPredicate(format: "%K != NULL",                                                                      TeamRemoteIdentifierKey
+        let teamRemoteIdentifierPredicate = NSPredicate(format: "%K != NULL",                                                                      TeamRemoteIdentifierDataKey
         )
 
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [searchPredicate,
-                                                                   activeMemberPredicate,
-                                                                   basePredicate, NSCompoundPredicate(notPredicateWithSubpredicate:NSCompoundPredicate(andPredicateWithSubpredicates:[
-                                                                   activeParticipantsPredicate,
-                                                                   userDefinedNamePredicate,
-                                                                   teamRemoteIdentifierPredicate]))])
+        let notTeamMemberPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: NSCompoundPredicate(andPredicateWithSubpredicates: [
+            activeParticipantsPredicate,
+            userDefinedNamePredicate ,
+            teamRemoteIdentifierPredicate
+            ]))
+
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [
+            searchPredicate,
+            activeMemberPredicate,
+            basePredicate,
+            notTeamMemberPredicate
+            ])
     }
 
     @objc(predicateForConversationsInTeam:)

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -83,8 +83,8 @@ static NSString *const LastReadMessageKey = @"lastReadMessage";
 static NSString *const lastEditableMessageKey = @"lastEditableMessage";
 static NSString *const NeedsToBeUpdatedFromBackendKey = @"needsToBeUpdatedFromBackend";
 static NSString *const RemoteIdentifierKey = @"remoteIdentifier";
-NSString *const TeamRemoteIdentifierKey = @"teamRemoteIdentifier";
-static NSString *const TeamRemoteIdentifierDataKey = @"teamRemoteIdentifier_data";
+static NSString *const TeamRemoteIdentifierKey = @"teamRemoteIdentifier";
+NSString *const TeamRemoteIdentifierDataKey = @"teamRemoteIdentifier_data";
 static NSString *const VoiceChannelKey = @"voiceChannel";
 static NSString *const VoiceChannelStateKey = @"voiceChannelState";
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios-data-model/pull/572, group conversation contains the matching user is not shown.

### Causes


The predicate check for TeamRemoteIdentifierKey, which is not the valid key.


### Solutions


User TeamRemoteIdentifierDataKey instead of TeamRemoteIdentifierKey.
