### PR TITLE
Added nil condition to managedByWire

### DIFF
--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -213,7 +213,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     }
     
     public var managedByWire: Bool {
-        return user?.managedByWire ?? false
+        return user?.managedByWire != false
     }
     
     public var isPendingApprovalByOtherUser: Bool {

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -260,7 +260,7 @@ static NSString *const NeedsRichProfileUpdateKey = @"needsRichProfileUpdate";
 }
 
 - (BOOL) managedByWire {
-    return [self.managedBy isEqualToString:@"wire"];
+    return self.managedBy == nil || [self.managedBy isEqualToString:@"wire"];
 }
 
 - (NSString *)displayName;

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -838,6 +838,23 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.emailAddress);
 }
 
+- (void)testThatItSetsManagedByAsWire
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    [payload setObject:ManagedByWire forKey:@"managed_by"];
+    
+    // when
+    [user updateWithTransportData:payload authoritative:NO];
+    
+    // then
+    XCTAssertEqual([self managedByString:user], ManagedByWire);
+}
+
 - (void)testThatNilManagedByIsConsideredAsManagedByWire
 {
     // given

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -838,7 +838,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.emailAddress);
 }
 
-- (void)testThatItSetsManagedByAsWire
+- (void)testThatNilManagedByIsConsideredAsManagedByWire
 {
     // given
     NSUUID *uuid = [NSUUID createUUID];
@@ -846,13 +846,13 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     user.remoteIdentifier = uuid;
     
     NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
-    [payload setObject:ManagedByWire forKey:@"managed_by"];
+    [payload removeObjectForKey:@"managed_by"];
     
     // when
     [user updateWithTransportData:payload authoritative:NO];
     
     // then
-    XCTAssertEqual([self managedByString:user], ManagedByWire);
+    XCTAssertTrue(user.managedByWire);
 }
 
 - (void)testThatItSetsManagedByAsScim


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users are not able to edit profile when the `managedBy` property is `nil`.

### Solutions

Added this case to the`managedByWire` property.