### PR TITLE
Fix failing integration tests

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -289,9 +289,8 @@ extension ZMConversation {
                                                      timestamp: timestamp)
         systemMessage.needsUpdatingUsers = true
         
-        if let previousLastMessage = previousLastMessage as? ZMSystemMessage,
-            previousLastMessage.systemMessageType == .potentialGap,
-            previousLastMessage.serverTimestamp < timestamp {
+        if let previousLastMessage = previousLastMessage as? ZMSystemMessage, previousLastMessage.systemMessageType == .potentialGap,
+           let previousLastMessageTimestamp = previousLastMessage.serverTimestamp, previousLastMessageTimestamp <= timestamp {
             // In case the message before the new system message was also a system message of
             // the type ZMSystemMessageTypePotentialGap, we delete the old one and update the
             // users property of the new one to use old users and calculate the added / removed users

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -755,7 +755,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     } else if (create) {
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:moc];
         conversation.remoteIdentifier = UUID;
-        conversation.lastModifiedDate = [NSDate dateWithTimeIntervalSince1970:0];
         conversation.lastServerTimeStamp = [NSDate dateWithTimeIntervalSince1970:0];
         if (nil != created) {
             *created = YES;


### PR DESCRIPTION
## What's new in this PR?

### Issues

The integration tests started failing after we fixed the conversation list order when restoring from a backup https://github.com/wireapp/wire-ios-data-model/pull/749

Two tests started to fail:

`testThatTheConversationListOrderIsUpdatedAsWeReceiveMessages`
`testThatPreviousPotentialGapSystemMessageGetsDeletedAndNewOneUpdatesWithOldUsers`

### Causes

`testThatTheConversationListOrderIsUpdatedAsWeReceiveMessages`:

This test was failing because a new group conversation would have the `lastModifiedDate` set to the 1970:s until the first message is posted. Since `lastModifiedDate`is used to calculate the conversation list order the test started to fail.

The reason why the `lastModifiedDate` was stuck to 1970:s is because we assign an initial `lastModifiedDate` when creating a conversation and since https://github.com/wireapp/wire-ios-data-model/pull/749 we no longer update `lastModifiedDate` when updating the conversation metadata if `lastModifiedDate != nil`.

-----

`testThatPreviousPotentialGapSystemMessageGetsDeletedAndNewOneUpdatesWithOldUsers`

Since `lastModifiedDate` is no longer updated when re-fetching the metadata of a conversation if it's already set, `lastModifiedDate` stayed the same which had the side effect that we inserted `.potentialGap` system messages with the same timestamp. 

This made some logic we had for collapsing multiple `.potentialGap` messages into one single `.potentialGap` message fail.


### Solutions

`testThatTheConversationListOrderIsUpdatedAsWeReceiveMessages`:

Don't assign an initial `lastModifiedDate` when creating a conversation so that the initial correct `lastModifiedDate` can be assigned from the conversation metadata.

-----

`testThatPreviousPotentialGapSystemMessageGetsDeletedAndNewOneUpdatesWithOldUsers`

Collapse `.potentialGap` messages together also if they have the timestamp.