### PR TITLE
Unarchive a conversation when you are added to it

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -1120,6 +1120,10 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     if ([participants intersectsSet:selfUserSet]) {
         self.isSelfAnActiveMember = YES;
         self.needsToBeUpdatedFromBackend = YES;
+        
+        if (self.mutedStatus == MutedMessageOptionValueNone) {
+            self.isArchived = NO;
+        }
     }
     
     if (otherUsers.count > 0) {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -137,6 +137,41 @@
     XCTAssertEqualObjects(expectedActiveParticipants, conversation.lastServerSyncedActiveParticipants);
 }
 
+- (void)testThatItDoesNotUnarchiveTheConversationWhenTheSelfUserIsAddedIfMuted
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.isArchived = YES;
+    conversation.mutedStatus = MutedMessageOptionValueAll;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    selfUser.remoteIdentifier = [NSUUID createUUID];
+    
+    // when
+    [conversation internalAddParticipants:[NSSet setWithObjects:selfUser, nil]];
+    WaitForAllGroupsToBeEmpty(0.5f);
+    
+    // then
+    XCTAssertTrue(conversation.isArchived);
+}
+
+- (void)testThatItUnarchivesTheConversationWhenTheSelfUserIsAdded
+{
+    // given
+    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
+    conversation.conversationType = ZMConversationTypeGroup;
+    conversation.isArchived = YES;
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    selfUser.remoteIdentifier = [NSUUID createUUID];
+
+    // when
+    [conversation internalAddParticipants:[NSSet setWithObjects:selfUser, nil]];
+    WaitForAllGroupsToBeEmpty(0.5f);
+    
+    // then
+    XCTAssertFalse(conversation.isArchived);
+}
+
 - (void)testThatItCanRemoveTheSelfUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you leave a group the conversation will get archived, if you later get added back the conversation will stay in archive.

### Causes

it's unclear what was causing the unarchiving previously. (*checking*)

### Solutions

Unarchive the conversation if it isn't muted.