### PR TITLE
Fix: conversations in folder also appearing under groups & people

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -81,7 +81,7 @@ extern NSString *const ZMConversationLastReadLocalTimestampKey;
 extern NSString *const ZMConversationLegalHoldStatusKey;
 
 extern NSString *const SecurityLevelKey;
-extern NSString *const LabelsKey;
+extern NSString *const ZMConversationLabelsKey;
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -96,15 +96,20 @@ extension ZMConversation {
     @objc(predicateForGroupConversations)
     class func predicateForGroupConversations() -> NSPredicate {
         let groupConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
+        let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
         
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), groupConversationPredicate])
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), groupConversationPredicate, notInFolderPredicate])
     }
     
     @objc(predicateForLabeledConversations:)
     class func predicateForLabeledConversations(_ label: Label) -> NSPredicate {
-        let labelPredicate = NSPredicate(format: "%@ IN \(LabelsKey)", label)
+        let labelPredicate = NSPredicate(format: "%@ IN \(ZMConversationLabelsKey)", label)
         
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), labelPredicate])
+    }
+    
+    class func predicateForConversationsInFolders() -> NSPredicate {
+        return NSPredicate(format: "ANY %K.%K == \(Label.Kind.folder.rawValue)", ZMConversationLabelsKey, #keyPath(Label.type))
     }
     
     class func predicateForUnconnectedConversations() -> NSPredicate {
@@ -133,8 +138,9 @@ extension ZMConversation {
     class func predicateForOneToOneConversations() -> NSPredicate {
         // We consider a conversation to be one-to-one if it's of type .oneToOne, is a team 1:1 or an outgoing connection request.
         let oneToOneConversationPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicateForOneToOneConversation(), predicateForTeamOneToOneConversation(), predicateForUnconnectedConversations()])
+        let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
         
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), oneToOneConversationPredicate])
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), oneToOneConversationPredicate, notInFolderPredicate])
     }
     
     @objc(predicateForArchivedConversations)

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -73,7 +73,7 @@ NSString *const ZMNotificationConversationKey = @"ZMNotificationConversationKey"
 NSString *const ZMConversationEstimatedUnreadCountKey = @"estimatedUnreadCount";
 NSString *const ZMConversationRemoteIdentifierDataKey = @"remoteIdentifier_data";
 NSString *const SecurityLevelKey = @"securityLevel";
-NSString *const LabelsKey = @"labels";
+NSString *const ZMConversationLabelsKey = @"labels";
 
 static NSString *const ConnectedUserKey = @"connectedUser";
 static NSString *const CreatorKey = @"creator";
@@ -374,7 +374,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             HasReadReceiptsEnabledKey,
             ZMConversationLegalHoldStatusKey,
             ZMConversationNeedsToVerifyLegalHoldKey,
-            LabelsKey
+            ZMConversationLabelsKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];

--- a/Source/Model/Label/Label.swift
+++ b/Source/Model/Label/Label.swift
@@ -40,7 +40,7 @@ public class Label: ZMManagedObject, LabelType {
     @NSManaged public private(set) var markedForDeletion: Bool
     
     @NSManaged private var remoteIdentifier_data: Data?
-    @NSManaged private var type: Int16
+    @NSManaged public private(set) var type: Int16
     
     public override var ignoredKeys: Set<AnyHashable>? {
         var ignoredKeys = super.ignoredKeys

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -35,7 +35,9 @@
 @property (nonatomic) ZMConversation *outgoingPendingConnectionConversation;
 @property (nonatomic) ZMConversation *invalidConversation;
 @property (nonatomic) ZMConversation *groupConversation;
+@property (nonatomic) ZMConversation *groupConversationInFolder;
 @property (nonatomic) ZMConversation *oneToOneConversation;
+@property (nonatomic) ZMConversation *oneToOneConversationInFolder;
 @property (nonatomic) ZMConversation *clearedConversation;
 @property (nonatomic) ZMConversation *favoritedConversation;
 
@@ -60,6 +62,9 @@
     
     ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     otherUser.remoteIdentifier = [NSUUID createUUID];
+    
+    Label *folder = [Label insertNewObjectInManagedObjectContext:self.uiMOC];
+    folder.name = @"folder A";
     
     self.archivedGroupConversation = [self createConversation];
     self.archivedGroupConversation.conversationType = ZMConversationTypeGroup;
@@ -89,11 +94,23 @@
     self.groupConversation.conversationType = ZMConversationTypeGroup;
     self.groupConversation.userDefinedName = @"groupConversation";
     
+    self.groupConversationInFolder = [self createConversation];
+    self.groupConversationInFolder.conversationType = ZMConversationTypeGroup;
+    self.groupConversationInFolder.userDefinedName = @"groupConversationInFolder";
+    self.groupConversationInFolder.labels = [NSSet setWithObject:folder];
+    
     self.oneToOneConversation = [self createConversation];
     self.oneToOneConversation.conversationType = ZMConversationTypeOneOnOne;
     self.oneToOneConversation.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.uiMOC];
     self.oneToOneConversation.connection.status = ZMConnectionStatusAccepted;
     self.oneToOneConversation.userDefinedName = @"oneToOneConversation";
+    
+    self.oneToOneConversationInFolder = [self createConversation];
+    self.oneToOneConversationInFolder.conversationType = ZMConversationTypeOneOnOne;
+    self.oneToOneConversationInFolder.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.uiMOC];
+    self.oneToOneConversationInFolder.connection.status = ZMConnectionStatusAccepted;
+    self.oneToOneConversationInFolder.userDefinedName = @"oneToOneConversationInFolder";
+    self.oneToOneConversationInFolder.labels = [NSSet setWithObject:folder];
     
     self.invalidConversation = [self createConversation];
     self.invalidConversation.conversationType = ZMConversationTypeInvalid;
@@ -139,7 +156,9 @@
     NSSet *expected = [NSSet setWithArray:@[self.archivedGroupConversation,
                                             self.archivedOneToOneConversation,
                                             self.groupConversation,
+                                            self.groupConversationInFolder,
                                             self.oneToOneConversation,
+                                            self.oneToOneConversationInFolder,
                                             self.outgoingPendingConnectionConversation,
                                             self.favoritedConversation]];
     // then
@@ -151,7 +170,12 @@
 {
     // when
     ZMConversationList *list = self.uiMOC.conversationListDirectory.unarchivedConversations;
-    NSSet *expected = [NSSet setWithArray:@[self.groupConversation, self.oneToOneConversation, self.outgoingPendingConnectionConversation, self.favoritedConversation]];
+    NSSet *expected = [NSSet setWithArray:@[self.groupConversation,
+                                            self.oneToOneConversation,
+                                            self.outgoingPendingConnectionConversation,
+                                            self.favoritedConversation,
+                                            self.groupConversationInFolder,
+                                            self.oneToOneConversationInFolder]];
     
     // then
     XCTAssertEqualObjects([NSSet setWithArray:list], expected);


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you add a conversation to a folder is would still be visible under the groups or people section.

### Causes

We were not filtering out conversations in folders from the groups and people sections.

### Solutions

Update conversation list predicates to filter out conversations in folders.