### PR TITLE
Fix: Change search query length limit

### DIFF
--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -183,7 +183,7 @@ public class TextSearchQuery: NSObject {
         self.conversation = conversation
         self.conversationRemoteIdentifier = conversation.remoteIdentifier!
         self.originalQuery = query
-        self.queryStrings = query.normalizedForSearch().components(separatedBy: .whitespacesAndNewlines).filter { TextSearchQuery.isValid(query: $0) }
+        self.queryStrings = query.normalizedForSearch().components(separatedBy: .whitespacesAndNewlines).filter(TextSearchQuery.isValid)
         self.delegate = delegate
         self.fetchConfiguration = configuration
     }

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -128,7 +128,7 @@ private let zmLog = ZMSLog(tag: "text search")
 
 /// This class should be used to perform a text search for messages in a conversation.
 /// Each instance can only be used to perform a search once. A running instance can be cancelled.
-@objcMembers public class TextSearchQuery: NSObject {
+public class TextSearchQuery: NSObject {
 
     private let uiMOC: NSManagedObjectContext
     private let syncMOC: NSManagedObjectContext
@@ -153,6 +153,10 @@ private let zmLog = ZMSLog(tag: "text search")
     private var indexedMessageCount = 0
     private var notIndexedMessageCount = 0
 
+    public class func isValid(query: String) -> Bool {
+        return query.count >= 1
+    }
+
     /// Creates a new `TextSearchQuery` object.
     /// - parameter conversation: The conversation in which the search should be performed. Needs to belong to the UI context.
     /// - parameter query: The query string which will be searched for in the messages of the conversation.
@@ -165,7 +169,7 @@ private let zmLog = ZMSLog(tag: "text search")
         configuration: TextSearchQueryFetchConfiguration = .init(notIndexedBatchSize: 200, indexedBatchSize: 200)
         ) {
 
-        guard query.count > 1 else { return nil }
+        guard TextSearchQuery.isValid(query: query) else { return nil }
         guard let uiMOC = conversation.managedObjectContext, let syncMOC = uiMOC.zm_sync else {
             fatal("NSManagedObjectContexts not accessible.")
         }
@@ -179,7 +183,7 @@ private let zmLog = ZMSLog(tag: "text search")
         self.conversation = conversation
         self.conversationRemoteIdentifier = conversation.remoteIdentifier!
         self.originalQuery = query
-        self.queryStrings = query.normalizedForSearch().components(separatedBy: .whitespacesAndNewlines).filter { $0.count > 1 }
+        self.queryStrings = query.normalizedForSearch().components(separatedBy: .whitespacesAndNewlines).filter { TextSearchQuery.isValid(query: $0) }
         self.delegate = delegate
         self.fetchConfiguration = configuration
     }

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -154,7 +154,7 @@ public class TextSearchQuery: NSObject {
     private var notIndexedMessageCount = 0
 
     public class func isValid(query: String) -> Bool {
-        return query.count >= 1
+        return !query.isEmpty
     }
 
     /// Creates a new `TextSearchQuery` object.

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -358,18 +358,18 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         verifyThatItFindsMessage(withText: "This is a test message", whenSearchingFor: "this conversation", shouldFind: false)
     }
 
-    func testThatItDoesNotCreateASearchQueryWithQuerySmallerThanTwoCharacters() {
+    func testThatItDoesNotCreateASearchQueryWithQuerySmallerThanOneCharacters() {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
 
         // Then
         XCTAssertNil(TextSearchQuery(conversation: conversation, query: "", delegate: MockTextSearchQueryDelegate()))
-        XCTAssertNil(TextSearchQuery(conversation: conversation, query: "a", delegate: MockTextSearchQueryDelegate()))
+        XCTAssertNotNil(TextSearchQuery(conversation: conversation, query: "a", delegate: MockTextSearchQueryDelegate()))
         XCTAssertNotNil(TextSearchQuery(conversation: conversation, query: "ab", delegate: MockTextSearchQueryDelegate()))
     }
 
-    func testThatItDoesNotReturnsAnyResultsWithOnlyOneCharacterSearchTerms() {
+    func testThatItReturnsResultsWithOnlyOneCharacterSearchTerms() {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
@@ -390,7 +390,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         let result = delegate.fetchedResults.first!
         XCTAssertFalse(result.hasMore)
 
-        XCTAssertTrue(result.matches.isEmpty, "Expected to not find a match")
+        XCTAssertFalse(result.matches.isEmpty, "Expected to find a match")
     }
 
     func testThatItUpdatesTheNormalizedTextWhenEditingAMessage() {


### PR DESCRIPTION
## What's new in this PR?

Change search query length limit form 2-character to 1-character.