### PR TITLE
Provide method signatures without default args for objc

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -33,6 +33,15 @@ extension ZMConversation {
         return appendClientMessage(with: ZMGenericMessage.message(content: ZMKnock.knock(), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
+    @discardableResult @objc(appendText:mentions:fetchLinkPreview:nonce:)
+    public func append(text: String,
+                       mentions: [Mention] = [],
+                       fetchLinkPreview: Bool = true,
+                       nonce: UUID = UUID()) -> ZMConversationMessage? {
+        
+        return append(text: text, mentions: mentions, replyingTo: nil, fetchLinkPreview: fetchLinkPreview, nonce: nonce)
+    }
+    
     @discardableResult @objc(appendText:mentions:replyingToMessage:fetchLinkPreview:nonce:)
     public func append(text: String,
                        mentions: [Mention] = [],

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -168,6 +168,10 @@ extension ZMKnock: EphemeralMessageContentType {
 @objc
 extension ZMText: EphemeralMessageContentType {
     
+    public static func text(with message: String, mentions: [Mention] = [], linkPreviews: [ZMLinkPreview] = []) -> ZMText {
+        return text(with: message, mentions: mentions, linkPreviews: linkPreviews, quoteMessageId: nil)
+    }
+    
     public static func text(with message: String, mentions: [Mention] = [], linkPreviews: [ZMLinkPreview] = [], quoteMessageId: String? = nil) -> ZMText {
         let builder = ZMTextBuilder()
                 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Changes to the API for adding a message to the conversation with a reply as well as creating text content with a reply were written in swift and used default arguments. Unfortunately, this API is also called from Objective C code in other frameworks, which requires that arguments be explicitly declared. This leads to several compilation errors requiring changes to method calls.

### Solutions

Redefine the old API methods that simply call the new methods with the default parameters provided.
