### PR TITLE
fix: ZMConversationTests.m - tests are not detected in categories

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1906,9 +1906,8 @@
     // then
     XCTAssertEqualObjects(conversation.lastEditableMessage, message);
 }
-@end
 
-@implementation ZMConversationTests (KeyValueObserving)
+#pragma mark - KeyValueObserving
 
 - (void)testThatItRecalculatesHasDraftMessageWhenDraftMessageTextChanges
 {
@@ -2009,10 +2008,7 @@
     XCTAssertEqualObjects(selfConversationID, selfUserID);
 }
 
-@end
-
-
-@implementation ZMConversationTests (Clearing)
+#pragma mark - Clearing
 
 - (void)testThatGettingRemovedIsNotMovingConversationToClearedList
 {
@@ -2183,11 +2179,7 @@
     XCTAssertTrue(conversation.isArchived);
 }
 
-@end
-
-
-
-@implementation ZMConversationTests (Archiving)
+#pragma mark - Archiving
 
 - (void)testThatLeavingAConversationMarksItAsArchived
 {
@@ -2285,11 +2277,7 @@
     XCTAssertEqual([conversation.archivedChangedTimestamp timeIntervalSince1970], [conversation.lastServerTimeStamp timeIntervalSince1970]);
 }
 
-@end
-
-
-
-@implementation ZMConversationTests (Knocking)
+#pragma mark - Knocking
 
 - (ZMConversation *)createConversationWithMessages;
 {
@@ -2326,9 +2314,7 @@
     [self spinMainQueueWithTimeout:interval];
 }
 
-@end
-
-@implementation ZMConversationTests (UnreadCount)
+#pragma mark - UnreadCount
 
 - (void)testThatItDoesNotCountExcludedConversationWithUnreadMessagesAsUnread
 {
@@ -2508,12 +2494,7 @@
     }];
 }
 
-
-@end
-
-
-
-@implementation ZMConversationTests (ConversationListIndicator)
+#pragma mark - ConversationListIndicator
 
 - (void)setConversationAsHavingKnock:(ZMConversation *)conversation
 {
@@ -2682,11 +2663,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
-
-@end
-
-
-@implementation ZMConversationTests (SearchQuerys)
+#pragma mark - SearchQuerys
 
 - (void)testThatItFindsConversationsWithUserDefinedNameByParticipantName
 {
@@ -2908,11 +2885,7 @@
     XCTAssertEqualObjects(result.firstObject, conversation1);
 }
 
-@end
-
-
-
-@implementation ZMConversationTests (Predicates)
+#pragma mark - Predicates
 
 - (void)testThatItFiltersOut_SelfConversation
 {
@@ -3105,11 +3078,7 @@
     XCTAssertTrue([sut evaluateWithObject:conversation]);
 }
 
-@end
-
-
-
-@implementation ZMConversationTests (SelfConversationSync)
+#pragma mark - SelfConversationSync
 
 - (void)testThatItUpdatesTheConversationWhenItReceivesALastReadMessage
 {
@@ -3393,10 +3362,7 @@
     }];
 }
 
-@end
-
-
-@implementation ZMConversationTests (SendOnlyEncryptedMessages)
+#pragma mark - SendOnlyEncryptedMessages
 
 - (void)testThatItInsertsEncryptedTextMessages
 {
@@ -3448,10 +3414,7 @@
     XCTAssertTrue([result.firstObject isKindOfClass:[ZMClientMessage class]]);
 }
 
-@end
-
-
-@implementation ZMConversationTests (SystemMessags)
+#pragma mark - SystemMessags
 
 - (void)testThatItSetsHasUnreadMissedCallForMissedCallMessages
 {
@@ -3656,10 +3619,7 @@
     }];
 }
 
-@end
-
-
-@implementation ZMConversationTests (GroupCallingV3)
+#pragma mark - GroupCallingV3
 
 - (void)testThatItReturnsActiveCall_isCallDeviceActive
 {


### PR DESCRIPTION
## What's new in this PR?

Convert `ZMConversationTests` categories into `#pragma mark -` to fix tests not detected by Xcode issue.