### PR TITLE
Make Availability conform to CaseIterable

### DIFF
--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -19,8 +19,7 @@
 
 import Foundation
 
-@objc
-public enum Availability : Int {
+@objc public enum Availability : Int, CaseIterable {
     case none, available, busy, away
 }
 
@@ -38,7 +37,7 @@ extension Availability {
             self = .busy
         }
     }
-    
+
 }
 
 /// Describes how the user should be notified about a change.


### PR DESCRIPTION
## What's new in this PR?

This allows us to remove a helper in UI that implements the behavior of CaseIterable to access all the cases of the enum.