### PR TITLE
ZIOS-10734: Fix user logout after updating to new login stack

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -45,6 +45,16 @@ public final class Account: NSObject, Codable {
         }
     }
 
+    enum CodingKeys: String, CodingKey {
+        case userName = "name"
+        case teamName = "team"
+        case userIdentifier = "identifier"
+        case imageData = "image"
+        case teamImageData = "teamImage"
+        case unreadConversationCount = "unreadConversationCount"
+        case loginCredentials = "loginCredentials"
+    }
+
     public required init(userName: String,
                          userIdentifier: UUID,
                          teamName: String? = nil,

--- a/Tests/Source/Model/AccountStoreTests.swift
+++ b/Tests/Source/Model/AccountStoreTests.swift
@@ -293,4 +293,60 @@ final class AccountStoreTests: ZMConversationTestsBase {
         XCTAssertEqual(store.load(), [account2])
     }
 
+    func testThatItDecodesAccountOnDiskWithoutLoginCredentials() throws {
+        // given
+        let store = AccountStore(root: url)
+        let accountID = UUID(uuidString: "012B6D4F-590B-4355-AC8A-8A531F9F30EE")!
+
+        let accountJSON = """
+        {
+            "name": "Alexis",
+            "identifier": "\(accountID)",
+            "team": "Wire",
+            "image": "",
+            "unreadConversationCount": 1
+        }
+        """.data(using: .utf8)!
+
+        try accountJSON.write(to: url.appendingPathComponent("Accounts/" + accountID.uuidString))
+
+        // when
+        let account = store.load(accountID)
+
+        // then
+        let expectedAccount = Account(userName: "Alexis", userIdentifier: accountID, teamName: "Wire", imageData: Data(), teamImageData: nil, unreadConversationCount: 1, loginCredentials: nil)
+        XCTAssertEqual(account, expectedAccount)
+    }
+
+    func testThatItDecodesAccountOnDiskWithLoginCredentials() throws {
+        // given
+        let store = AccountStore(root: url)
+        let accountID = UUID(uuidString: "012B6D4F-590B-4355-AC8A-8A531F9F30EE")!
+
+        let accountJSON = """
+        {
+            "name": "Alexis",
+            "identifier": "\(accountID)",
+            "team": "Wire",
+            "image": "",
+            "unreadConversationCount": 0,
+            "loginCredentials": {
+                "emailAddress": "alexis@example.com",
+                "hasPassword": true,
+                "usesCompanyLogin": false
+            }
+        }
+        """.data(using: .utf8)!
+
+        try accountJSON.write(to: url.appendingPathComponent("Accounts/" + accountID.uuidString))
+
+        // when
+        let account = store.load(accountID)
+
+        // then
+        let expectedCredentials = LoginCredentials(emailAddress: "alexis@example.com", phoneNumber: nil, hasPassword: true, usesCompanyLogin: false)
+        let expectedAccount = Account(userName: "Alexis", userIdentifier: accountID, teamName: "Wire", imageData: Data(), teamImageData: nil, unreadConversationCount: 0, loginCredentials: expectedCredentials)
+        XCTAssertEqual(account, expectedAccount)
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When updating to a build that includes the login changes, users get logged out.

### Causes

This happened because we were not using the correct JSON keys for decoding the account in the account store. So the SE tried to login using the legacy store migrator, which couldn't find any account either, which caused the logout.

### Solutions

We fix the JSON Coding Keys for the account model to use the ones that were used in the previous version.