### PR TITLE
Message stuck in sending

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -223,10 +223,11 @@ private let zmLog = ZMSLog(tag: "UserClient")
     /// If called on a client belonging to the self user this method does nothing.
     
     public func update(with payload: [String: Any]) {
+        self.needsToBeUpdatedFromBackend = false
+        
         guard user?.isSelfUser == false, let deviceClass = payload["class"] as? String else { return }
         
         self.deviceClass = DeviceClass(rawValue: deviceClass)
-        self.needsToBeUpdatedFromBackend = false
     }
 
     /// Resets releationships and ends an exisiting session before deleting the object

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -835,3 +835,49 @@ extension UserClientTests {
     }
 }
 
+// MARK: - Update from payload
+
+extension UserClientTests {
+    
+    func testThatItUpdatesDeviceClassFromPayload() {
+        // given
+        let allCases: [DeviceClass] = [.desktop, .phone, .tablet, .legalHold]
+        let client = UserClient.insertNewObject(in: uiMOC)
+        client.user = createUser(in: uiMOC)
+        
+        for deviceClass in allCases {
+            // when
+            client.update(with: ["class": deviceClass.rawValue])
+            
+            // then
+            XCTAssertEqual(client.deviceClass, deviceClass)
+        }
+    }
+    
+    func testThatItSelfClientsAreNotUpdatedFromPayload() {
+        // given
+        let deviceClass = DeviceClass.desktop
+        let selfClient = createSelfClient()
+        
+        // when
+        selfClient.update(with: ["class": deviceClass.rawValue])
+        
+        // then
+        XCTAssertNotEqual(selfClient.deviceClass, deviceClass)
+    }
+    
+    func testThatItResetsNeedsToBeUpdatedFromBackend() {
+        // given
+        let client = UserClient.insertNewObject(in: uiMOC)
+        client.user = createUser(in: uiMOC)
+        client.needsToBeUpdatedFromBackend = true
+        
+        // when
+        client.update(with: [:])
+        
+        // then
+        XCTAssertFalse(client.needsToBeUpdatedFromBackend)
+    }
+        
+}
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

Messages fail to send certain conversations

### Causes

The message depends on a client to be updated but it never updates because the server response doesn't contain the expected `class` field

### Solutions

The  `class` field is optional so we should not require it to be present.