### PR TITLE
Fix: folder list observers not created after returning from background

### DIFF
--- a/Source/ConversationList/ZMConversationListDirectory.m
+++ b/Source/ConversationList/ZMConversationListDirectory.m
@@ -177,6 +177,7 @@ static NSString * const PendingKey = @"Pending";
     
     NSArray *allFolders = [self fetchAllFolders:moc];
     self.folderList = [[FolderList alloc] initWithLabels:allFolders];
+    self.listsByFolder = nil;
     self.listsByFolder = [self createListsFromFolders:allFolders allConversations:allConversations];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed that the folder sometimes does not update when moving a conversation.

### Causes

When a `ZMConversationList` is deallocated it attempt to unregister itself with the `ConversationListSnapshotObserver` and when it's allocated it registers itself.

When the app comes back from being the background we recreate all the folder lists which caused the following to happen:

1. register newly created folders lists with the observer centre
2. assign newly created folders lists to  `listsByFolder` this will cause the old folder lists to deallocate which in turn will deregister the newly registered lists.

### Solutions

Nil out `listsByFolder` before assign the new folder lists to avoid scenario above.
