### PR TITLE
Support receipt mode when creating conversations

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -91,6 +91,7 @@ NS_ASSUME_NONNULL_END
 + (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants inTeam:(nullable Team *)team;
 + (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants name:(nullable NSString *)name inTeam:(nullable Team *)team;
 + (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants name:(nullable NSString *)name inTeam:(nullable Team *)team allowGuests:(BOOL)allowGuests;
++ (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipants:(nonnull NSArray <ZMUser *>*)participants name:(nullable NSString *)name inTeam:(nullable Team *)team allowGuests:(BOOL)allowGuests readReceipts:(BOOL)readReceipts;
 + (nullable instancetype)fetchOrCreateTeamConversationInManagedObjectContext:(nonnull NSManagedObjectContext *)moc withParticipant:(nonnull ZMUser *)participant team:(nonnull Team *)team;
 
 + (nonnull ZMConversationList *)conversationsIncludingArchivedInContext:(nonnull NSManagedObjectContext *)moc;

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -39,6 +39,7 @@ static NSString *const ConversationInfoTeamIdKey = @"team";
 static NSString *const ConversationInfoAccessModeKey = @"access";
 static NSString *const ConversationInfoAccessRoleKey = @"access_role";
 static NSString *const ConversationInfoMessageTimer = @"message_timer";
+static NSString *const ConversationInfoReceiptMode = @"receipt_mode";
 
 NSString *const ZMConversationInfoOTRMutedValueKey = @"otr_muted";
 NSString *const ZMConversationInfoOTRMutedStatusValueKey = @"otr_muted_status";
@@ -108,6 +109,11 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     NSUUID *teamId = [transportData optionalUuidForKey:ConversationInfoTeamIdKey];
     if (nil != teamId) {
         [self updateTeamWithIdentifier:teamId];
+    }
+    
+    NSNumber *receiptMode = [transportData optionalNumberForKey:ConversationInfoReceiptMode];
+    if (nil != receiptMode) {
+        self.hasReadReceiptsEnabled = receiptMode.intValue > 0;
     }
     
     self.accessModeStrings = [transportData optionalArrayForKey:ConversationInfoAccessModeKey];

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -422,12 +422,29 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
                                                         inTeam:(nullable Team *)team
                                                    allowGuests:(BOOL)allowGuests
 {
+    return [self insertGroupConversationIntoUserSession:session
+                                       withParticipants:participants
+                                                   name:name
+                                                 inTeam:team
+                                            allowGuests:allowGuests
+                                           readReceipts:NO];
+}
+
+
++ (nonnull instancetype)insertGroupConversationIntoUserSession:(nonnull id<ZMManagedObjectContextProvider> )session
+                                              withParticipants:(nonnull NSArray<ZMUser *> *)participants
+                                                          name:(nullable NSString*)name
+                                                        inTeam:(nullable Team *)team
+                                                   allowGuests:(BOOL)allowGuests
+                                                  readReceipts:(BOOL)readReceipts
+{
     VerifyReturnNil(session != nil);
     return [self insertGroupConversationIntoManagedObjectContext:session.managedObjectContext
                                                 withParticipants:participants
                                                             name:name
                                                           inTeam:team
-                                                     allowGuests:allowGuests];
+                                                     allowGuests:allowGuests
+                                                    readReceipts:readReceipts];
 }
 
 + (instancetype)existingOneOnOneConversationWithUser:(ZMUser *)otherUser inUserSession:(id<ZMManagedObjectContextProvider>)session;
@@ -851,6 +868,22 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
                                                                   inTeam:(nullable Team *)team
                                                              allowGuests:(BOOL)allowGuests
 {
+    return [self insertGroupConversationIntoManagedObjectContext:moc
+                                                withParticipants:participants
+                                                            name:name
+                                                          inTeam:team
+                                                     allowGuests:allowGuests
+                                                    readReceipts:NO];
+}
+
+
++ (nullable instancetype)insertGroupConversationIntoManagedObjectContext:(nonnull NSManagedObjectContext *)moc
+                                                        withParticipants:(nonnull NSArray <ZMUser *>*)participants
+                                                                    name:(nullable NSString *)name
+                                                                  inTeam:(nullable Team *)team
+                                                             allowGuests:(BOOL)allowGuests
+                                                            readReceipts:(BOOL)readReceipts
+{
     ZMUser *selfUser = [ZMUser selfUserInContext:moc];
 
     if (nil != team && !selfUser.canCreateConversation) {
@@ -865,6 +898,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     conversation.userDefinedName = name;
     if (nil != team) {
         conversation.allowGuests = allowGuests;
+        conversation.hasReadReceiptsEnabled = readReceipts;
     }
     
     for (ZMUser *participant in participants) {

--- a/Source/Public/ZMConversation.h
+++ b/Source/Public/ZMConversation.h
@@ -113,6 +113,14 @@ extern NSString * _Null_unspecified const ZMIsDimmedKey; ///< Specifies that a r
                                                         inTeam:(nullable Team *)team
                                                    allowGuests:(BOOL)allowGuests;
 
+/// Insert a new group conversation with name into the user session
++ (nonnull instancetype)insertGroupConversationIntoUserSession:(nonnull id<ZMManagedObjectContextProvider> )session
+                                              withParticipants:(nonnull NSArray<ZMUser *> *)participants
+                                                          name:(nullable NSString*)name
+                                                        inTeam:(nullable Team *)team
+                                                   allowGuests:(BOOL)allowGuests
+                                                  readReceipts:(BOOL)readReceipts;
+
 /// If that conversation exists, it is returned, @c nil otherwise.
 + (nullable instancetype)existingOneOnOneConversationWithUser:(nonnull ZMUser *)otherUser inUserSession:(nonnull id<ZMManagedObjectContextProvider> )session;
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -44,7 +44,8 @@
                                     silencedStatus:silencedStatus
                                             teamID:nil
                                         accessMode:@[]
-                                        accessRole:@"non_activated"];
+                                        accessRole:@"non_activated"
+                                       receiptMode:0];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
@@ -60,7 +61,8 @@
                                     silencedStatus:@(MutedMessageOptionValueAll)
                                             teamID:nil
                                         accessMode:@[]
-                                        accessRole:@"non_activated"];
+                                        accessRole:@"non_activated"
+                                       receiptMode:0];
 }
 
 - (NSDictionary *)payloadForMetaDataOfConversation:(ZMConversation *)conversation
@@ -74,6 +76,7 @@
                                             teamID:(NSUUID *)teamID
                                         accessMode:(NSArray<NSString *> *)accessMode
                                         accessRole:(NSString *)accessRole
+                                       receiptMode:(NSInteger)receiptMode
 {
     NSMutableArray *others = [NSMutableArray array];
     for (NSUUID *uuid in activeUserIDs) {
@@ -102,6 +105,7 @@
                               @"team": [teamID transportString] ?: [NSNull null],
                               @"access": accessMode,
                               @"access_role": accessRole,
+                              @"receipt_mode": @(receiptMode)
                               };
     return  payload;
 }
@@ -425,7 +429,8 @@
                                                         silencedStatus:@(MutedMessageOptionValueAll)
                                                                 teamID:teamID
                                                             accessMode:@[]
-                                                            accessRole:@"non_activated"];
+                                                            accessRole:@"non_activated"
+                                                           receiptMode:0];
 
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -477,7 +482,8 @@
                                                         silencedStatus:@(MutedMessageOptionValueAll)
                                                                 teamID:team.remoteIdentifier
                                                             accessMode:@[]
-                                                            accessRole:@"non_activated"];
+                                                            accessRole:@"non_activated"
+                                                           receiptMode:0];
 
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -530,7 +536,8 @@
                                                         silencedStatus:@(MutedMessageOptionValueAll)
                                                                 teamID:nil
                                                             accessMode:@[]
-                                                            accessRole:@"non_activated"];
+                                                            accessRole:@"non_activated"
+                                                           receiptMode:0];
 
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -577,7 +584,8 @@
                                                         silencedStatus:@(MutedMessageOptionValueAll)
                                                                 teamID:nil
                                                             accessMode:@[@"invite", @"code"]
-                                                            accessRole:@"non_activated"];
+                                                            accessRole:@"non_activated"
+                                                           receiptMode:0];
         
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -611,7 +619,8 @@
                                                         silencedStatus:@(MutedMessageOptionValueAll)
                                                                 teamID:nil
                                                             accessMode:@[]
-                                                            accessRole:@"team"];
+                                                            accessRole:@"team"
+                                                           receiptMode:0];
         
         // when
         [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
@@ -621,6 +630,38 @@
         XCTAssertEqual(conversation.accessRoleString, @"team");
         BOOL arraysEqual = [conversation.accessModeStrings isEqual:@[]];
         XCTAssertTrue(arraysEqual);
+    }];
+}
+
+- (void)testThatItUpdatesItselfFromTransportDataWithReceiptMode
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        // given
+        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        NSDate *serverTimestamp = [NSDate date];
+        NSUUID *uuid = NSUUID.createUUID;
+        conversation.remoteIdentifier = uuid;
+        
+        NSUUID *user1UUID = [NSUUID createUUID];
+        
+        NSDictionary *payload = [self payloadForMetaDataOfConversation:conversation
+                                                      conversationType:ZMConvTypeGroup
+                                                         activeUserIDs:@[user1UUID]
+                                                            isArchived:NO
+                                                           archivedRef:nil
+                                                            isSilenced:NO
+                                                           silencedRef:nil
+                                                        silencedStatus:@(MutedMessageOptionValueAll)
+                                                                teamID:nil
+                                                            accessMode:@[]
+                                                            accessRole:@"team"
+                                                           receiptMode:1];
+        
+        // when
+        [conversation updateWithTransportData:payload serverTimeStamp:serverTimestamp];
+        
+        // then
+        XCTAssertTrue(conversation.hasReadReceiptsEnabled);
     }];
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -192,6 +192,33 @@
     XCTAssertEqual(conversation.messages.count, 1u); // new conversation system message
 }
 
+- (void)testThatItSetsReceiptModeWhenCreatingAGroupConversationInATeam
+{
+    // given
+    ZMUser *otherUser1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *otherUser2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    
+    // when
+    ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.uiMOC withParticipants:@[otherUser1, otherUser2] name:@"abc" inTeam:team allowGuests:NO readReceipts:YES];
+    
+    // then
+    XCTAssertTrue(conversation.hasReadReceiptsEnabled);
+}
+
+- (void)testThatItReceiptModeIsIgnoredWhenCreatingAGroupConversationWithoutATeam
+{
+    // given
+    ZMUser *otherUser1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *otherUser2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    
+    // when
+    ZMConversation *conversation = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.uiMOC withParticipants:@[otherUser1, otherUser2] name:@"abc" inTeam:nil allowGuests:NO readReceipts:YES];
+    
+    // then
+    XCTAssertFalse(conversation.hasReadReceiptsEnabled);
+}
+
 - (void)testThatItHasLocallyModifiedDataFields
 {
     XCTAssertTrue([ZMConversation isTrackingLocalModifications]);


### PR DESCRIPTION
## What's new in this PR?

Support receipt mode when creating conversations when creating conversations locally or remotely.