### PR TITLE
Fix: app crashes when calling addParticipantIfMissing

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -316,12 +316,7 @@ extension ZMConversation {
     ///   - dateOptional: if provide a nil, current date will be used
     @objc(addParticipantIfMissing:date:)
     public func addParticipantIfMissing(_ user: ZMUser, date dateOptional: Date?) {
-        let date: Date
-        if let dataOptional = dateOptional{
-            date = dataOptional
-        } else {
-            date = Date()
-        }
+        let date = dateOptional ?? Date()
 
         guard !activeParticipants.contains(user) else { return }
         

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -311,6 +311,10 @@ extension ZMConversation {
 
     /// Adds the user to the list of participants if not already present and inserts a .participantsAdded system message
     @objc(addParticipantIfMissing:date:)
+    public func addParticipantIfMissing(_ user: ZMUser, date: Date?) {
+        addParticipantIfMissing(user, at: date ?? Date())
+    }
+
     public func addParticipantIfMissing(_ user: ZMUser, at date: Date = Date()) {
         guard !activeParticipants.contains(user) else { return }
         

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -310,12 +310,19 @@ extension ZMConversation {
     }
 
     /// Adds the user to the list of participants if not already present and inserts a .participantsAdded system message
+    ///
+    /// - Parameters:
+    ///   - user: the participant to add
+    ///   - dateOptional: if provide a nil, current date will be used
     @objc(addParticipantIfMissing:date:)
-    public func addParticipantIfMissing(_ user: ZMUser, date: Date?) {
-        addParticipantIfMissing(user, at: date ?? Date())
-    }
+    public func addParticipantIfMissing(_ user: ZMUser, date dateOptional: Date?) {
+        let date: Date
+        if let dataOptional = dateOptional{
+            date = dataOptional
+        } else {
+            date = Date()
+        }
 
-    public func addParticipantIfMissing(_ user: ZMUser, at date: Date = Date()) {
         guard !activeParticipants.contains(user) else { return }
         
         switch conversationType {

--- a/Source/Model/Message/ZMOTRMessage+VerifySender.swift
+++ b/Source/Model/Message/ZMOTRMessage+VerifySender.swift
@@ -25,6 +25,6 @@ extension ZMConversation {
         guard let senderUUID = updateEvent.senderUUID(),
               let user = ZMUser(remoteID: senderUUID, createIfNeeded: true, in: moc) else { return }
 
-        addParticipantIfMissing(user, at: updateEvent.timeStamp()?.addingTimeInterval(-0.01) ?? Date())
+        addParticipantIfMissing(user, date: updateEvent.timeStamp()?.addingTimeInterval(-0.01))
     }
 }

--- a/Source/Model/Message/ZMOTRMessage+VerifySender.swift
+++ b/Source/Model/Message/ZMOTRMessage+VerifySender.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMConversation {
+    @objc
+    public func verifySender(of updateEvent: ZMUpdateEvent, moc: NSManagedObjectContext) {
+
+        guard let senderUUID = updateEvent.senderUUID(),
+              let user = ZMUser(remoteID: senderUUID, createIfNeeded: true, in: moc) else { return }
+
+        addParticipantIfMissing(user, at: updateEvent.timeStamp()?.addingTimeInterval(-0.01) ?? Date())
+    }
+}

--- a/Source/Model/Message/ZMOTRMessage.m
+++ b/Source/Model/Message/ZMOTRMessage.m
@@ -174,7 +174,7 @@ NSString * const DeliveredKey = @"delivered";
     }
     
     // Verify sender is part of conversation
-    [conversation addParticipantIfMissing:[ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc] date: [updateEvent.timeStamp dateByAddingTimeInterval:-0.01]];
+    [conversation verifySenderOf:updateEvent moc:moc];
 
     // Insert the message
 

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */; };
 		EF17175B22D4CC8E00697EB0 /* Team+MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */; };
 		EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */; };
+		EF1F850422FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F850322FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift */; };
 		EF2C247322AFF368009389C6 /* store2-72-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EF2C247222AFF368009389C6 /* store2-72-0.wiredatabase */; };
 		EF2CBDA720061E2D0004F65E /* ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CBDA620061E2D0004F65E /* ServiceUser.swift */; };
 		EF3510FA22CA07BB00115B97 /* ZMConversationTests+Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3510F922CA07BB00115B97 /* ZMConversationTests+Transport.swift */; };
@@ -854,6 +855,7 @@
 		EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+HasMessages.swift"; sourceTree = "<group>"; };
 		EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+MockTeam.swift"; sourceTree = "<group>"; };
 		EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Filename.swift"; sourceTree = "<group>"; };
+		EF1F850322FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+VerifySender.swift"; sourceTree = "<group>"; };
 		EF2C247122AFE408009389C6 /* zmessaging2.72.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.72.0.xcdatamodel; sourceTree = "<group>"; };
 		EF2C247222AFF368009389C6 /* store2-72-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-72-0.wiredatabase"; sourceTree = "<group>"; };
 		EF2CBDA620061E2D0004F65E /* ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceUser.swift; sourceTree = "<group>"; };
@@ -1574,6 +1576,7 @@
 				F9A706011CAEE01D00C2F5FE /* ZMOTRMessage.h */,
 				F9A706021CAEE01D00C2F5FE /* ZMOTRMessage.m */,
 				16030DC421AEE25500F8032E /* ZMOTRMessage+Confirmations.swift */,
+				EF1F850322FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift */,
 				544A46AD1E2E82BA00D6A748 /* ZMOTRMessage+SecurityDegradation.swift */,
 				8704676A21513DE900C628D7 /* ZMOTRMessage+Unarchive.swift */,
 				165E0F68217F871400E36D08 /* ZMOTRMessage+ContentHashing.swift */,
@@ -2652,6 +2655,7 @@
 				547E664B1F750E4A008CB1FA /* ZMConnection+Notification.swift in Sources */,
 				BF10B59D1E645A3300E7036E /* Analytics+UnknownMessage.swift in Sources */,
 				D5D10DA9203B161700145497 /* ZMConversation+AccessMode.swift in Sources */,
+				EF1F850422FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift in Sources */,
 				165DC523214A614100090B7B /* ZMConversation+Message.swift in Sources */,
 				F9A706811CAEE01D00C2F5FE /* ZMMessage.m in Sources */,
 				F9B71F2B1CB264EF001DB03F /* ZMConversation+Transport.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS 13, App crashes at the line 
```
conversation addParticipantIfMissing:[ZMUser userWithRemoteID:updateEvent.senderUUID createIfNeeded:YES inContext:moc] date: [updateEvent.timeStamp dateByAddingTimeInterval:-0.01]];
```

### Causes

`addParticipantIfMissing` does not accept optional value but it has a default value for `date`.  A mehtod with default value should not exposed to objc callers.

### Solutions

Refactor the method to Swift and make sure all arguments are non nil.