### PR TITLE
Check if link preview exists

### DIFF
--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -209,7 +209,7 @@ extension ZMText: EphemeralMessageContentType {
     public func updateLinkPeview(from text: ZMText) -> ZMText {
         guard let builder = self.toBuilder() else { return self }
         
-        if text.linkPreview.count > 0 {
+        if let linkPreview = text.linkPreview, linkPreview.count > 0 {
             builder.setLinkPreviewArray(text.linkPreview)
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Guest from ObjC world, `text.linkPreview` can be nil.