### PR TITLE
Fix: Create one on one conversation Predicate 

### DIFF
--- a/Source/ConversationList/ZMConversationList.m
+++ b/Source/ConversationList/ZMConversationList.m
@@ -235,16 +235,17 @@
     return session.managedObjectContext.conversationListDirectory.unarchivedConversations;
 }
 
-+ (ZMConversationList *)archivedConversationsInUserSession:(id<ZMManagedObjectContextProvider>)session
++ (ZMConversationList *)archivedConversationsInUserSession:(id<ZMManagedObjectContextProvider>)session ///TODO: move to session's extension?
 {
     VerifyReturnNil(session != nil);
     return session.managedObjectContext.conversationListDirectory.archivedConversations;
 }
 
+///TODO: mark depercated
 + (ZMConversationList *)pendingConnectionConversationsInUserSession:(id<ZMManagedObjectContextProvider>)session
 {
     VerifyReturnNil(session != nil);
-    return session.managedObjectContext.conversationListDirectory.pendingConnectionConversations;
+    return session.managedObjectContext.pendingConnectionConversations;
 }
 
 + (ZMConversationList *)clearedConversationsInUserSession:(id<ZMManagedObjectContextProvider>)session

--- a/Source/ConversationList/ZMConversationListDirectory.h
+++ b/Source/ConversationList/ZMConversationListDirectory.h
@@ -29,6 +29,9 @@
 @interface ZMConversationListDirectory : NSObject
 
 @property (nonatomic, readonly, nonnull) ZMConversationList* unarchivedConversations; ///< archived, not pending
+
+@property (nonatomic, readonly, nonnull) ZMConversationList* oneOnOneunarchivedConversations; ///< archived, not pending, oneOnOne only
+
 @property (nonatomic, readonly, nonnull) ZMConversationList* conversationsIncludingArchived; ///< unarchived, not pending,
 @property (nonatomic, readonly, nonnull) ZMConversationList* archivedConversations; ///< archived, not pending
 @property (nonatomic, readonly, nonnull) ZMConversationList* pendingConnectionConversations; ///< pending

--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -34,6 +34,7 @@ static NSString * const PendingKey = @"Pending";
 @interface ZMConversationListDirectory ()
 
 @property (nonatomic) ZMConversationList* unarchivedConversations;
+@property (nonatomic) ZMConversationList* oneOnOneunarchivedConversations;
 @property (nonatomic) ZMConversationList* conversationsIncludingArchived;
 @property (nonatomic) ZMConversationList* archivedConversations;
 @property (nonatomic) ZMConversationList* pendingConnectionConversations;
@@ -57,6 +58,14 @@ static NSString * const PendingKey = @"Pending";
                                                                          filteringPredicate:ZMConversation.predicateForConversationsExcludingArchived
                                                                                         moc:moc
                                                                                 description:@"unarchivedConversations"];
+
+        self.oneOnOneunarchivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
+                                                                         filteringPredicate:ZMConversation.forOneOnOneConversationsExcludingArchived
+                                                                                        moc:moc
+                                                                                description:@"oneOnOneunarchivedConversations"];
+
+
+
         self.archivedConversations = [[ZMConversationList alloc] initWithAllConversations:allConversations
                                                                        filteringPredicate:ZMConversation.predicateForArchivedConversations
                                                                                       moc:moc

--- a/Source/ConversationList/ZMManagedObjectContextProvider+ConversationList.swift
+++ b/Source/ConversationList/ZMManagedObjectContextProvider+ConversationList.swift
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMManagedObjectContextProvider {
+
+    public var oneOnOneConversations: [ZMConversation] {
+        return managedObjectContext.conversationListDirectory().oneOnOneunarchivedConversations as? [ZMConversation] ?? []
+    }
+}

--- a/Source/ManagedObjectContext/NSManagedObjectContext+ConversationList.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+ConversationList.swift
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension NSManagedObjectContext {
+    @objc
+    var pendingConnectionConversations: ZMConversationList {
+        return conversationListDirectory().pendingConnectionConversations
+    }
+}

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -105,11 +105,29 @@ extension ZMConversation {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsIncludingArchived(), notArchivedPredicate])
     }
 
+    @objc(forOneOnOneConversationsExcludingArchived)
+    class func forOneOnOneConversationsExcludingArchived() -> NSPredicate {
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [forOneOnOneConversations(), predicateForConversationsExcludingArchived()])
+    }
+
+
+    class func forOneOnOneConversations() -> NSPredicate {
+        let predicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.oneOnOne.rawValue)")
+
+        return predicate
+    }
+
+    class func forGroupConversations() -> NSPredicate {
+        let predicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
+
+        return predicate
+    }
+
     @objc(predicateForSharableConversations)
     class func predicateForSharableConversations() -> NSPredicate {
         let basePredicate = predicateForConversationsIncludingArchived()
         let hasOtherActiveParticipants = NSPredicate(format: "\(ZMConversationLastServerSyncedActiveParticipantsKey).@count > 0")
-        let oneOnOneOrGroupConversation = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.oneOnOne.rawValue) OR \(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
+        let oneOnOneOrGroupConversation = NSCompoundPredicate(orPredicateWithSubpredicates: [forOneOnOneConversations(), forGroupConversations()])
         let selfIsActiveMember = NSPredicate(format: "isSelfAnActiveMember == YES")
         let synced = NSPredicate(format: "\(remoteIdentifierDataKey()!) != NULL")
         

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -711,9 +711,10 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return moc.conversationListDirectory.unarchivedConversations;
 }
 
+///TODO: make depercated
 + (ZMConversationList *)pendingConversationsInContext:(NSManagedObjectContext *)moc;
 {
-    return moc.conversationListDirectory.pendingConnectionConversations;
+    return moc.pendingConnectionConversations;
 }
 
 - (void)mergeWithExistingConversationWithRemoteID:(NSUUID *)remoteID;

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -138,6 +138,9 @@
     XCTAssertEqualObjects([NSSet setWithArray:list], exepected);
 }
 
+
+///TODO: oneOnOneunarchivedConversations
+
 - (void)testThatItReturnsArchivedConversations;
 {
     // when
@@ -198,6 +201,8 @@
     XCTAssertTrue([directory.allConversationLists containsObject:directory.archivedConversations]);
     XCTAssertTrue([directory.allConversationLists containsObject:directory.pendingConnectionConversations]);
     XCTAssertTrue([directory.allConversationLists containsObject:directory.clearedConversations]);
+
+    ///TODO: oneOnOneunarchivedConversations
 }
 
 @end

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */; };
 		EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */; };
+		EF07C755232FE028004ED088 /* NSManagedObjectContext+ConversationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF07C754232FE028004ED088 /* NSManagedObjectContext+ConversationList.swift */; };
 		EF17175B22D4CC8E00697EB0 /* Team+MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */; };
 		EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */; };
 		EF1F4F542301634500E4872C /* ZMSystemMessage+ChildMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F4F532301634500E4872C /* ZMSystemMessage+ChildMessages.swift */; };
@@ -866,6 +867,7 @@
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
 		EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+HasMessages.swift"; sourceTree = "<group>"; };
 		EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+HasMessages.swift"; sourceTree = "<group>"; };
+		EF07C754232FE028004ED088 /* NSManagedObjectContext+ConversationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+ConversationList.swift"; sourceTree = "<group>"; };
 		EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+MockTeam.swift"; sourceTree = "<group>"; };
 		EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Filename.swift"; sourceTree = "<group>"; };
 		EF1F4F532301634500E4872C /* ZMSystemMessage+ChildMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSystemMessage+ChildMessages.swift"; sourceTree = "<group>"; };
@@ -1441,6 +1443,7 @@
 				F9A705CC1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h */,
 				F9A705CD1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.m */,
 				54FB03AE1E41FC86000E13DC /* NSManagedObjectContext+Patches.swift */,
+				EF07C754232FE028004ED088 /* NSManagedObjectContext+ConversationList.swift */,
 				F93265201D8950F10076AAD6 /* NSManagedObjectContext+FetchRequest.swift */,
 				544E8C101E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift */,
 				87D9CCE81F27606200AA4388 /* NSManagedObjectContext+TearDown.swift */,
@@ -2719,6 +2722,7 @@
 				168913DC2085066800F1E98A /* ZMGenericMessage+Debug.swift in Sources */,
 				F9A7069C1CAEE01D00C2F5FE /* ZMCalculateSetChanges.mm in Sources */,
 				54E3EE3F1F6169A800A261E3 /* ZMAssetClientMessage+FileMessageData.swift in Sources */,
+				EF07C755232FE028004ED088 /* NSManagedObjectContext+ConversationList.swift in Sources */,
 				EF1F4F542301634500E4872C /* ZMSystemMessage+ChildMessages.swift in Sources */,
 				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */; };
 		EF1F4F542301634500E4872C /* ZMSystemMessage+ChildMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F4F532301634500E4872C /* ZMSystemMessage+ChildMessages.swift */; };
 		EF1F850422FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F850322FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift */; };
+		EF26EBDF23326E81001EB65A /* ZMManagedObjectContextProvider+ConversationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF26EBDE23326E80001EB65A /* ZMManagedObjectContextProvider+ConversationList.swift */; };
 		EF2C247322AFF368009389C6 /* store2-72-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EF2C247222AFF368009389C6 /* store2-72-0.wiredatabase */; };
 		EF2CBDA720061E2D0004F65E /* ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CBDA620061E2D0004F65E /* ServiceUser.swift */; };
 		EF3510FA22CA07BB00115B97 /* ZMConversationTests+Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3510F922CA07BB00115B97 /* ZMConversationTests+Transport.swift */; };
@@ -872,6 +873,7 @@
 		EF18C7E51F9E4F8A0085A832 /* ZMUser+Filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Filename.swift"; sourceTree = "<group>"; };
 		EF1F4F532301634500E4872C /* ZMSystemMessage+ChildMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSystemMessage+ChildMessages.swift"; sourceTree = "<group>"; };
 		EF1F850322FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+VerifySender.swift"; sourceTree = "<group>"; };
+		EF26EBDE23326E80001EB65A /* ZMManagedObjectContextProvider+ConversationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMManagedObjectContextProvider+ConversationList.swift"; sourceTree = "<group>"; };
 		EF2C247122AFE408009389C6 /* zmessaging2.72.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.72.0.xcdatamodel; sourceTree = "<group>"; };
 		EF2C247222AFF368009389C6 /* store2-72-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-72-0.wiredatabase"; sourceTree = "<group>"; };
 		EF2CBDA620061E2D0004F65E /* ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceUser.swift; sourceTree = "<group>"; };
@@ -2174,6 +2176,7 @@
 				F9B71F051CB264DF001DB03F /* ZMConversationList+Internal.h */,
 				F9B71F071CB264DF001DB03F /* ZMConversationListDirectory.h */,
 				F9B71F081CB264DF001DB03F /* ZMConversationListDirectory.m */,
+				EF26EBDE23326E80001EB65A /* ZMManagedObjectContextProvider+ConversationList.swift */,
 			);
 			name = ConversationList;
 			path = Source/ConversationList;
@@ -2769,6 +2772,7 @@
 				EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */,
 				16DF3B5D2285B13100D09365 /* UserClientType.swift in Sources */,
 				54E3EE431F6194A400A261E3 /* ZMAssetClientMessage+GenericMessage.swift in Sources */,
+				EF26EBDF23326E81001EB65A /* ZMManagedObjectContextProvider+ConversationList.swift in Sources */,
 				5E39FC67225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift in Sources */,
 				F9A706C31CAEE01D00C2F5FE /* UserImageLocalCache.swift in Sources */,
 				16519D36231D1BB200C9D76D /* ZMConversation+Deletion.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Create new property `ZMManagedObjectContextProvider.oneOnOneConversations` to get the non-archived one-on-one conversations.

The old ways to access a subset of conversations e.g. `ZMConversationList.pendingConnectionConversations` is replaced by `ZMManagedObjectContextProvider.pendingConnectionConversations`
