### PR TITLE
Add support deleting conversations

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Deletion.swift
+++ b/Source/Model/Conversation/ZMConversation+Deletion.swift
@@ -1,0 +1,29 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMConversation {
+    
+    open override func prepareForDeletion() {
+        super.prepareForDeletion()
+        
+        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache.deleteAssetData($0)} )
+    }
+    
+}

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -174,7 +174,7 @@ public protocol UserType: NSObjectProtocol {
     @objc(canRemoveUserFromConversation:)
     func canRemoveUser(from conversation: ZMConversation) -> Bool
     
-    /// Wheather the user can delete conversation
+    /// Wheather the user can delete the conversation
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool
     

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -174,6 +174,10 @@ public protocol UserType: NSObjectProtocol {
     @objc(canRemoveUserFromConversation:)
     func canRemoveUser(from conversation: ZMConversation) -> Bool
     
+    /// Wheather the user can delete conversation
+    @objc(canDeleteConversation:)
+    func canDeleteConversation(_ conversation: ZMConversation) -> Bool
+    
     /// Whether the user can toggle the read receipts setting in the conversation.
     @objc(canModifyReadReceiptSettingsInConversation:)
     func canModifyReadReceiptSettings(in conversation: ZMConversation) -> Bool

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -350,6 +350,10 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         return user?.canRemoveUser(from: conversation) == true
     }
     
+    public func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
+        return user?.canDeleteConversation(conversation) == true
+    }
+    
     public func canModifyTitle(in conversation: ZMConversation) -> Bool {
         return user?.canModifyTitle(in: conversation) == true
     }

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -50,6 +50,11 @@ public extension ZMUser {
         return canAddUser(to: conversation)
     }
     
+    @objc(canDeleteConversation:)
+    func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
+        return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
+    }
+    
     @objc(canModifyReadReceiptSettingsInConversation:)
     func canModifyReadReceiptSettings(in conversation: ZMConversation) -> Bool {
         guard !isGuest(in: conversation), conversation.isSelfAnActiveMember else { return false }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Deletion.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Deletion.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class ZMConversationTests_Deletion: ZMConversationTestsBase {
+
+    func testThatCachedAssetsAreDeleted_WhenConversationIsDeleted() {
+        // GIVEN
+        let sut = createConversation(in: uiMOC)
+        let fileMetadata = createFileMetadata()
+        let message = sut.append(file: fileMetadata)!
+        let cacheKey = FileAssetCache.cacheKeyForAsset(message)!
+        self.uiMOC.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: Data.secureRandomData(ofLength: 100))
+        XCTAssertNotNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
+        
+        // WHEN
+        uiMOC.delete(sut)
+        
+        // THEN
+        XCTAssertNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
+    }
+
+}

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -50,6 +50,7 @@ class ZMAssetClientMessageTests_Ephemeral : BaseZMAssetClientMessageTests {
     var deletionTimer : ZMMessageDestructionTimer? {
         return uiMOC.zm_messageDeletionTimer
     }
+    
 }
 
 // MARK: Sending
@@ -58,7 +59,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
     func testThatItInsertsAnEphemeralMessageForAssets(){
         // given
         conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
-        let fileMetadata = addFile()
+        let fileMetadata = createFileMetadata()
         
         // when
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
@@ -98,7 +99,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
     func testThatWhenUpdatingTheThumbnailAssetIDWeReplaceAnEphemeralMessageWithAnEphemeral(){
         // given
         conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
-        let fileMetadata = addFile()
+        let fileMetadata = createFileMetadata()
         
         // when
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
@@ -118,7 +119,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         self.syncMOC.performGroupedBlockAndWait {
             // given
             self.syncConversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
-            let fileMetadata = self.addFile()
+            let fileMetadata = self.createFileMetadata()
             let message = self.syncConversation.append(file: fileMetadata) as! ZMAssetClientMessage
             
             // when
@@ -140,7 +141,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
             self.syncConversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
             
             // send file
-            let fileMetadata = self.addFile()
+            let fileMetadata = self.createFileMetadata()
             message = self.syncConversation.append(file: fileMetadata) as? ZMAssetClientMessage
             message.update(withPostPayload: [:], updatedKeys: Set([#keyPath(ZMAssetClientMessage.transferState)]))
             
@@ -171,7 +172,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
             self.syncConversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
             
             // send file
-            let fileMetadata = self.addFile()
+            let fileMetadata = self.createFileMetadata()
             message = self.syncConversation.append(file: fileMetadata) as? ZMAssetClientMessage
             message.update(withPostPayload: [:], updatedKeys: Set([#keyPath(ZMAssetClientMessage.transferState)]))
             
@@ -206,7 +207,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
         
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
         message.sender = sender
         message.add(ZMGenericMessage.message(content: ZMAsset.asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
@@ -290,7 +291,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
         
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
         message.sender = sender
         XCTAssertFalse(message.genericAssetMessage!.assetData!.hasUploaded())
@@ -310,7 +311,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
         
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
         message.sender = sender
         message.add(ZMGenericMessage.message(content: ZMAsset.asset(withNotUploaded: .CANCELLED), nonce: message.nonce!))
@@ -328,7 +329,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         // given
         let timeout : TimeInterval = 0.1
         conversation.messageDestructionTimeout =  .local(MessageDestructionTimeoutValue(rawValue: timeout))
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
         message.add(ZMGenericMessage.message(content: ZMAsset.asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.genericAssetMessage!.assetData!.hasUploaded())
@@ -345,7 +346,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let timeout : TimeInterval = 0.1
         conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeout))
         
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         let message = conversation.append(file: fileMetadata) as! ZMAssetClientMessage
         conversation.conversationType = .oneOnOne
         message.sender = ZMUser.insertNewObject(in: uiMOC)
@@ -380,7 +381,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         self.conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
         
         // send file
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         message = self.conversation.append(file: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
         message.sender?.remoteIdentifier = UUID.create()
@@ -412,7 +413,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         self.conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: 10))
         
         // send file
-        let fileMetadata = self.addFile()
+        let fileMetadata = self.createFileMetadata()
         message = self.conversation.append(file: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
         message.sender?.remoteIdentifier = UUID.create()

--- a/Tests/Source/Model/ModelObjectsTests+Helpers.swift
+++ b/Tests/Source/Model/ModelObjectsTests+Helpers.swift
@@ -20,6 +20,8 @@ import Foundation
 
 extension ModelObjectsTests {
     
+    // MARK: Users & Teams Members
+    
     @discardableResult func createTeamAndMember(for user: ZMUser, with permissions: Permissions? = nil) -> (Team, Member) {
         let member = Member.insertNewObject(in: uiMOC)
         member.team = .insertNewObject(in: uiMOC)
@@ -37,6 +39,46 @@ extension ModelObjectsTests {
         member.user?.remoteIdentifier = .create()
         member.team = team
         return (member.user!, member)
+    }
+    
+    // MARK: Files
+    
+    func createFileMetadata(filename: String? = nil) -> ZMFileMetadata {
+        let fileURL: URL
+        
+        if let fileName = filename {
+            fileURL = testURLWithFilename(fileName)
+        } else {
+            fileURL = testURLWithFilename("file.dat")
+        }
+        
+        _ = createTestFile(at: fileURL)
+        
+        return ZMFileMetadata(fileURL: fileURL)
+    }
+    
+    func testURLWithFilename(_ filename: String) -> URL {
+        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        let documentsURL = URL(fileURLWithPath: documents)
+        return documentsURL.appendingPathComponent(filename)
+    }
+    
+    func createTestFile(at url: URL) -> Data {
+        let data: Data! = "Some other data".data(using: String.Encoding.utf8)
+        try! data.write(to: url, options: [])
+        return data
+    }
+    
+    func removeTestFile(at url: URL) {
+        do {
+            let fm = FileManager.default
+            if !fm.fileExists(atPath: url.path) {
+                return
+            }
+            try fm.removeItem(at: url)
+        } catch {
+            XCTFail("Error removing file: \(error)")
+        }
     }
     
 }

--- a/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -126,6 +126,37 @@ class ZMUserTests_Permissions: ModelObjectsTests {
         XCTAssertTrue(selfUser.canAddUser(to: self.conversation))
     }
     
+    // MARK: Deleting conversation
+    
+    func testThatConversationCanBeDeleted_ByItsCreator() {
+        // when
+        makeSelfUserTeamMember(withPermissions: .member)
+        conversation.creator = selfUser
+        
+        // then
+        XCTAssertTrue(ZMUser.selfUser(in: uiMOC).canDeleteConversation(conversation))
+    }
+    
+    func testThatConversationCantBeDeleted_ByItsCreatorIfNotAnActiveParticipant() {
+        // when
+        makeSelfUserTeamMember(withPermissions: .member)
+        conversation.isSelfAnActiveMember = false
+        conversation.creator = selfUser
+        
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canDeleteConversation(conversation))
+    }
+    
+    func testThatConversationCantBeDeleted_ByItsCreatorIfANonTeamConversation() {
+        // when
+        makeSelfUserTeamMember(withPermissions: .member)
+        conversation.creator = selfUser
+        conversation.teamRemoteIdentifier = nil
+        
+        // then
+        XCTAssertFalse(ZMUser.selfUser(in: uiMOC).canDeleteConversation(conversation))
+    }
+    
     // MARK: Guests
     
     func testThatItDoesNotReportIsGuest_ForANonTeamConversation() {

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		165124D42188B613006A3C75 /* ZMClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */; };
 		165124D62188CF66006A3C75 /* ZMClientMessage+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */; };
 		165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */; };
+		16519D36231D1BB200C9D76D /* ZMConversation+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16519D35231D1BB200C9D76D /* ZMConversation+Deletion.swift */; };
+		16519D54231D6F8200C9D76D /* ZMConversationTests+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16519D53231D6F8200C9D76D /* ZMConversationTests+Deletion.swift */; };
 		1651F9BE1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */; };
 		165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */; };
 		165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */; };
@@ -591,6 +593,8 @@
 		165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Quotes.swift"; sourceTree = "<group>"; };
 		165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Editing.swift"; sourceTree = "<group>"; };
 		165124D72189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMAssetClientMessage+Quotes.swift"; sourceTree = "<group>"; };
+		16519D35231D1BB200C9D76D /* ZMConversation+Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Deletion.swift"; sourceTree = "<group>"; };
+		16519D53231D6F8200C9D76D /* ZMConversationTests+Deletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Deletion.swift"; sourceTree = "<group>"; };
 		1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+TextMessage.swift"; sourceTree = "<group>"; };
 		165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Predicates.swift"; sourceTree = "<group>"; };
 		165D3A2B1E1D47AB0052E654 /* ZMCallState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMCallState.swift; sourceTree = "<group>"; };
@@ -1500,6 +1504,7 @@
 				F163784E1E5C454C00898F84 /* ZMConversation+Patches.swift */,
 				165911541DF054AD007FA847 /* ZMConversation+Predicates.swift */,
 				545FA5D61E2FD3750054171A /* ZMConversation+MessageDeletion.swift */,
+				16519D35231D1BB200C9D76D /* ZMConversation+Deletion.swift */,
 				BF6EA4D11E2512E800B7BD4B /* ZMConversation+DisplayName.swift */,
 				16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */,
 				BF2ADF621E28CF1E00E81B1E /* SharedObjectStore.swift */,
@@ -1885,6 +1890,7 @@
 				8767E8672163B9EE00390F75 /* ZMConversationTests+Mute.swift */,
 				16030DBD21AE8FAB00F8032E /* ZMConversationTests+Confirmations.swift */,
 				EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */,
+				16519D53231D6F8200C9D76D /* ZMConversationTests+Deletion.swift */,
 				F9B71F571CB2BC85001DB03F /* ZMConversationTests.h */,
 				F9B71F581CB2BC85001DB03F /* ZMConversationTests.m */,
 				F9C8770A1E015AAF00792613 /* AssetColletionTests.swift */,
@@ -2758,6 +2764,7 @@
 				54E3EE431F6194A400A261E3 /* ZMAssetClientMessage+GenericMessage.swift in Sources */,
 				5E39FC67225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift in Sources */,
 				F9A706C31CAEE01D00C2F5FE /* UserImageLocalCache.swift in Sources */,
+				16519D36231D1BB200C9D76D /* ZMConversation+Deletion.swift in Sources */,
 				BF1F52BA1ECC3C9E002FB553 /* Team+Transport.swift in Sources */,
 				1626344B20D935C0000D4063 /* ZMConversation+Timestamps.swift in Sources */,
 				87C125F71EF94EE800D28DC1 /* ZMManagedObject+Grouping.swift in Sources */,
@@ -2926,6 +2933,7 @@
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				16C391E2214BD438003AB3AD /* MentionTests.swift in Sources */,
 				F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */,
+				16519D54231D6F8200C9D76D /* ZMConversationTests+Deletion.swift in Sources */,
 				BF103FA11F0138390047FDE5 /* ManagedObjectContextChangeObserverTests.swift in Sources */,
 				5E9EA4D62242942900D401B2 /* ZMClientMessageTests+LinkAttachments.swift in Sources */,
 				F1B58928202DCF0C002BB59B /* ZMConversationTests+CreationSystemMessages.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- Delete associated cached assets when deleting a conversation
- Add method `canDeleteConversation(_ : ZMConversation)`. on the `UserType`