### PR TITLE
Fix: asset message preview cannot be downloaded

### DIFF
--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -165,12 +165,11 @@ extension V3Asset: AssetProxyType {
     }
 
     public func requestImageDownload() {
-        // Do not try to download the images being uploaded now.
-        guard !assetClientMessage.transferState.isOne(of: [.uploading]) else {
-            return
-        }
-        
         if isImage {
+            // Do not try to download the images being uploaded now.
+            guard !assetClientMessage.transferState.isOne(of: [.uploading]) else {
+                return
+            }
             requestFileDownload()
         } else if assetClientMessage.genericAssetMessage?.assetData?.hasPreview() == true {
             guard !assetClientMessage.objectID.isTemporaryID else { return }

--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -200,8 +200,7 @@ extension ZMAssetClientMessage {
         // V2, we do not set the thumbnail assetId in case there is one in the protobuf, 
         // then we can access it directly for V3
         
-        if let assetData = message.assetData,
-            assetData.preview.hasRemote() && !assetData.hasUploaded() {
+        if let assetData = message.assetData, assetData.preview.hasRemote() {
             
             if !assetData.preview.remote.hasAssetId() {
                 if let thumbnailId = eventData["id"] as? String {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some Sync Engine tests started failing after #603 because we have a possibility (not sure if ever used in practice) to download a preview of asset message while it's still being uploaded by the sender. This (sort of) makes sense, when a person sending the message has uploaded a preview and is in the process of uploading the full asset. Then the receiver can look at the preview until an updated message with full asset come

### Solutions

Do not check for transfer state when we are about to download a preview for file message.
