### PR TITLE
Create .newConversation system messages with a timestamp

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -106,10 +106,6 @@ NS_ASSUME_NONNULL_END
 
 @property (nonatomic) BOOL internalIsArchived;
 
-/// Returns true if the conversation have been changed since it was created by the slow sync or if it was
-/// created from an update event.
-@property (nonatomic) BOOL hasBeenModifiedSinceSlowSync;
-
 @property (nonatomic, nullable) NSDate *pendingLastReadServerTimestamp;
 @property (nonatomic, nullable) NSDate *lastServerTimeStamp;
 @property (nonatomic, nullable) NSDate *lastReadServerTimeStamp;
@@ -158,11 +154,6 @@ NS_ASSUME_NONNULL_END
 - (nonnull ZMClientMessage *)appendMessage:(nonnull ZMClientMessage *)clientMessage expires:(BOOL)expires hidden:(BOOL)hidden;
 
 - (nullable ZMAssetClientMessage *)appendAssetClientMessageWithNonce:(nonnull NSUUID *)nonce imageData:(nonnull NSData *)imageData;
-
-
-- (void)appendNewConversationSystemMessageIfNeeded;
-
-+ (nonnull NSDate *)newConversationMessageTimestamp;
 
 @property (nonatomic, nullable) id _recentMessagesFetcher;
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -910,9 +910,6 @@ NSString * const ZMMessageExpectReadConfirmationKey = @"expectsReadConfirmation"
     message.users = usersSet;
     message.text = messageText != nil ? messageText : name;
     
-    [message updateNewConversationSystemMessageIfNeededWithUsers:usersSet
-                                                         context:moc
-                                                    conversation:conversation];
     [conversation updateMessageFetcher];
     [conversation updateTimestampsAfterUpdatingMessage:message];
     
@@ -1030,7 +1027,7 @@ NSString * const ZMMessageExpectReadConfirmationKey = @"expectsReadConfirmation"
             return [self.users containsObject:selfUser] && !self.sender.isSelfUser;
         }
         case ZMSystemMessageTypeNewConversation:
-            return !self.sender.isSelfUser && self.conversation.hasBeenModifiedSinceSlowSync;
+            return !self.sender.isSelfUser;
         case ZMSystemMessageTypeMissedCall:
             return self.relevantForConversationStatus;
         default:

--- a/Source/Model/Message/ZMSystemMessage+NewConversation.swift
+++ b/Source/Model/Message/ZMSystemMessage+NewConversation.swift
@@ -22,23 +22,3 @@ public extension ZMSystemMessage {
     @NSManaged public var numberOfGuestsAdded: Int16  // Only filled for .newConversation
     @NSManaged public var allTeamUsersAdded: Bool     // Only filled for .newConversation
 }
-
-extension ZMSystemMessage {
-
-    @objc(updateNewConversationSystemMessageIfNeededWithUsers:context:conversation:)
-    func updateNewConversationSystemMessagePropertiesIfNeeded(
-        users: Set<ZMUser>,
-        context: NSManagedObjectContext,
-        conversation: ZMConversation
-        ) {
-        guard systemMessageType == .newConversation else { return }
-        guard let team = ZMUser.selfUser(in: context).team else { return }
-        
-        let members = team.members.compactMap { $0.user }
-        let guests = users.filter { $0.isGuest(in: conversation) }
-
-        allTeamUsersAdded = users.isSuperset(of: members)
-        numberOfGuestsAdded = Int16(guests.count)
-    }
-
-}

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -217,23 +217,22 @@ extension ConversationTests_Teams {
         let otherMember = Member.insertNewObject(in: uiMOC)
         otherMember.team = team
         otherMember.user = otherUser
-        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser], in: team)
-        conversation?.lastModifiedDate = Date(timeIntervalSinceNow: -100)
-        let timestamp = Date(timeIntervalSinceNow: -20)
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser], in: team)!
+        let previousLastModifiedDate = conversation.lastModifiedDate!
+        let timestamp = Date(timeIntervalSinceNow: 100)
         
         // when
-        conversation?.appendTeamMemberRemovedSystemMessage(user: otherUser, at: timestamp)
+        conversation.appendTeamMemberRemovedSystemMessage(user: otherUser, at: timestamp)
         
         // then
-        guard let message = conversation?.recentMessages.last as? ZMSystemMessage else { XCTFail("Last message should be system message"); return }
+        guard let message = conversation.recentMessages.last as? ZMSystemMessage else { XCTFail("Last message should be system message"); return }
         
         XCTAssertEqual(message.systemMessageType, .teamMemberLeave)
         XCTAssertEqual(message.sender, otherUser)
         XCTAssertEqual(message.users, [otherUser])
         XCTAssertEqual(message.serverTimestamp, timestamp)
         XCTAssertFalse(message.shouldGenerateUnreadCount())
-        guard let lastModified = conversation?.lastModifiedDate else { XCTFail("Conversation should have last modified date"); return }
-        XCTAssertNotEqual(lastModified.timeIntervalSince1970, timestamp.timeIntervalSince1970, accuracy: 0.1, "Message should not change lastModifiedDate")
+        XCTAssertEqual(conversation.lastModifiedDate, previousLastModifiedDate, "Message should not change lastModifiedDate")
     }
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -869,20 +869,6 @@
     XCTAssertFalse(firstMessage.expectsReadConfirmation);
 }
 
-- (void)testThatAppendingNewConversationSystemMessageTwiceDoesNotCreateTwoSystemMessage;
-{
-    //given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    [conversation appendNewConversationSystemMessageIfNeeded];
-    XCTAssertEqual(conversation.recentMessages.count, 1u);
-    
-    //when
-    [conversation appendNewConversationSystemMessageIfNeeded];
-    
-    //then
-    XCTAssertEqual(conversation.recentMessages.count, 1u);
-}
-
 @end // general
 
 

--- a/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
@@ -33,23 +33,7 @@ class ZMMessageTests_ShouldGenerateUnreadCount: BaseZMClientMessageTests {
         systemMessage.visibleInConversation = conversation
         
         // then
-        XCTAssertTrue(conversation.hasBeenModifiedSinceSlowSync)
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
-    }
-    
-    func testThatNewConversationSystemMessage_fromOtherDoesntGenerateUnreadCount_WhenNotModifiedSinceSlowSync() {
-        // given
-        let conversation = createConversation(in: uiMOC)
-        conversation.lastServerTimeStamp = Date(timeIntervalSince1970: 0)
-        
-        let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
-        systemMessage.systemMessageType = .newConversation
-        systemMessage.sender = user1
-        systemMessage.visibleInConversation = conversation
-        
-        // then
-        XCTAssertFalse(conversation.hasBeenModifiedSinceSlowSync)
-        XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
     
     func testThatNewConversationSystemMessage_fromSelfDoesntGenerateUnreadCount() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

`.newConversation` system messages can now generate unread dots, this created unwanted unread  conversation for people who upgrade.

### Causes

We previously tried to solve this by introducing `hasBeenModifiedSinceSlowSync` but that solution didn't cover all the edge cases,  a conversation can be modified by for example someone being added or removed causing the same issue to re-appear.

### Solutions

`.newConversation` system message will from now on have a correct `serverTimestamp` associated with them since that timestamp will be visible when you read the message, to enable this  we need to re-factor `appendNewConversationSystemMessageIfNeeded` to take a timestamp parameter.

NOTE: The solution for the unwanted unread conversations is done in sync engine.
