### PR TITLE
Fix team logo not updating

### DIFF
--- a/Source/Model/Message/FileAssetCache.swift
+++ b/Source/Model/Message/FileAssetCache.swift
@@ -353,11 +353,11 @@ private struct FileCache : Cache {
     }
 
     public static func cacheKeyForAsset(for team : Team, identifier: String? = nil, encrypted: Bool = false) -> String? {
-        guard let teamID = team.remoteIdentifier?.uuidString else {
+        guard let teamID = team.remoteIdentifier?.uuidString, let assetID = team.pictureAssetId else {
             return nil
         }
-
-        let key = [teamID, identifier, encrypted ? "encrypted" : nil].compactMap({ $0 }).joined(separator: "_")
+        
+        let key = [teamID, assetID, identifier, encrypted ? "encrypted" : nil].compactMap({ $0 }).joined(separator: "_")
 
         return key.data(using: .utf8)?.zmSHA256Digest().zmHexEncodedString()
     }

--- a/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -445,6 +445,7 @@ extension FileAssetCacheTests {
         syncMOC.performGroupedBlockAndWait {
 
             let team = Team.mockTeam(context: self.syncMOC)
+            team.pictureAssetId = "abc123"
 
             sut.storeAssetData(for: team,
                                format: .medium,
@@ -466,6 +467,7 @@ extension FileAssetCacheTests {
         syncMOC.performGroupedBlockAndWait {
             // given
             let team = Team.mockTeam(context: self.syncMOC)
+            team.pictureAssetId = "abc123"
             let sut = FileAssetCache()
             sut.storeAssetData(for: team,
                                format: .medium,


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the team logo was already assigned it would not update if it was changed.

### Causes

We would not download the new team logo because we would think that we already have the image data locally.

### Solutions

Include the team logo asset id in the cache key to differentiate between old and new team logos.