### PR TITLE
Do not create timers if they already exist

### DIFF
--- a/Source/Model/Message/Ephemeral/ZMMessageDestructionTimer.swift
+++ b/Source/Model/Message/Ephemeral/ZMMessageDestructionTimer.swift
@@ -33,7 +33,7 @@ public extension NSManagedObjectContext {
     
     @objc public var zm_messageObfuscationTimer : ZMMessageDestructionTimer? {
         precondition(zm_isSyncContext, "MessageObfuscationTimer should be started only on the syncContext")
-
+        
         return userInfo[MessageObfuscationTimerKey] as? ZMMessageDestructionTimer
     }
     
@@ -44,7 +44,7 @@ public extension NSManagedObjectContext {
             log.debug("Obfuscation timer already exists, skipping")
             return 
         }
-        
+
         userInfo[MessageObfuscationTimerKey] = ZMMessageDestructionTimer(managedObjectContext: self)
         log.debug("creating obfuscation timer")
     }

--- a/Source/Model/Message/Ephemeral/ZMMessageDestructionTimer.swift
+++ b/Source/Model/Message/Ephemeral/ZMMessageDestructionTimer.swift
@@ -26,33 +26,35 @@ private let log = ZMSLog(tag: "ephemeral")
 public extension NSManagedObjectContext {
     
     @objc public var zm_messageDeletionTimer : ZMMessageDestructionTimer? {
-        if !zm_isUserInterfaceContext {
-            preconditionFailure("MessageDeletionTimerKey should be started only on the uiContext")
-        }
-
+        precondition(zm_isUserInterfaceContext, "MessageDeletionTimerKey should be started only on the uiContext")
+        
         return userInfo[MessageDeletionTimerKey] as? ZMMessageDestructionTimer
     }
     
     @objc public var zm_messageObfuscationTimer : ZMMessageDestructionTimer? {
-        if !zm_isSyncContext {
-            preconditionFailure("MessageObfuscationTimer should be started only on the syncContext")
-        }
-        
+        precondition(zm_isSyncContext, "MessageObfuscationTimer should be started only on the syncContext")
+
         return userInfo[MessageObfuscationTimerKey] as? ZMMessageDestructionTimer
     }
     
     @objc public func zm_createMessageObfuscationTimer() {
-        if !zm_isSyncContext {
-            preconditionFailure("MessageObfuscationTimer should be started only on the syncContext")
+        precondition(zm_isSyncContext, "MessageObfuscationTimer should be started only on the syncContext")
+        
+        guard userInfo[MessageObfuscationTimerKey] == nil else {
+            log.debug("Obfuscation timer already exists, skipping")
+            return 
         }
-
+        
         userInfo[MessageObfuscationTimerKey] = ZMMessageDestructionTimer(managedObjectContext: self)
         log.debug("creating obfuscation timer")
     }
     
-    @objc public func zm_createMessageDeletionTimer() {        
-        if !zm_isUserInterfaceContext {
-            preconditionFailure("MessageDeletionTimer should be started only on the uiContext")
+    @objc public func zm_createMessageDeletionTimer() {            
+        precondition(zm_isUserInterfaceContext, "MessageDeletionTimer should be started only on the uiContext")
+        
+        guard userInfo[MessageDeletionTimerKey] == nil else {
+            log.debug("Deletion timer already exists, skipping")
+            return 
         }
 
         userInfo[MessageDeletionTimerKey] = ZMMessageDestructionTimer(managedObjectContext: self)
@@ -62,9 +64,7 @@ public extension NSManagedObjectContext {
     /// Tears down zm_messageObfuscationTimer and zm_messageDeletionTimer
     /// Call inside a performGroupedBlock(AndWait) when calling it from another context
     @objc public func zm_teardownMessageObfuscationTimer() {
-        if !zm_isSyncContext {
-            preconditionFailure("MessageObfuscationTimer is located on the syncContext")
-        }
+        precondition(zm_isSyncContext, "MessageObfuscationTimer is located on the syncContext")
         if let timer = userInfo[MessageObfuscationTimerKey] as? ZMMessageDestructionTimer {
             timer.tearDown()
             userInfo.removeObject(forKey: MessageObfuscationTimerKey)
@@ -75,9 +75,7 @@ public extension NSManagedObjectContext {
     /// Tears down zm_messageDeletionTimer
     /// Call inside a performGroupedBlock(AndWait) when calling it from another context
     @objc public func zm_teardownMessageDeletionTimer() {
-        if !zm_isUserInterfaceContext {
-            preconditionFailure("MessageDeletionTimerKey is located on the uiContext")
-        }
+        precondition(zm_isUserInterfaceContext, "MessageDeletionTimerKey is located on the uiContext")
         if let timer = userInfo[MessageDeletionTimerKey] as? ZMMessageDestructionTimer {
             timer.tearDown()
             userInfo.removeObject(forKey: MessageDeletionTimerKey)


### PR DESCRIPTION
## What's new in this PR?

### Issues

After #648 we have added API for creating timers explicitly. It was not very robust, because it would re-create timers if they existed.

### Solutions

Create timers only if they don't exist.

## Notes

Tweaked the checks for correct MOC from:

```swift
if(!zm_isUserInterfaceContext) {
   preconditionFailure("must be UI MOC")
}
```

to a simpler

```swift
precondition(zm_isUserInterfaceContext, "must be UI MOC")
```