### PR TITLE
Fix: new clients are reported as new users joining the conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -522,7 +522,6 @@ extension ZMConversation {
             addedUsers = users
         case .addedClients(let clients, let message):
             addedClients = clients
-            addedUsers = Set(clients.compactMap(\.user))
             if let message = message, message.conversation == self {
                 timestamp = self.timestamp(before: message)
             } else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

New clients are reported as new users joining the conversation.

### Causes

The new clients system message included a non-empty set of  `addedUsers` which causes the UI report it as new users joining the conversation.

### Solutions

Don't set `addedUsers` when discovering a new clients.
