### PR TITLE
Fix issues with legal hold being discovered by a message edit

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -342,7 +342,7 @@ extension ZMConversation {
     private func appendLegalHoldEnabledSystemMessageForConversation(cause: SecurityChangeCause) {
         var timestamp : Date?
         
-        if case .addedClients(_, let message) = cause, message?.conversation == self {
+        if case .addedClients(_, let message) = cause, message?.conversation == self, message?.isUpdatingExistingMessage == false {
             timestamp = self.timestamp(before: message)
         }
         
@@ -698,6 +698,15 @@ extension ZMSystemMessage {
         let fetchRequest = ZMSystemMessage.sortedFetchRequest(with: compound)!
         let result = conversation.managedObjectContext!.executeFetchRequestOrAssert(fetchRequest)!
         return result.first as? ZMSystemMessage
+    }
+}
+
+extension ZMOTRMessage {
+    
+    fileprivate var isUpdatingExistingMessage: Bool {
+        guard let genericMessage = genericMessage else { return false }
+        
+        return genericMessage.hasEdited() || genericMessage.hasReaction()
     }
 }
 

--- a/Source/Model/Message/ZMClientMessage.m
+++ b/Source/Model/Message/ZMClientMessage.m
@@ -237,6 +237,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     if (self.genericMessage.hasEdited) {
         // Re-apply the edit since we've restored the orignal nonce when the message expired
         [self editText:self.textMessageData.messageText mentions:self.textMessageData.mentions fetchLinkPreview:YES];
+        [super resend];
     } else {
         [super resend];
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.m
@@ -259,6 +259,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    XCTAssertFalse(message.isExpired);
     XCTAssertNotEqualObjects(editNonce2, editNonce1);
     XCTAssertEqualObjects(message.genericMessage.edited.replacingMessageId, originalNonce.transportString);
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

@VictorWissink discovered several issues with edited messages when discovering legal hold.

1. An edited message doesn't trigger the legal hold discovered alert
2. An edited message which is expired can't be resent by tapping the resend button.
3. The `legal hold discovered` system message is inserted above the edited message which would falsely indicate that all the following messages are also under legal hold.

### Causes

#### 1.  An edited message doesn't trigger the legal hold discovered alert

This happens when the original message which was edited message is older than the message timeout limit (60 seconds) because the fetch request which collects the undelivered messages was only looking for messages with a `serverTimestamp` not older than the message timeout limit. Edited messages don't modify the `serverTimestamp` instead they assign the `updatedTimestamp`.

#### 2.  An edited message which is expired can't be resent by tapping the resend button.

When resending an edited message we were re-applying the edit but not resetting the `isExpired` flag by calling `[super resend]`.


#### 3. The `legal hold discovered` system message is inserted above the edited message

If a legal hold was discovered by a message we were always inserting the system above the message which discovered it.

### Solutions

#### 1. An edited message doesn't trigger the legal hold discovered alert

Also include messages with an `updatedTimestamp` newer than the timeout limit.

#### 2. An edited message which is expired can't be resent by tapping the resend button.

Call the `[super resend]` method also for edited messages in order to reset the `isExpired` flag.

#### 3. The `legal hold discovered` system message is inserted above the edited message

Insert the legal hold enabled system message at the bottom if it was discovered by an edited message (or reaction).