### PR TITLE
Added self user setting

### DIFF
--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -30,6 +30,7 @@
 extern NSString * __nonnull const SessionObjectIDKey;
 extern NSString * __nonnull const UserClientsKey;
 extern NSString * __nonnull const AvailabilityKey;
+extern NSString * __nonnull const EnableReadReceiptsKey;
 
 @interface ZMUser (Internal)
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -82,6 +82,7 @@ static NSString *const ProviderIdentifierKey = @"providerIdentifier";
 NSString *const AvailabilityKey = @"availability";
 static NSString *const ExpiresAtKey = @"expiresAt";
 static NSString *const UsesCompanyLoginKey = @"usesCompanyLogin";
+NSString *const EnableReadReceiptsKey = @"EnableReadReceipts";
 
 static NSString *const TeamIdentifierDataKey = @"teamIdentifier_data";
 static NSString *const TeamIdentifierKey = @"teamIdentifier";
@@ -869,6 +870,22 @@ static NSString *const TeamIdentifierKey = @"teamIdentifier";
     [self didChangeValueForKey:EmailAddressKey];
     
     self.normalizedEmailAddress = [self.emailAddress normalizedEmailaddress];
+}
+
+- (void)setEnableReadReceipts:(BOOL)enableReadReceipts
+{
+    NSAssert(self.isSelfUser, @"setEnableReadReceipts called for non-self user");
+    [self.managedObjectContext setPersistentStoreMetadata:@(enableReadReceipts) forKey:EnableReadReceiptsKey];
+}
+
+- (BOOL)enableReadReceipts
+{
+    NSAssert(self.isSelfUser, @"enableReadReceipts called for non-self user");
+    id value = [self.managedObjectContext persistentStoreMetadataForKey:EnableReadReceiptsKey];
+    if (nil != value && [value respondsToSelector:@selector(boolValue)]) {
+        return [value boolValue];
+    }
+    return NO;
 }
 
 @end

--- a/Source/Public/ZMEditableUser.h
+++ b/Source/Public/ZMEditableUser.h
@@ -31,5 +31,6 @@
 @property (nonatomic) ZMAccentColor accentColorValue;
 @property (nonatomic, copy, readonly) NSString *emailAddress;
 @property (nonatomic, copy, readonly) NSString *phoneNumber;
+@property (nonatomic) BOOL enableReadReceipts;
 
 @end

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -613,3 +613,47 @@ extension ZMUserTests {
         XCTAssertEqual(round(sut.expiresAfter), 0)
     }
 }
+
+// MARK: - Self user tests
+extension ZMUserTests {
+    func testThatItIsPossibleToSetEnableReadReceipts() {
+        // GIVEN
+        let sut = ZMUser.selfUser(in: uiMOC)
+        // WHEN
+        sut.enableReadReceipts = true
+        // THEN
+        XCTAssertEqual(sut.enableReadReceipts, true)
+    }
+    
+    func testThatItIsPossibleToSetEnableReadReceipts_andReset() {
+        // GIVEN
+        let sut = ZMUser.selfUser(in: uiMOC)
+        // WHEN
+        sut.enableReadReceipts = true
+        // THEN
+        XCTAssertEqual(sut.enableReadReceipts, true)
+        // AND WHEN
+        sut.enableReadReceipts = false
+        // THEN
+        XCTAssertEqual(sut.enableReadReceipts, false)
+    }
+    
+    func testThatItUpdatesOtherContextForEnableReadReceipts() {
+        // GIVEN
+        let sut = ZMUser.selfUser(in: uiMOC)
+        // WHEN
+        sut.enableReadReceipts = true
+        self.uiMOC.saveOrRollback()
+        
+        // THEN
+        
+        self.syncMOC.performGroupedBlock {
+            let syncSelfUser = ZMUser.selfUser(in: self.syncMOC)
+
+            XCTAssertEqual(syncSelfUser.enableReadReceipts, true)
+        }
+        
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+}
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

As discussed, I've added the setting to `ZMEditableUser`. I am saving the setting to the context metadata, this seems to be the most appropriate. I could have added the database field to all users, but this seems unnecessary, since we don't know and don't care about the settings of other users.