### PR TITLE
ZIOS-10986: Allow liking message with read delivery state

### DIFF
--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -32,7 +32,7 @@ extension ZMMessage {
     
     static func appendReaction(_ unicodeValue: String?, toMessage message: ZMConversationMessage) -> ZMClientMessage? {
         guard let message = message as? ZMMessage, let context = message.managedObjectContext, let messageID = message.nonce else { return nil }
-        guard message.deliveryState == ZMDeliveryState.sent || message.deliveryState == ZMDeliveryState.delivered else { return nil }
+        guard message.deliveryState.isOne(of: .sent, .delivered, .read) else { return nil }
         
         let emoji = unicodeValue ?? ""
         let genericMessage = ZMGenericMessage.message(content: ZMReaction(emoji: emoji, messageID: messageID))    


### PR DESCRIPTION
## What's new in this PR?

### Issues

It was not possible to like your own message when it was marked as read.

### Causes

We only allowed liking messages it their delivery state was `delivered` or `sent`.

### Solutions

Add the missing check for `read` state.