### PR TITLE
ZIOS-11007: Allow deleting read message

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -259,7 +259,7 @@ extension ZMMessage {
     
     
     @objc public var canBeDeleted : Bool {
-        return deliveryState == .delivered || deliveryState == .sent || deliveryState == .failedToSend
+        return deliveryState == .delivered || deliveryState == .sent || deliveryState == .failedToSend || deliveryState == .read
     }
     
     @objc public var hasBeenDeleted: Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read messages could not be deleted.

### Causes + Solutions

We were not allowing to delete the message if the state is read. We fixed the comparison to include the read state.

### Note

This issue happened a lot during the run, it would be good to look on the issue to identify ways we can catch new delivery state changes in the future.