### PR TITLE
Old conversations generate a badge count

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -106,6 +106,10 @@ NS_ASSUME_NONNULL_END
 
 @property (nonatomic) BOOL internalIsArchived;
 
+/// Returns true if the conversation have been changed since it was created by the slow sync or if it was
+/// created from an update event.
+@property (nonatomic) BOOL hasBeenModifiedSinceSlowSync;
+
 @property (nonatomic, nullable) NSDate *pendingLastReadServerTimestamp;
 @property (nonatomic, nullable) NSDate *lastServerTimeStamp;
 @property (nonatomic, nullable) NSDate *lastReadServerTimeStamp;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -937,6 +937,10 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return [ZMConversation conversationWithRemoteID:selfUserID createIfNeeded:NO inContext:managedObjectContext];
 }
 
+- (BOOL)hasBeenModifiedSinceSlowSync {
+    return self.lastServerTimeStamp != nil && self.lastServerTimeStamp.timeIntervalSince1970 != 0;
+}
+
 - (ZMClientMessage *)appendClientMessageWithGenericMessage:(ZMGenericMessage *)genericMessage
 {
     return [self appendClientMessageWithGenericMessage:genericMessage expires:YES hidden:NO];

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -1030,7 +1030,7 @@ NSString * const ZMMessageExpectReadConfirmationKey = @"expectsReadConfirmation"
             return [self.users containsObject:selfUser] && !self.sender.isSelfUser;
         }
         case ZMSystemMessageTypeNewConversation:
-            return !self.sender.isSelfUser;
+            return !self.sender.isSelfUser && self.conversation.hasBeenModifiedSinceSlowSync;
         case ZMSystemMessageTypeMissedCall:
             return self.relevantForConversationStatus;
         default:

--- a/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
@@ -24,12 +24,32 @@ class ZMMessageTests_ShouldGenerateUnreadCount: BaseZMClientMessageTests {
     
     func testThatNewConversationSystemMessage_fromOtherGeneratesUnreadCount() {
         // given
+        let conversation = createConversation(in: uiMOC)
+        conversation.lastServerTimeStamp = Date()
+        
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .newConversation
         systemMessage.sender = user1
+        systemMessage.visibleInConversation = conversation
         
         // then
+        XCTAssertTrue(conversation.hasBeenModifiedSinceSlowSync)
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
+    }
+    
+    func testThatNewConversationSystemMessage_fromOtherDoesntGenerateUnreadCount_WhenNotModifiedSinceSlowSync() {
+        // given
+        let conversation = createConversation(in: uiMOC)
+        conversation.lastServerTimeStamp = Date(timeIntervalSince1970: 0)
+        
+        let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
+        systemMessage.systemMessageType = .newConversation
+        systemMessage.sender = user1
+        systemMessage.visibleInConversation = conversation
+        
+        // then
+        XCTAssertFalse(conversation.hasBeenModifiedSinceSlowSync)
+        XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
     
     func testThatNewConversationSystemMessage_fromSelfDoesntGenerateUnreadCount() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed that internal users get an unread badge count without seemingly having any unread conversations. 

### Causes

We recently started including `.newConversation` system messages in the unread count if the conversation was started by someone else than the self user. This had the side effect of marking all conversations which were slow synced on login as unread. The badge count wouldn't update immediately since we only re-calculate the unread count when something unfaults the conversation.

### Solutions

Distinguish between conversations which were slow synced and conversations which were created from an update event. One way of doing this is by looking at the `lastServerTimestamp` which doesn't exist for slow synced conversations and therefore is set to the UNIX reference. timestamp.