### PR TITLE
Delete read and delivery receipts when deleting the message

### DIFF
--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -83,9 +83,16 @@ extension ZMMessage {
     }
 
     @objc public func clearAllReactions() {
+        let oldReactions = self.reactions
         reactions.removeAll()
         guard let moc = managedObjectContext else { return }
-        reactions.forEach(moc.delete)
+        oldReactions.forEach(moc.delete)
     }
     
+    @objc public func clearConfirmations() {
+        let oldConfirmations = self.confirmations
+        mutableSetValue(forKey: ZMMessageConfirmationKey).removeAllObjects()
+        guard let moc = managedObjectContext else { return }
+        oldConfirmations.forEach(moc.delete)
+    }
 }

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -62,6 +62,7 @@ extern NSString * _Nonnull const ZMMessageSystemMessageClientsKey;
 extern NSString * _Nonnull const ZMMessageDeliveryStateKey;
 extern NSString * _Nonnull const ZMMessageRepliesKey;
 extern NSString * _Nonnull const ZMMessageQuoteKey;
+extern NSString * _Nonnull const ZMMessageConfirmationKey;
 
 @interface ZMMessage : ZMManagedObject
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -336,7 +336,8 @@ NSString * const ZMMessageExpectReadConfirmationKey = @"expectsReadConfirmation"
     self.visibleInConversation = nil;
     self.replies = [[NSSet alloc] init];
     [self clearAllReactions];
-
+    [self clearConfirmations];
+    
     if (clearingSender) {
         self.sender = nil;
         self.senderClientID = nil;

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -280,6 +280,77 @@ extension ZMMessageTests_Confirmation {
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
     }
 
+    func testThatItDeletesConfirmationsForDeletedMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = .create()
+        conversation.conversationType = .group
+        conversation.hasReadReceiptsEnabled = true
+        
+        let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
+        remoteUser.remoteIdentifier = .create()
+        
+        let textMessage = insertMessage(conversation, fromSender: selfUser)
+        let confirmation = ZMMessageConfirmation(type: .read, message: textMessage.message!, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
+        textMessage.message!.mutableSetValue(forKey: "confirmations").add(confirmation)
+        
+        XCTAssertEqual(textMessage.message!.confirmations.count, 1)
+        // when
+        textMessage.message!.hideForSelfUser()
+        uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertEqual(textMessage.message!.confirmations.count, 0)
+        XCTAssertNil(confirmation.managedObjectContext)
+    }
+    
+    func testThatItDeletesConfirmationsForDeletedForEveryoneMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = .create()
+        conversation.conversationType = .group
+        conversation.hasReadReceiptsEnabled = true
+        
+        let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
+        remoteUser.remoteIdentifier = .create()
+        
+        let textMessage = insertMessage(conversation, fromSender: selfUser)
+        let confirmation = ZMMessageConfirmation(type: .read, message: textMessage.message!, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
+        textMessage.message!.mutableSetValue(forKey: "confirmations").add(confirmation)
+        
+        XCTAssertEqual(textMessage.message!.confirmations.count, 1)
+        // when
+        textMessage.message!.deleteForEveryone()
+        uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertEqual(textMessage.message!.confirmations.count, 0)
+        XCTAssertNil(confirmation.managedObjectContext)
+    }
+    
+    func testThatItKeepsConfirmationsForObfuscatedMessage() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        conversation.remoteIdentifier = .create()
+        conversation.conversationType = .group
+        conversation.hasReadReceiptsEnabled = true
+        
+        let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
+        remoteUser.remoteIdentifier = .create()
+        
+        let textMessage = insertMessage(conversation, fromSender: selfUser)
+        let confirmation = ZMMessageConfirmation(type: .read, message: textMessage.message!, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
+        textMessage.message!.mutableSetValue(forKey: "confirmations").add(confirmation)
+        
+        XCTAssertEqual(textMessage.message!.confirmations.count, 1)
+        // when
+        textMessage.message!.obfuscate()
+        uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertEqual(textMessage.message!.confirmations.count, 1)
+        XCTAssertNotNil(confirmation.managedObjectContext)
+    }
 }
 
 // MARK: - Receiving confirmation messages


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need to remove the confirmations when removing the message. The confirmations must persist when the message is obfuscated.

I added the code to assert the behavior and some tests on top.
