### PR TITLE
Fix observering of read receipts on assets

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -50,7 +50,8 @@ extension ZMAssetClientMessage {
                               #keyPath(ZMAssetClientMessage.hasDownloadedImage),
                               #keyPath(ZMAssetClientMessage.hasDownloadedFile),
                               #keyPath(ZMAssetClientMessage.progress),
-                              #keyPath(ZMMessage.reactions)]
+                              #keyPath(ZMMessage.reactions),
+                              #keyPath(ZMMessage.confirmations)]
         return keys.union(additionalKeys)
     }
 }

--- a/Tests/Source/Model/Observer/MessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/MessageObserverTests.swift
@@ -306,6 +306,21 @@ class MessageObserverTests : NotificationDispatcherTestBase {
         )
     }
     
+    func testThatItNotifiesWhenUserReadsTheMessage_Asset() {
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let message = conversation.append(imageFromData: verySmallJPEGData())  as! ZMAssetClientMessage
+        uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(
+            message,
+            modifier: { _ in
+                let _ = ZMMessageConfirmation(type: .read, message: message, sender: ZMUser.selfUser(in: uiMOC), serverTimestamp: Date(), managedObjectContext: uiMOC)
+        },
+            expectedChangedFields: [#keyPath(MessageChangeInfo.confirmationsChanged), #keyPath(MessageChangeInfo.deliveryStateChanged)]
+        )
+    }
+    
     func testThatItNotifiesConversationWhenMessageGenericDataIsChanged() {
         
         let clientMessage = ZMClientMessage(nonce: UUID.create(), managedObjectContext: uiMOC)


### PR DESCRIPTION
## What's new in this PR?

### Issues

List of read receipts didn't live update for assets

### Causes

The `confirmations` property wasn't included in the list observable keys for asset messages.

### Solutions

Make The `confirmations` property observable.