### PR TITLE
Feature: Support extracting conversationId from .teamConversationDelete event

### DIFF
--- a/Source/Utilis/ZMUpdateEvent+WireDataModel.m
+++ b/Source/Utilis/ZMUpdateEvent+WireDataModel.m
@@ -52,6 +52,10 @@
     if (self.type == ZMUpdateEventTypeUserConnection) {
         return  [[self.payload optionalDictionaryForKey:@"connection"] optionalUuidForKey:@"conversation"];
     }
+    if (self.type == ZMUpdateEventTypeTeamConversationDelete) {
+        return [[self.payload optionalDictionaryForKey:@"data"] optionalUuidForKey:@"conv"];
+    }
+    
     return [self.payload optionalUuidForKey:@"conversation"];
 }
 


### PR DESCRIPTION
## What's new in this PR?

Support extracting the conversation uuid from `.teamConversationDelete` event.