### PR TITLE
expose ConversationDirectoryChangeInfo init for UI unit tests

### DIFF
--- a/Source/ConversationList/ConversationDirectory.swift
+++ b/Source/ConversationList/ConversationDirectory.swift
@@ -26,6 +26,11 @@ public struct ConversationDirectoryChangeInfo {
     
     public var reloaded: Bool
     public var updatedLists: [ConversationListType]
+
+    public init(reloaded: Bool, updatedLists: [ConversationListType]) {
+        self.reloaded = reloaded
+        self.updatedLists = updatedLists
+    }
     
 }
 


### PR DESCRIPTION
## What's new in this PR?

Allow other projects creating `ConversationDirectoryChangeInfo` instance