### PR TITLE
Do not reset company login flag from notification stream

### DIFF
--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -275,6 +275,23 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssert(user.usesCompanyLogin);
 }
 
+- (void)testThatItUpdatesSSODataOnAnExistingUserWhenRefetchingUser
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"sso_id"] = @{@"tenant": @"some-xml"};
+    
+    // when
+    [user updateWithTransportData:payload authoritative:NO];
+    [user updateWithTransportData:[self samplePayloadForUserID:uuid] authoritative:NO];
+
+    // then
+    XCTAssert(user.usesCompanyLogin);
+}
+
 - (void)testThatItUpdatesSSODataOnAnExistingUser_NoSSOData
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

SSO user lost the information about it's being an SSO user after receiving any profile update.

### Problem

We use one method to process /self response and any notification stream self update payload.

