### PR TITLE
Confirmations observation + Conversation hasReadReceiptsEnabled observation

### DIFF
--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -78,7 +78,7 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
         }
     }
     
-    convenience init(type:MessageConfirmationType,  message: ZMMessage, sender: ZMUser, serverTimestamp: Date, managedObjectContext: NSManagedObjectContext) {
+    convenience init(type: MessageConfirmationType, message: ZMMessage, sender: ZMUser, serverTimestamp: Date, managedObjectContext: NSManagedObjectContext) {
         let entityDescription = NSEntityDescription.entity(forEntityName: ZMMessageConfirmation.entityName(), in: managedObjectContext)!
         self.init(entity: entityDescription, insertInto: managedObjectContext)
         self.message = message

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -40,7 +40,8 @@ extension ZMConversation : ObjectInSnapshot {
                     #keyPath(ZMConversation.remoteIdentifier),
                     #keyPath(ZMConversation.localMessageDestructionTimeout),
                     #keyPath(ZMConversation.syncedMessageDestructionTimeout),
-                    #keyPath(ZMConversation.language)
+                    #keyPath(ZMConversation.language),
+                    #keyPath(ZMConversation.hasReadReceiptsEnabled)
             ])
     }
 
@@ -127,6 +128,10 @@ extension ZMConversation : ObjectInSnapshot {
                 changedKeysContain(keys: #keyPath(ZMConversation.syncedMessageDestructionTimeout))
     }
     
+    public var hasReadReceiptsEnabledChanged : Bool {
+        return changedKeysContain(keys: #keyPath(ZMConversation.hasReadReceiptsEnabled))
+    }
+    
     public var conversation : ZMConversation { return self.object as! ZMConversation }
     
     public override var description : String { return self.debugDescription }
@@ -145,7 +150,9 @@ extension ZMConversation : ObjectInSnapshot {
                 "teamChanged \(teamChanged)",
                 "createdRemotelyChanged \(createdRemotelyChanged)",
                 "destructionTimeoutChanged \(destructionTimeoutChanged)",
-                "languageChanged \(languageChanged)"].joined(separator: ", ")
+                "languageChanged \(languageChanged)",
+                "hasReadReceiptsEnabledChanged \(hasReadReceiptsEnabledChanged)",
+            ].joined(separator: ", ")
     }
     
     public required init(object: NSObject) {

--- a/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -53,7 +53,8 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
             "createdRemotelyChanged",
             "allowGuestsChanged",
             "destructionTimeoutChanged",
-            "languageChanged"
+            "languageChanged",
+            "hasReadReceiptsEnabledChanged"
         ]
     }
     
@@ -760,6 +761,21 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
         
         // then
         XCTAssertEqual(observer.notifications.count, 0)
+    }
+    
+    func testThatItSendsUpdateForReadReceiptsEnabled() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        conversation.conversationType = .group
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(conversation,
+                                                     modifier: { conversation, _ in
+                                                        conversation.hasReadReceiptsEnabled = true
+        },
+                                                     expectedChangedFields: ["hasReadReceiptsEnabledChanged"],
+                                                     expectedChangedKeys: ["hasReadReceiptsEnabled"])
     }
 }
 

--- a/Tests/Source/Model/Observer/MessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/MessageObserverTests.swift
@@ -43,6 +43,16 @@ class MessageObserverTests : NotificationDispatcherTestBase {
         expectedChangedField: String?,
         customAffectedKeys: AffectedKeys? = nil
         ) {
+        let fields = expectedChangedField == nil ? [] : [expectedChangedField!]
+        checkThatItNotifiesTheObserverOfAChange(message, modifier: modifier, expectedChangedFields: fields, customAffectedKeys: customAffectedKeys)
+    }
+    
+    func checkThatItNotifiesTheObserverOfAChange<T: ZMMessage>(
+        _ message: T,
+        modifier: (T) -> Void,
+        expectedChangedFields: [String],
+        customAffectedKeys: AffectedKeys? = nil
+        ) {
         
         // given
         withExtendedLifetime(MessageChangeInfo.add(observer: self.messageObserver, for: message, managedObjectContext: self.uiMOC)) { () -> () in
@@ -55,7 +65,7 @@ class MessageObserverTests : NotificationDispatcherTestBase {
             self.spinMainQueue(withTimeout: 0.5)
             
             // then
-            XCTAssertEqual(messageObserver.notifications.count, expectedChangedField != nil ? 1 : 0)
+            XCTAssertEqual(messageObserver.notifications.count, expectedChangedFields.isEmpty ? 0 : 1)
             
             // and when
             self.uiMOC.saveOrRollback()
@@ -71,13 +81,14 @@ class MessageObserverTests : NotificationDispatcherTestBase {
                 #keyPath(MessageChangeInfo.isObfuscatedChanged),
                 #keyPath(MessageChangeInfo.childMessagesChanged),
                 #keyPath(MessageChangeInfo.reactionsChanged),
-                #keyPath(MessageChangeInfo.transferStateChanged)
+                #keyPath(MessageChangeInfo.transferStateChanged),
+                #keyPath(MessageChangeInfo.confirmationsChanged),
             ]
 
-            guard let changedField = expectedChangedField else { return }
+            guard !expectedChangedFields.isEmpty else { return }
             guard let changes = messageObserver.notifications.first else { return }
             changes.checkForExpectedChangeFields(userInfoKeys: messageInfoKeys,
-                                                 expectedChangedFields: [changedField])
+                                                 expectedChangedFields: expectedChangedFields)
         }
     }
 
@@ -275,6 +286,22 @@ class MessageObserverTests : NotificationDispatcherTestBase {
             message,
             modifier: { $0.mutableSetValue(forKey: #keyPath(ZMSystemMessage.childMessages)).add(otherMessage) },
             expectedChangedField: #keyPath(MessageChangeInfo.childMessagesChanged)
+        )
+    }
+
+    func testThatItNotifiesWhenUserReadsTheMessage() {
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let message = conversation.append(text: "foo") as! ZMClientMessage
+        uiMOC.saveOrRollback()
+        
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(
+            message,
+            modifier: { _ in
+                let _ = ZMMessageConfirmation(type: .read, message: message, sender: ZMUser.selfUser(in: uiMOC), serverTimestamp: Date(), managedObjectContext: uiMOC)
+            },
+            expectedChangedFields: [#keyPath(MessageChangeInfo.confirmationsChanged), #keyPath(MessageChangeInfo.deliveryStateChanged)]
         )
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Features

Support for observing the changes for confirmations. Also updated how the reactions observation is working.