### PR TITLE
Expose activeConversations on the UserType

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -57,6 +57,10 @@ extension ZMConversation {
             notTeamMemberPredicate
             ])
     }
+    
+    class func predicateForConversationsWhereSelfUserIsActive() -> NSPredicate {
+        return .init(format: "%K == YES", ZMConversationIsSelfAnActiveMemberKey)
+    }
 
     @objc(predicateForConversationsInTeam:)
     class func predicateForConversations(in team: Team?) -> NSPredicate {

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -105,6 +105,9 @@ public protocol UserType: NSObjectProtocol {
     /// Used to trigger rich profile download from backend
     var needsRichProfileUpdate: Bool { get set }
     
+    /// Conversations the user is a currently a participant of
+    var activeConversations: Set<ZMConversation> { get }
+    
     func requestPreviewProfileImage()
     func requestCompleteProfileImage()
     

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -132,7 +132,7 @@ extension NSManagedObjectContext
 
 
 @objc
-public class  ZMSearchUser: NSObject, UserType, UserConnectionType {
+public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     public var providerIdentifier: String?
     public var summary: String?
     public var assetKeys: SearchUserAssetKeys?

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -132,7 +132,7 @@ extension NSManagedObjectContext
 
 
 @objc
-public class ZMSearchUser: NSObject, UserType, UserConnectionType {
+public class  ZMSearchUser: NSObject, UserType, UserConnectionType {
     public var providerIdentifier: String?
     public var summary: String?
     public var assetKeys: SearchUserAssetKeys?
@@ -210,6 +210,10 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     public var readReceiptsEnabled: Bool {
         return user?.readReceiptsEnabled ?? false
+    }
+    
+    public var activeConversations: Set<ZMConversation> {
+        return user?.activeConversations ?? Set()
     }
     
     public var managedByWire: Bool {

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -52,6 +52,20 @@ extension ZMUser: UserType {
         return imageMediumData
     }
     
+    public var activeConversations: Set<ZMConversation> {
+        if isSelfUser {
+            guard let managedObjectContext = managedObjectContext else { return Set() }
+            
+            let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+            fetchRequest.predicate = ZMConversation.predicateForConversationsWhereSelfUserIsActive()
+            var result = Set(managedObjectContext.fetchOrAssert(request: fetchRequest))
+            result.remove(ZMConversation.selfConversation(in: managedObjectContext))
+            return result
+        } else {
+            return lastServerSyncedActiveConversations.set as? Set<ZMConversation> ?? Set()
+        }
+    }
+    
 }
 
 public struct AssetKey {

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -653,6 +653,32 @@ extension ZMUserTests {
     
 }
 
+// MARK: - Active conversations
+
+extension ZMUserTests {
+    
+    func testActiveConversationsForSelfUser() {
+        // given
+        let sut = ZMUser.selfUser(in: uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.isSelfAnActiveMember = true
+        
+        // then
+        XCTAssertEqual(sut.activeConversations, Set(arrayLiteral: conversation))
+    }
+    
+    func testActiveConversationsForOtherUser() {
+        // given
+        let sut = ZMUser.insertNewObject(in: uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.mutableLastServerSyncedActiveParticipants.add(sut)
+        
+        // then
+        XCTAssertEqual(sut.activeConversations, Set(arrayLiteral: conversation))
+    }
+    
+}
+
 // MARK: - Self user tests
 extension ZMUserTests {
     func testThatItIsPossibleToSetReadReceiptsEnabled() {


### PR DESCRIPTION
## What's new in this PR?

Expose `activeConversations` on the `UserType`. We need this property to in order to calculate the set of "active" users.