### PR TITLE
Rename collaborator to partner

### DIFF
--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -49,10 +49,10 @@ public struct Permissions: OptionSet {
     // to establish a bijective mapping between these four bitmasks and the four
     // cases of the TeamRole enum.
     
-    public static let collaborator: Permissions = [.createConversation, .getTeamConversations]
-    public static let member:       Permissions = [.collaborator, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
-    public static let admin:        Permissions = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
-    public static let owner:        Permissions = [.admin, .getBilling, .setBilling, .deleteTeam]
+    public static let partner: Permissions = [.createConversation, .getTeamConversations]
+    public static let member:  Permissions = [.partner, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
+    public static let admin:   Permissions = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
+    public static let owner:   Permissions = [.admin, .getBilling, .setBilling, .deleteTeam]
 
 }
 
@@ -101,12 +101,12 @@ extension Permissions: Hashable {
 /// specific users.
 ///
 @objc public enum TeamRole: Int {
-    case none, collaborator, member, admin, owner
+    case none, partner, member, admin, owner
     
     public init(rawPermissions: Int64) {
         switch rawPermissions {
-        case Permissions.collaborator.rawValue:
-            self = .collaborator
+        case Permissions.partner.rawValue:
+            self = .partner
         case Permissions.member.rawValue:
             self = .member
         case Permissions.admin.rawValue:
@@ -121,11 +121,11 @@ extension Permissions: Hashable {
     /// The permissions granted to this role.
     public var permissions: Permissions {
         switch self {
-        case .none:         return .none
-        case .collaborator: return .collaborator
-        case .member:       return .member
-        case .admin:        return .admin
-        case .owner:        return .owner
+        case .none:    return .none
+        case .partner: return .partner
+        case .member:  return .member
+        case .admin:   return .admin
+        case .owner:   return .owner
         }
     }
     

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -71,7 +71,7 @@ class PermissionsTests: BaseZMClientMessageTests {
         ]
 
         // then
-        XCTAssertEqual(Permissions.collaborator, permissions)
+        XCTAssertEqual(Permissions.partner, permissions)
     }
 
     func testAdminPermissions() {
@@ -101,7 +101,7 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     func testThatItCreatesPermissionsFromPayload() {
         XCTAssertEqual(Permissions(rawValue: 5), [.createConversation, .addTeamMember])
-        XCTAssertEqual(Permissions(rawValue: 0x401), .collaborator)
+        XCTAssertEqual(Permissions(rawValue: 0x401), .partner)
         XCTAssertEqual(Permissions(rawValue: 1587), .member)
         XCTAssertEqual(Permissions(rawValue: 5951), .admin)
         XCTAssertEqual(Permissions(rawValue: 8191), .owner)
@@ -114,7 +114,7 @@ class PermissionsTests: BaseZMClientMessageTests {
     // MARK: - TeamRole (Objective-C Interoperability)
 
     func testThatItCreatesTheCorrectSwiftPermissions() {
-        XCTAssertEqual(TeamRole.collaborator.permissions, .collaborator)
+        XCTAssertEqual(TeamRole.partner.permissions, .partner)
         XCTAssertEqual(TeamRole.member.permissions, .member)
         XCTAssertEqual(TeamRole.admin.permissions, .admin)
         XCTAssertEqual(TeamRole.owner.permissions, .owner)
@@ -133,31 +133,31 @@ class PermissionsTests: BaseZMClientMessageTests {
 
     func testTeamRoleIsARelationships() {
         XCTAssert(TeamRole.none.isA(role: .none))
-        XCTAssertFalse(TeamRole.none.isA(role: .collaborator))
+        XCTAssertFalse(TeamRole.none.isA(role: .partner))
         XCTAssertFalse(TeamRole.none.isA(role: .member))
         XCTAssertFalse(TeamRole.none.isA(role: .admin))
         XCTAssertFalse(TeamRole.none.isA(role: .owner))
         
-        XCTAssert(TeamRole.collaborator.isA(role: .none))
-        XCTAssert(TeamRole.collaborator.isA(role: .collaborator))
-        XCTAssertFalse(TeamRole.collaborator.isA(role: .member))
-        XCTAssertFalse(TeamRole.collaborator.isA(role: .admin))
-        XCTAssertFalse(TeamRole.collaborator.isA(role: .owner))
+        XCTAssert(TeamRole.partner.isA(role: .none))
+        XCTAssert(TeamRole.partner.isA(role: .partner))
+        XCTAssertFalse(TeamRole.partner.isA(role: .member))
+        XCTAssertFalse(TeamRole.partner.isA(role: .admin))
+        XCTAssertFalse(TeamRole.partner.isA(role: .owner))
         
         XCTAssert(TeamRole.member.isA(role: .none))
-        XCTAssert(TeamRole.member.isA(role: .collaborator))
+        XCTAssert(TeamRole.member.isA(role: .partner))
         XCTAssert(TeamRole.member.isA(role: .member))
         XCTAssertFalse(TeamRole.member.isA(role: .admin))
         XCTAssertFalse(TeamRole.member.isA(role: .owner))
         
         XCTAssert(TeamRole.admin.isA(role: .none))
-        XCTAssert(TeamRole.admin.isA(role: .collaborator))
+        XCTAssert(TeamRole.admin.isA(role: .partner))
         XCTAssert(TeamRole.admin.isA(role: .member))
         XCTAssert(TeamRole.admin.isA(role: .admin))
         XCTAssertFalse(TeamRole.admin.isA(role: .owner))
         
         XCTAssert(TeamRole.owner.isA(role: .none))
-        XCTAssert(TeamRole.owner.isA(role: .collaborator))
+        XCTAssert(TeamRole.owner.isA(role: .partner))
         XCTAssert(TeamRole.owner.isA(role: .member))
         XCTAssert(TeamRole.owner.isA(role: .admin))
         XCTAssert(TeamRole.owner.isA(role: .owner))


### PR DESCRIPTION
## What's new in this PR?

Renamed occurrences of `collaborator` to `partner`, to maintain consistency with feature terminology.