### PR TITLE
Fix broken image when an image upload fails

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -214,9 +214,12 @@ import Foundation
         self.transferState = .failedUpload
         
         // When we expire an asset message because the conversation degraded we do not want to send
-        // a `NOT UPLOADED` message. In all other cases we do want to sent a `NOT UPLOADED` 
-        // message to let the reveicers know we stopped uploading.
-        if self.uploadState == .uploadingPlaceholder {
+        // a `NOT UPLOADED` message. In all other cases we do want to sent a `NOT UPLOADED` message
+        // to let the receivers know we stopped uploading, except for images for which we don't send
+        // placeholders.
+        if isImage {
+            self.uploadState = .uploadingFailed
+        } else if self.uploadState == .uploadingPlaceholder {
             self.uploadState = .done
         } else {
             self.didFailToUploadFileData()

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -294,6 +294,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertFalse(sut.delivered)
         XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
         XCTAssertEqual(sut.uploadState.rawValue, AssetUploadState.uploadingFailed.rawValue)
+        XCTAssertTrue(sut.genericAssetMessage!.assetData!.hasNotUploaded())
         XCTAssertTrue(sut.isExpired)
     }
 
@@ -310,6 +311,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertFalse(sut.delivered)
         XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
         XCTAssertEqual(sut.uploadState.rawValue, AssetUploadState.uploadingFailed.rawValue)
+        XCTAssertTrue(sut.genericAssetMessage!.assetData!.hasNotUploaded())
         XCTAssertTrue(sut.isExpired)
     }
     
@@ -327,6 +329,7 @@ extension ZMAssetClientMessageTests {
             XCTAssertFalse(sut.delivered)
             XCTAssertEqual(sut.transferState.rawValue, ZMFileTransferState.failedUpload.rawValue)
             XCTAssertEqual(sut.uploadState, .uploadingFailed)
+            XCTAssertFalse(sut.genericAssetMessage!.assetData!.hasNotUploaded())
             XCTAssertTrue(sut.isExpired)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If an image upload times out while sending, re-sending it would send a broken image.

### Causes

We do not send placeholders for images while uploading them it therefore also doesn't make sense to send a "failed-to-upload" update for images like we do for files. When an asset message expire we didn't make a distinction between files and images so we were sending a "failed-to-upload" update for images when they expired. Upon successfully sending that update the image was marked as successfully sent since the rest of the image sending code were expecting to only send an update once the full image is uploaded.

### Solutions

Don't add an `NotUploaded` to image protobufs when they expire which will prevent the asset strategy from sending out an update. 