### PR TITLE
Establish reply/quote relationships when receiving a message

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -45,17 +45,17 @@ extension ZMConversation {
     @discardableResult @objc(appendText:mentions:replyingToMessage:fetchLinkPreview:nonce:)
     public func append(text: String,
                        mentions: [Mention] = [],
-                       replyingTo replyToMessage: ZMClientMessage? = nil,
+                       replyingTo quotedMessage: ZMConversationMessage? = nil,
                        fetchLinkPreview: Bool = true,
                        nonce: UUID = UUID()) -> ZMConversationMessage? {
         
         guard !(text as NSString).zmHasOnlyWhitespaceCharacters() else { return nil }
         
-        let textContent = ZMText.text(with: text, mentions: mentions, linkPreviews: [], quoteMessageId: replyToMessage?.genericMessage?.messageId)
+        let textContent = ZMText.text(with: text, mentions: mentions, linkPreviews: [], replyingTo: quotedMessage as? ZMOTRMessage)
         let clientMessage = ZMGenericMessage.message(content: textContent, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
         let message = appendClientMessage(with: clientMessage)!
         message.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
-        message.quote = replyToMessage
+        message.quote = quotedMessage as? ZMMessage
         
         if let managedObjectContext = managedObjectContext {
             NotificationInContext(name: ZMConversation.clearTypingNotificationName,

--- a/Source/Model/Message/ZMAssetClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Quotes.swift
@@ -16,26 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-extension ZMOTRMessage {
+extension ZMAssetClientMessage {
     
-    @objc
-    func updateQuoteRelationships() {
-        // Should be overridden in subclasses
-    }
-        
-    func establishRelationshipsForInsertedQuote(_ quote: ZMQuote) {
-        
-        guard let managedObjectContext = managedObjectContext,
-              let conversation = conversation,
-              let quotedMessageId = UUID(uuidString: quote.quotedMessageId),
-              let quotedMessage = ZMOTRMessage.fetch(withNonce: quotedMessageId, for: conversation, in: managedObjectContext) else { return }
-        
-        if quotedMessage.hashOfContent == quote.quotedMessageSha256 {
-            quotedMessage.replies.insert(self)
-        }
+    override func updateQuoteRelationships() {
+        // Asset messages don't support quotes at the moment
     }
     
 }

--- a/Source/Model/Message/ZMClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMClientMessage+Quotes.swift
@@ -1,0 +1,29 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMClientMessage {
+    
+    override func updateQuoteRelationships() {
+        guard let quote = genericMessage?.text?.quote else { return }
+        
+        establishRelationshipsForInsertedQuote(quote)
+    }
+    
+}

--- a/Source/Model/Message/ZMOTRMessage+Quotes.swift
+++ b/Source/Model/Message/ZMOTRMessage+Quotes.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension ZMOTRMessage {
+    
+    @objc
+    func updateQuoteRelationships() {
+        assertionFailure("Subclasses should override this method")
+    }
+        
+    func establishRelationshipsForInsertedQuote(_ quote: ZMQuote) {
+        
+        guard let managedObjectContext = managedObjectContext,
+              let conversation = conversation,
+              let quotedMessageId = UUID(uuidString: quote.quotedMessageId),
+              let quotedMessage = ZMOTRMessage.fetch(withNonce: quotedMessageId, for: conversation, in: managedObjectContext) else { return }
+        
+        if quotedMessage.hashOfContent == quote.quotedMessageSha256 {
+            quotedMessage.replies.insert(self)
+        }
+    }
+    
+}

--- a/Source/Model/Message/ZMOTRMessage+Replies.swift
+++ b/Source/Model/Message/ZMOTRMessage+Replies.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension ZMOTRMessage {
+    
+    @objc
+    func updateQuoteRelationships() {
+        // Should be overridden in subclasses
+    }
+        
+    func establishRelationshipsForInsertedQuote(_ quote: ZMQuote) {
+        
+        guard let managedObjectContext = managedObjectContext,
+              let conversation = conversation,
+              let quotedMessageId = UUID(uuidString: quote.quotedMessageId),
+              let quotedMessage = ZMOTRMessage.fetch(withNonce: quotedMessageId, for: conversation, in: managedObjectContext) else { return }
+        
+        if quotedMessage.hashOfContent == quote.quotedMessageSha256 {
+            quotedMessage.replies.insert(self)
+        }
+    }
+    
+}

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -239,6 +239,7 @@ NSString * const DeliveredKey = @"delivered";
     }
     
     [clientMessage updateWithUpdateEvent:updateEvent forConversation:conversation];
+    [clientMessage updateQuoteRelationships];
     [clientMessage unarchiveIfNeeded:conversation];
     [clientMessage updateCategoryCache];
     [conversation resortMessagesWithUpdatedMessage:clientMessage];

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -167,21 +167,18 @@ extension ZMKnock: EphemeralMessageContentType {
 
 @objc
 extension ZMText: EphemeralMessageContentType {
-    
-    public static func text(with message: String, mentions: [Mention] = [], linkPreviews: [ZMLinkPreview] = []) -> ZMText {
-        return text(with: message, mentions: mentions, linkPreviews: linkPreviews, quoteMessageId: nil)
-    }
-    
-    public static func text(with message: String, mentions: [Mention] = [], linkPreviews: [ZMLinkPreview] = [], quoteMessageId: String? = nil) -> ZMText {
+        
+    public static func text(with message: String, mentions: [Mention] = [], linkPreviews: [ZMLinkPreview] = [], replyingTo quotedMessage: ZMOTRMessage? = nil) -> ZMText {
         let builder = ZMTextBuilder()
                 
         builder.setContent(message)
         builder.setMentionsArray(mentions.compactMap(ZMMention.mention))
         builder.setLinkPreviewArray(linkPreviews)
         
-        if let quote = quoteMessageId {
+        if let quotedMessage = quotedMessage, let quotedMessageNonce = quotedMessage.nonce {
             let quoteBuilder = ZMQuoteBuilder()
-            quoteBuilder.setQuotedMessageId(quote)
+            quoteBuilder.setQuotedMessageId(quotedMessageNonce.transportString())
+            quoteBuilder.setQuotedMessageSha256(quotedMessage.hashOfContent)
             builder.setQuote(quoteBuilder)
         }
         

--- a/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
+++ b/Tests/Source/ManagedObjectContext/ZMSyncMergePolicyTests.m
@@ -142,7 +142,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         NSUUID *nonce = [NSUUID createUUID];
         ZMClientMessage *m = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
-        [m addData:[ZMGenericMessage messageWithContent:[ZMText textWith:@"X" mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:NSUUID.createUUID].data];
+        [m addData:[ZMGenericMessage messageWithContent:[ZMText textWith:@"X" mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:NSUUID.createUUID].data];
         m.serverTimestamp = [self nextDate];
         [self.syncConversation.mutableMessages addObject:m];
         XCTAssert([self.syncMOC saveOrRollback]);
@@ -281,7 +281,7 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         NSUUID *nonce = NSUUID.createUUID;
         ZMClientMessage *m = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
-        [m addData:[ZMGenericMessage messageWithContent:[ZMText textWith:@"X" mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:NSUUID.createUUID].data];
+        [m addData:[ZMGenericMessage messageWithContent:[ZMText textWith:@"X" mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:NSUUID.createUUID].data];
         m.serverTimestamp = [self nextDate];
         [self.syncConversation.mutableMessages addObject:m];
     }];

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1820,7 +1820,7 @@
     message.sender = sender;
     [message markAsSent];
     
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMMessageEdit editWith:[ZMText textWith:@"Edited Test Message" mentions:@[] linkPreviews:@[] quoteMessageId:nil] replacingMessageId:message.nonce] nonce:NSUUID.createUUID];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMMessageEdit editWith:[ZMText textWith:@"Edited Test Message" mentions:@[] linkPreviews:@[] replyingTo:nil] replacingMessageId:message.nonce] nonce:NSUUID.createUUID];
     NSDictionary *payload = @{
                               @"conversation": conversation.remoteIdentifier.transportString,
                               @"from": message.sender.remoteIdentifier.transportString,

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -380,7 +380,7 @@
 
 - (ZMUpdateEvent *)createMessageEditUpdateEventWithOldNonce:(NSUUID *)oldNonce newNonce:(NSUUID *)newNonce conversationID:(NSUUID*)conversationID senderID:(NSUUID *)senderID newText:(NSString *)newText
 {
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMMessageEdit editWith:[ZMText textWith:newText mentions:@[] linkPreviews:@[] quoteMessageId:nil] replacingMessageId:oldNonce] nonce:newNonce];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMMessageEdit editWith:[ZMText textWith:newText mentions:@[] linkPreviews:@[] replyingTo:nil] replacingMessageId:oldNonce] nonce:newNonce];
     
     NSDictionary *payload = @{
                    @"conversation": conversationID.transportString,
@@ -397,7 +397,7 @@
 
 - (ZMUpdateEvent *)createTextAddedEventWithNonce:(NSUUID *)nonce conversationID:(NSUUID*)conversationID senderID:(NSUUID *)senderID
 {
-    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:@"Yeah!" mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *genericMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:@"Yeah!" mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     
     NSDictionary *payload = @{
                               @"conversation": conversationID.transportString,

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.m
@@ -169,7 +169,7 @@
     conversation.remoteIdentifier = [NSUUID createUUID];
     
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSData *contentData = message.data;
     
     NSString *data = [contentData base64EncodedStringWithOptions:0];
@@ -203,7 +203,7 @@
     
     NSString *senderClientID = [NSString createAlphanumericalString];
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSData *contentData = message.data;
     
     NSDictionary *data = @{ @"sender": senderClientID, @"text" : [contentData base64EncodedStringWithOptions:0] };
@@ -237,7 +237,7 @@
 
     NSString *senderClientID = [NSString createAlphanumericalString];
     NSUUID *nonce = [NSUUID createUUID];
-    ZMGenericMessage *prototype = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *prototype = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     ZMGenericMessageBuilder *builder = [ZMGenericMessage builderWithPrototype:prototype];
     [builder setMessageId:@"please-fail"];
 
@@ -352,12 +352,12 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     
-    ZMGenericMessage *modifiedMessage =     [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *modifiedMessage =     [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -389,13 +389,13 @@
     NSString *unknownSender = [NSString createAlphanumericalString];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message =     [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message =     [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
-    ZMGenericMessage *modifiedMessage =     [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *modifiedMessage =     [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSDictionary *data = @{ @"sender" : unknownSender, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -426,13 +426,13 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message =     [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:NSUUID.createUUID];
+    ZMGenericMessage *message =     [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:NSUUID.createUUID];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
     
@@ -463,14 +463,14 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:NSUUID.createUUID];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:NSUUID.createUUID];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
     ZMLinkPreview *linkPreview = [ZMLinkPreview linkPreviewWithOriginalURL:@"http://www.sunet.se" permanentURL:@"http://www.sunet.se" offset:0 title:@"Test" summary:nil imageAsset:nil];
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[linkPreview] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:modifiedText mentions:@[] linkPreviews:@[linkPreview] replyingTo:nil] nonce:nonce];
     
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
@@ -501,14 +501,14 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
     ZMLinkPreview *linkPreview = [ZMLinkPreview linkPreviewWithOriginalURL:@"http://www.sunet.se" permanentURL:@"http://www.sunet.se" offset:0 title:@"Test" summary:nil imageAsset:nil];
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[linkPreview] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[linkPreview] replyingTo:nil] nonce:nonce];
     
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
@@ -540,14 +540,14 @@
     UserClient *selfClient = [self createSelfClient];
     
     ZMClientMessage *existingMessage = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     [existingMessage addData:message.data];
     existingMessage.visibleInConversation = conversation;
     existingMessage.sender = self.selfUser;
     existingMessage.senderClientID = selfClient.remoteIdentifier;
     
     ZMLinkPreview *linkPreview = [ZMLinkPreview linkPreviewWithOriginalURL:@"http://www.sunet.se" permanentURL:@"http://www.sunet.se" offset:0 title:@"Test" summary:nil imageAsset:nil];
-    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[linkPreview] quoteMessageId:nil] nonce:nonce timeout:3600];
+    ZMGenericMessage *modifiedMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:initialText mentions:@[] linkPreviews:@[linkPreview] replyingTo:nil] nonce:nonce timeout:3600];
     
     NSDictionary *data = @{ @"sender" : selfClient.remoteIdentifier, @"recipient": selfClient.remoteIdentifier, @"text": modifiedMessage.data.base64String };
     NSDictionary *payload = [self payloadForMessageInConversation:conversation type:EventConversationAddOTRMessage data:data time:[NSDate date] fromUser:self.selfUser];
@@ -579,7 +579,7 @@
     existingMessage.nonce = nonce;
     existingMessage.visibleInConversation = conversation;
     
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     NSData *contentData = message.data;
     
     NSString *data = [contentData base64EncodedStringWithOptions:0];

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
@@ -21,12 +21,32 @@ import XCTest
 
 class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
     
-    func testQuoteIsReturned() {
+    func testQuoteRelationshipIsEstablishedWhenSendingMessage() {
         let quotedMessage = conversation.append(text: "I have a proposal", mentions: [], replyingTo: nil, fetchLinkPreview: false, nonce: UUID()) as! ZMClientMessage
         
         let message = conversation.append(text: "That's fine", mentions: [], replyingTo: quotedMessage, fetchLinkPreview: false, nonce: UUID()) as! ZMTextMessageData
         
         XCTAssertEqual(message.quote, quotedMessage)
+    }
+    
+    func testQuoteRelationshipIsEstablishedWhenReceivingMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC); conversation.remoteIdentifier = UUID.create()
+        let quotedMessage = conversation.append(text: "The sky is blue") as? ZMClientMessage
+        let replyMessage = ZMGenericMessage.message(content: ZMText.text(with: "I agree", replyingTo: quotedMessage))
+        let data = ["sender": NSString.createAlphanumerical(), "text": replyMessage.data()?.base64EncodedString()]
+        let payload = payloadForMessage(in: conversation, type: EventConversationAddOTRMessage, data: data)!
+        let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)
+        
+        // when
+        var sut: ZMClientMessage! = nil
+        performPretendingUiMocIsSyncMoc {
+            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message as? ZMClientMessage
+        }
+        
+        // then
+        XCTAssertNotNil(sut);
+        XCTAssertEqual(sut.quote, quotedMessage)
     }
     
 }

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -194,7 +194,7 @@ NSString * const ReactionsKey = @"reactions";
         
         
         NSUUID *nonce = [NSUUID createUUID];
-        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+        ZMGenericMessage *textMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:self.name mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
         ZMClientMessage *msg = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.syncMOC];
         [msg addData:textMessage.data];
         

--- a/Tests/Source/Model/ZMBaseManagedObjectTest.m
+++ b/Tests/Source/Model/ZMBaseManagedObjectTest.m
@@ -203,7 +203,7 @@
 {
     NSUUID *nonce = [NSUUID createUUID];
     ZMClientMessage *message = [[ZMClientMessage alloc] initWithNonce:nonce managedObjectContext:self.uiMOC];
-    ZMGenericMessage *textMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:text mentions:@[] linkPreviews:@[] quoteMessageId:nil] nonce:nonce];
+    ZMGenericMessage *textMessage = [ZMGenericMessage messageWithContent:[ZMText textWith:text mentions:@[] linkPreviews:@[] replyingTo:nil] nonce:nonce];
     [message addData:textMessage.data];
     return message;
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -17,8 +17,9 @@
 		16460A44206515370096B616 /* NSManagedObjectContext+BackupImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */; };
 		16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A45206544B00096B616 /* PersistentMetadataKeys.swift */; };
 		164A55D320F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */; };
-		165124D221886EDB006A3C75 /* ZMOTRMessage+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */; };
+		165124D221886EDB006A3C75 /* ZMOTRMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */; };
 		165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */; };
+		165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */; };
 		1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */; };
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
@@ -529,8 +530,9 @@
 		16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+BackupImport.swift"; sourceTree = "<group>"; };
 		16460A45206544B00096B616 /* PersistentMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMetadataKeys.swift; sourceTree = "<group>"; };
 		164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+ProfileImages.swift"; sourceTree = "<group>"; };
-		165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Replies.swift"; sourceTree = "<group>"; };
+		165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Quotes.swift"; sourceTree = "<group>"; };
 		165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Quotes.swift"; sourceTree = "<group>"; };
+		165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Quotes.swift"; sourceTree = "<group>"; };
 		1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+TextMessage.swift"; sourceTree = "<group>"; };
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
@@ -1425,6 +1427,7 @@
 				54E3EE3E1F6169A800A261E3 /* ZMAssetClientMessage+FileMessageData.swift */,
 				54E3EE421F6194A400A261E3 /* ZMAssetClientMessage+GenericMessage.swift */,
 				54A885A51F62955F00AFBA95 /* ZMAssetClientMessage+ImageAssetStorage.swift */,
+				165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */,
 				7CBC3FC020177C3C008D06E4 /* RasterImages+Protobuf.swift */,
 				BFCD8A2C1DCB4E8A00C6FCCF /* V2Asset.swift */,
 				BF4666291DCB71B0007463FF /* V3Asset.swift */,
@@ -1456,7 +1459,7 @@
 				544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */,
 				8704676A21513DE900C628D7 /* ZMOTRMessage+Unarchive.swift */,
 				165E0F68217F871400E36D08 /* ZMOTRMessage+ContentHashing.swift */,
-				165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */,
+				165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */,
 				F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
 			);
@@ -2389,6 +2392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF1B98041EC313C600DE033B /* Team.swift in Sources */,
+				165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */,
 				BF5DF5CD20F4EB3E002BCB67 /* ZMSystemMessage+NewConversation.swift in Sources */,
 				F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */,
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
@@ -2544,7 +2548,7 @@
 				5E0FB2012051493700FD9867 /* Set+Filter.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,
-				165124D221886EDB006A3C75 /* ZMOTRMessage+Replies.swift in Sources */,
+				165124D221886EDB006A3C75 /* ZMOTRMessage+Quotes.swift in Sources */,
 				87D9CCE91F27606200AA4388 /* NSManagedObjectContext+TearDown.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMGenericMessage+Utils.m in Sources */,
 				F11F3E891FA32463007B6D3D /* InvalidClientsRemoval.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		16460A44206515370096B616 /* NSManagedObjectContext+BackupImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */; };
 		16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A45206544B00096B616 /* PersistentMetadataKeys.swift */; };
 		164A55D320F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */; };
+		165124D221886EDB006A3C75 /* ZMOTRMessage+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */; };
+		165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */; };
 		1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */; };
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
@@ -527,6 +529,8 @@
 		16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+BackupImport.swift"; sourceTree = "<group>"; };
 		16460A45206544B00096B616 /* PersistentMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMetadataKeys.swift; sourceTree = "<group>"; };
 		164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+ProfileImages.swift"; sourceTree = "<group>"; };
+		165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Replies.swift"; sourceTree = "<group>"; };
+		165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Quotes.swift"; sourceTree = "<group>"; };
 		1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+TextMessage.swift"; sourceTree = "<group>"; };
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
@@ -1429,6 +1433,7 @@
 				165DC52021491D8700090B7B /* ZMClientMessage+TextMessageData.swift */,
 				54D809FB1F681D6400B2CCB4 /* ZMClientMessage+LinkPreview.swift */,
 				54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */,
+				165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */,
 				BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */,
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
@@ -1451,6 +1456,7 @@
 				544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */,
 				8704676A21513DE900C628D7 /* ZMOTRMessage+Unarchive.swift */,
 				165E0F68217F871400E36D08 /* ZMOTRMessage+ContentHashing.swift */,
+				165124D121886EDB006A3C75 /* ZMOTRMessage+Replies.swift */,
 				F93666FC1D78274D00E15420 /* MessageUpdateResult.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
 			);
@@ -2441,6 +2447,7 @@
 				54F84CFD1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift in Sources */,
 				87C1C25F207F7DA80083BF6B /* InvalidGenericMessageDataRemoval.swift in Sources */,
 				544E8C111E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift in Sources */,
+				165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */,
 				BF1B98071EC31A3C00DE033B /* Member.swift in Sources */,
 				F118CB921F41D520004DCF96 /* ZMTestSession.m in Sources */,
 				54CD460A1DEDA55C00BA3429 /* AddressBookEntry.swift in Sources */,
@@ -2537,6 +2544,7 @@
 				5E0FB2012051493700FD9867 /* Set+Filter.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,
+				165124D221886EDB006A3C75 /* ZMOTRMessage+Replies.swift in Sources */,
 				87D9CCE91F27606200AA4388 /* NSManagedObjectContext+TearDown.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMGenericMessage+Utils.m in Sources */,
 				F11F3E891FA32463007B6D3D /* InvalidClientsRemoval.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

We need to establish a core data relationship when we receive a message containing a quote of another message.

## Notes

- Changed the `ZMText` builder method to take a `ZMMessage` instead of a `id`since we need to compute the hash of the quoted content.
- The case for when a message is edited will come in a separate PR.