### PR TITLE
Expose needsReadConfirmation in the message protocol

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -61,6 +61,9 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     
     /// List of recipients who have read the message.
     var readReceipts: [ReadReceipt] { get }
+
+    /// Whether the message expects read confirmations.
+    var needsReadConfirmation: Bool { get }
     
     /// The textMessageData of the message which also contains potential link previews. If the message has no text, it will be nil
     var textMessageData : ZMTextMessageData? { get }


### PR DESCRIPTION
## What's new in this PR?

We add the `needsReadConfirmation` property to the `ZMConversationMessage` protocol to be able to access it and mock it from UI.