### PR TITLE
Crash when sending ephemeral gif

### DIFF
--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -100,14 +100,15 @@ extension String {
     }
 
     public var originalSize: CGSize {
-        let genericMessage = assetClientMessage.mediumGenericMessage
-        guard let asset = genericMessage?.imageAssetData, asset.originalWidth > 0 else { return assetClientMessage.preprocessedSize }
+        guard let asset = assetClientMessage.mediumGenericMessage?.imageAssetData else  { return .zero }
         let size = CGSize(width: Int(asset.originalWidth), height: Int(asset.originalHeight))
+        
         if size != .zero {
             return size
         }
-
+        
         return assetClientMessage.preprocessedSize
+        
     }
 
     // MARK: - Helper

--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -120,8 +120,8 @@ private let zmLog = ZMSLog(tag: "AssetV3")
     public var originalSize: CGSize {
         guard nil != assetClientMessage.fileMessageData, isImage else { return .zero }
         guard let asset = assetClientMessage.genericAssetMessage?.assetData else { return .zero }
-        guard asset.original.hasRasterImage, asset.original.image.width > 0 else { return assetClientMessage.preprocessedSize }
         let size = CGSize(width: Int(asset.original.image.width), height: Int(asset.original.image.height))
+        
         if size != .zero {
             return size
         }

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -33,14 +33,14 @@ import Foundation
     {
         self.init(nonce: nonce, managedObjectContext: managedObjectContext)
         
-        // We update the size once the preprocessing is done
         // mimeType is assigned first, to make sure UI can handle animated GIF file correctly
         let mimeType = ZMAssetMetaDataEncoder.contentType(forImageData: imageData) ?? ""
-        let asset = ZMAsset.asset(originalWithImageSize: CGSize.zero, mimeType: mimeType, size: UInt64(imageData.count))
+        // We update the size again when the the preprocessing is done
+        let imageSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData)
+        let asset = ZMAsset.asset(originalWithImageSize: imageSize, mimeType: mimeType, size: UInt64(imageData.count))
         let message = ZMGenericMessage.message(content: asset, nonce: nonce, expiresAfter: timeout)
         
         add(message)
-        preprocessedSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData)
         transferState = .uploading
         version = 3
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes after sending ephemeral gif

### Causes

App crashes due to division by zero when computing image constraints because the image size is reported as zero.

The image size is zero because we don't do image preprocessing for GIFs so were relying on the value of `preprocessedSize`, which gets set to zero when the image gets obfuscated.

### Solutions

- Add the image size into the protobuf from the start, we don't need  the`preprocessedSize` property anymore but we have to keep for now to be compatible with older images.
- Make constraint code resilient to zero size images.