### PR TITLE
Include byte order marker when hashing image asset id

### DIFF
--- a/Source/Utilis/Protos/ZMGenericMessage+Hashing.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Hashing.swift
@@ -48,9 +48,7 @@ extension ZMMessageEdit: BigEndianDataConvertible {
 extension ZMText: BigEndianDataConvertible {
     
     var asBigEndianData: Data {
-        var data = Data(bytes: [0xFE, 0xFF]) // Byte order marker
-        data.append(content.data(using: .utf16BigEndian)!)
-        return data
+        return content.asBigEndianData
     }
     
 }
@@ -68,7 +66,7 @@ extension ZMLocation: BigEndianDataConvertible {
 extension ZMAsset: BigEndianDataConvertible {
     
     var asBigEndianData: Data {
-        return uploaded?.assetId.data(using: .utf16BigEndian) ?? Data()
+        return uploaded?.assetId.asBigEndianData ?? Data()
     }
 }
 
@@ -77,6 +75,16 @@ fileprivate extension Float {
     var times1000: Int {
         return Int(roundf(self * 1000.0))
     }
+}
+
+extension String: BigEndianDataConvertible {
+    
+    var asBigEndianData: Data {
+        var data = Data(bytes: [0xFE, 0xFF]) // Byte order marker
+        data.append(self.data(using: .utf16BigEndian)!)
+        return data
+    }
+    
 }
 
 extension Int: BigEndianDataConvertible {

--- a/Tests/Source/Utils/ZMGenericMessageTests+Hashing.swift
+++ b/Tests/Source/Utils/ZMGenericMessageTests+Hashing.swift
@@ -91,14 +91,27 @@ class ZMGenericMessageTests_Hashing: XCTestCase {
     func testCorrectHashValueForAsset1() {
         // given
         var assetMessage = ZMGenericMessage.message(content: ZMAsset.asset(withUploadedOTRKey: Data(), sha256: Data()))
-        assetMessage = assetMessage.updatedUploaded(withAssetId: "assetId1", token: nil)!
+        assetMessage = assetMessage.updatedUploaded(withAssetId: "3-2-1-38d4f5b9", token: nil)!
         let timestamp = Date(timeIntervalSince1970: 1540213769)
         
         // when
         let hash = assetMessage.hashOfContent(with: timestamp)
         
         // then
-        XCTAssertEqual(hash?.zmHexEncodedString(), "eba94f40053c5c854e95d2360a457ec47a7c783d98298476188fa74e729941a9")
+        XCTAssertEqual(hash?.zmHexEncodedString(), "bf20de149847ae999775b3cc88e5ff0c0382e9fa67b9d382b1702920b8afa1de")
+    }
+    
+    func testCorrectHashValueForAsset2() {
+        // given
+        var assetMessage = ZMGenericMessage.message(content: ZMAsset.asset(withUploadedOTRKey: Data(), sha256: Data()))
+        assetMessage = assetMessage.updatedUploaded(withAssetId: "3-3-3-82a62735", token: nil)!
+        let timestamp = Date(timeIntervalSince1970: 1540213965)
+        
+        // when
+        let hash = assetMessage.hashOfContent(with: timestamp)
+        
+        // then
+        XCTAssertEqual(hash?.zmHexEncodedString(), "2235f5b6c00d9b0917675399d0314c8401f0525457b00aa54a38998ab93b90d6")
     }
     
     // MARK: - Ephemeral


### PR DESCRIPTION
## What's new in this PR?

### Issues

Images quoted on iOS would show as "not available" on Web and Android.

### Causes

An image hash is based on its asset id which is a string, therefore we must include a byte order marker in the beginning of the data just like we do for text message hashes.

### Solutions

Include byte order marker and update tests.