### PR TITLE
Log a warning when a quote is rejected

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMClientMessage+Quotes.swift
@@ -21,11 +21,11 @@ import Foundation
 extension ZMClientMessage {
     
     override func updateQuoteRelationships() {
-        guard let quote = genericMessage?.textData?.quote else {
+        guard let text = genericMessage?.textData, text.hasQuote() else {
             return
         }
         
-        establishRelationshipsForInsertedQuote(quote)
+        establishRelationshipsForInsertedQuote(text.quote)
     }
     
 }

--- a/Source/Model/Message/ZMOTRMessage+Quotes.swift
+++ b/Source/Model/Message/ZMOTRMessage+Quotes.swift
@@ -19,6 +19,8 @@
 
 import Foundation
 
+private var log = ZMSLog(tag: "event-processing")
+
 extension ZMOTRMessage {
     
     @objc
@@ -35,6 +37,8 @@ extension ZMOTRMessage {
         
         if quotedMessage.hashOfContent == quote.quotedMessageSha256 {
             quotedMessage.replies.insert(self)
+        } else {
+            log.warn("Rejecting quote since local hash \(quotedMessage.hashOfContent?.zmHexEncodedString() ?? "N/A") doesn't match \(quote.quotedMessageSha256.zmHexEncodedString())")
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

Log when a quote is rejected because the hash doesn't match. This will make it easier to debug any issues with replies not working.