### PR TITLE
Return self conversation for oneToOneConversation on the self user

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -252,7 +252,9 @@ static NSString *const NeedsRichProfileUpdateKey = @"needsRichProfileUpdate";
 
 - (ZMConversation *)oneToOneConversation
 {
-    if (self.isTeamMember) {
+    if (self.isSelfUser) {
+        return [ZMConversation selfConversationInContext:self.managedObjectContext];
+    } else if (self.isTeamMember) {
         return [ZMConversation fetchOrCreateTeamConversationInManagedObjectContext:self.managedObjectContext
                                                                    withParticipant:self
                                                                               team:self.team];

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -1281,6 +1281,17 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertTrue(user.canBeConnected);
 }
 
+- (void)testThatOneToOneConversationReturnSelfConversationForTheSelfUser
+{
+    // given
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    ZMConversation *selfConversation = [ZMConversation selfConversationInContext:self.uiMOC];
+    
+    // then
+    XCTAssertNotNil(selfUser.oneToOneConversation);
+    XCTAssertEqual(selfConversation, selfUser.oneToOneConversation);
+}
+
 - (void)testThatItReturnsTheOneToOneConversationToAnUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

Support `oneToOneConversation` for the self user by returning the self conversation.