### PR TITLE
Fix nullability of messageUpdateResultFromUpdateEvent

### DIFF
--- a/Source/Model/Message/ZMOTRMessage.h
+++ b/Source/Model/Message/ZMOTRMessage.h
@@ -41,9 +41,9 @@ extern NSString * const DeliveredKey;
 
 - (void)updateWithGenericMessage:(ZMGenericMessage * )message updateEvent:(ZMUpdateEvent *)updateEvent initialUpdate:(BOOL)initialUpdate;
 
-+ (MessageUpdateResult *)messageUpdateResultFromUpdateEvent:(ZMUpdateEvent *)updateEvent
-                                     inManagedObjectContext:(NSManagedObjectContext *)moc
-                                             prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult;
++ (nullable MessageUpdateResult *)messageUpdateResultFromUpdateEvent:(ZMUpdateEvent *)updateEvent
+                                              inManagedObjectContext:(NSManagedObjectContext *)moc
+                                                      prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult;
 
 + (instancetype)createOrUpdateMessageFromUpdateEvent:(ZMUpdateEvent *)updateEvent
                               inManagedObjectContext:(NSManagedObjectContext *)moc

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Silencing.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Silencing.swift
@@ -114,7 +114,7 @@ class ZMConversationTests_Silencing: ZMConversationTestsBase {
         let event = self.event(for: "@selfUser", in: conversation, mentions: [mention])
         
         self.performPretendingUiMocIsSyncMoc {
-            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message)
+            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message)
         }
         
         // THEN
@@ -135,7 +135,7 @@ class ZMConversationTests_Silencing: ZMConversationTestsBase {
         let event = self.event(for: "@selfUser", in: conversation, mentions: [mention])
         
         self.performPretendingUiMocIsSyncMoc {
-            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message)
+            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message)
         }
         
         // THEN
@@ -162,7 +162,7 @@ class ZMConversationTests_Silencing: ZMConversationTestsBase {
         let event = self.event(for: "Hi!", in: conversation, replyingTo: quotedMessage)
         
         self.performPretendingUiMocIsSyncMoc {
-            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message)
+            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message)
         }
         
         // THEN
@@ -189,7 +189,7 @@ class ZMConversationTests_Silencing: ZMConversationTestsBase {
         let event = self.event(for: "Hi!", in: conversation, replyingTo: quotedMessage)
         
         self.performPretendingUiMocIsSyncMoc {
-            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message)
+            XCTAssertNotNil(ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message)
         }
         
         // THEN

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -1633,7 +1633,7 @@ extension ZMAssetClientMessageTests {
             // when
             var sut : ZMAssetClientMessage? = nil
             self.performPretendingUiMocIsSyncMoc { () -> Void in
-                sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent, in: self.uiMOC, prefetchResult: nil).message as? ZMAssetClientMessage
+                sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent, in: self.uiMOC, prefetchResult: nil)?.message as? ZMAssetClientMessage
             }
             
             // then
@@ -1671,7 +1671,7 @@ extension ZMAssetClientMessageTests {
         // when
         var sut: ZMAssetClientMessage!
         performPretendingUiMocIsSyncMoc {
-            sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent, in: self.uiMOC, prefetchResult: nil).message as? ZMAssetClientMessage
+            sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent, in: self.uiMOC, prefetchResult: nil)?.message as? ZMAssetClientMessage
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         
@@ -1712,7 +1712,7 @@ extension ZMAssetClientMessageTests {
             
             
             // when
-            let sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent1, in: self.syncMOC, prefetchResult: nil).message as! ZMAssetClientMessage
+            let sut = ZMAssetClientMessage.messageUpdateResult(from: updateEvent1, in: self.syncMOC, prefetchResult: nil)?.message as! ZMAssetClientMessage
             sut.update(with: updateEvent2, for: conversation)
             
             // then

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Replies.swift
@@ -41,7 +41,7 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         // when
         var sut: ZMClientMessage! = nil
         performPretendingUiMocIsSyncMoc {
-            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message as? ZMClientMessage
+            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message as? ZMClientMessage
         }
         
         // then
@@ -61,7 +61,7 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         // when
         var sut: ZMClientMessage! = nil
         performPretendingUiMocIsSyncMoc {
-            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil).message as? ZMClientMessage
+            sut = ZMClientMessage.messageUpdateResult(from: event, in: self.uiMOC, prefetchResult: nil)?.message as? ZMClientMessage
         }
         
         // then


### PR DESCRIPTION
## What's new in this PR?

### Issues

Nullability was broken with the recent update (method can return nil).