### PR TITLE
Allow editing read messages

### DIFF
--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -74,14 +74,16 @@ extension ZMMessage {
 }
 
 extension ZMClientMessage {
+    static let editableStates: Set<ZMDeliveryState> = Set([.sent, .delivered, .read])
+
     override var isEditableMessage : Bool {
         guard let genericMessage = genericMessage,
               let sender = sender, sender.isSelfUser
         else {
             return false
         }
-                
-        return genericMessage.hasEdited() || genericMessage.hasText() && !isEphemeral && (deliveryState == .sent || deliveryState == .delivered)
+        
+        return genericMessage.hasEdited() || genericMessage.hasText() && !isEphemeral && deliveryState.isOne(of: ZMClientMessage.editableStates)
     }
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1981,6 +1981,26 @@
     XCTAssertEqualObjects(conversation.lastEditableMessage, message);
 }
 
+- (void)testThatItReturnsMessageIfLastMessageIsTextRead
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    
+    // when
+    ZMMessage *message = (id)[conversation appendMessageWithText:@"Test Message"];
+    message.sender = self.selfUser;
+    [message markAsSent];
+
+    ZMMessageConfirmation *confirmation = [[ZMMessageConfirmation alloc] initWithContext:self.uiMOC];
+    confirmation.type = MessageConfirmationTypeRead;
+    
+    [[message mutableSetValueForKey:@"confirmations"] addObject:confirmation];
+    
+    XCTAssertEqual(message.deliveryState, ZMDeliveryStateRead);
+    
+    // then
+    XCTAssertEqualObjects(conversation.lastEditableMessage, message);
+}
 @end
 
 @implementation ZMConversationTests (Participants)


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is not possible to commit the edit on the read message.

### Causes

We forgot to update the enum use case where we've been checking if message is possible to edit: before we had sending, failed, sent, delivered states. Now we added the new seen state.

### Solutions

Consider the seen state.