### PR TITLE
Avoid migrating twice when upgrading from older version

### DIFF
--- a/Source/Utilis/PersistedDataPatches+Directory.swift
+++ b/Source/Utilis/PersistedDataPatches+Directory.swift
@@ -30,7 +30,6 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "81.2.1", block: InvalidClientsRemoval.removeInvalid),
         PersistedDataPatch(version: "103.0.2", block: InvalidGenericMessageDataRemoval.removeInvalid),
         PersistedDataPatch(version: "145.0.3", block: InvalidConversationRemoval.removeInvalid),
-        PersistedDataPatch(version: "158.0.0", block: TransferStateMigration.migrateLegacyTransferState),
         PersistedDataPatch(version: "161.0.1", block: TransferStateMigration.migrateLegacyTransferState)
     ]
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Having `migrateLegacyTransferState` twice in the patch list will apply the migration twice if the user upgraded from before `158.0.0`.

### Solutions

Remove `158.0.0` and  keep`161.0.1`.