### PR TITLE
Read receipts processing

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/.xccurrentversion
+++ b/Resources/zmessaging.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>zmessaging2.57.0.xcdatamodel</string>
+	<string>zmessaging2.58.0.xcdatamodel</string>
 </dict>
 </plist>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.58.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.58.0.xcdatamodel/contents
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="17G65" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.58.0">
+    <entity name="AddressBookEntry" representedClassName=".AddressBookEntry" syncable="YES">
+        <attribute name="cachedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localIdentifier" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="addressBookEntry" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="AssetClientMessage" representedClassName=".ZMAssetClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="assetId" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="assetId_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="associatedTaskIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preprocessedSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="preprocessedSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="progress" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="transferState" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="uploadState" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericMessageData" inverseName="asset" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="ClientMessage" representedClassName="ZMClientMessage" parentEntity="Message" syncable="YES">
+        <attribute name="delivered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkPreviewState" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="updatedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="dataSet" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericMessageData" inverseName="message" inverseEntity="GenericMessageData" syncable="YES"/>
+    </entity>
+    <entity name="Connection" representedClassName="ZMConnection" syncable="YES">
+        <attribute name="existsOnBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUpdateDateInGMT" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="message" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="connection" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="to" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="connection" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Conversation" representedClassName="ZMConversation" syncable="YES">
+        <attribute name="accessModeStrings" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="accessRoleString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="archivedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="clearedTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="conversationType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="draftMessageData" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="hasUnreadUnsentMessage" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadSelfMentionCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalEstimatedUnreadSelfReplyCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="language" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadKnockDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUnreadMissedCallDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="localMessageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="NO" elementID="messageDestructionTimeout" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="mutedStatus" attributeType="Integer 32" defaultValueString="NO" usesScalarValueType="NO" elementID="mutedStatus" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedUserDefinedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="securityLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="silencedChangedTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="syncedMessageDestructionTimeout" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="teamRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="teamRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="userDefinedName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="voiceChannel" optional="YES" transient="YES" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="conversation" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="conversationsCreated" inverseEntity="User" syncable="YES"/>
+        <relationship name="hiddenMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="hiddenInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveParticipants" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="User" inverseName="lastServerSyncedActiveConversations" inverseEntity="User" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Message" inverseName="visibleInConversation" inverseEntity="Message" syncable="YES"/>
+        <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="conversations" inverseEntity="Team" syncable="YES"/>
+        <compoundIndexes>
+            <compoundIndex>
+                <index value="internalIsArchived"/>
+                <index value="lastModifiedDate"/>
+            </compoundIndex>
+        </compoundIndexes>
+    </entity>
+    <entity name="GenericMessageData" representedClassName="ZMGenericMessageData" syncable="YES">
+        <attribute name="data" attributeType="Binary" syncable="YES"/>
+        <relationship name="asset" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AssetClientMessage" inverseName="dataSet" inverseEntity="AssetClientMessage" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClientMessage" inverseName="dataSet" inverseEntity="ClientMessage" syncable="YES"/>
+    </entity>
+    <entity name="ImageMessage" representedClassName="ZMImageMessage" parentEntity="Message" syncable="YES">
+        <attribute name="imageType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isAnimatedGIF" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumDataLoaded" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="originalDataProcessed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="originalSize" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="originalSize_data" optional="YES" attributeType="Binary" syncable="YES"/>
+    </entity>
+    <entity name="KnockMessage" representedClassName="ZMKnockMessage" parentEntity="Message" syncable="YES"/>
+    <entity name="Member" representedClassName=".Member" syncable="YES">
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="permissionsRawValue" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <relationship name="team" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Team" inverseName="members" inverseEntity="Team" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="membership" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Message" representedClassName="ZMMessage" isAbstract="YES" syncable="YES">
+        <attribute name="cachedCategory" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="destructionDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" versionHashModifier="add index" syncable="YES"/>
+        <attribute name="isExpired" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isObfuscated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="nonce" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="nonce_data" optional="YES" attributeType="Binary" indexed="YES" versionHashModifier="add_index1" syncable="YES"/>
+        <attribute name="normalizedText" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="senderClientID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="serverTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="confirmations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MessageConfirmation" inverseName="message" inverseEntity="MessageConfirmation" syncable="YES"/>
+        <relationship name="hiddenInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="hiddenMessages" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="missingRecipients" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="messagesMissingRecipient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="quote" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="replies" inverseEntity="Message" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Reaction" inverseName="message" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="replies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="quote" inverseEntity="Message" syncable="YES"/>
+        <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+        <relationship name="visibleInConversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation" syncable="YES"/>
+    </entity>
+    <entity name="MessageConfirmation" representedClassName="ZMMessageConfirmation" syncable="YES">
+        <attribute name="serverTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Reaction" representedClassName=".Reaction" syncable="YES">
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="unicodeValue" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="message" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="reactions" inverseEntity="Message" syncable="YES"/>
+        <relationship name="users" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="reactions" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Session" representedClassName="ZMSession" syncable="YES">
+        <relationship name="selfUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="SystemMessage" representedClassName="ZMSystemMessage" parentEntity="Message" syncable="YES">
+        <attribute name="allTeamUsersAdded" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="messageTimer" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsUpdatingUsers" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="numberOfGuestsAdded" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relevantForConversationStatus" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="systemMessageType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="addedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserAdded" inverseEntity="User" syncable="YES"/>
+        <relationship name="childMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="parentMessage" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="addedOrRemovedInSystemMessages" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="parentMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="childMessages" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="removedUsers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="showingUserRemoved" inverseEntity="User" syncable="YES"/>
+        <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="systemMessages" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="Team" representedClassName=".Team" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToRedownloadMembers" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pictureAssetId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pictureAssetKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="team" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="createdTeams" inverseEntity="User" syncable="YES"/>
+        <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Member" inverseName="team" inverseEntity="Member" syncable="YES"/>
+    </entity>
+    <entity name="TextMessage" representedClassName="ZMTextMessage" parentEntity="Message" syncable="YES">
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="User" representedClassName="ZMUser" syncable="YES">
+        <attribute name="accentColorValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="availability" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="completeProfileAssetIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="emailAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="expiresAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="handle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageMediumData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="imageSmallProfileData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localMediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="localSmallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="mediumRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="needsToBeUpdatedFromBackend" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="normalizedEmailAddress" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="normalizedName" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="previewProfileAssetIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="providerIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="remoteIdentifier_data" optional="YES" attributeType="Binary" indexed="YES" syncable="YES"/>
+        <attribute name="serviceIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="smallProfileRemoteIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="teamIdentifier" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="teamIdentifier_data" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="usesCompanyLogin" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="addressBookEntry" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AddressBookEntry" inverseName="user" inverseEntity="AddressBookEntry" syncable="YES"/>
+        <relationship name="clients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="user" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="connection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Connection" inverseName="to" inverseEntity="Connection" syncable="YES"/>
+        <relationship name="conversationsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="creator" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="createdTeams" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Team" inverseName="creator" inverseEntity="Team" syncable="YES"/>
+        <relationship name="lastServerSyncedActiveConversations" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Conversation" inverseName="lastServerSyncedActiveParticipants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="membership" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Member" inverseName="user" inverseEntity="Member" syncable="YES"/>
+        <relationship name="reactions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Reaction" inverseName="users" inverseEntity="Reaction" syncable="YES"/>
+        <relationship name="showingUserAdded" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="addedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="showingUserRemoved" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="removedUsers" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="systemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="users" inverseEntity="SystemMessage" syncable="YES"/>
+    </entity>
+    <entity name="UserClient" representedClassName=".UserClient" syncable="YES">
+        <attribute name="activationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="activationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLatitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="activationLocationLongitude" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="apsDecryptionKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="apsVerificationKey" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deviceClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="fingerprint" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="markedToDelete" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="model" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="needsToNotifyUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="needsToUploadSignalingKeys" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="numberOfKeysRemaining" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="preKeysRangeMax" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pushToken" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="remoteIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" attributeType="String" defaultValueString="permanent" syncable="YES"/>
+        <relationship name="addedOrRemovedInSystemMessages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SystemMessage" inverseName="clients" inverseEntity="SystemMessage" syncable="YES"/>
+        <relationship name="ignoredByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="ignoredClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="ignoredByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="messagesMissingRecipient" optional="YES" transient="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="missingRecipients" inverseEntity="Message" syncable="YES"/>
+        <relationship name="missedByClient" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missingClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="missingClients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="missedByClient" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedByClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="trustedClients" toMany="YES" deletionRule="Nullify" destinationEntity="UserClient" inverseName="trustedByClients" inverseEntity="UserClient" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="clients" inverseEntity="User" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AddressBookEntry" positionX="9" positionY="153" width="128" height="90"/>
+        <element name="AssetClientMessage" positionX="9" positionY="153" width="128" height="225"/>
+        <element name="ClientMessage" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Connection" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="Conversation" positionX="0" positionY="0" width="128" height="615"/>
+        <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="90"/>
+        <element name="ImageMessage" positionX="0" positionY="0" width="128" height="165"/>
+        <element name="KnockMessage" positionX="0" positionY="0" width="128" height="45"/>
+        <element name="Member" positionX="18" positionY="162" width="128" height="135"/>
+        <element name="Message" positionX="0" positionY="0" width="128" height="345"/>
+        <element name="MessageConfirmation" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Reaction" positionX="18" positionY="162" width="128" height="105"/>
+        <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
+        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="255"/>
+        <element name="Team" positionX="9" positionY="153" width="128" height="195"/>
+        <element name="TextMessage" positionX="-153" positionY="-117" width="128" height="60"/>
+        <element name="User" positionX="-434" positionY="-72" width="128" height="660"/>
+        <element name="UserClient" positionX="9" positionY="153" width="128" height="465"/>
+    </elements>
+</model>

--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -34,9 +34,10 @@ import CoreData
 }
 
 @objc(ZMMessageConfirmation) @objcMembers
-open class ZMMessageConfirmation: ZMManagedObject {
-
+open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
+    
     @NSManaged open var type: MessageConfirmationType
+    @NSManaged open var serverTimestamp: Date
     @NSManaged open var message: ZMMessage
     @NSManaged open var user: ZMUser
 

--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -37,7 +37,7 @@ import CoreData
 open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
     
     @NSManaged open var type: MessageConfirmationType
-    @NSManaged open var serverTimestamp: Date
+    @NSManaged open var serverTimestamp: Date?
     @NSManaged open var message: ZMMessage
     @NSManaged open var user: ZMUser
 
@@ -53,26 +53,38 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
         }
     }
     
-    
-    /// Creates a ZMMessageConfirmation object that holds a reference to a message that was confirmed and the user who confirmed it.
-    /// It can have 2 types: Delivered and Read depending on the genericMessage confirmation type
-    public static func createOrUpdateMessageConfirmation(_ genericMessage: ZMGenericMessage, conversation: ZMConversation, sender: ZMUser) -> ZMMessageConfirmation? {
+    /// Creates a ZMMessageConfirmation objects that holds a reference to a message that was confirmed and the user who confirmed it.
+    /// It can have 2 types: Delivered and Read depending on the confirmation type
+    @objc
+    @discardableResult
+    public static func createMessageMessageConfirmations(_ confirmation: ZMConfirmation, conversation: ZMConversation, updateEvent: ZMUpdateEvent) -> [ZMMessageConfirmation] {
         
-        guard genericMessage.hasConfirmation(),
-            let moc = conversation.managedObjectContext,
-            let messageUUID = UUID(uuidString: genericMessage.confirmation.firstMessageId),
-            let message = ZMMessage.fetch(withNonce: messageUUID, for: conversation, in: moc),
-            let originalSender = message.sender, originalSender.isSelfUser
-        else { return nil }
+        let type = MessageConfirmationType.convert(confirmation.type)
         
-        var confirmation = message.confirmations.filter{$0.user == sender}.first
-        if confirmation == nil {
-            confirmation = NSEntityDescription.insertNewObject(forEntityName: ZMMessageConfirmation.entityName(), into: moc) as? ZMMessageConfirmation
+        guard let managedObjectContext = conversation.managedObjectContext,
+              let senderUUID = updateEvent.senderUUID(),
+              let sender = ZMUser(remoteID: senderUUID, createIfNeeded: true, in: managedObjectContext),
+              let serverTimestamp = updateEvent.timeStamp(),
+              let firstMessageId = confirmation.firstMessageId else { return [] }
+        
+        let moreMessageIds = confirmation.moreMessageIds as? [String] ?? []
+        let confirmedMesssageIds = ([firstMessageId] + moreMessageIds).compactMap({ UUID(uuidString: $0) })
+        
+        return confirmedMesssageIds.compactMap { confirmedMessageId in
+            guard let message = ZMMessage.fetch(withNonce: confirmedMessageId, for: conversation, in: managedObjectContext),
+                !message.confirmations.contains(where: { $0.user == sender && $0.type == type }) else { return nil }
+            
+            return ZMMessageConfirmation(type: type, message: message, sender: sender, serverTimestamp: serverTimestamp, managedObjectContext: managedObjectContext)
         }
-        confirmation?.user = sender
-        confirmation?.message = message
-        confirmation?.type = MessageConfirmationType.convert(genericMessage.confirmation.type)
-        
-        return confirmation
     }
+    
+    convenience init(type:MessageConfirmationType,  message: ZMMessage, sender: ZMUser, serverTimestamp: Date, managedObjectContext: NSManagedObjectContext) {
+        let entityDescription = NSEntityDescription.entity(forEntityName: ZMMessageConfirmation.entityName(), in: managedObjectContext)!
+        self.init(entity: entityDescription, insertInto: managedObjectContext)
+        self.message = message
+        self.user = sender
+        self.type = type
+        self.serverTimestamp = serverTimestamp
+    }
+    
 }

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -154,7 +154,7 @@ extension ZMMessage : ZMConversationMessage {
     @NSManaged public var replies: Set<ZMMessage>
     
     public var readReceipts: [ReadReceipt] {
-        return confirmations.filter({ $0.type == .read }).sorted(by: { a, b in  a.serverTimestamp > b.serverTimestamp })
+        return confirmations.filter({ $0.type == .read }).sorted(by: { a, b in  a.serverTimestamp < b.serverTimestamp })
     }
 
     public var objectIdentifier: String {

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -34,7 +34,7 @@ public enum ZMDeliveryState : UInt {
 public protocol ReadReceipt {
     
     var user: ZMUser { get }
-    var serverTimestamp: Date { get }
+    var serverTimestamp: Date? { get }
     
 }
 
@@ -154,7 +154,7 @@ extension ZMMessage : ZMConversationMessage {
     @NSManaged public var replies: Set<ZMMessage>
     
     public var readReceipts: [ReadReceipt] {
-        return [] // TODO jacob return confirmations filtered by type .read
+        return confirmations.filter({ $0.type == .read }).sorted(by: { a, b in  a.serverTimestamp > b.serverTimestamp })
     }
 
     public var objectIdentifier: String {

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -27,7 +27,8 @@ public enum ZMDeliveryState : UInt {
     case pending = 1
     case sent = 2
     case delivered = 3
-    case failedToSend = 4
+    case read = 4
+    case failedToSend = 5
 }
 
 @objc

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -176,8 +176,7 @@ NSString * const DeliveredKey = @"delivered";
         
         [ZMMessage addReaction:message.reaction senderID:updateEvent.senderUUID conversation:conversation inManagedObjectContext:moc];
     } else if (message.hasConfirmation) {
-        ZMUser *sender = [ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc];
-        NOT_USED([ZMMessageConfirmation createOrUpdateMessageConfirmation:message conversation:conversation sender:sender]);
+        [ZMMessageConfirmation createMessageMessageConfirmations:message.confirmation conversation:conversation updateEvent:updateEvent];
     } else if (message.hasEdited) {
         NSUUID *editedMessageId = [NSUUID uuidWithTransportString:message.edited.replacingMessageId];
         ZMClientMessage *editedMessage = [ZMClientMessage fetchMessageWithNonce:editedMessageId forConversation:conversation inManagedObjectContext:moc prefetchResult:prefetchResult];

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -79,11 +79,14 @@ NSString * const DeliveredKey = @"delivered";
     else if (self.delivered == NO) {
         return ZMDeliveryStatePending;
     }
-    else if (self.confirmations.count == 0){
-        return ZMDeliveryStateSent;
+    else if (self.readReceipts.count > 0) {
+        return ZMDeliveryStateRead;
+    }
+    else if (self.confirmations.count > 0){
+        return ZMDeliveryStateDelivered;
     }
     else {
-        return ZMDeliveryStateDelivered;
+        return ZMDeliveryStateSent;
     }
 }
 

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1840,8 +1840,7 @@ extension ZMAssetClientMessageTests {
             message.expire()
         }
         if state == .delivered {
-            let genericMessage = ZMGenericMessage.message(content: ZMConfirmation.confirm(messageId: message.nonce!), nonce: UUID.create())
-            _ = ZMMessageConfirmation.createOrUpdateMessageConfirmation(genericMessage, conversation: message.conversation!, sender: message.sender!)
+            _ = ZMMessageConfirmation(type: .delivered, message: message, sender: message.sender!, serverTimestamp: Date(), managedObjectContext: message.managedObjectContext!)
             message.managedObjectContext?.saveOrRollback()
         }
     }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		16030DAE21AC536700F8032E /* zmessaging2.58.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.58.0.xcdatamodel; sourceTree = "<group>"; };
 		161541B91E27EBD400AC2FFB /* ZMConversation+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Calling.swift"; sourceTree = "<group>"; };
 		16168139207B982800BCF33A /* zmessaging2.46.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.46.0.xcdatamodel; sourceTree = "<group>"; };
 		1621E59120E62BD2006B2D17 /* ZMConversationTests+Silencing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Silencing.swift"; sourceTree = "<group>"; };
@@ -2927,6 +2928,7 @@
 		F189988C1E7BE03800E579A2 /* zmessaging.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				16030DAE21AC536700F8032E /* zmessaging2.58.0.xcdatamodel */,
 				EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */,
 				7CAE54512180B59800177A8E /* zmessaging2.56.0.xcdatamodel */,
 				16626495216763EE00300F45 /* zmessaging2.55.0.xcdatamodel */,
@@ -2974,7 +2976,7 @@
 				F18998A41E7BE03800E579A2 /* zmessaging2.8.xcdatamodel */,
 				F18998A51E7BE03800E579A2 /* zmessaging2.9.xcdatamodel */,
 			);
-			currentVersion = EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */;
+			currentVersion = 16030DAE21AC536700F8032E /* zmessaging2.58.0.xcdatamodel */;
 			path = zmessaging.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;


### PR DESCRIPTION
## What's new in this PR?

- Add `serverTimestamp` to `MessageConfirmation` 
- Support receiving multiple message confirmations at once (necessary for read receipts)  
- Implement .read case for `deliveryStatus`

## NOTE

Database migration tests will come later since there's will be more data model changes necessary.
