### PR TITLE
Fix: partner not being able to to create or fetch a team 1:1 conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -769,7 +769,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     VerifyReturnNil(team != nil);
     VerifyReturnNil(!participant.isSelfUser);
     ZMUser *selfUser = [ZMUser selfUserInContext:moc];
-    VerifyReturnNil(selfUser.canCreateConversation);
 
     ZMConversation *conversation = [self existingTeamConversationInManagedObjectContext:moc withParticipant:participant team:team];
     if (nil != conversation) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

A team member with the partner role can't open team 1:1 conversation

### Causes

The method for fetching a team 1:1 conversation was checking that the self user has the permission to create conversations, which partners don't have.

### Solutions

Remove incorrect permission check.