### PR TITLE
Undo - Change search query length limit

### DIFF
--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -154,7 +154,7 @@ public class TextSearchQuery: NSObject {
     private var notIndexedMessageCount = 0
 
     public class func isValid(query: String) -> Bool {
-        return !query.isEmpty
+        return query.length >= 2
     }
 
     /// Creates a new `TextSearchQuery` object.

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -154,7 +154,7 @@ public class TextSearchQuery: NSObject {
     private var notIndexedMessageCount = 0
 
     public class func isValid(query: String) -> Bool {
-        return query.length >= 2
+        return query.count >= 2
     }
 
     /// Creates a new `TextSearchQuery` object.

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -358,18 +358,18 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         verifyThatItFindsMessage(withText: "This is a test message", whenSearchingFor: "this conversation", shouldFind: false)
     }
 
-    func testThatItDoesNotCreateASearchQueryWithQuerySmallerThanOneCharacters() {
+    func testThatItDoesNotCreateASearchQueryWithQuerySmallerThanTwoCharacters() {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
 
         // Then
         XCTAssertNil(TextSearchQuery(conversation: conversation, query: "", delegate: MockTextSearchQueryDelegate()))
-        XCTAssertNotNil(TextSearchQuery(conversation: conversation, query: "a", delegate: MockTextSearchQueryDelegate()))
+        XCTAssertNil(TextSearchQuery(conversation: conversation, query: "a", delegate: MockTextSearchQueryDelegate()))
         XCTAssertNotNil(TextSearchQuery(conversation: conversation, query: "ab", delegate: MockTextSearchQueryDelegate()))
     }
 
-    func testThatItReturnsResultsWithOnlyOneCharacterSearchTerms() {
+    func testThatItDoesNotReturnsAnyResultsWithOnlyOneCharacterSearchTerms() {
         // Given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
@@ -390,7 +390,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         let result = delegate.fetchedResults.first!
         XCTAssertFalse(result.hasMore)
 
-        XCTAssertFalse(result.matches.isEmpty, "Expected to find a match")
+        XCTAssertTrue(result.matches.isEmpty, "Expected to not find a match")
     }
 
     func testThatItUpdatesTheNormalizedTextWhenEditingAMessage() {


### PR DESCRIPTION
## What's new in this PR?

After discussion with QA team, we decided to keep the current query length limit to align to other platforms at this moment. The changes in https://github.com/wireapp/wire-ios-data-model/pull/697 is keep but set the limit to 1 character.