### PR TITLE
ZIOS-11422: Make the conversation not secure when ignoring the new client alert

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -738,7 +738,7 @@
         XCTAssertFalse(message3.causedSecurityLevelDegradation);
         XCTAssertEqual(message3.deliveryState, ZMDeliveryStateFailedToSend);
         XCTAssertFalse(conversation.allUsersTrusted);
-        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
+        XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelNotSecure);
     }];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a conversation becomes unverified after discovering a client when sending a message, we show an alert to the user asking them whether we want to send the message anyway, see the device or cancel.

If they cancel, the conversation remains degraded, and the next time the user sends a message, we show the alert again.

### Causes

We do not decrease the security of the conversation when the user cancels the alert.

### Solutions

Mark the conversation as not secure when cancelling the alert, so that we don't ask the user again. That way, we align the behavior with calls and the upcoming legal hold feature.