### PR TITLE
Avoid unnecessary fetch request when updating the last read timestamp

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -239,11 +239,8 @@ extension ZMConversation {
     public func markMessagesAsRead(until message: ZMConversationMessage) {
         if let currentTimestamp = lastReadServerTimeStamp,
            let messageTimestamp = message.serverTimestamp,
-           message.sender?.isSelfUser == false,
            currentTimestamp.compare(messageTimestamp) == .orderedDescending {
             // Current last read timestamp is newer than message we are marking as read
-            // OR
-            // Messages sent by the self user are always considered read
             return
         }
         // Any unsent unread message is cleared when entering a conversation

--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -248,9 +248,9 @@ extension ZMConversation {
             hasUnreadUnsentMessage = false
         }
         
-        guard let messageTimestamp = message.serverTimestampIncludingChildMessages,
-            let unreadTimestamp = lastUnreadMessage(olderOrEqualThan: messageTimestamp)?.serverTimestamp else { return }
-        enqueueUpdateLastRead(unreadTimestamp)
+        guard let messageTimestamp = message.serverTimestampIncludingChildMessages else { return }
+        
+        enqueueUpdateLastRead(messageTimestamp)
     }
     
     /// Update the last read timestamp.
@@ -378,10 +378,6 @@ extension ZMConversation {
         fetchRequest.sortDescriptors = ZMMessage.defaultSortDescriptors()
         
         return managedObjectContext.fetchOrAssert(request: fetchRequest).filter(\.messageIsRelevantForConversationStatus)
-    }
-    
-    fileprivate func lastUnreadMessage(olderOrEqualThan date: Date) -> ZMMessage? {
-        return unreadMessagesIncludingInvisible(fetchLimit: 1, before: date, order: .descending).first
     }
     
     fileprivate enum Order {

--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -248,7 +248,6 @@ extension ZMConversation {
             hasUnreadUnsentMessage = false
         }
         
-        // If the message has timestamp
         guard let messageTimestamp = message.serverTimestampIncludingChildMessages,
               let unreadTimestamp = message.isSent ? messageTimestamp : unreadMessagesIncludingInvisible(until: messageTimestamp).last?.serverTimestamp else { return }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Marking messages as read does a fetch request which is fairly expensive

### Causes

When we mark a message as read we currently search backwards looking for the first unread message and update the last read timestamp using the `serverTimestamp` of that message. This search is done by a fetch request which is fairly expensive.

### Solutions

I believe that this backwards search is a left over from the time when we updated the last read state using event identifiers. Since we nowadays update the last read using a timestamp it should not be any harm in updating the last read state using a newer timestamp.