### PR TITLE
[Refactor] Add shouldHideAvailability property to ZMUser

### DIFF
--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -49,6 +49,9 @@ public protocol UserType: NSObjectProtocol {
     /// The availability of the user
     var availability: Availability { get set }
     
+    /// Wether or not the availability should be display for the user
+    var shouldHideAvailability: Bool { get }
+    
     /// The name of the team the user belongs to.
     var teamName: String? { get }
     

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -168,6 +168,12 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         set { user?.availability = newValue }
     }
     
+    public var shouldHideAvailability: Bool {
+        guard let user = user else { return false }
+        
+        return user.shouldHideAvailability
+    }
+    
     public var isSelfUser: Bool {
         guard let user = user else { return false }
         

--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -96,6 +96,21 @@ extension ZMUser {
         }
     }
     
+    public var shouldHideAvailability: Bool {
+        guard let moc = managedObjectContext, !isSelfUser else { return false }
+        
+        let selfUserTeam = ZMUser.selfUser(in: moc).team
+        
+        guard let userTeamId = self.team?.remoteIdentifier, let selfUserTeamId = selfUserTeam?.remoteIdentifier else {
+            return false
+        }
+        
+        let userIsTeammate = userTeamId == selfUserTeamId
+        let communicateStatus = selfUserTeam?.shouldCommunicateStatus ?? true
+        
+        return userIsTeammate && !communicateStatus
+    }
+    
     internal func updateAvailability(_ newValue : Availability) {
         self.willChangeValue(forKey: AvailabilityKey)
         self.setPrimitiveValue(NSNumber(value: newValue.rawValue), forKey: AvailabilityKey)

--- a/Tests/Source/Model/User/UserAvailabilityTests.swift
+++ b/Tests/Source/Model/User/UserAvailabilityTests.swift
@@ -1,0 +1,102 @@
+//
+//  UserAvailabilityTests.swift
+//  WireDataModelTests
+//
+//  Created by David Henner on 25.11.19.
+//  Copyright © 2019 Wire Swiss GmbH. All rights reserved.
+//
+
+
+import XCTest
+@testable import WireDataModel
+
+final class UserAvailabilityTests: ZMBaseManagedObjectTest {
+    var sut: ZMUser!
+    var selfUser: ZMUser!
+    var team1: Team!
+    var team2: Team!
+    
+    override func setUp() {
+        super.setUp()
+        selfUser = ZMUser.selfUser(in: uiMOC)
+        sut = ZMUser.insertNewObject(in: uiMOC)
+        team1 = Team.insertNewObject(in: uiMOC)
+        team1.remoteIdentifier = UUID()
+        team2 = Team.insertNewObject(in: uiMOC)
+        team2.remoteIdentifier = UUID()
+    }
+    
+    override func tearDown() {
+        selfUser = nil
+        sut = nil
+        team1 = nil
+        team2 = nil
+        super.tearDown()
+    }
+    
+    func testThatItShouldHideAvailabilityIfLimitIsReachedAndOtherUserIsTeammate() {
+        // given
+        for _ in 1...(Team.membersOptimalLimit - 2) { // Saving two users for later
+            team1.members.insert(Member.insertNewObject(in: uiMOC))
+        }
+        let member = Member.insertNewObject(in: uiMOC)
+        member.user = sut
+        member.team = team1
+        
+        let selfMember = Member.insertNewObject(in: uiMOC)
+        selfMember.user = selfUser
+        selfMember.team = team1
+        
+        // then
+        XCTAssertTrue(sut.shouldHideAvailability)
+    }
+    
+    func testThatItShouldntHideAvailabilityIfLimitIsReachedAndOtherUserIsntTeammate() {
+        // given
+        for _ in 1...(Team.membersOptimalLimit - 1) { // Saving one user for later
+            team1.members.insert(Member.insertNewObject(in: uiMOC))
+        }
+        let member = Member.insertNewObject(in: uiMOC)
+        member.user = sut
+        member.team = team2
+        
+        let selfMember = Member.insertNewObject(in: uiMOC)
+        selfMember.user = selfUser
+        selfMember.team = team1
+        
+        // then
+        XCTAssertFalse(sut.shouldHideAvailability)
+    }
+    
+    func testThatItShouldntHideAvailabilityIfLimitIsntReached() {
+        // given
+        for _ in 1...(Team.membersOptimalLimit - 3) { // Saving two users for later + going under limit
+            team1.members.insert(Member.insertNewObject(in: uiMOC))
+        }
+        let member = Member.insertNewObject(in: uiMOC)
+        member.user = sut
+        member.team = team1
+        
+        let selfMember = Member.insertNewObject(in: uiMOC)
+        selfMember.user = selfUser
+        selfMember.team = team1
+        
+        // then
+        XCTAssertFalse(sut.shouldHideAvailability)
+    }
+    
+    func testThatItShouldntHideAvailabilityIfSelfUser() {
+        // given
+        for _ in 1...(Team.membersOptimalLimit - 1) { // Saving two users for later
+            team1.members.insert(Member.insertNewObject(in: uiMOC))
+        }
+        
+        let selfMember = Member.insertNewObject(in: uiMOC)
+        selfMember.user = selfUser
+        selfMember.team = team1
+        
+        // then
+        XCTAssertFalse(selfUser.shouldHideAvailability)
+    }
+}
+

--- a/Tests/Source/Model/User/UserAvailabilityTests.swift
+++ b/Tests/Source/Model/User/UserAvailabilityTests.swift
@@ -1,11 +1,20 @@
 //
-//  UserAvailabilityTests.swift
-//  WireDataModelTests
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
 //
-//  Created by David Henner on 25.11.19.
-//  Copyright © 2019 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
-
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
 
 import XCTest
 @testable import WireDataModel

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */; };
 		5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */; };
 		5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */; };
+		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
 		7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */; };
 		7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */; };
@@ -762,6 +763,7 @@
 		5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMPropertyNormalizationResult.m; sourceTree = "<group>"; };
 		5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredUserTests.swift; sourceTree = "<group>"; };
 		5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizationResult.swift; sourceTree = "<group>"; };
+		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
 		7C2E467721072A31007E2566 /* zmessaging2.50.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.50.0.xcdatamodel; sourceTree = "<group>"; };
 		7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Replies.swift"; sourceTree = "<group>"; };
@@ -2015,6 +2017,7 @@
 				F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */,
 				5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */,
 				55C40BD422B0F75C00EFD8BD /* ZMUserLegalHoldTests.swift */,
+				6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */,
 			);
 			name = User;
 			path = Tests/Source/Model/User;
@@ -2851,6 +2854,7 @@
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
+				6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */,
 				F14B9C6F212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift in Sources */,
 				16626508217F4E0B00300F45 /* ZMGenericMessageTests+Hashing.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Moved the `shouldHideAvailability` property implementation & tests from `wire-ios` to `wire-ios-data-model`