### PR TITLE
fix: expose ZMConversation.folder

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Labels.swift
+++ b/Source/Model/Conversation/ZMConversation+Labels.swift
@@ -39,7 +39,7 @@ extension ZMConversation {
     }
     
     @objc
-    var folder: LabelType? {
+    public var folder: LabelType? {
         return labels.first(where: { $0.kind == .folder })
     }
     


### PR DESCRIPTION
## What's new in this PR?

Allow UI to get Conversation's folder label