### PR TITLE
fix: make savePendingLastRead public

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -272,7 +272,7 @@ extension ZMConversation {
     }
     
     @objc
-    func savePendingLastRead() {
+    public func savePendingLastRead() {
         guard let timestamp = pendingLastReadServerTimestamp else { return }
         confirmUnreadMessagesAsRead(until: timestamp)
         updateLastRead(timestamp, synchronize: false)


### PR DESCRIPTION
## What's new in this PR?

`wire-ios` project access `savePendingLastRead` but it is not public. After refactoring the UI code it is not able to access `savePendingLastRead`.