### PR TITLE
Allow editing failed messages

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -81,7 +81,7 @@ extension ZMClientMessage {
             return false
         }
                 
-        return (genericMessage.hasEdited() || genericMessage.hasText()) && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered || deliveryState == .failedToSend)
+        return genericMessage.hasEdited() || genericMessage.hasText() && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
     }
 }
 

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -81,7 +81,7 @@ extension ZMClientMessage {
             return false
         }
                 
-        return (genericMessage.hasEdited() || genericMessage.hasText()) && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
+        return (genericMessage.hasEdited() || genericMessage.hasText()) && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered || deliveryState == .failedToSend)
     }
 }
 


### PR DESCRIPTION
### Issues

SE integration tests were failing after message editing changes.

### Causes

In the failing test a message was edited but the message sending was intentionally failed, after this the edited message marked to be resent which failed to happen. The reason was for this was that we weren't allowing  messages with deliveryState  `failedToSend` to be edited.

### Solutions

~~Allow messages with deliveryState  `failedToSend` to be edited.~~

Revert back to previous logic which were always allowing previously edited messages to be edited again. This is safe since we can assume that an edited message was at some point successfully sent.