### PR TITLE
Removed unused code for fetching profile pictures

### DIFF
--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -321,8 +321,6 @@ extension ZMUser {
     @objc public func requestPreviewProfileImage() {
         guard let moc = self.managedObjectContext, moc.zm_isUserInterfaceContext, !moc.zm_userImageCache.hasUserImage(self, size: .preview) else { return }
         
-        localSmallProfileRemoteIdentifier = nil
-        
         NotificationInContext(name: .userDidRequestPreviewAsset,
                               context: moc.notificationContext,
                               object: self.objectID).post()
@@ -330,8 +328,6 @@ extension ZMUser {
     
     @objc public func requestCompleteProfileImage() {
         guard let moc = self.managedObjectContext, moc.zm_isUserInterfaceContext, !moc.zm_userImageCache.hasUserImage(self, size: .complete) else { return }
-        
-        localMediumRemoteIdentifier = nil
         
         NotificationInContext(name: .userDidRequestCompleteAsset,
                               context: moc.notificationContext,


### PR DESCRIPTION
## What's new in this PR?

After more thorough inspection it seems that there is no need to nil the identifiers when fetching profile picture. Posting notification is enough to trigger download.
