### PR TITLE
Temp: do not assert on multiple delivery receipts

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -439,7 +439,8 @@ NSString * const ZMMessageQuoteKey = @"quote";
         return NO;
     }];
     
-    NSAssert(confirmationReceipts.count <= 1, @"More than one confirmation receipt");
+    // TODO: Re-enable
+//    NSAssert(confirmationReceipts.count <= 1, @"More than one confirmation receipt");
     
     for (ZMClientMessage *confirmationReceipt in confirmationReceipts) {
         [self.managedObjectContext deleteObject:confirmationReceipt];


### PR DESCRIPTION
## What's new in this PR?

### Issues

In order to un-brick the user's device we need to temporarily disable the assert. We need to run the in-depth investigation to fix it.