### PR TITLE
Avoid unnecessary unfaulting

### DIFF
--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -325,7 +325,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     NSString *key = [self remoteIdentifierDataKey];
     NSData *data = uuid.data;
     for (NSManagedObject *mo in moc.registeredObjects) {
-        if ((mo.entity == entity) && [data isEqual:[mo valueForKey:key]]) {
+        if (!mo.isFault && mo.entity == entity && [data isEqual:[mo valueForKey:key]]) {
             return (id) mo;
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were observing that conversations were being faulted and un-faulted repeatedly during event processing.

### Causes

When fetching the self conversation we will end up calling `fetchObjectWithRemoteIdentifier:inManagedObjectContext:`which would un-fault all conversations when accessing  the `remoteIdentifier` property.

### Solutions

Skip the comparison for faults since we will anyway need to perform a fetch to get the object which is the current fallback if we don't find the object among the registered objects.