### PR TITLE
Fix legacy asset migration

### DIFF
--- a/Source/Utilis/PersistedDataPatches+Directory.swift
+++ b/Source/Utilis/PersistedDataPatches+Directory.swift
@@ -30,7 +30,8 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "81.2.1", block: InvalidClientsRemoval.removeInvalid),
         PersistedDataPatch(version: "103.0.2", block: InvalidGenericMessageDataRemoval.removeInvalid),
         PersistedDataPatch(version: "145.0.3", block: InvalidConversationRemoval.removeInvalid),
-        PersistedDataPatch(version: "157.0.0", block: TransferStateMigration.migrateLegacyTransferState)
+        PersistedDataPatch(version: "158.0.0", block: TransferStateMigration.migrateLegacyTransferState),
+        PersistedDataPatch(version: "159.0.1", block: TransferStateMigration.migrateLegacyTransferState),
     ]
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Asset are displayed as failed as cancelled when they are in fact uploaded.

### Causes

The legacy asset migration was linked with the wrong version of data model. The new assets were released in `158.0.0` but the migration was tagged for `157.0.0` 

This means that people who updated to `3.30` from  `3.28` and `3.29` didn't get the migration performed.

### Solutions

Correctly tag the migration as being part of `158.0.0` and also add the migration again for `159.0.1` for the people who already updated.

This unfortunately mean that will apply the migration twice for some people. This will have the effect that `.cancelled` and `.failed` assets will be marked as `.uploaded`. This is not that bad as we can update the state when we try to download it.