### PR TITLE
Temporarily ignore image size

### DIFF
--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -30,8 +30,7 @@ public protocol EphemeralMessageContentType: MessageContentType {
 @objc public extension ZMGenericMessage {
 
     var v3_isImage: Bool {
-        guard let original = assetData?.original else { return false }
-        return original.hasRasterImage && original.hasValidImageSize
+        return assetData?.original.hasRasterImage ?? false
     }
 
     var v3_uploadedAssetId: String? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The issue happens when user is trying to upload the image bigger than 5 MB.

### Causes

New logic to handle bigger images as files seem to fail when uploading the image.

### Solutions

Temporarily disable the new logic for the current release, fix properly for the new release.