### PR TITLE
Allow slow sync of user properties

### DIFF
--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -85,6 +85,7 @@ extern NSString * __nonnull const ReadReceiptsEnabledKey;
 
 - (void)setHandle:(NSString * __nullable)handle;
 - (void)setReadReceiptsEnabled:(BOOL)readReceiptsEnabled synchronize:(BOOL)synchronize;
+@property (nonatomic) BOOL needsPropertiesUpdate;
 @end
 
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -83,6 +83,7 @@ NSString *const AvailabilityKey = @"availability";
 static NSString *const ExpiresAtKey = @"expiresAt";
 static NSString *const UsesCompanyLoginKey = @"usesCompanyLogin";
 NSString *const ReadReceiptsEnabledKey = @"readReceiptsEnabled";
+NSString *const NeedsPropertiesUpdateKey = @"needsPropertiesUpdate";
 
 static NSString *const TeamIdentifierDataKey = @"teamIdentifier_data";
 static NSString *const TeamIdentifierKey = @"teamIdentifier";
@@ -894,6 +895,25 @@ static NSString *const TeamIdentifierKey = @"teamIdentifier";
         return [value boolValue];
     }
     return NO;
+}
+
+- (void)setNeedsPropertiesUpdate:(BOOL)needsPropertiesUpdate
+{
+    NSAssert(self.isSelfUser, @"setNeedsPropertiesUpdate called for non-self user");
+    [self.managedObjectContext setPersistentStoreMetadata:@(needsPropertiesUpdate) forKey:NeedsPropertiesUpdateKey];
+}
+
+- (BOOL)needsPropertiesUpdate
+{
+    NSAssert(self.isSelfUser, @"needsPropertiesUpdate called for non-self user");
+    NSNumber *currentValue = [self.managedObjectContext persistentStoreMetadataForKey:NeedsPropertiesUpdateKey];
+    if (nil == currentValue) {
+        /// We need to mark the self user properties to be re-fetched to get the initial value.
+        return YES;
+    }
+    else {
+        return currentValue.boolValue;
+    }
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

This adds one more key that indicates if the user properties must be synced.

It's set to true per default.