### PR TITLE
ZIOS-11452: Process legal hold hint flag when receiving message

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -208,11 +208,11 @@ extension ZMConversation {
         switch statusHint {
         case .ENABLED where !legalHoldStatus.denotesEnabledComplianceDevice:
             legalHoldStatus = .pendingApproval
-            appendLegalHoldEnabledSystemMessageForConversation(afterReceiving: message, at: timestamp)
+            appendLegalHoldEnabledSystemMessageForConversationAfterReceivingMessage(at: timestamp)
             expireAllPendingMessagesBecauseOfSecurityLevelDegradation()
         case .DISABLED where legalHoldStatus.denotesEnabledComplianceDevice:
             legalHoldStatus = .disabled
-            appendLegalHoldDisabledSystemMessageForConversation(afterReceiving: message, at: timestamp)
+            appendLegalHoldDisabledSystemMessageForConversationAfterReceivingMessage(at: timestamp)
         default:
             break
         }
@@ -318,7 +318,7 @@ extension ZMConversation {
                             timestamp: timestamp ?? timestampAfterLastMessage())
     }
 
-    private func appendLegalHoldEnabledSystemMessageForConversation(afterReceiving message: ZMGenericMessage, at timestamp: Date) {
+    private func appendLegalHoldEnabledSystemMessageForConversationAfterReceivingMessage(at timestamp: Date) {
         appendSystemMessage(type: .legalHoldEnabled,
                             sender: ZMUser.selfUser(in: self.managedObjectContext!),
                             users: nil,
@@ -334,7 +334,7 @@ extension ZMConversation {
                             timestamp: timestampAfterLastMessage())
     }
 
-    private func appendLegalHoldDisabledSystemMessageForConversation(afterReceiving message: ZMGenericMessage, at timestamp: Date) {
+    private func appendLegalHoldDisabledSystemMessageForConversationAfterReceivingMessage(at timestamp: Date) {
         appendSystemMessage(type: .legalHoldDisabled,
                             sender: ZMUser.selfUser(in: self.managedObjectContext!),
                             users: nil,

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -218,7 +218,6 @@ extension ZMConversation {
         }
     }
 
-
     // MARK: - Messages
 
     /// Creates system message that says that you started using this device, if you were not registered on this device

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -238,7 +238,7 @@ import Foundation
             self.serverTimestamp = serverTimestamp
             self.expectsReadConfirmation = self.conversation?.hasReadReceiptsEnabled ?? false
         }
-        
+
         conversation?.updateTimestampsAfterUpdatingMessage(self)
 
         // NOTE: Calling super since this is method overriden to handle special cases when receiving an asset

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -157,6 +157,9 @@ NSString * const DeliveredKey = @"delivered";
         return nil; // don't process messages in the self conversation not sent from the self user
     }
 
+    // Update the legal hold state in the conversation
+    [conversation updateSecurityLevelIfNeededAfterReceiving:message timestamp:updateEvent.timeStamp ?: [NSDate date]];
+
     if (!message.knownMessage) {
         [UnknownMessageAnalyticsTracker tagUnknownMessageWithAnalytics:moc.analytics];
     }

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -34,7 +34,7 @@ public protocol EphemeralMessageContentType: MessageContentType {
 
 extension MessageContentType {
 
-    /// An optional hint that indicates the state of legal hold on the sender's side<
+    /// An optional hint that indicates the state of legal hold on the sender's side.
     var legalHoldStatusHint: ZMLegalHoldStatus? {
         guard hasLegalHoldStatus() else {
             return nil

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -484,7 +484,7 @@ extension ZMEphemeral: MessageContentType {
     }
 
     public func hasLegalHoldStatus() -> Bool {
-        return false
+        return content?.hasLegalHoldStatus() == true
     }
 
     public var legalHoldStatus: ZMLegalHoldStatus {

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -21,6 +21,7 @@
 public protocol MessageContentType: NSObjectProtocol {
     func setContent(on builder: ZMGenericMessageBuilder)
     func expectsReadConfirmation() -> Bool
+    func hasLegalHoldStatus() -> Bool
     var legalHoldStatus: ZMLegalHoldStatus { get }
     func updateExpectsReadConfirmation(_ value: Bool) -> MessageContentType?
     func updateLegalHoldStatus(_ value: ZMLegalHoldStatus) -> MessageContentType?
@@ -29,6 +30,19 @@ public protocol MessageContentType: NSObjectProtocol {
 @objc
 public protocol EphemeralMessageContentType: MessageContentType {
     func setEphemeralContent(on builder: ZMEphemeralBuilder)
+}
+
+extension MessageContentType {
+
+    /// An optional hint that indicates the state of legal hold on the sender's side<
+    var legalHoldStatusHint: ZMLegalHoldStatus? {
+        guard hasLegalHoldStatus() else {
+            return nil
+        }
+
+        return legalHoldStatus
+    }
+
 }
 
 @objc public extension ZMGenericMessage {
@@ -469,6 +483,10 @@ extension ZMEphemeral: MessageContentType {
         return nil
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return content?.legalHoldStatus ?? .DISABLED
     }
@@ -547,6 +565,10 @@ extension ZMExternal: MessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 
@@ -643,6 +665,10 @@ extension ZMImageAsset: EphemeralMessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 
@@ -825,6 +851,10 @@ extension ZMAvailability: MessageContentType {
         return false
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return .DISABLED
     }
@@ -855,6 +885,10 @@ extension ZMMessageDelete: MessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 
@@ -892,6 +926,10 @@ extension ZMMessageHide: MessageContentType {
         return false
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return .DISABLED
     }
@@ -926,6 +964,10 @@ extension ZMMessageEdit: MessageContentType {
         return false
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return .DISABLED
     }
@@ -957,6 +999,10 @@ extension ZMReaction: MessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 
@@ -1009,6 +1055,10 @@ extension ZMConfirmation: MessageContentType {
         return false
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return .DISABLED
     }
@@ -1051,6 +1101,10 @@ extension ZMLastRead: MessageContentType {
         return false
     }
 
+    public func hasLegalHoldStatus() -> Bool {
+        return false
+    }
+
     public var legalHoldStatus: ZMLegalHoldStatus {
         return .DISABLED
     }
@@ -1072,6 +1126,10 @@ extension ZMCleared: MessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 
@@ -1104,6 +1162,10 @@ extension ZMCalling: MessageContentType {
     }
     
     public func expectsReadConfirmation() -> Bool {
+        return false
+    }
+
+    public func hasLegalHoldStatus() -> Bool {
         return false
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We added support for legal hold flags in messages in #731. We now need to process this flag when receiving a message to update the legal hold status in the conversation.

### Solutions

- Update the message content protocol to conditionally return the status, only if it's set in the protobuf
- Add a method on the conversation to update the status based on the hint and current status
- Update the OTR message downstream creation method to call the method mentioned above before inserting the message