### PR TITLE
Read correct message nonce for ephemeral replies

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMClientMessage+Quotes.swift
@@ -21,7 +21,16 @@ import Foundation
 extension ZMClientMessage {
     
     override func updateQuoteRelationships() {
-        guard let quote = genericMessage?.text?.quote else { return }
+        let quote: ZMQuote
+        if self.isEphemeral, let newQuote = genericMessage?.ephemeral?.text?.quote {
+            quote = newQuote
+        }
+        else if !self.isEphemeral, let newQuote = genericMessage?.text?.quote {
+            quote = newQuote
+        }
+        else {
+            return
+        }
         
         establishRelationshipsForInsertedQuote(quote)
     }

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
@@ -49,4 +49,23 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         XCTAssertEqual(sut.quote, quotedMessage)
     }
     
+    func testQuoteRelationshipIsEstablishedWhenReceivingEphemeralMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC); conversation.remoteIdentifier = UUID.create()
+        let quotedMessage = conversation.append(text: "The sky is blue") as? ZMClientMessage
+        let replyMessage = ZMGenericMessage.message(content: ZMEphemeral.ephemeral(content: ZMText.text(with: "I agree", replyingTo: quotedMessage), expiresAfter: 1000))
+        let data = ["sender": NSString.createAlphanumerical(), "text": replyMessage.data()?.base64EncodedString()]
+        let payload = payloadForMessage(in: conversation, type: EventConversationAddOTRMessage, data: data)!
+        let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)
+        
+        // when
+        var sut: ZMClientMessage! = nil
+        performPretendingUiMocIsSyncMoc {
+            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message as? ZMClientMessage
+        }
+        
+        // then
+        XCTAssertNotNil(sut);
+        XCTAssertEqual(sut.quote, quotedMessage)
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Ephemeral reply was not displaying the correct mentioned message.

### Causes

The `genericMessage?.ephemeral?.text?.quote` keypath must be used for the ephemeral messages to get to the text message's quote, since the text message is wrapped inside of the ephemeral container.