### PR TITLE
ZIOS-10799: Added quote field to DraftMessage

### DIFF
--- a/Source/Public/DraftMessage.swift
+++ b/Source/Public/DraftMessage.swift
@@ -26,16 +26,19 @@ import Foundation
     public let text: String
     /// The mentiones contained in the text.
     public let mentions: [Mention]
+    /// The quoted message, if available.
+    public let quote: ZMMessage?
     
-    public init(text: String, mentions: [Mention]) {
+    public init(text: String, mentions: [Mention], quote: ZMMessage?) {
         self.text = text
         self.mentions = mentions
+        self.quote = quote
         super.init()
     }
     
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? DraftMessage else { return false }
-        return (text, mentions) == (other.text, other.mentions)
+        return (text, mentions, quote) == (other.text, other.mentions, other.quote)
     }
 
 }
@@ -48,17 +51,22 @@ fileprivate final class StorableDraftMessage: NSObject, Codable {
     let text: String
     /// The mentiones contained in the text.
     let mentions: [StorableMention]
+    /// The quoted message, if available.
+    let quote: StorableQuote?
     
-    init(text: String, mentions: [StorableMention]) {
+    init(text: String, mentions: [StorableMention], quote: StorableQuote?) {
         self.text = text
         self.mentions = mentions
+        self.quote = quote
         super.init()
     }
     
     /// Converts this storable version into a regular `DraftMessage`.
     /// The passed in `context` is needed to fetch the user objects.
     fileprivate func draftMessage(in context: NSManagedObjectContext) -> DraftMessage {
-        return .init(text: text, mentions: mentions.compactMap { $0.mention(in: context) })
+        return .init(text: text,
+                     mentions: mentions.compactMap { $0.mention(in: context) },
+                     quote: quote?.quote(in: context))
     }
 }
 
@@ -77,6 +85,22 @@ fileprivate struct StorableMention: Codable {
         return ZMUser(remoteID: userIdentifier, createIfNeeded: false, in: context).map(papply(Mention.init, range))
     }
 
+}
+
+/// A serializable version of `ZMMessage` that conforms to `Codable` and
+/// stores the message identifier instead of a whole `ZMMessage` value.
+fileprivate struct StorableQuote: Codable {
+    
+    /// The identifier for the message being quoted.
+    let nonce: UUID?
+    
+    /// Converts the storable mention into a regular `Mention` object.
+    /// The passed in `context` is needed to fetch the user object.
+    func quote(in context: NSManagedObjectContext) -> ZMMessage? {
+        guard let nonce = nonce else { return nil }
+        return ZMMessage(nonce: nonce, managedObjectContext: context)
+    }
+    
 }
 
 // MARK: - Conversation Accessors
@@ -139,11 +163,21 @@ fileprivate extension Mention {
 
 }
 
+fileprivate extension ZMMessage {
+    
+    /// The storable version of the object.
+    var storable: StorableQuote {
+        return StorableQuote(nonce: nonce)
+    }
+}
+
 fileprivate extension DraftMessage {
 
     /// The storable version of the object.
     fileprivate var storable: StorableDraftMessage {
-        return .init(text: text, mentions: mentions.compactMap(\.storable))
+        return .init(text: text,
+                     mentions: mentions.compactMap(\.storable),
+                     quote: quote?.storable)
     }
 
 }

--- a/Source/Public/DraftMessage.swift
+++ b/Source/Public/DraftMessage.swift
@@ -163,21 +163,13 @@ fileprivate extension Mention {
 
 }
 
-fileprivate extension ZMMessage {
-    
-    /// The storable version of the object.
-    var storable: StorableQuote {
-        return StorableQuote(nonce: nonce)
-    }
-}
-
 fileprivate extension DraftMessage {
 
     /// The storable version of the object.
     fileprivate var storable: StorableDraftMessage {
         return .init(text: text,
                      mentions: mentions.compactMap(\.storable),
-                     quote: quote?.storable)
+                     quote: StorableQuote(nonce: quote?.nonce))
     }
 
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Validation.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Validation.m
@@ -136,7 +136,7 @@
 {
     // given
     ZMConversation *conversation1 = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation1.draftMessage = [[DraftMessage alloc] initWithText:@"My draft message text" mentions:@[]];
+    conversation1.draftMessage = [[DraftMessage alloc] initWithText:@"My draft message text" mentions:@[] quote:nil];
     conversation1.userDefinedName = @"My Name";
     XCTAssertTrue([self.uiMOC saveOrRollback]);
     

--- a/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
@@ -219,7 +219,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"" mentions:@[]];
+    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"" mentions:@[] quote:nil];
     
     // then
     XCTAssertFalse(conversation.hasDraftMessage);
@@ -237,13 +237,13 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"A" mentions:@[]];
+    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"A" mentions:@[] quote:nil];
     
     // then
     XCTAssertTrue(conversation.hasDraftMessage);
     
     // when
-    conversation.draftMessage =[[DraftMessage alloc] initWithText: @"Once upon a time" mentions:@[]];
+    conversation.draftMessage =[[DraftMessage alloc] initWithText: @"Once upon a time" mentions:@[] quote:nil];
     
     // then
     XCTAssertTrue(conversation.hasDraftMessage);

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -771,6 +771,21 @@
     XCTAssertEqualObjects(conversation.draftMessage.text, originalValue);
 }
 
+- (void)testThatItSavesQuotesNonce
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMMessage *message = [[ZMMessage alloc] initWithNonce:NSUUID.createUUID managedObjectContext:self.uiMOC];
+    
+    // when
+    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"" mentions:@[] quote:message];
+    
+    // then
+    NSUUID *draftNonce = conversation.draftMessage.quote.nonce;
+    NSUUID *messageNonce = message.nonce;
+    XCTAssertEqualObjects(draftNonce, messageNonce);
+}
+    
 - (void)addNotification:(NSNotification *)note
 {
     [self.receivedNotifications addObject:note];

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -230,7 +230,7 @@
 
 - (void)testThatWeCanSetAttributesOnConversation
 {
-    [self checkConversationAttributeForKey:@"draftMessage" value:[[DraftMessage alloc] initWithText:@"My draft message text" mentions:@[]]];
+    [self checkConversationAttributeForKey:@"draftMessage" value:[[DraftMessage alloc] initWithText:@"My draft message text" mentions:@[] quote:nil]];
     [self checkConversationAttributeForKey:ZMConversationUserDefinedNameKey value:@"Foo"];
     [self checkConversationAttributeForKey:@"normalizedUserDefinedName" value:@"Foo"];
     [self checkConversationAttributeForKey:@"conversationType" value:@(1)];
@@ -764,7 +764,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     
     // when
-    conversation.draftMessage = [[DraftMessage alloc] initWithText:mutableValue mentions:@[]];
+    conversation.draftMessage = [[DraftMessage alloc] initWithText:mutableValue mentions:@[] quote:nil];
     [mutableValue appendString:@".uk"];
     
     // then
@@ -2005,7 +2005,7 @@
 {
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"This is a test" mentions:@[]];
+    conversation.draftMessage = [[DraftMessage alloc] initWithText:@"This is a test" mentions:@[] quote:nil];
     
     XCTAssertTrue(conversation.hasDraftMessage);
     


### PR DESCRIPTION
## What's new in this PR?

Added the `quote` field to the `DraftMessage` class, and also added the supporting class `StorableQuote` and other methods. Updated tests.