### PR TITLE
Enqueue a delayed save when requesting to refetch link attachments

### DIFF
--- a/Source/Model/Message/ConversationMessage+Attachments.swift
+++ b/Source/Model/Message/ConversationMessage+Attachments.swift
@@ -18,21 +18,18 @@
 
 import Foundation
 
-extension ZMConversationMessage {
+extension ZMClientMessage {
 
     /**
      * Requests to refetch the link attachments of messages received prior to
      * the persistent link attachments update.
      */
 
-    public func refetchLinkAttachmentsIfNeeded() {
-        guard !needsLinkAttachmentsUpdate && textMessageData != nil else {
-            return
-        }
-
-        if linkAttachments == nil {
-            needsLinkAttachmentsUpdate = true
-        }
+    public override func refetchLinkAttachmentsIfNeeded() {
+        guard !needsLinkAttachmentsUpdate &&  linkAttachments == nil && textMessageData != nil else { return }
+        
+        needsLinkAttachmentsUpdate = true
+        managedObjectContext?.enqueueDelayedSave()
     }
 
 }

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -142,6 +142,8 @@ public protocol ZMConversationMessage : NSObjectProtocol {
 
     /// Used to trigger link attachments update for this message.
     var needsLinkAttachmentsUpdate: Bool { get set }
+    
+    func refetchLinkAttachmentsIfNeeded()
 }
 
 public extension Equatable where Self : ZMConversationMessage { }
@@ -230,6 +232,10 @@ extension ZMMessage : ZMConversationMessage {
             syncConversation.calculateLastUnreadMessages()
             syncContext.saveOrRollback()
         }
+    }
+    
+    public func refetchLinkAttachmentsIfNeeded() {
+        
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Performing many `refetchLinkAttachmentsIfNeeded` is expensive.

### Solutions

Take over the responsibility of saving the context and do it with a delayed save.