### PR TITLE
Fix editing message with quote

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Editing.swift
+++ b/Source/Model/Message/ZMClientMessage+Editing.swift
@@ -29,11 +29,13 @@ extension ZMClientMessage {
     func processMessageEdit(_ messageEdit: ZMMessageEdit, from updateEvent: ZMUpdateEvent) -> Bool {
         guard let nonce = updateEvent.messageNonce(),
               let senderUUID = updateEvent.senderUUID(),
-              senderUUID == sender?.remoteIdentifier,
-              messageEdit.hasText()
+              let originalText = genericMessage?.textData,
+              let editedText = messageEdit.text,
+              messageEdit.hasText(),
+              senderUUID == sender?.remoteIdentifier
         else { return false }
         
-        add(ZMGenericMessage.message(content: messageEdit.text, nonce: nonce).data())
+        add(ZMGenericMessage.message(content: originalText.applyEdit(from: editedText), nonce: nonce).data())
         updateNormalizedText()
         
         self.nonce = nonce

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -34,7 +34,7 @@ extension ZMClientMessage: ZMTextMessageData {
     }
     
     public var hasQuote: Bool {
-        return genericMessage?.text.hasQuote() ?? false
+        return genericMessage?.textData?.hasQuote() ?? false
     }
     
     public var messageText: String? {
@@ -64,8 +64,10 @@ extension ZMClientMessage: ZMTextMessageData {
     public func editText(_ text: String, mentions: [Mention], fetchLinkPreview: Bool) {
         guard let nonce = nonce, isEditableMessage else { return }
         
+        // Quotes are ignored in edits but keep it to mark that the message has quote for us locally
+        let editedText = ZMText.text(with: text, mentions: mentions, linkPreviews: [], replyingTo: self.quote as? ZMOTRMessage)
         let editNonce = UUID()
-        add(ZMGenericMessage.message(content: ZMMessageEdit.edit(with: ZMText.text(with: text, mentions: mentions), replacingMessageId: nonce), nonce: editNonce).data())
+        add(ZMGenericMessage.message(content: ZMMessageEdit.edit(with: editedText, replacingMessageId: nonce), nonce: editNonce).data())
         updateNormalizedText()
         
         self.nonce = editNonce

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -143,7 +143,7 @@ public extension ZMGenericMessage {
 
         return builder.buildAndValidate()
     }
-
+    
 }
 
 @objc
@@ -191,6 +191,19 @@ extension ZMText: EphemeralMessageContentType {
     
     public func setEphemeralContent(on builder: ZMEphemeralBuilder) {
         builder.setText(self)
+    }
+    
+    public func applyEdit(from text: ZMText) -> ZMText {
+        guard let builder = text.toBuilder() else { return self }
+        
+        // we keep always keep the quote from the original message
+        if hasQuote() {
+            builder.setQuote(self.quote)
+        } else {
+            builder.clearQuote()
+        }
+        
+        return builder.build()
     }
     
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
@@ -1,0 +1,75 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class ZMClientMessageTests_TextMessageData : BaseZMClientMessageTests {
+    
+    func testThatItUpdatesTheMesssageText_WhenEditing(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = UUID.create()
+        
+        let message = conversation.append(text: "hello") as! ZMClientMessage
+        message.delivered = true
+        
+        // when
+        message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
+        
+        // then
+        XCTAssertEqual(message.textMessageData?.messageText, "good bye")
+    }
+    
+    func testThatItClearReactions_WhenEditing(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = UUID.create()
+        
+        let message = conversation.append(text: "hello") as! ZMClientMessage
+        message.delivered = true
+        message.addReaction("🤠", forUser: selfUser)
+        XCTAssertFalse(message.reactions.isEmpty)
+        
+        // when
+        message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
+        
+        // then
+        XCTAssertTrue(message.reactions.isEmpty)
+    }
+    
+    func testThatItKeepsQuote_WhenEditing(){
+        
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = UUID.create()
+        
+        let quotedMessage = conversation.append(text: "Let's grab some lunch") as! ZMClientMessage
+        let message = conversation.append(text: "Yes!", replyingTo: quotedMessage) as! ZMClientMessage
+        message.delivered = true
+        XCTAssertTrue(message.hasQuote)
+        
+        // when
+        message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
+        
+        // then
+        XCTAssertTrue(message.hasQuote)
+    }
+    
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1687ABAD20ECD51E0007C240 /* ZMSearchUser.swift */; };
 		1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1687C0E12150EE91003099DD /* ZMClientMessageTests+Mentions.swift */; };
 		168913DC2085066800F1E98A /* ZMGenericMessage+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */; };
+		1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */; };
 		16AD86BA1F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */; };
 		16C391E2214BD438003AB3AD /* MentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C391E1214BD437003AB3AD /* MentionTests.swift */; };
 		16D5260D20DD1D9400608D8E /* ZMConversationTests+Timestamps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D5260C20DD1D9400608D8E /* ZMConversationTests+Timestamps.swift */; };
@@ -552,6 +553,7 @@
 		1687ABAD20ECD51E0007C240 /* ZMSearchUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMSearchUser.swift; sourceTree = "<group>"; };
 		1687C0E12150EE91003099DD /* ZMClientMessageTests+Mentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Mentions.swift"; sourceTree = "<group>"; };
 		168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessage+Debug.swift"; sourceTree = "<group>"; };
+		1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Editing.swift"; sourceTree = "<group>"; };
 		16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+NotificationContext.swift"; sourceTree = "<group>"; };
 		16C391E1214BD437003AB3AD /* MentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionTests.swift; sourceTree = "<group>"; };
 		16D5260C20DD1D9400608D8E /* ZMConversationTests+Timestamps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Timestamps.swift"; sourceTree = "<group>"; };
@@ -1822,6 +1824,7 @@
 				F9B71F611CB2BC85001DB03F /* ZMMessageTests.m */,
 				F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */,
 				F9B0FF311D79D1140098C17C /* ZMClientMessageTests+Unarchiving.swift */,
+				1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */,
 				CEB15E501D7EE53A0048A011 /* ZMClientMessagesTests+Reaction.swift */,
 				F963E9841D9D47D100098AD3 /* ZMClientMessageTests+Ephemeral.swift */,
 				F963E9921D9E9D1800098AD3 /* ZMAssetClientMessageTests+Ephemeral.swift */,
@@ -2609,6 +2612,7 @@
 			files = (
 				F920AE171E38C547001BC14F /* NotificationObservers.swift in Sources */,
 				F93265291D89648B0076AAD6 /* ZMAssetClientMessageTests.swift in Sources */,
+				1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */,
 				F19550392040628400338E91 /* ZMUpdateEvent+Helper.swift in Sources */,
 				F9B71F9C1CB2BF18001DB03F /* ZMCallStateTests.swift in Sources */,
 				BF491CEB1F063F480055EE44 /* AccountManagerTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were losing the quote when applying a message edit.

### Causes

According to the spec we do not allow users to edit the quote in a message, only the text can be edited. This means we should copy only text part of an edit but leave any existing quote as they are. We didn't do this but instead copied all the fields from the edit.

### Solutions

Keep the quote from the original message when applying a text edit.