### PR TITLE
Data model: fix array vs set and relation cardinality

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.56.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.56.0.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="17G65" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.56.0">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="18A391" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.56.0">
     <entity name="AddressBookEntry" representedClassName=".AddressBookEntry" syncable="YES">
         <attribute name="cachedName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="localIdentifier" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
@@ -122,7 +122,7 @@
         <relationship name="missingRecipients" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="messagesMissingRecipient" inverseEntity="UserClient" syncable="YES"/>
         <relationship name="quote" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="replies" inverseEntity="Message" syncable="YES"/>
         <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Reaction" inverseName="message" inverseEntity="Reaction" syncable="YES"/>
-        <relationship name="replies" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="quote" inverseEntity="Message" syncable="YES"/>
+        <relationship name="replies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="quote" inverseEntity="Message" syncable="YES"/>
         <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
         <relationship name="visibleInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation" syncable="YES"/>
     </entity>

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -53,9 +53,10 @@ extension ZMConversation {
         
         let textContent = ZMText.text(with: text, mentions: mentions, linkPreviews: [], quoteMessageId: replyToMessage?.genericMessage?.messageId)
         let clientMessage = ZMGenericMessage.message(content: textContent, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
-        let message = appendClientMessage(with: clientMessage)
-        message?.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
-        
+        let message = appendClientMessage(with: clientMessage)!
+        message.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
+        message.quote = replyToMessage
+        replyToMessage?.mutableSetValue(forKey: "replies").add(message)
         if let managedObjectContext = managedObjectContext {
             NotificationInContext(name: ZMConversation.clearTypingNotificationName,
                                   context: managedObjectContext.notificationContext,

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -56,7 +56,7 @@ extension ZMConversation {
         let message = appendClientMessage(with: clientMessage)!
         message.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
         message.quote = replyToMessage
-        replyToMessage?.mutableSetValue(forKey: ZMMessageRepliesKey).add(message)
+        
         if let managedObjectContext = managedObjectContext {
             NotificationInContext(name: ZMConversation.clearTypingNotificationName,
                                   context: managedObjectContext.notificationContext,

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -56,7 +56,7 @@ extension ZMConversation {
         let message = appendClientMessage(with: clientMessage)!
         message.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
         message.quote = replyToMessage
-        replyToMessage?.mutableSetValue(forKey: "replies").add(message)
+        replyToMessage?.mutableSetValue(forKey: ZMMessageRepliesKey).add(message)
         if let managedObjectContext = managedObjectContext {
             NotificationInContext(name: ZMConversation.clearTypingNotificationName,
                                   context: managedObjectContext.notificationContext,

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -111,6 +111,8 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     
     /// Checks if the message can be marked unread
     var canBeMarkedUnread: Bool { get }
+    
+    var replies: Set<ZMMessage> { get }
 }
 
 public extension ZMConversationMessage {
@@ -134,6 +136,8 @@ extension ZMMessage {
 // MARK:- Conversation Message protocol implementation
 
 extension ZMMessage : ZMConversationMessage {
+    @NSManaged public var replies: Set<ZMMessage>
+    
     public var causedSecurityLevelDegradation : Bool {
         return false
     }

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -27,11 +27,6 @@ fileprivate extension NSRange {
 @objc
 extension ZMClientMessage: ZMTextMessageData {
     
-    public var replies: [ZMMessage]? {
-        /// TODO
-        return []
-    }
-    
     public var quote: ZMMessage? {
         guard let proto = genericMessage?.textData?.quote,
             let moc = managedObjectContext,

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -27,14 +27,7 @@ fileprivate extension NSRange {
 @objc
 extension ZMClientMessage: ZMTextMessageData {
     
-    public var quote: ZMMessage? {
-        guard let proto = genericMessage?.textData?.quote,
-            let moc = managedObjectContext,
-            let quotedMessageId = UUID(uuidString: proto.quotedMessageId)
-        else { return nil}
-        
-        return ZMMessage(nonce: quotedMessageId, managedObjectContext: moc)
-    }
+    @NSManaged public var quote: ZMMessage?
     
     public var isQuotingSelf: Bool{
         return quote?.sender?.isSelfUser ?? false

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -790,9 +790,9 @@ NSString * const ZMMessageQuoteKey = @"quote";
     return nil;
 }
 
--(NSArray<ZMMessage *> *)replies
+-(NSSet<ZMMessage *> *)replies
 {
-    return @[];
+    return [NSSet set];
 }
 
 -(BOOL)hasQuote

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -90,7 +90,6 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, readonly, nullable) NSString *messageText;
 @property (nonatomic, readonly, nullable) LinkPreview *linkPreview;
 @property (nonatomic, readonly, nonnull) NSArray<Mention *> *mentions;
-@property (nonatomic, readonly, nullable) NSArray<ZMMessage*> *replies;
 @property (nonatomic, readonly, nullable) ZMMessage *quote;
 
 /// Returns true if the link preview will have an image

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
@@ -21,16 +21,10 @@ import XCTest
 
 class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
     
-    func createMessage(text: String, quote: String?) -> ZMClientMessage {
-        let zmText = ZMText.text(with: text, mentions: [], linkPreviews: [], quoteMessageId: quote)
-        let message = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
-        message.add(ZMGenericMessage.message(content: zmText).data())
-        return message
-    }
-    
     func testQuoteIsReturned() {
-        let quotedMessage = createMessage(text: "I have a proposal", quote: nil)
-        let message = createMessage(text: "That's fine", quote: quotedMessage.genericMessage?.messageId)
+        let quotedMessage = conversation.append(text: "I have a proposal", mentions: [], replyingTo: nil, fetchLinkPreview: false, nonce: UUID()) as! ZMClientMessage
+        
+        let message = conversation.append(text: "That's fine", mentions: [], replyingTo: quotedMessage, fetchLinkPreview: false, nonce: UUID()) as! ZMTextMessageData
         
         XCTAssertEqual(message.quote, quotedMessage)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

- Changed the relation cardinality from 1-1 to 1-many for the Message.replies-Message.quote relation.
- Fixed type to be Set, no array.
- Moved the replies from ZMTextMessage to ZMClientMessage.