### PR TITLE
Make sure delayed save can be completed in background

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -451,7 +451,7 @@ static BackgroundActivity *delayedSaveActivity = nil;
                 [group leave];
             }
             [self leaveAllGroups:otherGroups];
-            if (delayedSaveActivity) {
+            if (didSave && delayedSaveActivity != nil) {
                 [[BackgroundActivityFactory sharedFactory] endBackgroundActivity:delayedSaveActivity];
                 delayedSaveActivity = nil;
             }

--- a/Tests/Source/ManagedObjectContext/MockBackgroundActivityManager.swift
+++ b/Tests/Source/ManagedObjectContext/MockBackgroundActivityManager.swift
@@ -1,0 +1,40 @@
+////
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireTransport
+
+@objc class MockBackgroundActivityManager: NSObject, BackgroundActivityManager {
+    
+    var backgroundTimeRemaining: TimeInterval = 10
+    
+    var applicationState: UIApplication.State = .active
+    
+    // MARK: - BackgroundActivityManager
+    
+    @objc public var startedTasks = [String]()
+    func beginBackgroundTask(withName name: String?, expirationHandler: (() -> Void)?) -> Int {
+        startedTasks.append(name ?? "NO-NAME")
+        return startedTasks.count
+    }
+    
+    @objc public var endedTasks = [Int]()
+    func endBackgroundTask(_ task: Int) {
+        endedTasks.append(task)
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		F137EEBE212C14300043FDEB /* ZMConversation+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = F137EEBD212C14300043FDEB /* ZMConversation+Services.swift */; };
 		F13A89D1210628F700AB40CB /* PushToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13A89D0210628F600AB40CB /* PushToken.swift */; };
 		F14B9C6F212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B9C6E212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift */; };
+		F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14FA376221DB05B005E7EF5 /* MockBackgroundActivityManager.swift */; };
 		F1517922212DAE2E00BA3EBD /* ZMConversationTests+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1517921212DAE2E00BA3EBD /* ZMConversationTests+Services.swift */; };
 		F1549D4A1FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */; };
 		F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */; };
@@ -825,6 +826,7 @@
 		F13A89D0210628F600AB40CB /* PushToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushToken.swift; sourceTree = "<group>"; };
 		F13A89D22106293000AB40CB /* PushTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushTokenTests.swift; sourceTree = "<group>"; };
 		F14B9C6E212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMBaseManagedObjectTest+Helpers.swift"; sourceTree = "<group>"; };
+		F14FA376221DB05B005E7EF5 /* MockBackgroundActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackgroundActivityManager.swift; sourceTree = "<group>"; };
 		F1517921212DAE2E00BA3EBD /* ZMConversationTests+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Services.swift"; sourceTree = "<group>"; };
 		F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserFetchAndMergeTests.swift; sourceTree = "<group>"; };
 		F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Patches.swift"; sourceTree = "<group>"; };
@@ -1699,6 +1701,7 @@
 			children = (
 				F9A708041CAEEB7400C2F5FE /* ManagedObjectContextSaveNotificationTests.m */,
 				F9A708051CAEEB7400C2F5FE /* ManagedObjectContextTests.m */,
+				F14FA376221DB05B005E7EF5 /* MockBackgroundActivityManager.swift */,
 				54929FAD1E12AC8B0010186B /* NSPersistentStoreMetadataTests.swift */,
 				F9A708061CAEEB7400C2F5FE /* NSManagedObjectContext+TestHelpers.h */,
 				F9A708071CAEEB7400C2F5FE /* NSManagedObjectContext+TestHelpers.m */,
@@ -2736,6 +2739,7 @@
 				F929C1721E40D6530018ADA4 /* ZMUserDisplayNameGeneratorTest.m in Sources */,
 				F9B71FA61CB2BF37001DB03F /* ZMConversationTests+Transport.m in Sources */,
 				1621E59220E62BD2006B2D17 /* ZMConversationTests+Silencing.swift in Sources */,
+				F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */,
 				544034341D6DFE8500860F2D /* ZMAddressBookContactTests.swift in Sources */,
 				F920AE3B1E3B844E001BC14F /* SearchUserObserverCenterTests.swift in Sources */,
 				F9B71FA81CB2BF37001DB03F /* ZMConversationTests+Validation.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

In several places instead of regular save we do a delayed save - an optimization that can coalesce several requests to save the data store and do only a single real save. There is a problem with this when app is in the background, because we do not wrap this operation with an active background activity and it can potentially lead to crashes and data loss.

### Causes

It all depends on timing but if iOS decides to suspend the app while we are doing a save the app will crash. This happens because SQLite locks the file when saving and iOS kills the app if it encounters this while suspending the process.

### Solutions

We start an activity the first time someone calls `enqueueDelayedSave` and finish it when we do the real save in `saveOrRollback`.

