### PR TITLE
Fix for GIFs getting stuck

### DIFF
--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -165,6 +165,11 @@ extension V3Asset: AssetProxyType {
     }
 
     public func requestImageDownload() {
+        // Do not try to download the images being uploaded now.
+        guard !assetClientMessage.transferState.isOne(of: [.uploading]) else {
+            return
+        }
+        
         if isImage {
             requestFileDownload()
         } else if assetClientMessage.genericAssetMessage?.assetData?.hasPreview() == true {

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -2112,6 +2112,26 @@ extension ZMAssetClientMessageTests {
         XCTAssertEqual(sut.transferState, .downloading)
     }
     
+    func testThatRequestingUploadingImageDownloadHasNoEffect() {
+        // given
+        let (sut, nonce) = createMessageWithNonce()
+        let image = ZMAssetImageMetaData.imageMetaData(withWidth: 123, height: 4569)
+        let original = originalGenericMessage(nonce: nonce, image: image, preview: nil)
+        let uploaded = uploadedGenericMessage(nonce: nonce)
+        
+        // when
+        sut.update(with: original, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.update(with: uploaded, updateEvent: ZMUpdateEvent(), initialUpdate: false)
+        sut.transferState = .uploading
+        XCTAssertEqual(sut.transferState, .uploading)
+        
+        // when
+        sut.imageMessageData?.requestImageDownload()
+        
+        // then
+        XCTAssertEqual(sut.transferState, .uploading)
+    }
+    
     func testThatRequestingFileDoesNotResetTheTransferStateForUnavailableAssets_V3() {
         // given
         let (sut, nonce) = createMessageWithNonce()


### PR DESCRIPTION
## What's new in this PR?

### Issues

In UI we started to post GIF only after the confirmation controller is dismissed. This caused the image appear while it is still not started to upload. 

We have the code that is requesting the download immediately when it sees the image, the data model was confused and allowed the uploading image to be set to be downloaded. This caused the uploader not to pick up the image.

### Solution

Check in `requestImageDownload` if the image being uploaded now before marking it to be downloaded.