### PR TITLE
Observe asset identifier in addition to the image data

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -33,6 +33,8 @@ extension ZMUser : ObjectInSnapshot {
             #keyPath(ZMUser.accentColorValue),
             #keyPath(ZMUser.imageMediumData),
             #keyPath(ZMUser.imageSmallProfileData),
+            #keyPath(ZMUser.previewProfileAssetIdentifier),
+            #keyPath(ZMUser.completeProfileAssetIdentifier),
             #keyPath(ZMUser.emailAddress),
             #keyPath(ZMUser.phoneNumber),
             #keyPath(ZMUser.canBeConnected),
@@ -96,11 +98,11 @@ extension ZMUser : ObjectInSnapshot {
     }
 
     open var imageMediumDataChanged : Bool {
-        return changedKeysContain(keys: #keyPath(UserType.completeImageData))
+        return changedKeysContain(keys: #keyPath(UserType.completeImageData), #keyPath(ZMUser.completeProfileAssetIdentifier))
     }
 
     open var imageSmallProfileDataChanged : Bool {
-        return changedKeysContain(keys: #keyPath(UserType.previewImageData))
+        return changedKeysContain(keys: #keyPath(UserType.previewImageData), #keyPath(ZMUser.previewProfileAssetIdentifier))
     }
 
     open var profileInformationChanged : Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Your own profile image wouldn't update immediately after changing it.

### Causes

 We observing when the image data changed on disk but at the time when it changes the `previewProfileAssetIdentifier` and `completeProfileAssetIdentifier` were not yet updated on the UI context. This resulted in that we fetched the old profile image from the cache instead of the new one.

### Solutions

Also observe changes to `previewProfileAssetIdentifier` and `completeProfileAssetIdentifier`.