### PR TITLE
ZIOS-11133: Fix clearing all conversations when clearing only one

### DIFF
--- a/Source/Model/Conversation/ZMConversation+DeleteOlderMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+DeleteOlderMessages.swift
@@ -29,7 +29,11 @@ extension ZMConversation {
         }
         
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ZMMessage.entityName())
-        fetchRequest.predicate = NSPredicate(format: "%K <= %@", #keyPath(ZMMessage.serverTimestamp), clearedTimeStamp as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "(%K == %@ OR %K == %@) AND %K <= %@",
+                                             ZMMessageConversationKey, self,
+                                             ZMMessageHiddenInConversationKey, self,
+                                             #keyPath(ZMMessage.serverTimestamp),
+                                             clearedTimeStamp as CVarArg)
         
         let result = try! managedObjectContext.fetch(fetchRequest) as! [ZMMessage]
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a user tapped the "Delete and leave" button on a conversation in the conversation list, we would clear the contents of all conversations instead of clearing only the contents of the selected conversation.

### Causes

In the `deleteOlderMessages` method on the conversation, we used a fetch request to delete all the messages received before the time the deletion was requested. However, this fetch request did not check the conversation of the messages, and thus would match all the messages in the database, regardless of the conversation.

### Solutions

In the predicate of the fetch request, we now check that the conversation of the messages matches the receiver of `deleteOlderMessages`.