### PR TITLE
Fix: folder created while in the background does not appear until restart

### DIFF
--- a/Source/ConversationList/ConversationDirectory.swift
+++ b/Source/ConversationList/ConversationDirectory.swift
@@ -78,7 +78,7 @@ extension ZMConversationListDirectory: ConversationDirectoryType {
             return favoriteConversations as! [ZMConversation]
         case .folder(let label):
             guard let objectID = (label as? Label)?.objectID else { return [] } // TODO jacob make optional?
-            return listsByFolder[objectID] as! [ZMConversation]
+            return listsByFolder[objectID] as? [ZMConversation] ?? []
         }
     }
         

--- a/Source/ConversationList/ZMConversationList.m
+++ b/Source/ConversationList/ZMConversationList.m
@@ -104,7 +104,7 @@
 - (void)recreateWithAllConversations:(NSArray *)conversations
 {
     [self createBackingList:conversations];
-    [self.moc.conversationListObserverCenter recreateSnapshotFor:self];
+    [self.moc.conversationListObserverCenter startObservingList:self];
 }
 
 - (void)calculateKeysAffectingPredicateAndSort;

--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -138,7 +138,7 @@ static NSString * const PendingKey = @"Pending";
     return [[ZMConversationList alloc] initWithAllConversations:allConversations
                                              filteringPredicate:[ZMConversation predicateForLabeledConversations:folder]
                                                             moc:self.managedObjectContext
-                                                    description:folder.name
+                                                    description:folder.objectIDURLString
                                                           label:folder];
 }
 
@@ -175,9 +175,9 @@ static NSString * const PendingKey = @"Pending";
         [list recreateWithAllConversations:allConversations];
     }
     
-    for (ZMConversationList *list in self.listsByFolder.allValues) {
-        [list recreateWithAllConversations:allConversations];
-    }
+    NSArray *allFolders = [self fetchAllFolders:moc];
+    self.folderList = [[FolderList alloc] initWithLabels:allFolders];
+    self.listsByFolder = [self createListsFromFolders:allFolders allConversations:allConversations];
 }
 
 - (NSArray *)allConversationLists;

--- a/Source/Notifications/ConversationListObserverCenter.swift
+++ b/Source/Notifications/ConversationListObserverCenter.swift
@@ -62,21 +62,17 @@ public class ConversationListObserverCenter : NSObject, ZMConversationObserver, 
         self.managedObjectContext = managedObjectContext
     }
     
-    /// Adds a conversationList to the objects to observe
+    /// Adds a conversationList to the objects to observe or replace any existing snapshot
     @objc public func startObservingList(_ conversationList: ZMConversationList)
     {
         if listSnapshots[conversationList.identifier] == nil {
             zmLog.debug("Adding conversationList with identifier \(conversationList.identifier)")
-            listSnapshots[conversationList.identifier] = ConversationListSnapshot(conversationList: conversationList, managedObjectContext: self.managedObjectContext)
-        }
-    }
-    
-    /// Overwrites the current snapshot of the specified conversationList
-    @objc public func recreateSnapshot(for conversationList: ZMConversationList) {
-        zmLog.debug("Recreating snapshot for conversationList with identifier \(conversationList.identifier)")
-        zmLog.ifDebug {
-            (conversationList as Array).forEach{
-                zmLog.debug("Conversation in \(conversationList.identifier) includes: \(String(describing: $0.objectID)) with type: \($0.conversationType.rawValue)")
+        } else {
+            zmLog.debug("Recreating snapshot for conversationList with identifier \(conversationList.identifier)")
+            zmLog.ifDebug {
+                (conversationList as Array).forEach{
+                    zmLog.debug("Conversation in \(conversationList.identifier) includes: \(String(describing: $0.objectID)) with type: \($0.conversationType.rawValue)")
+                }
             }
         }
         listSnapshots[conversationList.identifier] = ConversationListSnapshot(conversationList: conversationList, managedObjectContext: self.managedObjectContext)

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests+Labels.swift
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests+Labels.swift
@@ -1,0 +1,52 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class ZMConversationListDirectoryTests_Labels: ZMBaseManagedObjectTest {
+
+    func testThatItRefetchesAllFolders() {
+        // given
+        let sut = uiMOC.conversationListDirectory()
+        XCTAssertEqual(sut.allFolders.count, 0)
+        let folder = sut.createFolder("Folder A")!
+        
+        // when
+        sut.refetchAllLists(in: uiMOC)
+        
+        // then
+        XCTAssertEqual(sut.allFolders.count, 1)
+        XCTAssertEqual(sut.allFolders.first as? Label, folder as? Label)
+    }
+    
+    func testThatItRefetchesFoldersLists() {
+        // given
+        let conversation = createConversation(in: uiMOC)
+        let sut = uiMOC.conversationListDirectory()
+        let folder = sut.createFolder("Folder A")!
+        conversation.moveToFolder(folder)
+        XCTAssertEqual(sut.conversations(by: .folder(folder)).count, 0)
+        
+        // when
+        sut.refetchAllLists(in: uiMOC)
+        
+        // then
+        XCTAssertEqual(sut.conversations(by: .folder(folder)), [conversation])
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1687C0E12150EE91003099DD /* ZMClientMessageTests+Mentions.swift */; };
 		168913DC2085066800F1E98A /* ZMGenericMessage+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */; };
 		1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */; };
+		16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */; };
 		16A86B4A22A6BF5B00A674F8 /* store2-71-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */; };
 		16A9E354220CAB790062CFCD /* store2-60-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */; };
 		16AD86BA1F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */; };
@@ -650,6 +651,7 @@
 		168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMGenericMessage+Debug.swift"; sourceTree = "<group>"; };
 		1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Editing.swift"; sourceTree = "<group>"; };
 		168E96C4220B445000FC92FA /* zmessaging2.61.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.61.0.xcdatamodel; sourceTree = "<group>"; };
+		16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationListDirectoryTests+Labels.swift"; sourceTree = "<group>"; };
 		16A86B23229EC29800A674F8 /* zmessaging2.71.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.71.0.xcdatamodel; sourceTree = "<group>"; };
 		16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-71-0.wiredatabase"; sourceTree = "<group>"; };
 		16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-60-0.wiredatabase"; path = "Tests/Resources/store2-60-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
@@ -1962,6 +1964,7 @@
 			isa = PBXGroup;
 			children = (
 				F9B71F5A1CB2BC85001DB03F /* ZMConversationListDirectoryTests.m */,
+				16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */,
 				BFE3A96B1ED2EC110024A05B /* ZMConversationListDirectoryTests+Teams.swift */,
 				BFE3A96D1ED301020024A05B /* ZMConversationListTests+Teams.swift */,
 				1672A6292345102400380537 /* ZMConversationListTests+Labels.swift */,
@@ -2980,6 +2983,7 @@
 				7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */,
 				F9B71FA91CB2BF37001DB03F /* ZMConversationTests.m in Sources */,
 				F963E9931D9E9D1800098AD3 /* ZMAssetClientMessageTests+Ephemeral.swift in Sources */,
+				16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */,
 				1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */,
 				F9A708341CAEEB7500C2F5FE /* ManagedObjectContextSaveNotificationTests.m in Sources */,
 				BF491CEC1F063F4B0055EE44 /* AccountStoreTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you create folder on a second device while the app is in the background these would not appear until the app is restarted.

### Causes

When the app is in the background we do not observe any changes so we need re-fetch all conversations & folders which were potentially created in the background. 

We were not re-fetching the folders.

### Solutions

Also re-fetch the folders when re-starting the observation system.