### PR TITLE
Add login credentials to Account model

### DIFF
--- a/Source/Model/LoginCredentials.swift
+++ b/Source/Model/LoginCredentials.swift
@@ -24,10 +24,10 @@ import Foundation
 
 @objc public class LoginCredentials: NSObject, Codable {
 
-    public let emailAddress: String?
-    public let phoneNumber: String?
-    public let hasPassword: Bool
-    public let usesCompanyLogin: Bool
+    @objc public let emailAddress: String?
+    @objc public let phoneNumber: String?
+    @objc public let hasPassword: Bool
+    @objc public let usesCompanyLogin: Bool
 
     public init(emailAddress: String?, phoneNumber: String?, hasPassword: Bool, usesCompanyLogin: Bool) {
         self.emailAddress = emailAddress

--- a/Source/Model/LoginCredentials.swift
+++ b/Source/Model/LoginCredentials.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * Contains the credentials used by a user to sign into the app.
+ */
+
+@objc public class LoginCredentials: NSObject, Codable {
+
+    public let emailAddress: String?
+    public let phoneNumber: String?
+    public let hasPassword: Bool
+    public let usesCompanyLogin: Bool
+
+    public init(emailAddress: String?, phoneNumber: String?, hasPassword: Bool, usesCompanyLogin: Bool) {
+        self.emailAddress = emailAddress
+        self.phoneNumber = phoneNumber
+        self.hasPassword = hasPassword
+        self.usesCompanyLogin = usesCompanyLogin
+    }
+
+    public override var debugDescription: String {
+        return "<LoginCredentials>:\n\temailAddress: \(String(describing: emailAddress))\n\tphoneNumber: \(String(describing: phoneNumber))\n\thasPassword: \(hasPassword)\n\tusesCompanyLogin: \(usesCompanyLogin)"
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let otherCredentials = object as? LoginCredentials else {
+            return false
+        }
+
+        let emailEquals = self.emailAddress == otherCredentials.emailAddress
+        let phoneNumberEquals = self.phoneNumber == otherCredentials.phoneNumber
+        let passwordEquals = self.hasPassword == otherCredentials.hasPassword
+        let companyLoginEquals = self.usesCompanyLogin == otherCredentials.usesCompanyLogin
+
+        return emailEquals && phoneNumberEquals && passwordEquals && companyLoginEquals
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(emailAddress)
+        hasher.combine(phoneNumber)
+        hasher.combine(hasPassword)
+        hasher.combine(usesCompanyLogin)
+        return hasher.finalize()
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		5E0FB2012051493700FD9867 /* Set+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB2002051493700FD9867 /* Set+Filter.swift */; };
 		5E0FB215205176B400FD9867 /* Set+ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */; };
 		5E454C60210638E300DB4501 /* PushTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13A89D22106293000AB40CB /* PushTokenTests.swift */; };
+		5E67168E2174B9AF00522E61 /* LoginCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E67168D2174B9AF00522E61 /* LoginCredentials.swift */; };
 		5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E771F372080BB0000575629 /* PBMessage+Validation.swift */; };
 		5E771F3B2080C42300575629 /* PBMessageValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E771F392080C40B00575629 /* PBMessageValidationTests.swift */; };
 		5EDDC7A62088CE3B00B24850 /* ZMConversation+Invalid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDDC7A52088CE3B00B24850 /* ZMConversation+Invalid.swift */; };
@@ -615,6 +616,7 @@
 		54FB03AE1E41FC86000E13DC /* NSManagedObjectContext+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Patches.swift"; sourceTree = "<group>"; };
 		5E0FB2002051493700FD9867 /* Set+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Filter.swift"; sourceTree = "<group>"; };
 		5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+ServiceUser.swift"; sourceTree = "<group>"; };
+		5E67168D2174B9AF00522E61 /* LoginCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCredentials.swift; sourceTree = "<group>"; };
 		5E771F372080BB0000575629 /* PBMessage+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBMessage+Validation.swift"; sourceTree = "<group>"; };
 		5E771F392080C40B00575629 /* PBMessageValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBMessageValidationTests.swift; sourceTree = "<group>"; };
 		5EDDC7A52088CE3B00B24850 /* ZMConversation+Invalid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Invalid.swift"; sourceTree = "<group>"; };
@@ -1227,6 +1229,7 @@
 				BF491CE51F063EE50055EE44 /* AccountStore.swift */,
 				BF491CE71F063EEB0055EE44 /* AccountManager.swift */,
 				BF8361D91F0A3C41009AE5AC /* NSSecureCoding+Swift.swift */,
+				5E67168D2174B9AF00522E61 /* LoginCredentials.swift */,
 			);
 			name = Accounts;
 			sourceTree = "<group>";
@@ -2368,6 +2371,7 @@
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
 				162A81DD202DA4BC00F6200C /* AssetCache.swift in Sources */,
 				16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */,
+				5E67168E2174B9AF00522E61 /* LoginCredentials.swift in Sources */,
 				CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */,
 				545FA5D71E2FD3750054171A /* ZMConversation+MessageDeletion.swift in Sources */,
 				BFD2E79A1CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user is logged out in the background (ex: remote client removal), and reopens the app, we show the screen to reauthenticate. However, the login field is not pre-filled as the user session is not available and we cannot access the email of the account.

### Causes

When the user is removed when the app is in the foreground, we can pre-fill because the user session sends the token expired notification with the login credentials of its `ZMUser`.

However, in the case where the logout happens when we open the app, we can't pass the credentials in the notification because we don't have a user session to get the required details.

### Solutions

The `LoginCredentials` structure is now a part of the Account object, which makes it available in all contexts.

We also update the `Account` serialization to use `Codable` instead of custom encoding and decoding.

## Note

This PR points to the branch for the modular authentication updates. Do not release a framework bump.