### PR TITLE
Don't update legal status while we are still gathering client changes

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -167,6 +167,11 @@ extension ZMConversation {
     }
 
     private func updateLegalHoldState(cause: SecurityChangeCause) {
+        guard !needsToVerifyLegalHold, !activeParticipants.any({ $0.clients.any(\.needsToBeUpdatedFromBackend) }) else {
+            // We don't update the legal hold status if we are still gathering information about which clients were added/deleted
+            return
+        }
+        
         let detectedParticipantsUnderLegalHold = activeParticipants.any(\.isUnderLegalHold)
 
         switch (legalHoldStatus, detectedParticipantsUnderLegalHold) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When discovering a legal hold through metadata flag we would insert too many legal hold system messages.

### Causes

We would update legal hold status after each client change we discover. This would cause us to disable and then immediately enabled legal hold depending on the order of how we discover the clients.

Example:

1. We receive a message with `legal hold = true` metadata flag
**We insert legal hold enabled system message**
2. We start verifying the legal hold by fetching all the clients in the conversations and discover client A and B, where client B is the legal hold client.
3. Client A metadata  arrives first and we recompute the legal hold status and discover that there's no legal hold.
**We insert legal hold disabled system message**
4. Client B metadata  arrives and we recompute the legal hold status and finally discovers the legal hold client.
**We insert legal hold enabled system message**

### Solutions

Don't re-compute the legal hold status while we are in the process of gathering all the client changes.

This is safe to do since we are guaranteed to attempt to re-compute legal hold after fetching client metadata and after fetching the clients present in a conversation.