### PR TITLE
Add support for observing when the team image data changes

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -112,6 +112,13 @@ extension Team {
         }
 
         set {
+            defer {
+                if let uiContext = managedObjectContext?.zm_userInterface {
+                    // Notify about a non core data change since the image is persisted in the file cache
+                    NotificationDispatcher.notifyNonCoreDataChanges(objectID: objectID, changedKeys: [#keyPath(Team.imageData)], uiContext: uiContext)
+                }
+            }
+            
             guard let newValue = newValue else {
                 managedObjectContext?.zm_fileAssetCache.deleteAssetData(for: self, format: Team.defaultLogoFormat, encrypted: false)
                 return

--- a/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
@@ -26,6 +26,8 @@ extension Team : ObjectInSnapshot {
         return [
             #keyPath(Team.name),
             #keyPath(Team.members),
+            #keyPath(Team.imageData),
+            #keyPath(Team.pictureAssetId),
         ]
     }
     
@@ -59,6 +61,10 @@ extension Team : ObjectInSnapshot {
     public var nameChanged : Bool {
         return changedKeys.contains(#keyPath(Team.name))
     }
+    
+    public var imageDataChanged : Bool {
+        return changedKeysContain(keys: #keyPath(Team.imageData), #keyPath(Team.pictureAssetId))
+    }
 
 }
 
@@ -72,7 +78,17 @@ extension Team : ObjectInSnapshot {
 extension TeamChangeInfo {
     
     // MARK: Registering TeamObservers
+    
+    /// Adds an observer for a team
+    ///
+    /// You must hold on to the token and use it to unregister
+    @objc(addTeamObserver:forTeam:)
+    public static func add(observer: TeamObserver, for team: Team) -> NSObjectProtocol {
+        return add(observer: observer, for: team, managedObjectContext: team.managedObjectContext!)
+    }
+    
     /// Adds an observer for the team if one specified or to all Teams is none is specified
+    ///
     /// You must hold on to the token and use it to unregister
     @objc(addTeamObserver:forTeam:managedObjectContext:)
     public static func add(observer: TeamObserver, for team: Team?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
@@ -84,7 +100,8 @@ extension TeamChangeInfo {
             
             observer.teamDidChange(changeInfo)
         }
-    }    
+    }
+    
 }
 
 

--- a/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
@@ -37,7 +37,8 @@ class TeamObserverTests: NotificationDispatcherTestBase {
     var userInfoKeys : Set<String> {
         return [
             #keyPath(TeamChangeInfo.membersChanged),
-            #keyPath(TeamChangeInfo.nameChanged)
+            #keyPath(TeamChangeInfo.nameChanged),
+            #keyPath(TeamChangeInfo.imageDataChanged)
         ]
     }
     
@@ -50,6 +51,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
         
         // when
         modifier(team)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         self.uiMOC.saveOrRollback()
         
         // then
@@ -79,6 +81,18 @@ class TeamObserverTests: NotificationDispatcherTestBase {
                                                      expectedChangedFields: [#keyPath(TeamChangeInfo.nameChanged)]
         )
         
+    }
+    
+    func testThatItNotifiesTheObserverOfChangedImageData() {
+        // given
+        let team = Team.insertNewObject(in: self.uiMOC)
+        self.uiMOC.saveOrRollback()
+        
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(team,
+                                                     modifier: { $0.imageData = "image".data(using: .utf8)! },
+                                                     expectedChangedFields: [#keyPath(TeamChangeInfo.imageDataChanged)]
+        )
     }
 
     func testThatItNotifiesTheObserverOfInsertedMembers() {
@@ -114,5 +128,6 @@ class TeamObserverTests: NotificationDispatcherTestBase {
                                                      expectedChangedFields: [#keyPath(TeamChangeInfo.membersChanged)]
         )
     }
+    
 }
 


### PR DESCRIPTION
## What's new in this PR?

- Add support for observing when the `imageData` property changes on a `Team`. 
- Add `Team.add(observer: TeamObserver, for team: Team)` so that UI can observe a team without having a reference to the managed object context.