### PR TITLE
Fix .newClient system message not having any users set

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -514,13 +514,16 @@ extension ZMConversation {
     
     fileprivate func appendNewAddedClientSystemMessage(cause: SecurityChangeCause) {
         var timestamp : Date?
+        var affectedUsers: Set<ZMUser> = []
         var addedUsers: Set<ZMUser> = []
         var addedClients: Set<UserClient> = []
         
         switch cause {
         case .addedUsers(let users):
+            affectedUsers = users
             addedUsers = users
         case .addedClients(let clients, let message):
+            affectedUsers = Set(clients.compactMap(\.user))
             addedClients = clients
             if let message = message, message.conversation == self {
                 timestamp = self.timestamp(before: message)
@@ -536,7 +539,7 @@ extension ZMConversation {
         
         self.appendSystemMessage(type: .newClient,
                                  sender: ZMUser.selfUser(in: self.managedObjectContext!),
-                                 users: addedUsers,
+                                 users: affectedUsers,
                                  addedUsers: addedUsers,
                                  clients: addedClients,
                                  timestamp: timestamp ?? timestampAfterLastMessage())


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tests were failing because `.newClient` system message didn't have any users.

### Causes

This broke in https://github.com/wireapp/wire-ios-data-model/pull/735

### Solutions

Restore previous behaviour but keep the distinction between `users` and `addedUsers`