### PR TITLE
Fix: fetch role predicate fix and create tests for fetching

### DIFF
--- a/Source/Model/ConversationRole/Action.swift
+++ b/Source/Model/ConversationRole/Action.swift
@@ -39,7 +39,7 @@ final public class Action: ZMManagedObject {
         
         let actions = context.fetchOrAssert(request: fetchRequest)
         return actions.first(where:{
-            $0.role == role            
+            role.actions.contains($0)
         })
     }
 

--- a/Source/Model/ConversationRole/Action.swift
+++ b/Source/Model/ConversationRole/Action.swift
@@ -30,8 +30,7 @@ final public class Action: ZMManagedObject {
         return String(describing: Action.self)
     }
     
-    ///TODO: private
-    static func fetchExistingAction(with name: String,
+    private static func fetchExistingAction(with name: String,
                                     role: Role,
                                     in context: NSManagedObjectContext) -> Action? {
         let fetchRequest = NSFetchRequest<Action>(entityName: self.entityName())
@@ -43,16 +42,16 @@ final public class Action: ZMManagedObject {
         })
     }
 
-    ///TODO: private
     @objc
     @discardableResult
-    static public func create(managedObjectContext: NSManagedObjectContext,
+    private static func create(managedObjectContext: NSManagedObjectContext,
                               name: String) -> Action {
         let entry = Action.insertNewObject(in: managedObjectContext)
         entry.name = name
         return entry
     }
     
+    @discardableResult
     public static func fetchOrCreate(with name: String,
                                      role: Role,
                                      in context: NSManagedObjectContext, created: inout Bool) -> Action {

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -56,7 +56,7 @@ public final class Role: ZMManagedObject {
     @discardableResult
     static public func create(managedObjectContext: NSManagedObjectContext,
                               name: String,
-                              team: Team) -> Role {
+                              team: Team?) -> Role {
         let entry = Role.insertNewObject(in: managedObjectContext)
         entry.name = name
         entry.team = team
@@ -64,9 +64,9 @@ public final class Role: ZMManagedObject {
     }
 
     @objc
-    static func fetchExistingRole(with conversationRole: String, in context: NSManagedObjectContext) -> Role? {
+    static func fetchExistingRole(with name: String, in context: NSManagedObjectContext) -> Role? {
         let fetchRequest = NSFetchRequest<Role>(entityName: Role.entityName())
-        fetchRequest.predicate = NSPredicate(format: "%K == %@", Role.nameKey, conversationRole)
+        fetchRequest.predicate = NSPredicate(format: "%K == %@", Role.nameKey, name)
         fetchRequest.fetchLimit = 1
         
         return context.fetchOrAssert(request: fetchRequest).first

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -87,14 +87,8 @@ public final class Role: ZMManagedObject {
         let role = fetchedRole ?? Role.insertNewObject(in: context)
         
         actionNames.forEach() { actionName in
-            let action = Action.fetchExistingAction(with: actionName, role: role, in: context)
-            
-            if action == nil {
-                let newAction = Action.create(managedObjectContext: context, name: actionName)
-                
-                role.actions.insert(newAction)
-            }
-            
+            var created = false
+            Action.fetchOrCreate(with: actionName, role: role, in: context, created: &created)
         }
 
         role.team = team

--- a/Tests/Source/Model/ConversationRole/ActionTests.swift
+++ b/Tests/Source/Model/ConversationRole/ActionTests.swift
@@ -28,4 +28,22 @@ final class ActionTests: ZMBaseManagedObjectTest {
         
         XCTAssertEqual(sut.keysTrackedForLocalModifications(), expectedKeys)
     }
+    
+    func testThatFetchOrCreate_FetchesAnExistingAction() {
+        let name = "dummy action"
+        let role = Role.create(managedObjectContext: uiMOC, name: "DUMMY", team: nil)
+        
+        // given
+        var created = false
+        let action = Action.fetchOrCreate(with: name, role:role, in: uiMOC, created: &created)
+//        uiMOC.processPendingChanges()
+        XCTAssert(created)
+
+        // when
+        let fetchedAction = Action.fetchOrCreate(with: name, role: role, in: uiMOC, created: &created)
+
+        // then
+        XCTAssertFalse(created)
+        XCTAssertEqual(action, fetchedAction)
+    }
 }

--- a/Tests/Source/Model/ConversationRole/RoleTests.swift
+++ b/Tests/Source/Model/ConversationRole/RoleTests.swift
@@ -21,6 +21,34 @@ import XCTest
 
 final class RoleTests: ZMBaseManagedObjectTest {
     
+    let payload: [String : Any] = [
+        "actions" : [
+            "add_conversation_member",
+            "remove_conversation_member",
+            "modify_conversation_name",
+            "modify_conversation_message_timer",
+            "modify_conversation_receipt_mode",
+            "modify_conversation_access",
+            "modify_other_conversation_member",
+            "leave_conversation",
+            "delete_conversation"
+        ],
+        "conversation_role" : "wire_admin"
+    ]
+
+    var mockConversation: ZMConversation!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockConversation = ZMConversation.insertNewObject(in: uiMOC)
+    }
+
+    override func tearDown() {
+        mockConversation = nil
+        super.tearDown()
+    }
+
     func testThatItTracksCorrectKeys() {
         let expectedKeys = Set(arrayLiteral: Role.nameKey,
                                              Role.teamKey,
@@ -34,25 +62,8 @@ final class RoleTests: ZMBaseManagedObjectTest {
     }
     
     func testThatActionsAreCreatedFromPayload() {
-        // given
-        let payload: [String : Any] = [
-            "actions" : [
-                "add_conversation_member",
-                "remove_conversation_member",
-                "modify_conversation_name",
-                "modify_conversation_message_timer",
-                "modify_conversation_receipt_mode",
-                "modify_conversation_access",
-                "modify_other_conversation_member",
-                "leave_conversation",
-                "delete_conversation"
-            ],
-            "conversation_role" : "wire_admin"
-        ]
-        let conversation = ZMConversation.insertNewObject(in: uiMOC)
-        
-        // when
-        let sut = Role.createOrUpdate(with: payload, team: nil, conversation: conversation, context: uiMOC)!
+        // given & when
+        let sut = Role.createOrUpdate(with: payload, team: nil, conversation: mockConversation, context: uiMOC)!
         
         // then
         XCTAssertEqual(sut.actions.count, 9)
@@ -60,5 +71,16 @@ final class RoleTests: ZMBaseManagedObjectTest {
         
         let action = sut.actions.sorted(by: { $0.name < $1.name }).first!
         XCTAssertEqual(action.name, "add_conversation_member")
+    }
+    
+    func testThatCreateOrUpdate_FetchesAnExistingRole() {
+        // given
+        let role = Role.createOrUpdate(with: payload, team: nil, conversation: mockConversation, context: uiMOC)
+
+        // when
+        let fetchedRole = Role.createOrUpdate(with: payload, team: nil, conversation: mockConversation, context: uiMOC)
+
+        // then
+        XCTAssertEqual(role, fetchedRole)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Fix logic to fetched existing matching `Action`.
Create tests to check that repeated `Role` or `Action` would be fetched but not created.