### PR TITLE
Fix: service conversations appearing under groups

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -97,8 +97,9 @@ extension ZMConversation {
     class func predicateForGroupConversations() -> NSPredicate {
         let groupConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
         let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
+        let notTeamOneToOneConveration = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForTeamOneToOneConversation())
         
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), groupConversationPredicate, notInFolderPredicate])
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), groupConversationPredicate, notInFolderPredicate, notTeamOneToOneConveration])
     }
     
     @objc(predicateForLabeledConversations:)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Service conversation would appear under the group section

### Causes

The Group section predicate was not filtering out fake 1:1 conversations

### Solutions

Filter out fake 1:1 conversations.