### PR TITLE
Fix legal hold disclosure issues

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -178,8 +178,8 @@ NS_ASSUME_NONNULL_END
 
 @interface ZMConversation (ParticipantsInternal)
 
-- (void)internalAddParticipants:(nonnull NSSet<ZMUser *> *)participants;
-- (void)internalRemoveParticipants:(nonnull NSSet<ZMUser *> *)participants sender:(nonnull ZMUser *)sender;
+- (void)internalAddParticipants:(nonnull NSArray<ZMUser *> *)participants;
+- (void)internalRemoveParticipants:(nonnull NSArray<ZMUser *> *)participants sender:(nonnull ZMUser *)sender;
 
 @property (nonatomic) BOOL isSelfAnActiveMember; ///< whether the self user is an active member (as opposed to a past member)
 @property (readonly, nonatomic, nonnull) NSOrderedSet<ZMUser *> *lastServerSyncedActiveParticipants;

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -307,7 +307,7 @@ extension ZMConversation {
         switch conversationType {
         case .group:
             appendSystemMessage(type: .participantsAdded, sender: user, users: Set(arrayLiteral: user), clients: nil, timestamp: date)
-            internalAddParticipants(Set(arrayLiteral: user))
+            internalAddParticipants([user])
         case .oneOnOne, .connection:
             if user.connection == nil {
                 user.connection = connection ?? ZMConnection.insertNewObject(in: managedObjectContext!)

--- a/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -37,11 +37,11 @@ extension ZMConversation {
                             timestamp: timestamp)
     }
     
-    @objc(appendNewConversationSystemMessageAtTimestamp:)
-    public func appendNewConversationSystemMessage(at timestamp: Date) {
+    @objc(appendNewConversationSystemMessageAtTimestamp:users:)
+    public func appendNewConversationSystemMessage(at timestamp: Date, users: Set<ZMUser>) {
         let systemMessage = appendSystemMessage(type: .newConversation,
                                                 sender: creator,
-                                                users: activeParticipants,
+                                                users: users,
                                                 clients: nil,
                                                 timestamp: timestamp)
         
@@ -51,9 +51,9 @@ extension ZMConversation {
         if let context = managedObjectContext, let selfUserTeam = ZMUser.selfUser(in: context).team, team == selfUserTeam {
             
             let members = selfUserTeam.members.compactMap { $0.user }
-            let guests = activeParticipants.filter { $0.isGuest(in: self) }
+            let guests = users.filter { !$0.isServiceUser && $0.membership == nil }
             
-            systemMessage.allTeamUsersAdded = activeParticipants.isSuperset(of: members)
+            systemMessage.allTeamUsersAdded = users.isSuperset(of: members)
             systemMessage.numberOfGuestsAdded = Int16(guests.count)
         }
         

--- a/Source/Model/Conversation/ZMConversation+Transport.m
+++ b/Source/Model/Conversation/ZMConversation+Transport.m
@@ -169,8 +169,8 @@ NSString *const ZMConversationInfoOTRArchivedReferenceKey = @"otr_archived_ref";
     
     ZMLogDebug(@"updateMembersWithPayload (%@) added = %lu removed = %lu", self.remoteIdentifier.transportString, (unsigned long)addedParticipants.count, (unsigned long)removedParticipants.count);
     
-    [self internalAddParticipants:addedParticipants];
-    [self internalRemoveParticipants:removedParticipants sender:[ZMUser selfUserInContext:self.managedObjectContext]];
+    [self internalAddParticipants:addedParticipants.allObjects];
+    [self internalRemoveParticipants:removedParticipants.allObjects sender:[ZMUser selfUserInContext:self.managedObjectContext]];
 }
 
 - (void)updateTeamWithIdentifier:(NSUUID *)teamId

--- a/Source/Model/User/ZMUser+LegalHoldRequest.swift
+++ b/Source/Model/User/ZMUser+LegalHoldRequest.swift
@@ -182,6 +182,17 @@ extension ZMUser: SelfLegalHoldSubject {
         }
 
         legalHoldRequest = nil
+
+        // Add the legal hold enabled system message locally
+        if let legalHoldClient = clients.filter(\.isLegalHoldDevice).first {
+            let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+            fetchRequest.predicate = ZMConversation.predicateForConversationsIncludingArchived()
+            let conversations = managedObjectContext!.fetchOrAssert(request: fetchRequest)
+
+            conversations.forEach {
+                $0.decreaseSecurityLevelIfNeededAfterDiscovering(clients: [legalHoldClient], causedBy: [self])
+            }
+        }
     }
 
     /**

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -295,7 +295,7 @@ extension ZMUser {
                 conversation.appendParticipantRemovedSystemMessage(user: self, at: timestamp)
             }
             
-            conversation.internalRemoveParticipants(Set(arrayLiteral: self), sender: self)
+            conversation.internalRemoveParticipants([self], sender: self)
         }
     }
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.m
@@ -103,14 +103,14 @@
         unconnectedUserClient.user = newUnconnectedUser;
         
         // when adding a new participant
-        [conversation internalAddParticipants:[NSSet setWithObject:newUnconnectedUser]];
+        [conversation internalAddParticipants:@[newUnconnectedUser]];
         
         // then the conversation should degrade
         XCTAssertFalse(conversation.allUsersTrusted);
         XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
         
         // when
-        [conversation internalRemoveParticipants:[NSSet setWithObjects:newUnconnectedUser, nil] sender:self.selfUser];
+        [conversation internalRemoveParticipants:@[newUnconnectedUser] sender:self.selfUser];
         
         // then
         XCTAssertTrue(conversation.allUsersTrusted);
@@ -178,7 +178,7 @@
         
         // when adding a new participant
         ZMUser *user3 = [self createUsersWithClientsOnSyncMOCWithCount:1].lastObject;
-        [conversation internalAddParticipants:[NSSet setWithObjects:user3, nil]];
+        [conversation internalAddParticipants:@[user3]];
         
         // then the conversation should degrade
         XCTAssertFalse(conversation.allUsersTrusted);
@@ -191,7 +191,7 @@
         XCTAssertEqualObjects(conversationDegradedMessage.users, [NSSet setWithObject:user3]);
         
         // when
-        [conversation internalRemoveParticipants:[NSSet setWithObject:user3] sender:self.selfUser];
+        [conversation internalRemoveParticipants:@[user3] sender:self.selfUser];
         
         // then
         XCTAssertTrue(conversation.allUsersTrusted);
@@ -596,14 +596,14 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    [conversation internalAddParticipants:[NSSet setWithObject:otherUser]];
+    [conversation internalAddParticipants:@[otherUser]];
     UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     client.user = otherUser;
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
     [[selfUser selfClient] trustClient:client];
     
     // WHEN
-    [conversation internalRemoveParticipants:[NSSet setWithObject:selfUser] sender:otherUser];
+    [conversation internalRemoveParticipants:@[selfUser] sender:otherUser];
     
     // THEN
     XCTAssertFalse(conversation.allUsersTrusted);
@@ -925,7 +925,7 @@
     UserClient *verifiedUserClient = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
     verifiedUserClient.user = verifiedUser;
     
-    [conversation internalAddParticipants:[NSSet setWithObject:verifiedUser]];
+    [conversation internalAddParticipants:@[verifiedUser]];
     
     [selfClient trustClients:[NSSet setWithObject:verifiedUserClient]];
     [conversation increaseSecurityLevelIfNeededAfterTrustingClients:[NSSet setWithObject:verifiedUserClient]];
@@ -964,7 +964,7 @@
     verifiedUserClient.user = verifiedUser;
     [selfUser.selfClient trustClients:[NSSet setWithObject:verifiedUserClient]];
 
-    [conversation internalAddParticipants:[NSSet setWithObject:verifiedUser]];
+    [conversation internalAddParticipants:@[verifiedUser]];
     
     // THEN
     XCTAssertTrue([conversation.lastMessage isKindOfClass:[ZMSystemMessage class]]);
@@ -986,7 +986,7 @@
     
     // WHEN
     NSSet<ZMUser *> *unverifiedUsers = [self setupUnverifiedUsers:1];
-    [conversation internalAddParticipants:unverifiedUsers];
+    [conversation internalAddParticipants:unverifiedUsers.allObjects];
     
     NSSet<ZMUser *> *otherUnverifiedUsers = [self setupUnverifiedUsers:1];
 
@@ -1016,7 +1016,7 @@
     [participant block];
     
     // when
-    [conversation internalAddParticipants:[NSSet setWithObject:participant]];
+    [conversation internalAddParticipants:@[participant]];
     
     // then
     XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecure);

--- a/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+participants.m
@@ -49,7 +49,7 @@
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
-    [conversation internalAddParticipants:[NSSet setWithObject:user]];
+    [conversation internalAddParticipants:@[user]];
     
     // when
     [conversation addParticipantIfMissing:user date:[NSDate date]];
@@ -129,8 +129,8 @@
     ZMUser *user2 = [self createUser];
     
     // when
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
-    [conversation internalAddParticipants:[NSSet setWithObject:user2]];
+    [conversation internalAddParticipants:@[user1]];
+    [conversation internalAddParticipants:@[user2]];
     
     // then
     NSOrderedSet *expectedActiveParticipants = [NSOrderedSet orderedSetWithObjects:user1, user2, nil];
@@ -148,7 +148,7 @@
     selfUser.remoteIdentifier = [NSUUID createUUID];
     
     // when
-    [conversation internalAddParticipants:[NSSet setWithObjects:selfUser, nil]];
+    [conversation internalAddParticipants:@[selfUser]];
     WaitForAllGroupsToBeEmpty(0.5f);
     
     // then
@@ -165,7 +165,7 @@
     selfUser.remoteIdentifier = [NSUUID createUUID];
 
     // when
-    [conversation internalAddParticipants:[NSSet setWithObjects:selfUser, nil]];
+    [conversation internalAddParticipants:@[selfUser]];
     WaitForAllGroupsToBeEmpty(0.5f);
     
     // then
@@ -182,12 +182,12 @@
     selfUser.remoteIdentifier = [NSUUID createUUID];
     
 //    [conversation addParticipant:user1];
-    [conversation internalAddParticipants:[NSSet setWithObjects:selfUser, user1, nil]];
+    [conversation internalAddParticipants:@[selfUser, user1]];
     
     XCTAssertTrue(conversation.isSelfAnActiveMember);
     
     // when
-    [conversation internalRemoveParticipants:[NSSet setWithObject:selfUser] sender:user1];
+    [conversation internalRemoveParticipants:@[selfUser] sender:user1];
     WaitForAllGroupsToBeEmpty(0.5f);
     
     // then
@@ -204,10 +204,10 @@
     ZMUser *user3 = [self createUser];
     ZMUser *unknownUser = [self createUser];
     
-    [conversation internalAddParticipants:[NSSet setWithObjects:user1, user2, user3, nil]];
+    [conversation internalAddParticipants:@[user1, user2, user3]];
     
     // when
-    [conversation internalRemoveParticipants:[NSSet setWithObject:unknownUser] sender:user1];
+    [conversation internalRemoveParticipants:@[unknownUser] sender:user1];
     
     // then
     NSSet *expectedActiveParticipants = [NSSet setWithObjects:user1, user2, user3, nil];
@@ -332,7 +332,7 @@
     user3.name = @"Susi Super";
     user4.name = @"Super Susann";
     
-    [conversation internalAddParticipants:[NSSet setWithObjects:user1, user2, user3, user4, nil]];
+    [conversation internalAddParticipants:@[user1, user2, user3, user4]];
     [self.uiMOC saveOrRollback];
     
     NSArray *expected = @[user2, user1, user4, selfUser, user3];

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -880,7 +880,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
@@ -895,7 +895,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
@@ -909,7 +909,7 @@
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.userDefinedName = @"Some conversation";
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
@@ -923,7 +923,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
-    [conversation internalAddParticipants:[NSSet setWithObjects:user1, user2, nil]];
+    [conversation internalAddParticipants:@[user1, user2]];
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
@@ -935,7 +935,7 @@
     ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeGroup);
@@ -948,7 +948,7 @@
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertEqual(conversation.connectedUser, user1);
@@ -960,7 +960,7 @@
     ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
-    [conversation internalAddParticipants:[NSSet setWithObject:user1]];
+    [conversation internalAddParticipants:@[user1]];
     
     // then
     XCTAssertNil(conversation.connectedUser);
@@ -1951,7 +1951,7 @@
     ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMUser *user2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     
-    [conversation internalAddParticipants:[NSSet setWithObjects:user1, user2, nil]];
+    [conversation internalAddParticipants:@[user1, user2]];
     
     XCTAssertTrue(conversation.isSelfAnActiveMember);
     XCTAssertEqual(conversation.lastServerSyncedActiveParticipants.count, 2u);
@@ -1962,7 +1962,7 @@
     
     // when
 
-    [conversation internalRemoveParticipants:[NSSet setWithObject:user2] sender:user1];
+    [conversation internalRemoveParticipants:@[user2] sender:user1];
     
     // then
     XCTAssertTrue(conversation.isSelfAnActiveMember);
@@ -1981,7 +1981,7 @@
     ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMUser *user2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     
-    [conversation internalAddParticipants:[NSSet setWithObjects:user1, user2, nil]];
+    [conversation internalAddParticipants:@[user1, user2]];
     
     XCTAssertTrue(conversation.isSelfAnActiveMember);
     XCTAssertEqual(conversation.lastServerSyncedActiveParticipants.count, 2u);
@@ -2129,7 +2129,7 @@
     ZMConversationList *clearedList = [ZMConversationList clearedConversationsInUserSession:self.mockUserSessionWithUIMOC];
     
     // when
-    [conversation internalRemoveParticipants:[NSSet setWithObject:selfUser] sender:user0];
+    [conversation internalRemoveParticipants:@[selfUser] sender:user0];
     
     // then
     XCTAssertTrue([activeList predicateMatchesConversation:conversation]);
@@ -2254,7 +2254,7 @@
     message2.serverTimestamp = [NSDate date];
     
     // when
-    [conversation internalRemoveParticipants:[NSSet setWithObject:user1] sender:self.selfUser];
+    [conversation internalRemoveParticipants:@[user1] sender:self.selfUser];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -2295,7 +2295,7 @@
     XCTAssertFalse(conversation.isArchived);
     
     // when
-    [conversation internalRemoveParticipants:[NSSet setWithObject:selfUser] sender:selfUser];
+    [conversation internalRemoveParticipants:@[selfUser] sender:selfUser];
     WaitForAllGroupsToBeEmpty(0.5f);
     
     // then
@@ -3239,7 +3239,7 @@
     groupConversationWithSelf.remoteIdentifier = [NSUUID createUUID];
     
     ZMConversation *groupConversationWithNoOtherParticipants = [ZMConversation insertGroupConversationIntoManagedObjectContext:self.uiMOC withParticipants:@[otherUser, secondUser]];
-    [groupConversationWithNoOtherParticipants internalRemoveParticipants:[NSSet setWithObjects:otherUser, secondUser, nil] sender:self.selfUser];
+    [groupConversationWithNoOtherParticipants internalRemoveParticipants:@[otherUser, secondUser] sender:self.selfUser];
     groupConversationWithNoOtherParticipants.isSelfAnActiveMember = YES;
     
     ZMConversation *archived = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -703,7 +703,7 @@ extension ZMAssetClientMessageTests {
         let otherClient = createClient(for: otherUser, createSessionWithSelfUser: true)
         let conversation = ZMConversation.insertNewObject(in:self.syncMOC)
         conversation.conversationType = .group
-        conversation.internalAddParticipants(Set(arrayLiteral: otherUser))
+        conversation.internalAddParticipants([otherUser])
         XCTAssertTrue(self.syncMOC.saveOrRollback())
         
         return (otherClient, conversation)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -47,7 +47,7 @@ extension ClientMessageTests_OTR {
             let conversation = ZMConversation.insertNewObject(in:self.syncMOC)
             conversation.conversationType = .group
             conversation.remoteIdentifier = UUID.create()
-            conversation.internalAddParticipants(Set(arrayLiteral: otherUser))
+            conversation.internalAddParticipants([otherUser])
             XCTAssertTrue(self.syncMOC.saveOrRollback())
             
             // when

--- a/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -674,7 +674,7 @@ class ConversationObserverTests : NotificationDispatcherTestBase {
         self.checkThatItNotifiesTheObserverOfAChange(conversation,
                                                      modifier: { conversation, _ in
                                                         let user = ZMUser.insertNewObject(in: self.uiMOC)
-                                                        conversation.internalAddParticipants(Set(arrayLiteral: user))
+                                                        conversation.internalAddParticipants([user])
         },
                                                      expectedChangedFields: ["securityLevelChanged", "messagesChanged", "nameChanged", "participantsChanged"],
                                                      expectedChangedKeys: ["displayName", "allMessages", "lastServerSyncedActiveParticipants", "securityLevel"])

--- a/Tests/Source/Model/User/ZMUserLegalHoldTests.swift
+++ b/Tests/Source/Model/User/ZMUserLegalHoldTests.swift
@@ -47,6 +47,9 @@ class ZMUserLegalHoldTests: ModelObjectsTests {
         let selfUser = ZMUser.selfUser(in: uiMOC)
         createSelfClient(onMOC: uiMOC)
 
+        let conversation = createConversation(in: uiMOC)
+        conversation.internalAddParticipants([selfUser])
+
         // WHEN
         let request = LegalHoldRequest.mockRequest(for: selfUser)
         selfUser.userDidReceiveLegalHoldRequest(request)
@@ -59,6 +62,10 @@ class ZMUserLegalHoldTests: ModelObjectsTests {
         // THEN
         XCTAssertEqual(selfUser.legalHoldStatus, .enabled)
         XCTAssertTrue(selfUser.needsToAcknowledgeLegalHoldStatus)
+
+        let lastMessage = conversation.lastMessage as? ZMSystemMessage
+        XCTAssertEqual(lastMessage?.systemMessageType, .legalHoldEnabled)
+        XCTAssertTrue(conversation.isUnderLegalHold)
     }
 
     func testThatItDoesntClearPendingStatus_AfterAcceptingWrongRequest() {

--- a/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
+++ b/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
@@ -315,9 +315,9 @@ extension DuplicatedEntityRemovalTests {
         let conversation1 = createConversation()
         let conversation2 = createConversation()
         let conversation3 = createConversation()
-        conversation1.internalAddParticipants(Set([user1, user2]))
-        conversation2.internalAddParticipants(Set([user1]))
-        conversation3.internalAddParticipants(Set([user2]))
+        conversation1.internalAddParticipants([user1, user2])
+        conversation2.internalAddParticipants([user1])
+        conversation3.internalAddParticipants([user2])
         self.moc.saveOrRollback()
         
         // sanity check
@@ -341,9 +341,9 @@ extension DuplicatedEntityRemovalTests {
         let conversation1 = createConversation()
         let conversation2 = createConversation()
         let conversation3 = createConversation()
-        conversation1.internalAddParticipants(Set([user1, user2]))
-        conversation2.internalAddParticipants(Set([user1]))
-        conversation3.internalAddParticipants(Set([user2]))
+        conversation1.internalAddParticipants([user1, user2])
+        conversation2.internalAddParticipants([user1])
+        conversation3.internalAddParticipants([user2])
         self.moc.saveOrRollback()
         
         // sanity check


### PR DESCRIPTION
## What's new in this PR?

In this PR, we fix bugs related to the disclosure of legal hold to the user.

### ZIOS-11493: Wrong position of legal hold system message when creating a group

When a user under legal hold created a group conversation, the system message indicating that legal hold is enabled was inserted before the "new conversation" system messages. The expected behavior is the opposite.

#### Causes

The method `+[ZMConversation insertGroupConversationIntoManagedObjectContext:withParticipants:]` previously inserted the users in the conversation before inserting the new conversation message. However, the call to insert users (`-[ZMConversation internalParticipants:]`) also called the method to degrade the conversation if needed.

While this didn't have any effect on verification, because the conversation isn't verified when created, it actually caused the legal hold to be enabled, because the conversation is legal-hold-disabled by default and the degradation enables it.

#### Solutions

We refactor this method to insert the users after inserting the new conversation message, thus avoiding the degradation before inserting the message. To support this, we update the `appendNewConversationSystemMessage` method to pass in the users that were initially added.

Another change we did is updating the `internalAddParticipants` to take an array instead of a set. The reason behind this is that previously, the insert conversation method, which takes an array of users, iterated over the users and called `internalAddParticipants` with a set of one user at a time, to retain the order inside the mutableLastServerSyncedActiveParticipants, which is an ordered set. To make it more efficient, we now pass an array to this method and convert it to an ordered set.

### ZIOS-11498: Legal hold status isn't displayed in any conversation on the device where it was accepted

There was a bug where the device where legal hold is accepted doesn't display any indication that legal hold is enabled in the conversations that existed prior to the approval.

#### Causes

Legal hold is enabled for conversations in a call for `decreaseSecurityLevelIfNeededAfterDiscoveringClients`, which is called when a client is added remotely, not locally, as it's the case for the legal hold client on the client that accepts the hold.

#### Solutions

Call the degradation flow via `decreaseSecurityLevelIfNeededAfterDiscoveringClients` in the block called by the request strategy when the user accepts the legal hold request.