### PR TITLE
Fire message change notification when quote is deleted

### DIFF
--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -34,7 +34,7 @@ extension ZMClientMessage: ZMTextMessageData {
     }
     
     public var hasQuote: Bool {
-        return quote != nil
+        return genericMessage?.text.hasQuote() ?? false
     }
     
     public var messageText: String? {

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -218,6 +218,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     self.dataSet = [NSOrderedSet orderedSet];
     self.normalizedText = nil;
     self.genericMessage = nil;
+    self.quote = nil;
 }
 
 - (void)removeMessageClearingSender:(BOOL)clearingSender

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -335,6 +335,7 @@ NSString * const ZMMessageQuoteKey = @"quote";
 {
     self.hiddenInConversation = self.conversation;
     self.visibleInConversation = nil;
+    self.replies = [[NSSet alloc] init];
     [self clearAllReactions];
 
     if (clearingSender) {

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -131,21 +131,21 @@ extension ZMConversation : ObjectInSnapshot {
     
     public override var description : String { return self.debugDescription }
     public override var debugDescription : String {
-        return "messagesChanged: \(messagesChanged)," +
-        "participantsChanged: \(participantsChanged)," +
-        "nameChanged: \(nameChanged)," +
-        "unreadCountChanged: \(unreadCountChanged)," +
-        "lastModifiedDateChanged: \(lastModifiedDateChanged)," +
-        "connectionStateChanged: \(connectionStateChanged)," +
-        "isArchivedChanged: \(isArchivedChanged)," +
-        "mutedMessageTypesChanged: \(mutedMessageTypesChanged)," +
-        "conversationListIndicatorChanged \(conversationListIndicatorChanged)," +
-        "clearedChanged \(clearedChanged)," +
-        "securityLevelChanged \(securityLevelChanged)," +
-        "teamChanged \(teamChanged)" +
-        "createdRemotelyChanged \(createdRemotelyChanged)" +
-        "destructionTimeoutChanged \(destructionTimeoutChanged)" +
-        "languageChanged \(languageChanged)"
+        return ["messagesChanged: \(messagesChanged)",
+                "participantsChanged: \(participantsChanged)",
+                "nameChanged: \(nameChanged)",
+                "unreadCountChanged: \(unreadCountChanged)",
+                "lastModifiedDateChanged: \(lastModifiedDateChanged)",
+                "connectionStateChanged: \(connectionStateChanged)",
+                "isArchivedChanged: \(isArchivedChanged)",
+                "mutedMessageTypesChanged: \(mutedMessageTypesChanged)",
+                "conversationListIndicatorChanged \(conversationListIndicatorChanged)",
+                "clearedChanged \(clearedChanged)",
+                "securityLevelChanged \(securityLevelChanged)",
+                "teamChanged \(teamChanged)",
+                "createdRemotelyChanged \(createdRemotelyChanged)",
+                "destructionTimeoutChanged \(destructionTimeoutChanged)",
+                "languageChanged \(languageChanged)"].joined(separator: ", ")
     }
     
     public required init(object: NSObject) {

--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -63,6 +63,7 @@ extension ZMClientMessage {
                               #keyPath(ZMClientMessage.linkPreviewState),
                               #keyPath(ZMClientMessage.genericMessage),
                               #keyPath(ZMMessage.reactions),
+                              #keyPath(ZMClientMessage.quote),
                               MessageKey.linkPreview.rawValue]
         return keys.union(additionalKeys)
     }
@@ -96,11 +97,11 @@ extension ZMSystemMessage {
 
     static func changeInfo(for message: ZMMessage, changes: Changes) -> MessageChangeInfo? {
         var originalChanges = changes.originalChanges
-        let clientChanges = originalChanges.removeValue(forKey: ReactionChangeInfoKey) as? [NSObject : [String : Any]]
+        let reactionChanges = originalChanges.removeValue(forKey: ReactionChangeInfoKey) as? [NSObject : [String : Any]]
         
-        if let clientChanges = clientChanges {
+        if let reactionChanges = reactionChanges {
             var reactionChangeInfos = [ReactionChangeInfo]()
-            clientChanges.forEach {
+            reactionChanges.forEach {
                 let changeInfo = ReactionChangeInfo(object: $0)
                 changeInfo.changeInfos = $1 as! [String : NSObject]
                 reactionChangeInfos.append(changeInfo)
@@ -121,6 +122,22 @@ extension ZMSystemMessage {
         self.message = object as! ZMMessage
         super.init(object: object)
     }
+    
+    public override var debugDescription: String {
+        return ["deliveryStateChanged: \(deliveryStateChanged)",
+                "reactionsChanged: \(reactionsChanged)",
+                "childMessagesChanged: \(childMessagesChanged)",
+                "quoteChanged: \(quoteChanged)",
+                "imageChanged: \(imageChanged)",
+                "fileAvailabilityChanged: \(fileAvailabilityChanged)",
+                "usersChanged: \(usersChanged)",
+                "linkPreviewChanged: \(linkPreviewChanged)",
+                "transferStateChanged: \(transferStateChanged)",
+                "senderChanged: \(senderChanged)",
+                "isObfuscatedChanged: \(isObfuscatedChanged)"
+                ].joined(separator: ", ")
+    }
+    
     public var deliveryStateChanged : Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.deliveryState))
     }
@@ -131,6 +148,10 @@ extension ZMSystemMessage {
 
     public var childMessagesChanged : Bool {
         return changedKeysContain(keys: #keyPath(ZMSystemMessage.childMessages))
+    }
+    
+    public var quoteChanged: Bool {
+        return changedKeysContain(keys: #keyPath(ZMClientMessage.quote))
     }
 
     /// Whether the image data on disk changed

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -1561,6 +1561,46 @@ NSString * const ReactionsKey = @"reactions";
     XCTAssertTrue(removed);
 }
 
+- (void)testThatRepliesAreRemoved
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+    
+    ZMClientMessage *message1 = (ZMClientMessage *)[conversation appendMessageWithText:@"Test"];
+    ZMClientMessage *message2 = (ZMClientMessage *)[conversation appendText:@"Test 2" mentions:@[] replyingToMessage:message1 fetchLinkPreview:NO nonce:NSUUID.createUUID];
+    XCTAssertEqualObjects(message2.quote, message1);
+    XCTAssertFalse(message1.replies.isEmpty);
+    
+    // when
+    [message1 removeMessageClearingSender:YES];
+    [self.uiMOC saveOrRollback];
+    
+    // then
+    XCTAssertTrue(message1.replies.isEmpty);
+    XCTAssertNil(message2.quote);
+}
+
+- (void)testThatQuotesAreRemoved
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.remoteIdentifier = [NSUUID createUUID];
+    
+    ZMClientMessage *message1 = (ZMClientMessage *)[conversation appendMessageWithText:@"Test"];
+    ZMClientMessage *message2 = (ZMClientMessage *)[conversation appendText:@"Test 2" mentions:@[] replyingToMessage:message1 fetchLinkPreview:NO nonce:NSUUID.createUUID];
+    XCTAssertEqualObjects(message2.quote, message1);
+    XCTAssertFalse(message1.replies.isEmpty);
+    
+    // when
+    [message2 removeMessageClearingSender:YES];
+    [self.uiMOC saveOrRollback];
+    
+    // then
+    XCTAssertTrue(message1.replies.isEmpty);
+    XCTAssertNil(message2.quote);
+}
+
 - (void)testThatAMessageIsRemovedWhenAskForDeletionWithMessageHide;
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

Fire a change notification when a quote is changed (currently only when a quote is deleted).

## Notes

- `hasQuote` now only check if the protobuf contains a quote. The `quote` property might still be nil if the quote is not valid.