### PR TITLE
Feature/permissions update list

### DIFF
--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -47,10 +47,10 @@ public struct Permissions: OptionSet {
     // to establish a bijective mapping between these four bitmasks and the four
     // cases of the TeamRole enum.
     
-    public static let partner: Permissions = [.createConversation, .getTeamConversations]
-    public static let member: Permissions = [.partner, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
-    public static let admin: Permissions  = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
-    public static let owner: Permissions  = [.admin, .getBilling, .setBilling, .deleteTeam]
+    public static let collaborator: Permissions = [.createConversation, .getTeamConversations]
+    public static let member:       Permissions = [.collaborator, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
+    public static let admin:        Permissions = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
+    public static let owner:        Permissions = [.admin, .getBilling, .setBilling, .deleteTeam]
 
 }
 
@@ -99,12 +99,12 @@ extension Permissions: Hashable {
 /// specific users.
 ///
 @objc public enum TeamRole: Int {
-    case none, partner, member, admin, owner
+    case none, collaborator, member, admin, owner
     
     public init(rawPermissions: Int64) {
         switch rawPermissions {
-        case Permissions.partner.rawValue:
-            self = .partner
+        case Permissions.collaborator.rawValue:
+            self = .collaborator
         case Permissions.member.rawValue:
             self = .member
         case Permissions.admin.rawValue:
@@ -119,11 +119,11 @@ extension Permissions: Hashable {
     /// The permissions granted to this role.
     public var permissions: Permissions {
         switch self {
-        case .none:    return Permissions(rawValue: 0)
-        case .partner: return .partner
-        case .member:  return .member
-        case .admin:   return .admin
-        case .owner:   return .owner
+        case .none:         return Permissions(rawValue: 0)
+        case .collaborator: return .collaborator
+        case .member:       return .member
+        case .admin:        return .admin
+        case .owner:        return .owner
         }
     }
     

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -26,6 +26,7 @@ public struct Permissions: OptionSet {
     }
 
     // MARK: - Base Values
+    public static let none                        = Permissions(rawValue: 0x0000)
     public static let createConversation          = Permissions(rawValue: 0x0001)
     public static let deleteConversation          = Permissions(rawValue: 0x0002)
     public static let addTeamMember               = Permissions(rawValue: 0x0004)
@@ -119,7 +120,7 @@ extension Permissions: Hashable {
     /// The permissions granted to this role.
     public var permissions: Permissions {
         switch self {
-        case .none:         return Permissions(rawValue: 0)
+        case .none:         return .none
         case .collaborator: return .collaborator
         case .member:       return .member
         case .admin:        return .admin

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -26,19 +26,19 @@ public struct Permissions: OptionSet {
     }
 
     // MARK: - Base Values
-    public static let createConversation       = Permissions(rawValue: 0x0001)
-    public static let deleteConversation       = Permissions(rawValue: 0x0002)
-    public static let addTeamMember            = Permissions(rawValue: 0x0004)
-    public static let removeTeamMember         = Permissions(rawValue: 0x0008)
-    public static let addConversationMember    = Permissions(rawValue: 0x0010)
-    public static let removeConversationMember = Permissions(rawValue: 0x0020)
-    public static let getBilling               = Permissions(rawValue: 0x0040)
-    public static let setBilling               = Permissions(rawValue: 0x0080)
-    public static let setTeamData              = Permissions(rawValue: 0x0100)
-    public static let getMemberPermissions     = Permissions(rawValue: 0x0200)
-    public static let getTeamConversations     = Permissions(rawValue: 0x0400)
-    public static let deleteTeam               = Permissions(rawValue: 0x0800)
-    public static let setMemberPermissions     = Permissions(rawValue: 0x1000)
+    public static let createConversation          = Permissions(rawValue: 0x0001)
+    public static let deleteConversation          = Permissions(rawValue: 0x0002)
+    public static let addTeamMember               = Permissions(rawValue: 0x0004)
+    public static let removeTeamMember            = Permissions(rawValue: 0x0008)
+    public static let addRemoveConversationMember = Permissions(rawValue: 0x0010)
+    public static let modifyConversationMetaData  = Permissions(rawValue: 0x0020)
+    public static let getBilling                  = Permissions(rawValue: 0x0040)
+    public static let setBilling                  = Permissions(rawValue: 0x0080)
+    public static let setTeamData                 = Permissions(rawValue: 0x0100)
+    public static let getMemberPermissions        = Permissions(rawValue: 0x0200)
+    public static let getTeamConversations        = Permissions(rawValue: 0x0400)
+    public static let deleteTeam                  = Permissions(rawValue: 0x0800)
+    public static let setMemberPermissions        = Permissions(rawValue: 0x1000)
 
     // MARK: - Common Combined Values
 
@@ -48,7 +48,7 @@ public struct Permissions: OptionSet {
     // cases of the TeamRole enum.
     
     public static let partner: Permissions = [.createConversation, .getTeamConversations]
-    public static let member: Permissions = [.partner, .deleteConversation, .addConversationMember, .removeConversationMember, .getMemberPermissions]
+    public static let member: Permissions = [.partner, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
     public static let admin: Permissions  = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
     public static let owner: Permissions  = [.admin, .getBilling, .setBilling, .deleteTeam]
 
@@ -65,8 +65,8 @@ extension Permissions: CustomDebugStringConvertible {
         .deleteConversation: "DeleteConversation",
         .addTeamMember: "AddTeamMember",
         .removeTeamMember: "RemoveTeamMember",
-        .addConversationMember: "AddConversationMember",
-        .removeConversationMember: "RemoveConversationMember",
+        .addRemoveConversationMember: "AddRemoveConversationMember",
+        .modifyConversationMetaData: "ModifyConversationMetaData",
         .getMemberPermissions: "GetMemberPermissions",
         .getTeamConversations: "GetTeamConversations",
         .getBilling : "GetBilling",

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -43,13 +43,13 @@ public extension ZMUser {
     @objc(canAddUserToConversation:)
     public func canAddUser(to conversation: ZMConversation) -> Bool {
         guard !isGuest(in: conversation), conversation.isSelfAnActiveMember else { return false }
-        return permissions?.contains(.addConversationMember) ?? true
+        return permissions?.contains(.addRemoveConversationMember) ?? true
     }
 
     @objc(canRemoveUserFromConversation:)
     public func canRemoveUser(from conversation: ZMConversation) -> Bool {
         guard !isGuest(in: conversation), conversation.isSelfAnActiveMember else { return false }
-        return permissions?.contains(.removeConversationMember) ?? true
+        return permissions?.contains(.addRemoveConversationMember) ?? true
     }
 
     @objc public var canCreateConversation: Bool {

--- a/Tests/Source/Model/MemberTests.swift
+++ b/Tests/Source/Model/MemberTests.swift
@@ -174,14 +174,14 @@ extension MemberTests {
 
             let payload: [String: Any] = [
                 "user": user.remoteIdentifier!.transportString(),
-                "permissions": ["self": 33, "copy": 0]
+                "permissions": ["self": 17, "copy": 0]
             ]
 
             // when
             member.updatePermissions(with: payload)
 
             // then
-            XCTAssertEqual(member.permissions, [.createConversation, .removeConversationMember])
+            XCTAssertEqual(member.permissions, [.createConversation, .addRemoveConversationMember])
         }
     }
 

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -41,7 +41,7 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     func testThatDefaultValueDoesNotHaveAnyPermissions() {
         // given
-        let sut = Permissions(rawValue: 0)
+        let sut = Permissions.none
 
         // then
         XCTAssertFalse(sut.contains(.createConversation))
@@ -108,7 +108,7 @@ class PermissionsTests: BaseZMClientMessageTests {
     }
 
     func testThatItCreatesEmptyPermissionsFromEmptyPayload() {
-        XCTAssertEqual(Permissions(rawValue: 0), [])
+        XCTAssertEqual(Permissions.none, [])
     }
 
     // MARK: - TeamRole (Objective-C Interoperability)

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -71,7 +71,7 @@ class PermissionsTests: BaseZMClientMessageTests {
         ]
 
         // then
-        XCTAssertEqual(Permissions.partner, permissions)
+        XCTAssertEqual(Permissions.collaborator, permissions)
     }
 
     func testAdminPermissions() {
@@ -101,7 +101,7 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     func testThatItCreatesPermissionsFromPayload() {
         XCTAssertEqual(Permissions(rawValue: 5), [.createConversation, .addTeamMember])
-        XCTAssertEqual(Permissions(rawValue: 0x401), .partner)
+        XCTAssertEqual(Permissions(rawValue: 0x401), .collaborator)
         XCTAssertEqual(Permissions(rawValue: 1587), .member)
         XCTAssertEqual(Permissions(rawValue: 5951), .admin)
         XCTAssertEqual(Permissions(rawValue: 8191), .owner)
@@ -114,7 +114,7 @@ class PermissionsTests: BaseZMClientMessageTests {
     // MARK: - TeamRole (Objective-C Interoperability)
 
     func testThatItCreatesTheCorrectSwiftPermissions() {
-        XCTAssertEqual(TeamRole.partner.permissions, .partner)
+        XCTAssertEqual(TeamRole.collaborator.permissions, .collaborator)
         XCTAssertEqual(TeamRole.member.permissions, .member)
         XCTAssertEqual(TeamRole.admin.permissions, .admin)
         XCTAssertEqual(TeamRole.owner.permissions, .owner)
@@ -133,31 +133,31 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     func testTeamRoleIsARelationships() {
         XCTAssert(TeamRole.none.isA(role: .none))
-        XCTAssertFalse(TeamRole.none.isA(role: .partner))
+        XCTAssertFalse(TeamRole.none.isA(role: .collaborator))
         XCTAssertFalse(TeamRole.none.isA(role: .member))
         XCTAssertFalse(TeamRole.none.isA(role: .admin))
         XCTAssertFalse(TeamRole.none.isA(role: .owner))
         
-        XCTAssert(TeamRole.partner.isA(role: .none))
-        XCTAssert(TeamRole.partner.isA(role: .partner))
-        XCTAssertFalse(TeamRole.partner.isA(role: .member))
-        XCTAssertFalse(TeamRole.partner.isA(role: .admin))
-        XCTAssertFalse(TeamRole.partner.isA(role: .owner))
+        XCTAssert(TeamRole.collaborator.isA(role: .none))
+        XCTAssert(TeamRole.collaborator.isA(role: .collaborator))
+        XCTAssertFalse(TeamRole.collaborator.isA(role: .member))
+        XCTAssertFalse(TeamRole.collaborator.isA(role: .admin))
+        XCTAssertFalse(TeamRole.collaborator.isA(role: .owner))
         
         XCTAssert(TeamRole.member.isA(role: .none))
-        XCTAssert(TeamRole.member.isA(role: .partner))
+        XCTAssert(TeamRole.member.isA(role: .collaborator))
         XCTAssert(TeamRole.member.isA(role: .member))
         XCTAssertFalse(TeamRole.member.isA(role: .admin))
         XCTAssertFalse(TeamRole.member.isA(role: .owner))
         
         XCTAssert(TeamRole.admin.isA(role: .none))
-        XCTAssert(TeamRole.admin.isA(role: .partner))
+        XCTAssert(TeamRole.admin.isA(role: .collaborator))
         XCTAssert(TeamRole.admin.isA(role: .member))
         XCTAssert(TeamRole.admin.isA(role: .admin))
         XCTAssertFalse(TeamRole.admin.isA(role: .owner))
         
         XCTAssert(TeamRole.owner.isA(role: .none))
-        XCTAssert(TeamRole.owner.isA(role: .partner))
+        XCTAssert(TeamRole.owner.isA(role: .collaborator))
         XCTAssert(TeamRole.owner.isA(role: .member))
         XCTAssert(TeamRole.owner.isA(role: .admin))
         XCTAssert(TeamRole.owner.isA(role: .owner))

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -28,8 +28,8 @@ class PermissionsTests: BaseZMClientMessageTests {
         .deleteConversation,
         .addTeamMember,
         .removeTeamMember,
-        .addConversationMember,
-        .removeConversationMember,
+        .addRemoveConversationMember,
+        .modifyConversationMetaData,
         .getMemberPermissions,
         .getTeamConversations,
         .getBilling,
@@ -48,8 +48,8 @@ class PermissionsTests: BaseZMClientMessageTests {
         XCTAssertFalse(sut.contains(.deleteConversation))
         XCTAssertFalse(sut.contains(.addTeamMember))
         XCTAssertFalse(sut.contains(.removeTeamMember))
-        XCTAssertFalse(sut.contains(.addConversationMember))
-        XCTAssertFalse(sut.contains(.removeConversationMember))
+        XCTAssertFalse(sut.contains(.addRemoveConversationMember))
+        XCTAssertFalse(sut.contains(.modifyConversationMetaData))
         XCTAssertFalse(sut.contains(.getMemberPermissions))
         XCTAssertFalse(sut.contains(.getTeamConversations))
         XCTAssertFalse(sut.contains(.getBilling))
@@ -60,7 +60,7 @@ class PermissionsTests: BaseZMClientMessageTests {
     }
 
     func testMemberPermissions() {
-        XCTAssertEqual(Permissions.member, [.createConversation, .deleteConversation, .addConversationMember, .removeConversationMember, .getMemberPermissions, .getTeamConversations])
+        XCTAssertEqual(Permissions.member, [.createConversation, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions, .getTeamConversations])
     }
 
     func testPartnerPermissions() {
@@ -79,8 +79,8 @@ class PermissionsTests: BaseZMClientMessageTests {
         let adminPermissions: Permissions = [
             .createConversation,
             .deleteConversation,
-            .addConversationMember,
-            .removeConversationMember,
+            .addRemoveConversationMember,
+            .modifyConversationMetaData,
             .getMemberPermissions,
             .getTeamConversations,
             .addTeamMember,

--- a/Tests/Source/Model/ZMConversation+TeamsTests.swift
+++ b/Tests/Source/Model/ZMConversation+TeamsTests.swift
@@ -87,7 +87,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
             // when
             let selfUser = ZMUser.selfUser(in: self.uiMOC)
             let member = Member.getOrCreateMember(for: selfUser, in: self.team, context: self.uiMOC)
-            member.permissions = Permissions(rawValue: 0)
+            member.permissions = Permissions.none
             self.conversation.team = self.team
             
             // then
@@ -134,7 +134,7 @@ class ZMConversationTests_Teams: BaseTeamTests {
             // when
             let selfUser = ZMUser.selfUser(in: self.uiMOC)
             let member = Member.getOrCreateMember(for: selfUser, in: self.team, context: self.uiMOC)
-            member.permissions = Permissions(rawValue: 0)
+            member.permissions = Permissions.none
             self.conversation.team = self.team
             
             // then


### PR DESCRIPTION
## What's new in this PR?

## Changes
- As per BE specs, the two permissions `addConversationMember` and `removeConversationMember` have been merged into `addRemoveConversationMember`.
- Renamed `partner` to `collaborator`.

## New
- Added `none` property to `Permissions`.