### PR TITLE
Fix: folder being removed after being inserted

### DIFF
--- a/Source/Notifications/ConversationListObserverCenter.swift
+++ b/Source/Notifications/ConversationListObserverCenter.swift
@@ -123,11 +123,13 @@ public class ConversationListObserverCenter : NSObject, ZMConversationObserver, 
     }
     
     private func labelDidChange(_ changes: LabelChangeInfo) {
-        if changes.markedForDeletion, let label = changes.label as? Label, label.kind == .folder {
+        guard let label = changes.label as? Label else { return }
+        
+        if changes.markedForDeletion, label.kind == .folder, label.markedForDeletion {
             managedObjectContext.conversationListDirectory().deleteFolders([label])
         }
         
-        if changes.conversationsChanged, let label = changes.label as? Label {
+        if changes.conversationsChanged {
             for conversation in label.conversations {
                 let changeInfo = ConversationChangeInfo(object: conversation)
                 changeInfo.changedKeys.insert(#keyPath(ZMConversation.labels))


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you created a new folder and then put the app into background / foreground the folder would disappear.

### Causes

For a newly inserted folder we would get a change notification with all properties marked as "changed", including `markedForDeletion`. We would incorrectly assume that that the folder has been deleted even though `markedForDeletion == false`.

### Solutions

Only delete a folder if `markedForDeletion == true`