### PR TITLE
Convert deviceClass and type into typed enums

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -342,14 +342,11 @@ public extension UserClient {
         client.type = DeviceType(rawValue: type)
         client.activationAddress = activationAddress
         client.model = model
+        client.deviceClass = deviceClass.map({ DeviceClass(rawValue: $0) })
         client.activationDate = activationDate
         client.activationLocationLatitude = latitude
         client.activationLocationLongitude = longitude
         client.remoteIdentifier = id
-        
-        if let deviceClass = deviceClass {
-            client.deviceClass = DeviceClass(rawValue: deviceClass)
-        }
         
         let selfUser = ZMUser.selfUser(in: context)
         client.user = client.user ?? selfUser

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -58,7 +58,7 @@ private let zmLog = ZMSLog(tag: "UserClient")
         }
     }
     
-    @NSManaged public var type: String!
+    @NSManaged public var type: DeviceType
     @NSManaged public var label: String?
     @NSManaged public var markedToDelete: Bool
     @NSManaged public var preKeysRangeMax: Int64
@@ -72,7 +72,7 @@ private let zmLog = ZMSLog(tag: "UserClient")
     @NSManaged public var activationAddress: String?
     @NSManaged public var activationDate: Date?
     @NSManaged public var model: String?
-    @NSManaged public var deviceClass: String?
+    @NSManaged public var deviceClass: DeviceClass?
     @NSManaged public var activationLocationLatitude: NSNumber?
     @NSManaged public var activationLocationLongitude: NSNumber?
     @NSManaged public var needsToNotifyUser: Bool
@@ -164,6 +164,20 @@ private let zmLog = ZMSLog(tag: "UserClient")
         return NSPredicate(format: "%K == NULL", ZMUserClientRemoteIdentifierKey)
     }
     
+    /// Insert a new client of the local self user.
+    
+    @discardableResult
+    @objc(insertNewSelfClientInManagedObjectContext:selfUser:model:label:)
+    public static func insertNewSelfClient(in managedObjectContext: NSManagedObjectContext, selfUser: ZMUser, model: String, label: String) -> UserClient {
+        let userClient = UserClient.insertNewObject(in: managedObjectContext)
+        userClient.user = selfUser
+        userClient.model = model
+        userClient.label = label
+        userClient.deviceClass = model.hasSuffix("iPad") ? .tablet : .phone
+        
+        return userClient
+    }
+    
     public static func fetchUserClient(withRemoteId remoteIdentifier: String, forUser user:ZMUser, createIfNeeded: Bool) -> UserClient? {
         precondition(!createIfNeeded || user.managedObjectContext!.zm_isSyncContext, "clients can only be created on the syncContext")
         
@@ -193,6 +207,16 @@ private let zmLog = ZMSLog(tag: "UserClient")
         }
         
         return nil
+    }
+    
+    /// Update a user client with a backend payload
+    ///
+    /// If called on a client belonging to the self user this method does nothing.
+    
+    public func update(with payload: [String: Any]) {
+        guard user?.isSelfUser == false, let deviceClass = payload["class"] as? String else { return }
+        
+        self.deviceClass = DeviceClass(rawValue: deviceClass)
     }
 
     /// Resets releationships and ends an exisiting session before deleting the object
@@ -315,14 +339,17 @@ public extension UserClient {
         let client = fetchedClient ?? UserClient.insertNewObject(in: context)
 
         client.label = label
-        client.type = type
+        client.type = DeviceType(rawValue: type)
         client.activationAddress = activationAddress
         client.model = model
-        client.deviceClass = deviceClass
         client.activationDate = activationDate
         client.activationLocationLatitude = latitude
         client.activationLocationLongitude = longitude
         client.remoteIdentifier = id
+        
+        if let deviceClass = deviceClass {
+            client.deviceClass = DeviceClass(rawValue: deviceClass)
+        }
         
         let selfUser = ZMUser.selfUser(in: context)
         client.user = client.user ?? selfUser

--- a/Source/Model/UserClient/UserClientTypes.h
+++ b/Source/Model/UserClient/UserClientTypes.h
@@ -19,25 +19,71 @@
 
 @import Foundation;
 
-extern NSString * const ZMUserClientTypePermanent;
-extern NSString * const ZMUserClientTypeTemporary;
-extern NSString * const ZMUserClientTypeLegalHold;
-
 @class ZMUser;
-@class Team;
+
+typedef NSString * ZMUserClientType NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(DeviceType);
+
+extern ZMUserClientType const _Nonnull ZMUserClientTypePermanent;
+extern ZMUserClientType const _Nonnull ZMUserClientTypeTemporary;
+extern ZMUserClientType const _Nonnull ZMUserClientTypeLegalHold;
+
+typedef NSString * ZMUserClientDeviceClass NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(DeviceClass);
+
+extern ZMUserClientDeviceClass const _Nonnull ZMUserClientDeviceClassPhone;
+extern ZMUserClientDeviceClass const _Nonnull ZMUserClientDeviceClassTablet;
+extern ZMUserClientDeviceClass const _Nonnull ZMUserClientDeviceClassDesktop;
+extern ZMUserClientDeviceClass const _Nonnull ZMUserClientDeviceClassLegalHold;
 
 @protocol UserClientType <NSObject>
-@property (nonatomic) NSString *type;
-@property (nonatomic) NSString *label;
-@property (nonatomic) NSString *remoteIdentifier;
-@property (nonatomic) ZMUser *user;
-@property (nonatomic) NSString *activationAddress;
-@property (nonatomic) NSDate *activationDate;
-@property (nonatomic) NSString *model;
-@property (nonatomic) NSString *deviceClass;
+
+/// Type of client, this information is only available for your own clients
+
+@property (nonatomic, nonnull) ZMUserClientType type;
+
+/// Free-form string decribing the client, this information is only available for your own clients.
+
+@property (nonatomic, nullable) NSString *label;
+
+/// Remote identifier of the client
+
+@property (nonatomic, nullable) NSString *remoteIdentifier;
+
+/// Owner of the client
+
+@property (nonatomic, nullable) ZMUser *user;
+
+/// Estimated address of where the device was activated, , this information is only available for your own clients
+
+@property (nonatomic, nullable) NSString *activationAddress;
+
+/// Date of when the client was activated, this information is only available for your own clients
+
+@property (nonatomic, nullable) NSDate *activationDate;
+
+/// Model of the device, this information is only available for your own clients
+
+@property (nonatomic, nullable) NSString *model;
+
+/// The device class (phone, desktop, ...)
+
+@property (nonatomic, nullable) ZMUserClientDeviceClass deviceClass;
+
+/// Estimated latitude of where the device was activated, this information is only available for your own clients
+
 @property (nonatomic) double activationLatitude;
+
+/// Estimated longitude of where the device was activated, this information is only available for your own clients
+
 @property (nonatomic) double activationLongitude;
-@property (nonatomic) NSData *fingerprint;
+
+/// Unique fingerprint which can be used to identify & verify the client
+
+@property (nonatomic, nullable) NSData *fingerprint;
+
+/// True if the self user has verfied the client
+
 @property (nonatomic, readonly) BOOL verified;
+
 - (void)resetSession;
+
 @end

--- a/Source/Model/UserClient/UserClientTypes.h
+++ b/Source/Model/UserClient/UserClientTypes.h
@@ -84,6 +84,12 @@ extern ZMUserClientDeviceClass const _Nonnull ZMUserClientDeviceClassLegalHold;
 
 @property (nonatomic, readonly) BOOL verified;
 
+/// Delete the existing session and establish a new one
+
 - (void)resetSession;
+
+/// Retreive the fingerprint from the session, if there's no existing session a new one will be established.
+
+- (void)fetchFingerprintOrPrekeys;
 
 @end

--- a/Source/Model/UserClient/UserClientTypes.m
+++ b/Source/Model/UserClient/UserClientTypes.m
@@ -19,6 +19,11 @@
 
 #import "UserClientTypes.h"
 
-NSString * const ZMUserClientTypePermanent = @"permanent";
-NSString * const ZMUserClientTypeTemporary = @"temporary";
-NSString * const ZMUserClientTypeLegalHold = @"legalhold"; // TODO jacob not final spec
+ZMUserClientType const ZMUserClientTypePermanent = @"permanent";
+ZMUserClientType const ZMUserClientTypeTemporary = @"temporary";
+ZMUserClientType const ZMUserClientTypeLegalHold = @"legalhold";
+
+ZMUserClientDeviceClass const ZMUserClientDeviceClassPhone = @"phone";
+ZMUserClientDeviceClass const ZMUserClientDeviceClassTablet = @"tablet";
+ZMUserClientDeviceClass const ZMUserClientDeviceClassDesktop = @"desktop";
+ZMUserClientDeviceClass const ZMUserClientDeviceClassLegalHold = @"legalhold";

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -52,7 +52,7 @@ class UserClientTests: ZMBaseManagedObjectTest {
 
     func testThatItCanInitializeClient() {
         let client = UserClient.insertNewObject(in: self.uiMOC)
-        XCTAssertEqual(client.type, ZMUserClientTypePermanent, "Client type should be 'permanent'")
+        XCTAssertEqual(client.type, .permanent, "Client type should be 'permanent'")
     }
     
     func testThatItReturnsTrackedKeys() {
@@ -551,7 +551,7 @@ extension UserClientTests {
 // MARK : fetchFingerprintOrPrekeys
 
 extension UserClientTests {
-    
+        
     func testThatItSetsTheUserWhenInsertingANewSelfUserClient(){
         // given
         _ = createSelfClient()


### PR DESCRIPTION
## What's new in this PR?

- Turn `UserClient.type` and `UserClient.deviceClass` from `String` into extensible typed enums.
- Annotate `UserClientType` with nullability
- Add `update(with payload: [String: Any])` in order to move responsibility for parsing user client payload from request strategy to the data model.

