### PR TITLE
Feature/permissions roles

### DIFF
--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -126,6 +126,18 @@ extension Permissions: Hashable {
         case .owner:   return .owner
         }
     }
+    
+    /// Returns true if the role encompasses the given role.
+    /// E.g An admin is a member, but a member is not an admin.
+    func isA(role: TeamRole) -> Bool {
+        return hasPermissions(role.permissions)
+    }
+    
+    
+    /// Returns true if the role contains (all) the permissions.
+    func hasPermissions(_ permissions: Permissions) -> Bool {
+        return self.permissions.isSuperset(of: permissions)
+    }
 }
 
 extension Member {

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -101,7 +101,7 @@ extension Permissions: Hashable {
 @objc public enum TeamRole: Int {
     case none, partner, member, admin, owner
     
-    init(rawPermissions: Int64) {
+    public init(rawPermissions: Int64) {
         switch rawPermissions {
         case Permissions.partner.rawValue:
             self = .partner
@@ -117,7 +117,7 @@ extension Permissions: Hashable {
     }
     
     /// The permissions granted to this role.
-    var permissions: Permissions {
+    public var permissions: Permissions {
         switch self {
         case .none:    return Permissions(rawValue: 0)
         case .partner: return .partner
@@ -129,13 +129,13 @@ extension Permissions: Hashable {
     
     /// Returns true if the role encompasses the given role.
     /// E.g An admin is a member, but a member is not an admin.
-    func isA(role: TeamRole) -> Bool {
+    public func isA(role: TeamRole) -> Bool {
         return hasPermissions(role.permissions)
     }
     
     
     /// Returns true if the role contains (all) the permissions.
-    func hasPermissions(_ permissions: Permissions) -> Bool {
+    public func hasPermissions(_ permissions: Permissions) -> Bool {
         return self.permissions.isSuperset(of: permissions)
     }
 }

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -46,6 +46,9 @@ public protocol UserType: NSObjectProtocol {
     /// Whether this is the member of a team
     var isTeamMember: Bool { get }
 
+    /// The role (and permissions) e.g. partner, member, admin, owner
+    var teamRole: TeamRole { get }
+    
     /// Whether this is a service user (bot)
     var isServiceUser: Bool { get }
     

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -191,6 +191,12 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         return user.isTeamMember
     }
     
+    public var teamRole: TeamRole {
+        guard let user = user else { return .none }
+        
+        return user.teamRole
+    }
+    
     public var isServiceUser: Bool {
         return providerIdentifier != nil
     }

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -28,6 +28,10 @@ public extension ZMUser {
         return membership?.team
     }
     
+    public var teamRole: TeamRole {
+        return TeamRole(rawPermissions: membership?.permissions.rawValue ?? 0)
+    }
+    
     @objc static func keyPathsForValuesAffectingTeam() -> Set<String> {
          return [#keyPath(ZMUser.membership)]
     }

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -32,12 +32,12 @@ public extension ZMUser {
         return TeamRole(rawPermissions: membership?.permissions.rawValue ?? 0)
     }
     
+    var permissions: Permissions? {
+        return membership?.permissions
+    }
+    
     @objc static func keyPathsForValuesAffectingTeam() -> Set<String> {
          return [#keyPath(ZMUser.membership)]
-    }
-
-    public var permissions: Permissions? {
-        return membership?.permissions
     }
 
     @objc(canAddUserToConversation:)

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -29,10 +29,10 @@ public extension ZMUser {
     }
     
     public var teamRole: TeamRole {
-        return TeamRole(rawPermissions: membership?.permissions.rawValue ?? 0)
+        return TeamRole(rawPermissions: permissions?.rawValue ?? 0)
     }
     
-    var permissions: Permissions? {
+    private var permissions: Permissions? {
         return membership?.permissions
     }
     

--- a/Tests/Source/Model/MemberTests.swift
+++ b/Tests/Source/Model/MemberTests.swift
@@ -47,7 +47,7 @@ class MemberTests: BaseTeamTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.1))
 
         // then
-        XCTAssertEqual(user.permissions, .member)
+        XCTAssertEqual(user.teamRole.permissions, .member)
     }
 
     func testThatItReturnsIfAUserIsMemberOfATeam() {
@@ -104,7 +104,7 @@ class MemberTests: BaseTeamTests {
         XCTAssertTrue(user.isTeamMember)
         XCTAssertEqual(user.team, team)
         XCTAssertTrue(user.hasTeam)
-        XCTAssertEqual(user.permissions, .member)
+        XCTAssertEqual(user.teamRole.permissions, .member)
     }
 
     func testThatItReturnsExistingMemberOfAUserInATeam() {

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -114,18 +114,18 @@ class PermissionsTests: BaseZMClientMessageTests {
     // MARK: - Objective-C Interoperability
 
     func testThatItCreatesTheCorrectSwiftPermissions() {
-        XCTAssertEqual(PermissionsObjC.partner.permissions, .partner)
-        XCTAssertEqual(PermissionsObjC.member.permissions, .member)
-        XCTAssertEqual(PermissionsObjC.admin.permissions, .admin)
-        XCTAssertEqual(PermissionsObjC.owner.permissions, .owner)
+        XCTAssertEqual(TeamRole.partner.permissions, .partner)
+        XCTAssertEqual(TeamRole.member.permissions, .member)
+        XCTAssertEqual(TeamRole.admin.permissions, .admin)
+        XCTAssertEqual(TeamRole.owner.permissions, .owner)
     }
 
-    func testThatItSetsObjectiveCPermissions() {
+    func testThatItSetsTeamRolePermissions() {
         // given
         let member = Member.insertNewObject(in: uiMOC)
 
         // when
-        member.setPermissionsObjC(.admin)
+        member.setTeamRole(.admin)
 
         // then
         XCTAssertEqual(member.permissions, .admin)

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -111,7 +111,7 @@ class PermissionsTests: BaseZMClientMessageTests {
         XCTAssertEqual(Permissions(rawValue: 0), [])
     }
 
-    // MARK: - Objective-C Interoperability
+    // MARK: - TeamRole (Objective-C Interoperability)
 
     func testThatItCreatesTheCorrectSwiftPermissions() {
         XCTAssertEqual(TeamRole.partner.permissions, .partner)
@@ -131,4 +131,35 @@ class PermissionsTests: BaseZMClientMessageTests {
         XCTAssertEqual(member.permissions, .admin)
     }
 
+    func testTeamRoleIsARelationships() {
+        XCTAssert(TeamRole.none.isA(role: .none))
+        XCTAssertFalse(TeamRole.none.isA(role: .partner))
+        XCTAssertFalse(TeamRole.none.isA(role: .member))
+        XCTAssertFalse(TeamRole.none.isA(role: .admin))
+        XCTAssertFalse(TeamRole.none.isA(role: .owner))
+        
+        XCTAssert(TeamRole.partner.isA(role: .none))
+        XCTAssert(TeamRole.partner.isA(role: .partner))
+        XCTAssertFalse(TeamRole.partner.isA(role: .member))
+        XCTAssertFalse(TeamRole.partner.isA(role: .admin))
+        XCTAssertFalse(TeamRole.partner.isA(role: .owner))
+        
+        XCTAssert(TeamRole.member.isA(role: .none))
+        XCTAssert(TeamRole.member.isA(role: .partner))
+        XCTAssert(TeamRole.member.isA(role: .member))
+        XCTAssertFalse(TeamRole.member.isA(role: .admin))
+        XCTAssertFalse(TeamRole.member.isA(role: .owner))
+        
+        XCTAssert(TeamRole.admin.isA(role: .none))
+        XCTAssert(TeamRole.admin.isA(role: .partner))
+        XCTAssert(TeamRole.admin.isA(role: .member))
+        XCTAssert(TeamRole.admin.isA(role: .admin))
+        XCTAssertFalse(TeamRole.admin.isA(role: .owner))
+        
+        XCTAssert(TeamRole.owner.isA(role: .none))
+        XCTAssert(TeamRole.owner.isA(role: .partner))
+        XCTAssert(TeamRole.owner.isA(role: .member))
+        XCTAssert(TeamRole.owner.isA(role: .admin))
+        XCTAssert(TeamRole.owner.isA(role: .owner))
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

This PR introduces some abstractions over user permissions. This addresses both Objective C interoperability issues as well as semantic clarifications. 

### Issues

Currently we define permissions with a Swift `OptionSet` which defines individual permissions mapped to backend values. These permissions form bit masks that correspond to roles, of which there are four: partner, member, admin and owner.

To provide Objective C interoperability, there exists a `PermissionsObjC` enum which contains cases for only these four roles, from which the individual `Permissions` are accessible.

The main issues relate to mocking the `ZMUser` (in the UI framework) to be able to easily test permissions. We need a way to mock these permissions, without needing to mock the membership of a user (which is where the permissions are actually stored). This is currently not so simple.

Furthermore, it is unclear from a `Permissions` value what the associated role is, without comparing against a bit mask.

### Solutions

1. Rename and adapt `PermissionsObjC` to `TeamRole`.
2. Add a `teamRole` property to the `UserType` protocol
3. Implement this property on `ZMUser`.
4. Hide the `permissions` property on `ZMUser` (this is now accessible through `teamRole.permissions`.

## Notes

To mock permissions, you just need to add a `teamRole` property to `MockUser` (in UI). Then you can easily gain access to the permissions.

Additionally, there are some helper methods define on `TeamRole` to determine relationships between roles. For example, an `admin` is a `member`, but a `member` is not an `admin`.