### PR TITLE
ZIOS-11499: Fix redundant legal hold update messages

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests+Legalhold.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Legalhold.swift
@@ -196,9 +196,10 @@ class ZMConversationTests_Legalhold: ZMConversationTestsBase {
             conversation.conversationType = .group
             conversation.internalAddParticipants([selfUser, otherUser, otherUserB])
             conversation.legalHoldStatus = .disabled
-            
+
             // WHEN
-            conversation.updateSecurityLevelIfNeededAfterFetchingClients()
+            let noChanges: ZMConversationRemoteClientChangeSet = []
+            conversation.updateSecurityLevelIfNeededAfterFetchingClients(changes: noChanges)
             
             // THEN
             XCTAssertEqual(conversation.legalHoldStatus, .pendingApproval)
@@ -222,7 +223,8 @@ class ZMConversationTests_Legalhold: ZMConversationTestsBase {
             conversation.legalHoldStatus = .enabled
             
             // WHEN
-            conversation.updateSecurityLevelIfNeededAfterFetchingClients()
+            let noChanges: ZMConversationRemoteClientChangeSet = []
+            conversation.updateSecurityLevelIfNeededAfterFetchingClients(changes: noChanges)
             
             // THEN
             XCTAssertEqual(conversation.legalHoldStatus, .disabled)
@@ -247,7 +249,8 @@ class ZMConversationTests_Legalhold: ZMConversationTestsBase {
             XCTAssertEqual(conversation.legalHoldStatus, .pendingApproval)
             
             // WHEN
-            conversation.updateSecurityLevelIfNeededAfterFetchingClients()
+            let noChanges: ZMConversationRemoteClientChangeSet = []
+            conversation.updateSecurityLevelIfNeededAfterFetchingClients(changes: noChanges)
             
             // THEN
             XCTAssertEqual(conversation.legalHoldStatus, .pendingApproval)
@@ -271,7 +274,8 @@ class ZMConversationTests_Legalhold: ZMConversationTestsBase {
             XCTAssertEqual(conversation.legalHoldStatus, .disabled)
             
             // WHEN
-            conversation.updateSecurityLevelIfNeededAfterFetchingClients()
+            let noChanges: ZMConversationRemoteClientChangeSet = []
+            conversation.updateSecurityLevelIfNeededAfterFetchingClients(changes: noChanges)
             
             // THEN
             XCTAssertEqual(conversation.legalHoldStatus, .disabled)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When receiving a message with a legal hold hint, we would insert too many system messages:

```
<legal hold activated>
<message content>
<legal hold deactivated>
<legal hold activated>
```

### Causes

The reason behind this is that after we finish the request to the BE to verify the legal hold hint, we'd call `updateSecurityLevelIfNeededAfterFetchingClients`, which performs an unconditional legal hold state update before we actually fetch the legal hold client. This caused a legal hold disabled system message to be inserted, and a hold-enabled message to be inserted later after we actually fetch the device. 

### Solutions

- Create a `ZMConversationRemoteClientChangeSet` option set to pass the type of changes that occurred to `updateSecurityLevelIfNeededAfterFetchingClients`
- If there are no changes, that means that the local state is correct, and that therefore we can update the legal hold state.
- If there are changes, we need to wait for them to process (eg client metadata to be fetched), which will in turn cause a legal hold status update through existing flows (adding a client, removing a client, etc).

We also stop assuming which type of event enable or disable legal hold, and we always check for both scenarios in `updateLegalHoldState` (reduces complexity and possible errors). 