### PR TITLE
Fix: the initial sorting order folders is inverted

### DIFF
--- a/Source/ConversationList/FolderList.swift
+++ b/Source/ConversationList/FolderList.swift
@@ -37,7 +37,7 @@ public class FolderList: NSObject { // TODO jacob turn into struct and make gene
                 let result = sortDesriptor.compare(lhs, to: rhs)
                 
                 if result != .orderedSame {
-                    return result == .orderedDescending
+                    return result == .orderedAscending
                 }
             }
             
@@ -51,7 +51,7 @@ public class FolderList: NSObject { // TODO jacob turn into struct and make gene
             return
         }
         
-        let index = backingList.firstIndex(where: { return FolderList.comparator($0, label) }) ?? backingList.count
+        let index = backingList.firstIndex(where: { return FolderList.comparator(label, $0) }) ?? backingList.count
         
         backingList.insert(label, at: index)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The initial order of the folder is inverted.

### Causes

Comparator was flipped which was compensated for in the insertion sort method.

### Solutions

Correct the Comparator and undo the correction in the insertion sort method.