### PR TITLE
ZIOS-11329: Improve detection and observing of guest/services presence

### DIFF
--- a/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -60,29 +60,22 @@ extension ZMConversation {
 
         // Calculate the external participants state
         let canDisplayGuests = selfUser.team != nil
-
-        var areServicesPresent: Bool = false
-        var areGuestsPresent: Bool = false
+        var state = ExternalParticipantsState()
 
         for user in otherUsers {
             if user.isServiceUser {
-                areServicesPresent = true
+                state.insert(.visibleServices)
             } else if canDisplayGuests && user.isGuest(in: self) {
-                areGuestsPresent = true
+                state.insert(.visibleGuests)
             }
 
             // Early exit to avoid going through all users if we can avoid it
-            if areServicesPresent && (areGuestsPresent || !canDisplayGuests) {
+            if state.contains(.visibleServices) && (state.contains(.visibleGuests) || !canDisplayGuests) {
                 break
             }
         }
 
-        switch (areGuestsPresent, areServicesPresent) {
-        case (false, false): return []
-        case (true, false): return [.visibleGuests]
-        case (false, true): return [.visibleServices]
-        case (true, true): return [.visibleGuests, .visibleServices]
-        }
+        return state
     }
 
     /// Returns whether an services are present, regardless of the display rules.

--- a/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -1,0 +1,96 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * Represents the possible state of external participants in a conversation.
+ */
+
+@objc public enum ZMConversationExternalParticipantsState: Int, CustomStringConvertible {
+    /// All the conversation members are connected.
+    case none
+
+    /// The conversation contains guests.
+    case onlyGuests
+
+    /// The conversation contains services.
+    case onlyServices
+
+    /// The conversation contains both guests and services.
+    case guestsAndServices
+
+    public var description: String {
+        switch self {
+        case .none: return "none"
+        case .onlyGuests: return "onlyGuests"
+        case .onlyServices: return "onlyServices"
+        case .guestsAndServices: return "guestsAndServices"
+        }
+    }
+}
+
+extension ZMConversation {
+
+    @objc class func keyPathsForValuesAffectingExternalParticipantsState() -> Set<String> {
+        return ["lastServerSyncedActiveParticipants.isServiceUser", "lastServerSyncedActiveParticipants.membership"]
+    }
+
+    /// The state of external participants in the conversation.
+    @objc public var externalParticipantsState: ZMConversationExternalParticipantsState {
+        // Exception 1) We don't consider guests/services as external participants in 1:1 conversations
+        guard conversationType == .group else { return .none }
+
+        // Exception 2) If there is only one user in the group and it's a service, we don't consider it as external
+        let participants = self.activeParticipants
+        let selfUser = ZMUser.selfUser(in: managedObjectContext!)
+        let otherUsers = participants.subtracting([selfUser])
+
+        if otherUsers.count == 1, otherUsers.first!.isServiceUser {
+            return .none
+        }
+
+        // Calculate the external participants state
+        let selfUserTeam = selfUser.team
+        let canDisplayGuests = selfUserTeam != nil && team == selfUserTeam
+
+        var areServicesPresent: Bool = false
+        var areGuestsPresent: Bool = false
+
+        for user in otherUsers {
+            if user.isServiceUser {
+                areServicesPresent = true
+            } else if canDisplayGuests && user.isGuest(in: self) {
+                areGuestsPresent = true
+            }
+
+            // Early exit to avoid going through all users if we can avoid it
+            if areServicesPresent && (areGuestsPresent || !canDisplayGuests) {
+                break
+            }
+        }
+
+        switch (areGuestsPresent, areServicesPresent) {
+        case (false, false): return .none
+        case (true, false): return .onlyGuests
+        case (false, true): return .onlyServices
+        case (true, true): return .guestsAndServices
+        }
+    }
+
+}

--- a/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -48,7 +48,7 @@ import Foundation
 extension ZMConversation {
 
     @objc class func keyPathsForValuesAffectingExternalParticipantsState() -> Set<String> {
-        return ["lastServerSyncedActiveParticipants.isServiceUser", "lastServerSyncedActiveParticipants.membership"]
+        return ["lastServerSyncedActiveParticipants.isServiceUser", "lastServerSyncedActiveParticipants.hasTeam"]
     }
 
     /// The state of external participants in the conversation.
@@ -66,8 +66,7 @@ extension ZMConversation {
         }
 
         // Calculate the external participants state
-        let selfUserTeam = selfUser.team
-        let canDisplayGuests = selfUserTeam != nil && team == selfUserTeam
+        let canDisplayGuests = selfUser.team != nil
 
         var areServicesPresent: Bool = false
         var areGuestsPresent: Bool = false

--- a/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -92,4 +92,14 @@ extension ZMConversation {
         }
     }
 
+    /// Returns whether an services are present, regardless of the display rules.
+    public var areServicesPresent: Bool {
+        return activeParticipants.any(\.isServiceUser)
+    }
+
+    /// Returns whether guests are present, regardless of the display rules.
+    public var areGuestsPresent: Bool {
+        return activeParticipants.any { $0.isGuest(in: self) }
+    }
+
 }

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -56,6 +56,7 @@ extern NSString *const ZMIsDimmedKey;
 extern NSString *const ZMNormalizedUserDefinedNameKey;
 extern NSString *const ZMConversationListIndicatorKey;
 extern NSString *const ZMConversationConversationTypeKey;
+extern NSString *const ZMConversationExternalParticipantsStateKey;
 
 extern NSString *const ZMConversationLastReadServerTimeStampKey;
 extern NSString *const ZMConversationLastServerTimeStampKey;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -66,6 +66,7 @@ NSString *const ZMConversationLastReadServerTimeStampKey = @"lastReadServerTimeS
 NSString *const ZMConversationClearedTimeStampKey = @"clearedTimeStamp";
 NSString *const ZMConversationArchivedChangedTimeStampKey = @"archivedChangedTimestamp";
 NSString *const ZMConversationSilencedChangedTimeStampKey = @"silencedChangedTimestamp";
+NSString *const ZMConversationExternalParticipantsStateKey = @"externalParticipantsState";
 
 NSString *const ZMNotificationConversationKey = @"ZMNotificationConversationKey";
 

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -154,6 +154,11 @@ static NSString *const NeedsRichProfileUpdateKey = @"needsRichProfileUpdate";
     return self.serviceIdentifier != nil && self.providerIdentifier != nil;
 }
 
++ (NSSet<NSString *> *)keyPathsForValuesAffectingIsServiceUser
+{
+    return [NSSet setWithObjects:ServiceIdentifierKey, ProviderIdentifierKey, nil];
+}
+
 - (BOOL)isSelfUser
 {
     if ([self isZombieObject]) {

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -42,7 +42,7 @@ extension ZMConversation : ObjectInSnapshot {
                     #keyPath(ZMConversation.syncedMessageDestructionTimeout),
                     #keyPath(ZMConversation.language),
                     #keyPath(ZMConversation.hasReadReceiptsEnabled),
-                    #keyPath(ZMConversation.externalParticipantsState)
+                    ZMConversation.externalParticipantsStateKey
             ])
     }
 
@@ -134,7 +134,7 @@ extension ZMConversation : ObjectInSnapshot {
     }
 
     public var externalParticipantsStateChanged: Bool {
-        return changedKeysContain(keys: #keyPath(ZMConversation.externalParticipantsState))
+        return changedKeysContain(keys: ZMConversation.externalParticipantsStateKey)
     }
     
     public var conversation : ZMConversation { return self.object as! ZMConversation }

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -41,7 +41,8 @@ extension ZMConversation : ObjectInSnapshot {
                     #keyPath(ZMConversation.localMessageDestructionTimeout),
                     #keyPath(ZMConversation.syncedMessageDestructionTimeout),
                     #keyPath(ZMConversation.language),
-                    #keyPath(ZMConversation.hasReadReceiptsEnabled)
+                    #keyPath(ZMConversation.hasReadReceiptsEnabled),
+                    #keyPath(ZMConversation.externalParticipantsState)
             ])
     }
 
@@ -131,6 +132,10 @@ extension ZMConversation : ObjectInSnapshot {
     public var hasReadReceiptsEnabledChanged : Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.hasReadReceiptsEnabled))
     }
+
+    public var externalParticipantsStateChanged: Bool {
+        return changedKeysContain(keys: #keyPath(ZMConversation.externalParticipantsState))
+    }
     
     public var conversation : ZMConversation { return self.object as! ZMConversation }
     
@@ -153,6 +158,7 @@ extension ZMConversation : ObjectInSnapshot {
                 "destructionTimeoutChanged \(destructionTimeoutChanged)",
                 "languageChanged \(languageChanged)",
                 "hasReadReceiptsEnabledChanged \(hasReadReceiptsEnabledChanged)",
+                "externalParticipantsStateChanged \(externalParticipantsStateChanged)"
             ].joined(separator: ", ")
     }
     

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -48,6 +48,9 @@ extension ZMUser : ObjectInSnapshot {
             #keyPath(ZMUser.readReceiptsEnabled),
             #keyPath(ZMUser.readReceiptsEnabledChangedRemotely),
             ZMUserKeys.RichProfile,
+            #keyPath(ZMUser.isServiceUser),
+            #keyPath(ZMUser.serviceIdentifier),
+            #keyPath(ZMUser.providerIdentifier)
         ]
     }
 

--- a/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
@@ -54,31 +54,31 @@ class ZMConversationExternalParticipantsStateTests: BaseTeamTests {
 
     func testOneToOneCases() {
         // Personal Users
-        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.personal], expectedResult: .none)
-        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.personal], expectedResult: [])
+        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: [])
 
         // Team
-        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
-        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: .none)
-        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: .none)
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: [])
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: [])
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: [])
     }
 
     func testGroupCases() {
         // None
-        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.personal], expectedResult: .none)
-        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.personal], expectedResult: [])
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: [])
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: [])
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: [])
 
         // Only Guests
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: .onlyGuests)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: [.visibleGuests])
 
         // Only Services
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam, .service], expectedResult: .onlyServices)
-        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam, .service], expectedResult: .onlyServices)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam, .service], expectedResult: [.visibleServices])
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam, .service], expectedResult: [.visibleServices])
 
         // Guests and Services
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal, .service], expectedResult: .guestsAndServices)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal, .service], expectedResult: [.visibleGuests, .visibleServices])
     }
 
     // MARK: - Helpers
@@ -90,7 +90,7 @@ class ZMConversationExternalParticipantsStateTests: BaseTeamTests {
         return conversation
     }
 
-    func assertMatrixRow(_ conversationType: ZMConversationType, selfUser selfUserType: RelativeUserState, otherUsers: [RelativeUserState], expectedResult: ZMConversationExternalParticipantsState, file: StaticString = #file, line: UInt = #line) {
+    func assertMatrixRow(_ conversationType: ZMConversationType, selfUser selfUserType: RelativeUserState, otherUsers: [RelativeUserState], expectedResult: ZMConversation.ExternalParticipantsState, file: StaticString = #file, line: UInt = #line) {
         let conversation = createConversationWithSelfUser()
         conversation.conversationType = conversationType
 

--- a/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
@@ -1,0 +1,162 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+/**
+ * Tests for calculating the state of external users presence in a team conversation.
+ *
+ * Expected matrix:
+ *
+ * +---------------------------------------------------------------------------------+
+ * | Conversation Type | Self User  | Other Users          | Expected State For Self |
+ * |-------------------|------------|----------------------|-------------------------|
+ * | 1:1               | Personal   | Personal             | None                    |
+ * | 1:1               | Personal   | Team                 | None                    |
+ * | 1:1               | Team       | Team                 | None                    |
+ * | 1:1               | Team       | Personal             | None                    |
+ * | 1:1               | Team       | Service              | None                    |
+ * |-------------------|------------|----------------------|-------------------------|
+ * | Group             | Personal   | Personal             | None                    |
+ * | Group             | Personal   | Team                 | None                    |
+ * | Group             | Team       | Team                 | None                    |
+ * | Group             | Other Team | Team                 | None                    |
+ * | Group             | Other Team | Personal             | None                    |
+ * | Group             | Team       | Service              | None                    |
+ * | Group             | Team       | Personal             | Only Guests             |
+ * | Group             | Team       | Other Team           | Only Guests             |
+ * | Group             | Team       | Team & Service       | Only Services           |
+ * | Group             | Other Team | Team & Service       | Only Services           |
+ * | Group             | Other Team | Personal & Service   | Only Services           |
+ * | Group             | Team       | Personal & Service   | Guests & Services       |
+ * | Group             | Team       | Other Team & Service | Guests & Services       |
+ * +---------------------------------------------------------------------------------+
+ */
+
+class ZMConversationExternalParticipantsStateTests: ZMConversationTestsBase {
+
+    enum RelativeUserState {
+        case personal
+        case memberOfHostingTeam
+        case memberOfOtherTeam
+        case service
+    }
+
+    func testOneToOneCases() {
+        // Personal Users
+        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.personal], expectedResult: .none)
+        assertMatrixRow(.oneOnOne, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+
+        // Team
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: .none)
+        assertMatrixRow(.oneOnOne, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: .none)
+    }
+
+    func testGroupCases() {
+        // None
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.personal], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .memberOfOtherTeam, otherUsers: [.memberOfHostingTeam], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .memberOfOtherTeam, otherUsers: [.personal], expectedResult: .none)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: .none)
+
+        // Only Guests
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal], expectedResult: .onlyGuests)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfOtherTeam], expectedResult: .onlyGuests)
+
+        // Only Services
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam, .service], expectedResult: .onlyServices)
+        assertMatrixRow(.group, selfUser: .memberOfOtherTeam, otherUsers: [.memberOfHostingTeam, .service], expectedResult: .onlyServices)
+        assertMatrixRow(.group, selfUser: .memberOfOtherTeam, otherUsers: [.personal, .service], expectedResult: .onlyServices)
+
+        // Guests and Services
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.personal, .service], expectedResult: .guestsAndServices)
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfOtherTeam, .service], expectedResult: .guestsAndServices)
+    }
+
+    // MARK: - Helpers
+
+    func createConversationWithSelfUser() -> ZMConversation {
+        let conversation = createConversation(in: uiMOC)
+        conversation.internalAddParticipants([selfUser])
+        conversation.isSelfAnActiveMember = true
+        return conversation
+    }
+
+    func assertMatrixRow(_ conversationType: ZMConversationType, selfUser selfUserType: RelativeUserState, otherUsers: [RelativeUserState], expectedResult: ZMConversationExternalParticipantsState, file: StaticString = #file, line: UInt = #line) {
+        // 1) Create the conversation
+        let conversation = createConversationWithSelfUser()
+        conversation.conversationType = conversationType
+
+        var hostingTeam: Team?
+
+        switch selfUserType {
+        case .memberOfHostingTeam:
+            let team = createTeam(in: uiMOC)
+            hostingTeam = team
+            conversation.team = team
+            createMembership(in: uiMOC, user: selfUser, team: team)
+
+        case .memberOfOtherTeam:
+            let otherTeam = createTeam(in: uiMOC)
+            createMembership(in: uiMOC, user: selfUser, team: otherTeam)
+
+        case .personal:
+            break
+
+        case .service:
+            XCTFail("Self-user cannot be a service", file: file, line: line)
+        }
+
+        for otherUserType in otherUsers {
+            switch otherUserType {
+            case .memberOfHostingTeam:
+                if hostingTeam == nil {
+                    let team = createTeam(in: uiMOC)
+                    hostingTeam = team
+                    conversation.team = team
+                }
+
+                let otherTeamUser = createUser(in: uiMOC)
+                conversation.internalAddParticipants([otherTeamUser])
+                createMembership(in: uiMOC, user: otherTeamUser, team: hostingTeam!)
+
+            case .memberOfOtherTeam:
+                let otherTeam = createTeam(in: uiMOC)
+                let otherUser = createUser(in: uiMOC)
+                conversation.internalAddParticipants([otherUser])
+                createMembership(in: uiMOC, user: otherUser, team: otherTeam)
+
+            case .personal:
+                let otherUser = createUser(in: uiMOC)
+                conversation.internalAddParticipants([otherUser])
+
+            case .service:
+                let service = createService(in: uiMOC, named: "Bob the Robot")
+                conversation.internalAddParticipants([service as! ZMUser])
+            }
+        }
+
+        uiMOC.saveOrRollback()
+        XCTAssertEqual(conversation.externalParticipantsState, expectedResult, file: file, line: line)
+    }
+
+}

--- a/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -54,7 +54,8 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
             "allowGuestsChanged",
             "destructionTimeoutChanged",
             "languageChanged",
-            "hasReadReceiptsEnabledChanged"
+            "hasReadReceiptsEnabledChanged",
+            "externalParticipantsStateChanged"
         ]
     }
     
@@ -776,6 +777,25 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
         },
                                                      expectedChangedFields: ["hasReadReceiptsEnabledChanged"],
                                                      expectedChangedKeys: ["hasReadReceiptsEnabled"])
+    }
+
+    func testThatItSendsUpdateForUpdatedServiceUser() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        conversation.conversationType = .group
+
+        let user = createUser(in: uiMOC)
+        conversation.internalAddParticipants([user])
+        self.uiMOC.saveOrRollback()
+
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(conversation,
+                                                     modifier: { conversation, _ in
+                                                        user.serviceIdentifier = UUID().uuidString
+                                                        user.providerIdentifier = UUID().uuidString
+        },
+                                                     expectedChangedFields: ["externalParticipantsStateChanged"],
+                                                     expectedChangedKeys: ["externalParticipantsState"])
     }
 }
 

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		5E0FB2012051493700FD9867 /* Set+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB2002051493700FD9867 /* Set+Filter.swift */; };
 		5E0FB215205176B400FD9867 /* Set+ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */; };
 		5E36B45E21CA5BBA00B7063B /* UnverifiedCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36B45D21CA5BBA00B7063B /* UnverifiedCredentials.swift */; };
+		5E39FC67225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC66225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift */; };
+		5E39FC69225F2DC000C682B8 /* ZMConversationExternalParticipantsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC68225F2DC000C682B8 /* ZMConversationExternalParticipantsStateTests.swift */; };
 		5E454C60210638E300DB4501 /* PushTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13A89D22106293000AB40CB /* PushTokenTests.swift */; };
 		5E4BA9F62216FF7800F938A8 /* store2-62-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 5E4BA9F42216FF4000F938A8 /* store2-62-0.wiredatabase */; };
 		5E67168E2174B9AF00522E61 /* LoginCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E67168D2174B9AF00522E61 /* LoginCredentials.swift */; };
@@ -682,6 +684,8 @@
 		5E0FB2002051493700FD9867 /* Set+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Filter.swift"; sourceTree = "<group>"; };
 		5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+ServiceUser.swift"; sourceTree = "<group>"; };
 		5E36B45D21CA5BBA00B7063B /* UnverifiedCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnverifiedCredentials.swift; sourceTree = "<group>"; };
+		5E39FC66225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+ExternalParticipant.swift"; sourceTree = "<group>"; };
+		5E39FC68225F2DC000C682B8 /* ZMConversationExternalParticipantsStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationExternalParticipantsStateTests.swift; sourceTree = "<group>"; };
 		5E4BA9F32216F4B400F938A8 /* zmessaging2.63.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.63.0.xcdatamodel; sourceTree = "<group>"; };
 		5E4BA9F42216FF4000F938A8 /* store2-62-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-62-0.wiredatabase"; path = "Tests/Resources/store2-62-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		5E67168D2174B9AF00522E61 /* LoginCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCredentials.swift; sourceTree = "<group>"; };
@@ -1470,6 +1474,7 @@
 				87EFA3AB210F52C6004DFA53 /* ZMConversation+LastMessages.swift */,
 				87E9508A2118B2DA00306AA7 /* ZMConversation+DeleteOlderMessages.swift */,
 				EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */,
+				5E39FC66225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift */,
 			);
 			path = Conversation;
 			sourceTree = "<group>";
@@ -1837,6 +1842,7 @@
 				87A7FA23203DD11100AA066C /* ZMConversationTests+AccessMode.swift */,
 				873B88FD2040470900FBE254 /* ConversationCreationOptionsTests.swift */,
 				874D9797211064D300B07674 /* ZMConversationLastMessagesTest.swift */,
+				5E39FC68225F2DC000C682B8 /* ZMConversationExternalParticipantsStateTests.swift */,
 			);
 			name = Conversation;
 			path = Tests/Source/Model/Conversation;
@@ -2684,6 +2690,7 @@
 				F14B7AFF2220302B00458624 /* ZMUser+Predicates.swift in Sources */,
 				EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */,
 				54E3EE431F6194A400A261E3 /* ZMAssetClientMessage+GenericMessage.swift in Sources */,
+				5E39FC67225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift in Sources */,
 				F9A706C31CAEE01D00C2F5FE /* UserImageLocalCache.swift in Sources */,
 				BF1F52BA1ECC3C9E002FB553 /* Team+Transport.swift in Sources */,
 				1626344B20D935C0000D4063 /* ZMConversation+Timestamps.swift in Sources */,
@@ -2757,6 +2764,7 @@
 				1684142A2228421700FCB9BC /* ZMAssetClientMessageTests+AssetMessage.swift in Sources */,
 				F9B71FED1CB2C4C6001DB03F /* StringKeyPathTests.swift in Sources */,
 				F90D99A81E02E22900034070 /* AssetCollectionBatchedTests.swift in Sources */,
+				5E39FC69225F2DC000C682B8 /* ZMConversationExternalParticipantsStateTests.swift in Sources */,
 				F9AB395B1CB3AED900A7254F /* BaseTestSwiftHelpers.swift in Sources */,
 				F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

The system to detect if the conversation contains guests or services was located in UI, and was not observable. 

While it is fine in most cases, there are some cases where a service can be added remotely and we get the participants changed notification before we fetch that the added user is a service, we will not update the UI to reflect that it's a service once the fetch is done (e.g. we won't show the "services are present banner").

### Solutions

This PR contains two solutions to this problem:

1. We move the logic from `GuestBarState` that's defined in UI into data model. We create the `ZMConversationExternalParticipantsState` enum, and the `externalParticipantsState` property on the conversation. We add the matrix and the tests for this property.

2. We make this property observable as part of `ConversationChangeInfo`. This involved:
    - defining the keys that affect `isServiceUser` on `ZMUser`
    - defining the keys that affect the `externalParticipantsState`
    - updating the side effects store for the user to use the changed and affected keys when notifying conversation of participants changes instead of just the changed keys. We do that so that we can observe `isServiceUser` directly (ex: if `serviceIdentifierChanges` changes, then `isServiceUser` is affected, and we should allow the conversation to observe `lastSyncedActiveParticipants.isServiceUser` directly)