### PR TITLE
Edit messages in-place

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -80,9 +80,8 @@ extension ZMClientMessage {
         else {
             return false
         }
-        
-        return genericMessage.hasEdited() ||
-               genericMessage.hasText() && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
+                
+        return (genericMessage.hasEdited() || genericMessage.hasText()) && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
     }
 }
 

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -68,30 +68,6 @@ extension ZMMessage {
         return message
     }
     
-    @objc public static func edit(_ message: ZMConversationMessage, newText: String, mentions: [Mention] = [], fetchLinkPreview: Bool = true) -> ZMMessage? {
-        guard let castedMessage = message as? ZMMessage else { return nil }
-        return castedMessage.edit(newText, mentions: mentions, fetchLinkPreview: fetchLinkPreview)
-    }
-        
-    func edit(_ newText: String, mentions: [Mention] = [], fetchLinkPreview: Bool) -> ZMMessage? {
-        guard isEditableMessage else { return nil }
-        guard !isZombieObject, let sender = sender , sender.isSelfUser else { return nil }
-        guard let conversation = conversation, let messageNonce = nonce else { return nil }
-        guard let newMessage = conversation.append(message: ZMMessageEdit.edit(with: ZMText.text(with: newText, mentions: mentions), replacingMessageId: messageNonce), expires: true) else { return nil }
-        
-        newMessage.updatedTimestamp = newMessage.serverTimestamp
-        newMessage.serverTimestamp = serverTimestamp
-        let oldIndex = conversation.messages.index(of: self)
-        let newIndex = conversation.messages.index(of: newMessage)
-        conversation.mutableMessages.moveObjects(at: IndexSet(integer:newIndex), to: oldIndex)
-
-        hiddenInConversation = conversation
-        visibleInConversation = nil
-        normalizedText = nil
-        newMessage.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
-        return newMessage
-    }
-    
     @objc var isEditableMessage : Bool {
         return false
     }
@@ -99,12 +75,14 @@ extension ZMMessage {
 
 extension ZMClientMessage {
     override var isEditableMessage : Bool {
-        if let genericMsg = genericMessage {
-            return (self.sender?.isSelfUser ?? false) &&
-                   (genericMsg.hasEdited() ||
-                       (genericMsg.hasText() && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)))
+        guard let genericMessage = genericMessage,
+              let sender = sender, sender.isSelfUser
+        else {
+            return false
         }
-        return false
+        
+        return genericMessage.hasEdited() ||
+               genericMessage.hasText() && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
     }
 }
 

--- a/Source/Model/Message/ZMClientMessage+Edit.swift
+++ b/Source/Model/Message/ZMClientMessage+Edit.swift
@@ -35,6 +35,7 @@ extension ZMClientMessage {
         
         setTransientUUID(nonce, forKey: "nonce") // TODO do properly
         add(ZMGenericMessage.message(content: messageEdit.text, nonce: nonce).data())
+        updateNormalizedText()
         self.updatedTimestamp = updateEvent.timeStamp()
         self.reactions.removeAll()
         return true

--- a/Source/Model/Message/ZMClientMessage+Edit.swift
+++ b/Source/Model/Message/ZMClientMessage+Edit.swift
@@ -20,6 +20,11 @@ import Foundation
 
 extension ZMClientMessage {
     
+    /// Apply a message edit update
+    ///
+    /// - parameter messageEdit: Message edit update
+    /// - parameter updateEvent: Update event which delivered the message edit update
+    /// - Returns: true if edit was succesfully applied
     @objc
     func processMessageEdit(_ messageEdit: ZMMessageEdit, from updateEvent: ZMUpdateEvent) -> Bool {
         guard let nonce = updateEvent.messageNonce(),

--- a/Source/Model/Message/ZMClientMessage+Editing.swift
+++ b/Source/Model/Message/ZMClientMessage+Editing.swift
@@ -33,11 +33,13 @@ extension ZMClientMessage {
               messageEdit.hasText()
         else { return false }
         
-        setTransientUUID(nonce, forKey: "nonce") // TODO do properly
         add(ZMGenericMessage.message(content: messageEdit.text, nonce: nonce).data())
         updateNormalizedText()
+        
+        self.nonce = nonce
         self.updatedTimestamp = updateEvent.timeStamp()
         self.reactions.removeAll()
+        
         return true
     }
     

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -60,6 +60,20 @@ extension ZMClientMessage: ZMTextMessageData {
             return true
         })
     }
-    
+        
+    public func editText(_ text: String, mentions: [Mention], fetchLinkPreview: Bool) {
+        guard let nonce = nonce, isEditableMessage else { return }
+        
+        let editNonce = UUID()
+        add(ZMGenericMessage.message(content: ZMMessageEdit.edit(with: ZMText.text(with: text, mentions: mentions), replacingMessageId: nonce), nonce: editNonce).data())
+        updateNormalizedText()
+        
+        self.nonce = editNonce
+        self.updatedTimestamp = Date()
+        self.reactions.removeAll()
+        self.linkPreviewState = fetchLinkPreview ? .waitingToBeProcessed : .done
+        self.delivered = false
+    }
+        
 }
 

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -229,16 +229,10 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 - (void)expire
 {
     if (self.genericMessage.hasEdited) {
-        // Fetch original message
-        NSUUID *originalID = [NSUUID uuidWithTransportString:self.genericMessage.edited.replacingMessageId];
-        ZMMessage *originalMessage = [ZMMessage fetchMessageWithNonce:originalID forConversation:self.conversation inManagedObjectContext:self.managedObjectContext];
-        
         // Replace the nonce with the original
         // This way if we get a delete from a different device while we are waiting for the response it will delete this message
+        NSUUID *originalID = [NSUUID uuidWithTransportString:self.genericMessage.edited.replacingMessageId];
         self.nonce = originalID;
-        
-        // delete the original message - we do not care about the old one anymore
-        [self.managedObjectContext deleteObject:originalMessage];
     }
     [super expire];
 }
@@ -246,7 +240,8 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 - (void)resend
 {
     if (self.genericMessage.hasEdited) {
-        NOT_USED([ZMMessage edit:self newText:self.textMessageData.messageText mentions:self.textMessageData.mentions fetchLinkPreview:YES]); // TODO jacob why can't we just resend the message?
+        // Re-apply the edit since we've restored the orignal nonce when the message expired
+        [self editText:self.textMessageData.messageText mentions:self.textMessageData.mentions fetchLinkPreview:YES];
     } else {
         [super resend];
     }
@@ -308,9 +303,6 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
         if (serverTimestamp != nil) {
             self.updatedTimestamp = serverTimestamp;
         }
-        NSUUID *originalID = [NSUUID uuidWithTransportString:self.genericMessage.edited.replacingMessageId];
-        ZMMessage *original = [ZMMessage fetchMessageWithNonce:originalID forConversation:self.conversation inManagedObjectContext:self.managedObjectContext];
-        [original removeMessageClearingSender:NO];
     } else {
         [super updateWithPostPayload:payload updatedKeys:nil];
     }

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -97,14 +97,6 @@ extern NSString * _Nonnull const ZMMessageQuoteKey;
        conversation:(ZMConversation * _Nonnull)conversation
 inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
 
-/// Clears the content of a message for a ZMEditMessage
-/// Returns NO when the message was not found
-/// or if the sender of the ZMEditMessage is not the same as the sender of the original message
-+ (ZMMessage * _Nullable)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage * _Nonnull)genericEditMessage
-                                                 inConversation:(ZMConversation * _Nonnull)conversation
-                                                       senderID:(NSUUID * _Nonnull)senderID
-                                         inManagedObjectContext:(NSManagedObjectContext * _Nonnull)moc;
-
 @end
 
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -739,28 +739,6 @@ NSString * const ZMMessageQuoteKey = @"quote";
     return nil;
 }
 
-- (void)removeMessageClearingSender:(BOOL)clearingSender
-{
-    self.text = nil;
-    [super removeMessageClearingSender:clearingSender];
-}
-
-- (ZMDeliveryState)deliveryState
-{
-    return ZMDeliveryStateDelivered;
-}
-
-- (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *))completionHandler
-{
-    NOT_USED(queue);
-    NOT_USED(completionHandler);
-}
-
-- (void)requestLinkPreviewImageDownload
-{
-    
-}
-
 - (NSArray<Mention *> *)mentions
 {
     return @[];
@@ -785,6 +763,36 @@ NSString * const ZMMessageQuoteKey = @"quote";
 {
     return NO;
 }
+
+- (void)removeMessageClearingSender:(BOOL)clearingSender
+{
+    self.text = nil;
+    [super removeMessageClearingSender:clearingSender];
+}
+
+- (ZMDeliveryState)deliveryState
+{
+    return ZMDeliveryStateDelivered;
+}
+
+- (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData *))completionHandler
+{
+    NOT_USED(queue);
+    NOT_USED(completionHandler);
+}
+
+- (void)requestLinkPreviewImageDownload
+{
+    
+}
+
+- (void)editText:(NSString *)text mentions:(NSArray<Mention *> *)mentions fetchLinkPreview:(BOOL)fetchLinkPreview
+{
+    NOT_USED(text);
+    NOT_USED(mentions);
+    NOT_USED(fetchLinkPreview);
+}
+
 
 @end
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -445,25 +445,6 @@ NSString * const ZMMessageQuoteKey = @"quote";
     }
 }
 
-+ (ZMMessage *)clearedMessageForRemotelyEditedMessage:(ZMGenericMessage *)genericEditMessage inConversation:(ZMConversation *)conversation senderID:(NSUUID *)senderID inManagedObjectContext:(NSManagedObjectContext *)moc;
-{
-    if (!genericEditMessage.hasEdited) {
-        return nil;
-    }
-    NSUUID *messageID = [NSUUID uuidWithTransportString:genericEditMessage.edited.replacingMessageId];
-    ZMMessage *message = [ZMMessage fetchMessageWithNonce:messageID forConversation:conversation inManagedObjectContext:moc];
-    
-    // Only the sender of the original message can edit it
-    if (message == nil  || message.isZombieObject || ![senderID isEqual:message.sender.remoteIdentifier]) {
-        return nil;
-    }
-
-    // We do not want to clear the sender in case of an edit, as the message will still be visible
-    [message removeMessageClearingSender:NO];
-    return message;
-}
-
-
 - (NSUUID *)nonceFromPostPayload:(NSDictionary *)payload
 {
     ZMUpdateEventType eventType = [ZMUpdateEvent updateEventTypeForEventTypeString:[payload optionalStringForKey:@"type"]];

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -162,96 +162,73 @@ NSString * const DeliveredKey = @"delivered";
 
     if (message.hasLastRead && conversation.conversationType == ZMConversationTypeSelf) {
         [ZMConversation updateConversationWithZMLastReadFromSelfConversation:message.lastRead inContext:moc];
-    }
-    if (message.hasCleared && conversation.conversationType == ZMConversationTypeSelf) {
+    } else if (message.hasCleared && conversation.conversationType == ZMConversationTypeSelf) {
         [ZMConversation updateConversationWithZMClearedFromSelfConversation:message.cleared inContext:moc];
-    }
-    if (message.hasHidden && conversation.conversationType == ZMConversationTypeSelf) {
+    } else if (message.hasHidden && conversation.conversationType == ZMConversationTypeSelf) {
         [ZMMessage removeMessageWithRemotelyHiddenMessage:message.hidden inManagedObjectContext:moc];
-        return nil;
-    }
-    if (message.hasDeleted) {
+    } else if (message.hasDeleted) {
         [ZMMessage removeMessageWithRemotelyDeletedMessage:message.deleted inConversation:conversation senderID:updateEvent.senderUUID inManagedObjectContext:moc];
-        return nil;
-    }
-    if (message.hasReaction) {
-        
+    } else if (message.hasReaction) {
         // if we don't understand the reaction received, discard it
         if (message.reaction.emoji.length > 0 && [Reaction transportReactionFrom:message.reaction.emoji] == TransportReactionNone) {
             return nil;
         }
         
         [ZMMessage addReaction:message.reaction senderID:updateEvent.senderUUID conversation:conversation inManagedObjectContext:moc];
-        return nil;
-    }
-    if (message.hasConfirmation) {
+    } else if (message.hasConfirmation) {
         ZMUser *sender = [ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc];
         NOT_USED([ZMMessageConfirmation createOrUpdateMessageConfirmation:message conversation:conversation sender:sender]);
-        return nil;
-    }
-    ZMMessage *clearedMessage;
-    if (message.hasEdited) {
-        clearedMessage = [ZMMessage clearedMessageForRemotelyEditedMessage:message inConversation:conversation senderID:updateEvent.senderUUID inManagedObjectContext:moc];
-        if (clearedMessage == nil) {
+    } else if (message.hasEdited) {
+        NSUUID *editedMessageId = [NSUUID uuidWithTransportString:message.edited.replacingMessageId];
+        ZMClientMessage *editedMessage = [ZMClientMessage fetchMessageWithNonce:editedMessageId forConversation:conversation inManagedObjectContext:moc prefetchResult:prefetchResult];
+        if ([editedMessage processMessageEdit:message.edited from:updateEvent]) {
+            [editedMessage updateCategoryCache];
+            return [[MessageUpdateResult alloc] initWithMessage:editedMessage needsConfirmation:editedMessage.needsToBeConfirmed wasInserted:YES];
+        }
+    } else if ([conversation shouldAddEvent:updateEvent] && !(message.hasClientAction || message.hasCalling || message.hasAvailability)) {
+        NSUUID *nonce = [NSUUID uuidWithTransportString:message.messageId];
+        
+        Class messageClass = [ZMGenericMessage entityClassForGenericMessage:message];
+        ZMOTRMessage *clientMessage = [messageClass fetchMessageWithNonce:nonce
+                                                          forConversation:conversation
+                                                   inManagedObjectContext:moc
+                                                           prefetchResult:prefetchResult];
+        
+        if (clientMessage.isZombieObject) {
             return nil;
         }
-    }
-    
-    if (![conversation shouldAddEvent:updateEvent] || message.hasClientAction || message.hasCalling || message.hasAvailability) {
-        return nil;
-    }
-    
-    NSUUID *nonce = [NSUUID uuidWithTransportString:message.messageId];
-    
-    Class messageClass = [ZMGenericMessage entityClassForGenericMessage:message];
-    ZMOTRMessage *clientMessage = [messageClass fetchMessageWithNonce:nonce
-                                                      forConversation:conversation
-                                               inManagedObjectContext:moc
-                                                       prefetchResult:prefetchResult];
-    
-    if (clientMessage.isZombieObject) {
-        return nil;
-    }
-    
-    BOOL isNewMessage = NO;
-    if (clientMessage == nil) {
-        clientMessage = [[messageClass alloc] initWithNonce:nonce managedObjectContext:moc];
-        clientMessage.senderClientID = updateEvent.senderClientID;
         
-        if (clearedMessage != nil && [clientMessage isKindOfClass:[ZMClientMessage class]]) {
-            clientMessage.serverTimestamp = clearedMessage.serverTimestamp;
-            [(ZMClientMessage *)clientMessage setUpdatedTimestamp:updateEvent.timeStamp];
-        } else {
+        BOOL isNewMessage = NO;
+        if (clientMessage == nil) {
+            clientMessage = [[messageClass alloc] initWithNonce:nonce managedObjectContext:moc];
+            clientMessage.senderClientID = updateEvent.senderClientID;
             clientMessage.serverTimestamp = updateEvent.timeStamp;
+            isNewMessage = YES;
+        } else if (![clientMessage.senderClientID isEqualToString:updateEvent.senderClientID]) {
+            return nil;
         }
         
-        isNewMessage = YES;
-    } else if (![clientMessage.senderClientID isEqualToString:updateEvent.senderClientID]) {
-        return nil;
+        // In case of AssetMessages: If the payload does not match the sha265 digest, calling `updateWithGenericMessage:updateEvent` will delete the object.
+        [clientMessage updateWithGenericMessage:message updateEvent:updateEvent initialUpdate:isNewMessage];
+        
+        // It seems that if the object was inserted and immediately deleted, the isDeleted flag is not set to true.
+        // In addition the object will still have a managedObjectContext until the context is finally saved. In this
+        // case, we need to check the nonce (which would have previously been set) to avoid setting an invalid
+        // relationship between the deleted object and the conversation and / or sender
+        if (clientMessage.isZombieObject || clientMessage.nonce == nil) {
+            return nil;
+        }
+        
+        [clientMessage updateWithUpdateEvent:updateEvent forConversation:conversation];
+        [clientMessage updateQuoteRelationships];
+        [clientMessage unarchiveIfNeeded:conversation];
+        [clientMessage updateCategoryCache];
+        [conversation resortMessagesWithUpdatedMessage:clientMessage];
+        
+        return [[MessageUpdateResult alloc] initWithMessage:clientMessage needsConfirmation:clientMessage.needsToBeConfirmed wasInserted:isNewMessage];
     }
     
-    // In case of AssetMessages: If the payload does not match the sha265 digest, calling `updateWithGenericMessage:updateEvent` will delete the object.
-    [clientMessage updateWithGenericMessage:message updateEvent:updateEvent initialUpdate:isNewMessage];
-    
-    // It seems that if the object was inserted and immediately deleted, the isDeleted flag is not set to true. In addition the object will still have a managedObjectContext until the context is finally saved. In this case, we need to check the nonce (which would have previously been set) to avoid setting an invalid relationship between the deleted object and the conversation and / or sender
-    if (clientMessage.isZombieObject || clientMessage.nonce == nil) {
-        return nil;
-    }
-    
-    [clientMessage updateWithUpdateEvent:updateEvent forConversation:conversation];
-    [clientMessage updateQuoteRelationships];
-    [clientMessage unarchiveIfNeeded:conversation];
-    [clientMessage updateCategoryCache];
-    [conversation resortMessagesWithUpdatedMessage:clientMessage];
-    
-    BOOL needsConfirmation = NO;
-    if (isNewMessage && !clientMessage.sender.isSelfUser && conversation.conversationType == ZMConversationTypeOneOnOne) {
-        needsConfirmation = [self shouldConfirmMessage:clientMessage];
-    }
-    
-    
-    MessageUpdateResult *result = [[MessageUpdateResult alloc] initWithMessage:clientMessage needsConfirmation:needsConfirmation wasInserted:isNewMessage];
-    return result;
+    return nil;
 }
 
 @end

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -98,17 +98,20 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 /// Unique identifier for imageData. Returns nil there's not imageData associated with the message.
 @property (nonatomic, readonly, nullable) NSString *linkPreviewImageCacheKey;
 
+/// Detect if user replies to a message sent from himself
+@property (nonatomic, readonly) BOOL isQuotingSelf;
+
+/// Check if message has a quote
+@property (nonatomic, readonly) BOOL hasQuote;
+
 /// Fetch linkpreview image data from disk on the given queue
 - (void)fetchLinkPreviewImageDataWithQueue:(dispatch_queue_t _Nonnull )queue completionHandler:(void (^_Nonnull)(NSData * _Nullable imageData))completionHandler;
 
 /// Request link preview image to be downloaded
 - (void)requestLinkPreviewImageDownload;
 
-/// Detect if user replies to a message sent from himself
-@property (nonatomic, readonly) BOOL isQuotingSelf;
-
-/// Check if message has a quote
-@property (nonatomic, readonly) BOOL hasQuote;
+/// Edit the text content
+- (void)editText:(NSString * _Nonnull)text mentions:(NSArray<Mention *> * _Nonnull)mentions fetchLinkPreview:(BOOL)fetchLinkPreview;
 
 @end
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1854,12 +1854,12 @@
     ZMMessage *message = (id)[conversation appendMessageWithText:@"Test Message"];
     message.sender = self.selfUser;
     [message markAsSent];
-    ZMMessage *newMessage = (id)[ZMMessage edit:message newText:@"Edited Test Message" mentions:@[] fetchLinkPreview:YES];
+    [message.textMessageData editText:@"Edited Test Message" mentions:@[] fetchLinkPreview:YES];
 
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqualObjects(conversation.lastEditableMessage, newMessage);
+    XCTAssertEqualObjects(conversation.lastEditableMessage, message);
 }
 
 - (void)testThatItReturnsMessageIfLastMessageIsTextAndSentBySelfUser;

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -65,6 +65,7 @@
         XCTAssertEqualObjects(newMessage.serverTimestamp, message.serverTimestamp);
         XCTAssertEqual(newMessage.visibleInConversation, conversation);
         XCTAssertEqualObjects(newMessage.textMessageData.messageText, newText);
+        XCTAssertEqualObjects(newMessage.normalizedText, newText.lowercaseString);
         XCTAssertEqualObjects(newMessage.genericMessage.edited.replacingMessageId, originalNonce.transportString);
         XCTAssertNotEqualObjects(newMessage.nonce, originalNonce);
 

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -41,7 +41,7 @@
     
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = [NSUUID createUUID];
-    ZMMessage *message = (id)[conversation appendMessageWithText:oldText];
+    ZMClientMessage *message = (id)[conversation appendMessageWithText:oldText];
     message.sender = sender;
     [message markAsSent];
     message.serverTimestamp = [NSDate dateWithTimeIntervalSinceNow:-20];
@@ -52,33 +52,18 @@
     XCTAssertEqual(conversation.hiddenMessages.count, 0u);
     
     // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:YES];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
     XCTAssertEqual(conversation.messages.count, 1u);
     
     if (shouldEdit) {
-        XCTAssertEqual(conversation.hiddenMessages.count, 1u);
-        
-        XCTAssertNotNil(newMessage);
-        XCTAssertEqualObjects(newMessage.serverTimestamp, message.serverTimestamp);
-        XCTAssertEqual(newMessage.visibleInConversation, conversation);
-        XCTAssertEqualObjects(newMessage.textMessageData.messageText, newText);
-        XCTAssertEqualObjects(newMessage.normalizedText, newText.lowercaseString);
-        XCTAssertEqualObjects(newMessage.genericMessage.edited.replacingMessageId, originalNonce.transportString);
-        XCTAssertNotEqualObjects(newMessage.nonce, originalNonce);
-
-        XCTAssertEqual(message.hiddenInConversation, conversation);
-        XCTAssertNil(message.visibleInConversation);
-
-        XCTAssertEqualObjects(message.textMessageData.messageText, oldText);
+        XCTAssertEqualObjects(message.textMessageData.messageText, newText);
+        XCTAssertEqualObjects(message.normalizedText, newText.lowercaseString);
+        XCTAssertEqualObjects(message.genericMessage.edited.replacingMessageId, originalNonce.transportString);
+        XCTAssertNotEqualObjects(message.nonce, originalNonce);
     } else {
-        XCTAssertEqual(conversation.hiddenMessages.count, 0u);
-
-        XCTAssertNil(newMessage);
-        XCTAssertNil(message.hiddenInConversation);
-        XCTAssertEqual(message.visibleInConversation, conversation);
         XCTAssertEqualObjects(message.textMessageData.messageText, oldText);
     }
 }
@@ -91,35 +76,6 @@
 - (void)testThatItCanNotEditAMessage_DifferentSender
 {
     [self checkThatItCanEditAMessageFromSameSender:NO shouldEdit:NO];
-}
-
-- (void)testThatItInsertsTheNewMessageAtTheSameIndex
-{
-    // given
-    NSString *oldText = @"Hallo";
-    NSString *newText = @"Hello";
-    
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    ZMMessage *message = (id)[conversation appendMessageWithText:oldText];
-    message.serverTimestamp = [NSDate dateWithTimeIntervalSinceNow:-20];
-    [message markAsSent];
-
-    // Add some more messages
-    [conversation appendMessageWithText:@"Foo"];
-    [conversation appendMessageWithText:@"Foo"];
-    [conversation appendMessageWithText:@"Foo"];
-    
-    NSUInteger oldIndex = [conversation.messages indexOfObject:message];
-    
-    // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:YES];
-    
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // then
-    NSUInteger newIndex = [conversation.messages indexOfObject:newMessage];
-    XCTAssertEqual(newIndex, oldIndex);
 }
 
 - (void)testThatExtremeCombiningCharactersAreRemovedFromTheMessage
@@ -152,11 +108,11 @@
     XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateDone);
     
     // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:YES];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqual(newMessage.linkPreviewState, ZMLinkPreviewStateWaitingToBeProcessed);
+    XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateWaitingToBeProcessed);
 }
 
 - (void)testThatItDoesNotFetchLinkPreviewIfExplicitlyToldNotTo
@@ -175,11 +131,11 @@
     XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateDone);
     
     // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:fetchLinkPreview];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:fetchLinkPreview];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqual(newMessage.linkPreviewState, ZMLinkPreviewStateDone);
+    XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewStateDone);
 }
 
 - (void)testThatItDoesNotEditAMessageThatFailedToSend
@@ -196,41 +152,14 @@
     XCTAssertEqual(message.deliveryState, ZMDeliveryStateFailedToSend);
     
     // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:YES];
-    
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:YES];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertEqual(conversation.hiddenMessages.count, 0u);
-    
-    XCTAssertNil(newMessage);
-    XCTAssertNil(message.hiddenInConversation);
-    XCTAssertEqual(message.visibleInConversation, conversation);
     XCTAssertEqualObjects(message.textMessageData.messageText, oldText);
 }
 
-- (void)checkThatItCanNotEditAnImageMessage
-{
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    ZMMessage *message = (id) [conversation appendMessageWithImageData:self.verySmallJPEGData];
-    message.serverTimestamp = [NSDate dateWithTimeIntervalSinceNow:-20];
-    [message markAsSent];
-
-    XCTAssertEqual(message.visibleInConversation, conversation);
-    XCTAssertEqual(conversation.messages.count, 1u);
-    XCTAssertEqual(conversation.hiddenMessages.count, 0u);
-    
-    // when
-    ZMClientMessage *newMessage = (id)[ZMMessage edit:message newText:@"Foo" mentions:@[] fetchLinkPreview:NO];
-    WaitForAllGroupsToBeEmpty(0.5);
-
-    // then
-    XCTAssertNil(newMessage);
-}
-
-- (void)testThatItClearsTheMessageContentAfterSuccessfulUpdate
+- (void)testThatItUpdatesTheUpdatedTimestampAfterSuccessfulUpdate
 {
     // given
     NSString *oldText = @"Hallo";
@@ -251,34 +180,17 @@
     XCTAssertEqual(conversation.messages.count, 1u);
     XCTAssertEqual(conversation.hiddenMessages.count, 0u);
     
-    ZMMessage *newMessage = [ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:NO];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:NO];
     WaitForAllGroupsToBeEmpty(0.5);
-
-    // inserting the newMessage updates the lastModifiedDate
-    XCTAssertNotEqualObjects(conversation.lastModifiedDate, originalDate);
-    NSDate *lastModifiedDate = conversation.lastModifiedDate;
     
     // when
-    [newMessage updateWithPostPayload:@{@"time" : updateDate.transportString } updatedKeys:nil];
+    [message updateWithPostPayload:@{@"time" : updateDate.transportString } updatedKeys:nil];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
-    XCTAssertEqualObjects(newMessage.serverTimestamp, originalDate);
-    XCTAssertEqualObjects(newMessage.updatedAt, updateDate);
-    XCTAssertEqualObjects(newMessage.textMessageData.messageText, newText);
-
-    XCTAssertEqualObjects(conversation.lastModifiedDate, lastModifiedDate);
-    XCTAssertEqualObjects(conversation.lastServerTimeStamp, originalDate);
-
-    XCTAssertEqual(message.hiddenInConversation, conversation);
-    XCTAssertNil(message.visibleInConversation);
-    XCTAssertNil(message.textMessageData.messageText);
-
-    ZMClientMessage *clientMessage = (ZMClientMessage *)message;
-    XCTAssertNil(clientMessage.genericMessage);
-    XCTAssertEqual(clientMessage.dataSet.count, 0lu);
-    XCTAssertNil(message.textMessageData);
-    XCTAssertNotNil(message.sender);
+    XCTAssertEqualObjects(message.serverTimestamp, originalDate);
+    XCTAssertEqualObjects(message.updatedAt, updateDate);
+    XCTAssertEqualObjects(message.textMessageData.messageText, newText);
 }
 
 - (void)testThatItDoesNotOverwritesEditedTextWhenMessageExpiresButReplacesNonce
@@ -302,30 +214,18 @@
     XCTAssertEqual(conversation.messages.count, 1u);
     XCTAssertEqual(conversation.hiddenMessages.count, 0u);
     
-    ZMMessage *newMessage = [ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:NO];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:NO];
     WaitForAllGroupsToBeEmpty(0.5);
-
-    // inserting the newMessage updates the lastModifiedDate
-    XCTAssertNotEqualObjects(conversation.lastModifiedDate, originalDate);
-    NSDate *lastModifiedDate = conversation.lastModifiedDate;
     
     // when
-    [newMessage expire];
+    [message expire];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
-    XCTAssertEqualObjects(newMessage.serverTimestamp, originalDate);
-    XCTAssertEqualObjects(newMessage.updatedAt, lastModifiedDate);
-    XCTAssertEqualObjects(newMessage.textMessageData.messageText, newText);
-    XCTAssertEqualObjects(newMessage.nonce, originalNonce);
-
-    XCTAssertEqualObjects(conversation.lastModifiedDate, lastModifiedDate);
-    XCTAssertEqualObjects(conversation.lastServerTimeStamp, originalDate);
-    
-    XCTAssertTrue(message.isZombieObject);
+    XCTAssertEqualObjects(message.nonce, originalNonce);
 }
 
-- (void)testThatWhenResendingAFailedEditItInsertsANewMessage
+- (void)testThatWhenResendingAFailedEditItReappliesTheEdit
 {
     // given
     NSString *oldText = @"Hallo";
@@ -334,7 +234,7 @@
     
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.remoteIdentifier = [NSUUID createUUID];
-    ZMMessage *message = (id) [conversation appendMessageWithText:oldText];
+    ZMClientMessage *message = (id) [conversation appendMessageWithText:oldText];
     message.serverTimestamp = originalDate;
     [message markAsSent];
 
@@ -346,37 +246,21 @@
     XCTAssertEqual(conversation.messages.count, 1u);
     XCTAssertEqual(conversation.hiddenMessages.count, 0u);
     
-    ZMMessage *newMessage1 = [ZMMessage edit:message newText:newText mentions:@[] fetchLinkPreview:NO];
+    [message.textMessageData editText:newText mentions:@[] fetchLinkPreview:NO];
+    NSUUID *editNonce1 = message.nonce;
     WaitForAllGroupsToBeEmpty(0.5);
-
-    // inserting the newMessage updates the lastModifiedDate
-    XCTAssertNotEqualObjects(conversation.lastModifiedDate, originalDate);
-    NSDate *lastModifiedDate1 = conversation.lastModifiedDate;
     
-    [newMessage1 expire];
+    [message expire];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // when
-    [newMessage1 resend];
+    [message resend];
+    NSUUID *editNonce2 = message.nonce;
     WaitForAllGroupsToBeEmpty(0.5);
-
-    // inserting the new editMessage updates the lastModifiedDate
-    XCTAssertNotEqualObjects(conversation.lastModifiedDate, lastModifiedDate1);
-    NSDate *lastModifiedDate2 = conversation.lastModifiedDate;
     
     // then
-    ZMClientMessage *newMessage2 = conversation.messages.lastObject;
-    
-    XCTAssertEqualObjects(newMessage2.serverTimestamp, originalDate);
-    XCTAssertEqualObjects(newMessage2.updatedAt, lastModifiedDate2);
-    XCTAssertEqualObjects(newMessage2.textMessageData.messageText, newText);
-    XCTAssertNotEqualObjects(newMessage2.nonce, newMessage1.nonce);
-    XCTAssertEqualObjects(newMessage2.genericMessage.edited.replacingMessageId, originalNonce.transportString);
-
-    XCTAssertEqualObjects(conversation.lastModifiedDate, lastModifiedDate2);
-    XCTAssertEqualObjects(conversation.lastServerTimeStamp, originalDate);
-    
-    XCTAssertTrue(message.isZombieObject);
+    XCTAssertNotEqualObjects(editNonce2, editNonce1);
+    XCTAssertEqualObjects(message.genericMessage.edited.replacingMessageId, originalNonce.transportString);
 }
 
 - (ZMUpdateEvent *)createMessageEditUpdateEventWithOldNonce:(NSUUID *)oldNonce newNonce:(NSUUID *)newNonce conversationID:(NSUUID*)conversationID senderID:(NSUUID *)senderID newText:(NSString *)newText

--- a/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -568,13 +568,12 @@ class ConversationListObserverTests : NotificationDispatcherTestBase {
         self.token = ConversationListChangeInfo.add(observer: testObserver, for: conversationList, managedObjectContext: self.uiMOC)
         
         // when
-        let message = ZMTextMessage(nonce: UUID(), managedObjectContext: uiMOC)
-        conversation.mutableMessages.add(message)
+        let message = conversation.append(text: "hello")
         self.uiMOC.saveOrRollback()
         
         guard let user = conversation.activeParticipants.firstObject as? ZMUser else { XCTFail(); return }
         
-        _ = message.edit(user.displayName, mentions: [Mention(range: NSRange(location: 0, length: user.displayName.count), user: user)], fetchLinkPreview: false)
+        message?.textMessageData?.editText(user.displayName, mentions: [Mention(range: NSRange(location: 0, length: user.displayName.count), user: user)], fetchLinkPreview: false)
         self.uiMOC.saveOrRollback()
         
         // then

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -397,21 +397,18 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        let message = conversation.append(text: "Håkon") as! ZMMessage
+        let message = conversation.append(text: "Håkon") as! ZMClientMessage
         message.markAsSent()
         XCTAssert(uiMOC.saveOrRollback())
         XCTAssertEqual(message.normalizedText, "hakon")
 
         // When
-        let edited = ZMMessage.edit(message, newText: "Coração")
-        XCTAssertNotNil(edited)
+        message.textMessageData?.editText("Coração", mentions: [], fetchLinkPreview: false)
         XCTAssert(uiMOC.saveOrRollback())
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // Then
-        XCTAssertNil(message.visibleInConversation)
-        XCTAssertNil(message.normalizedText)
-        XCTAssertEqual(edited?.normalizedText, "coracao")
+        XCTAssertEqual(message.normalizedText, "coracao")
 
         guard let originalMatches = search(for: "hakon", in: conversation).first?.matches,
               let editedMatches = search(for: "coracao", in: conversation).first?.matches else {
@@ -423,7 +420,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
             return XCTFail("Unexpected number of edited matches")
         }
 
-        XCTAssertEqual(editedMatch, edited)
+        XCTAssertEqual(editedMatch, message)
     }
 
     func testThatItReturnsEphemeralMessagesAsSearchResults() {

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		165124D221886EDB006A3C75 /* ZMOTRMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */; };
 		165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */; };
 		165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */; };
+		165124D62188CF66006A3C75 /* ZMClientMessage+Edit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */; };
 		1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */; };
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
@@ -533,6 +534,7 @@
 		165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Quotes.swift"; sourceTree = "<group>"; };
 		165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Quotes.swift"; sourceTree = "<group>"; };
 		165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Quotes.swift"; sourceTree = "<group>"; };
+		165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Edit.swift"; sourceTree = "<group>"; };
 		1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+TextMessage.swift"; sourceTree = "<group>"; };
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
@@ -1437,6 +1439,7 @@
 				54D809FB1F681D6400B2CCB4 /* ZMClientMessage+LinkPreview.swift */,
 				54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */,
 				165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */,
+				165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */,
 				BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */,
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
@@ -2513,6 +2516,7 @@
 				BF3493F21EC3623200B0C314 /* ZMUser+Teams.swift in Sources */,
 				541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */,
 				165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */,
+				165124D62188CF66006A3C75 /* ZMClientMessage+Edit.swift in Sources */,
 				165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */,
 				F9A706731CAEE01D00C2F5FE /* AssetEncryption.swift in Sources */,
 				F9FD75731E2E6A2100B4558B /* ConversationListObserverCenter.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -19,8 +19,8 @@
 		164A55D320F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */; };
 		165124D221886EDB006A3C75 /* ZMOTRMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */; };
 		165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */; };
+		165124D62188CF66006A3C75 /* ZMClientMessage+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */; };
 		165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */; };
-		165124D62188CF66006A3C75 /* ZMClientMessage+Edit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */; };
 		1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */; };
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
@@ -533,8 +533,8 @@
 		164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+ProfileImages.swift"; sourceTree = "<group>"; };
 		165124D121886EDB006A3C75 /* ZMOTRMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Quotes.swift"; sourceTree = "<group>"; };
 		165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Quotes.swift"; sourceTree = "<group>"; };
+		165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Editing.swift"; sourceTree = "<group>"; };
 		165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Quotes.swift"; sourceTree = "<group>"; };
-		165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Edit.swift"; sourceTree = "<group>"; };
 		1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+TextMessage.swift"; sourceTree = "<group>"; };
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
@@ -1439,7 +1439,7 @@
 				54D809FB1F681D6400B2CCB4 /* ZMClientMessage+LinkPreview.swift */,
 				54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */,
 				165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */,
-				165124D52188CF66006A3C75 /* ZMClientMessage+Edit.swift */,
+				165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */,
 				BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */,
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
@@ -2516,7 +2516,7 @@
 				BF3493F21EC3623200B0C314 /* ZMUser+Teams.swift in Sources */,
 				541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */,
 				165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */,
-				165124D62188CF66006A3C75 /* ZMClientMessage+Edit.swift in Sources */,
+				165124D62188CF66006A3C75 /* ZMClientMessage+Editing.swift in Sources */,
 				165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */,
 				F9A706731CAEE01D00C2F5FE /* AssetEncryption.swift in Sources */,
 				F9FD75731E2E6A2100B4558B /* ConversationListObserverCenter.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

When editing a message we now update the edit message in-place instead of deleting the original message an inserting a new edited message. This has the benefit that any existing reply relationships will stay intact after a message is edited.
