### PR TITLE
Batch fetch users when updating conversation members

### DIFF
--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -56,7 +56,7 @@ extern NSString * __nonnull const ReadReceiptsEnabledKey;
 + (nullable instancetype)userWithEmailAddress:(nonnull NSString *)emailAddress inContext:(nonnull NSManagedObjectContext *)context;
 + (nullable instancetype)userWithPhoneNumber:(nonnull NSString *)phoneNumber inContext:(nonnull NSManagedObjectContext *)context;
 
-+ (nonnull NSOrderedSet <ZMUser *> *)usersWithRemoteIDs:(nonnull NSOrderedSet <NSUUID *>*)UUIDs inContext:(nonnull NSManagedObjectContext *)moc;
++ (nonnull NSSet <ZMUser *> *)usersWithRemoteIDs:(nonnull NSSet <NSUUID *>*)UUIDs inContext:(nonnull NSManagedObjectContext *)moc;
 
 + (ZMAccentColor)accentColorFromPayloadValue:(nullable NSNumber *)payloadValue;
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -473,7 +473,7 @@ static NSString *const NeedsRichProfileUpdateKey = @"needsRichProfileUpdate";
     }
 }
 
-+ (NSOrderedSet <ZMUser *> *)usersWithRemoteIDs:(NSOrderedSet <NSUUID *>*)UUIDs inContext:(NSManagedObjectContext *)moc;
++ (NSSet <ZMUser *> *)usersWithRemoteIDs:(NSSet <NSUUID *>*)UUIDs inContext:(NSManagedObjectContext *)moc;
 {
     return [self fetchObjectsWithRemoteIdentifiers:UUIDs inManagedObjectContext:moc];
 }

--- a/Source/Model/ZMManagedObject+Internal.h
+++ b/Source/Model/ZMManagedObject+Internal.h
@@ -64,7 +64,7 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedKeysKey;
 + (void)enumerateObjectsInContext:(nonnull NSManagedObjectContext *)moc withBlock:(nonnull ObjectsEnumerationBlock)block;
 
 + (nullable instancetype)fetchObjectWithRemoteIdentifier:(nonnull NSUUID *)uuid inManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
-+ (nullable NSOrderedSet *)fetchObjectsWithRemoteIdentifiers:(nonnull NSOrderedSet <NSUUID *> *)uuids inManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
++ (nullable NSSet *)fetchObjectsWithRemoteIdentifiers:(nonnull NSSet <NSUUID *> *)uuids inManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
 
 @end
 

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -337,7 +337,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     return fetchResult.firstObject;
 }
 
-+ (NSOrderedSet *)fetchObjectsWithRemoteIdentifiers:(NSOrderedSet <NSUUID *> *)uuids inManagedObjectContext:(NSManagedObjectContext *)moc;
++ (NSSet *)fetchObjectsWithRemoteIdentifiers:(NSSet <NSUUID *> *)uuids inManagedObjectContext:(NSManagedObjectContext *)moc;
 {
     // Executing a fetch request is quite expensive, because it will _always_ (1) round trip through
     // (1) the persistent store coordinator and the SQLite engine, and (2) touch the file system.
@@ -347,7 +347,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     NSEntityDescription *entity = moc.persistentStoreCoordinator.managedObjectModel.entitiesByName[self.entityName];
     Require(entity != nil);
     
-    NSMutableOrderedSet *objects = [[NSMutableOrderedSet alloc] init];
+    NSMutableSet *objects = [[NSMutableSet alloc] init];
     
     NSString *key = [self remoteIdentifierDataKey];
     NSMutableSet <NSData *> *uuidDataArray = [[uuids mapWithBlock:^NSData *(NSUUID *uuid) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

During profiling it's visible that `updateMembersWithPayload:` take up a significant time if the number of participants is big.

### Causes

Inside `updateMembersWithPayload:` the line which takes the most time is `[ZMUser userWithRemoteID:userId createIfNeeded:YES inContext:self.managedObjectContext]` since it's executed for every participant added to the conversation.

### Solutions

Fetch all participants in one batch.

## Notes

- I replaced `NSOrderedSet` with a plain `NSSet` since we don't rely on the order.