### PR TITLE
Parse self user role

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -21,8 +21,17 @@ import Foundation
 
 extension ZMConversation {
     
+    @objc(insertGroupConversationIntoManagedObjectContext:withParticipants:)
+    static public func insertGroupConversation(moc: NSManagedObjectContext,
+                                                     participants: [ZMUser]) -> ZMConversation? {
+        return self.insertGroupConversation(moc: moc,
+                                            participants: participants,
+                                            name: nil)
+    }
+    
     /// Insert a new group conversation with name into the user session
-    @objc static public func insertGroupConversation(session: ZMManagedObjectContextProvider,
+    @objc
+    static public func insertGroupConversation(session: ZMManagedObjectContextProvider,
                                               participants: [ZMUser],
                                               name: String? = nil,
                                               team: Team? = nil,
@@ -39,7 +48,8 @@ extension ZMConversation {
                                             participantsRole: participantsRole)
     }
     
-    @objc static func insertGroupConversation(moc: NSManagedObjectContext,
+    @objc
+    static public func insertGroupConversation(moc: NSManagedObjectContext,
                                        participants: [ZMUser],
                                        name: String? = nil,
                                        team: Team? = nil,

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -316,7 +316,7 @@ extension ZMConversation {
     /// - Parameters:
     ///   - user: the participant to add
     ///   - dateOptional: if provide a nil, current date will be used
-    func addParticipantIfMissing(_ user: ZMUser, date dateOptional: Date?) {
+    public func addParticipantAndSystemMessageIfMissing(_ user: ZMUser, date dateOptional: Date?) {
         let date = dateOptional ?? Date()
 
         guard !localParticipants.contains(user) else { return }
@@ -324,8 +324,6 @@ extension ZMConversation {
         switch conversationType {
         case .group:
             appendSystemMessage(type: .participantsAdded, sender: user, users: Set(arrayLiteral: user), clients: nil, timestamp: date)
-            // we will fetch the role once we fetch the entire convo metadata
-            self.addParticipantAndUpdateConversationState(user: user, role: nil)
         case .oneOnOne, .connection:
             if user.connection == nil {
                 user.connection = connection ?? ZMConnection.insertNewObject(in: managedObjectContext!)
@@ -336,6 +334,9 @@ extension ZMConversation {
         default:
             break
         }
+        
+        // we will fetch the role once we fetch the entire convo metadata
+        self.addParticipantAndUpdateConversationState(user: user, role: nil)
         
         // A missing user indicate that we are out of sync with the BE so we'll re-sync the conversation
         needsToBeUpdatedFromBackend = true

--- a/Source/Model/Conversation/ZMConversation+Transport.swift
+++ b/Source/Model/Conversation/ZMConversation+Transport.swift
@@ -56,6 +56,7 @@ extension ZMConversation {
         public static let nameKey = "name";
         public static let typeKey = "type";
         public static let IDKey = "id";
+        public static let targetKey = "target";
         
         public static let othersKey = "others";
         public static let membersKey = "members";
@@ -157,21 +158,6 @@ extension ZMConversation {
             }
         }
     }
-
-    private func fetchOrCreateAllUsers(uuids: Set<UUID>) -> Set<ZMUser> {
-        var remoteParticipants = ZMUser.users(withRemoteIDs: uuids, in: self.managedObjectContext!)
-        if remoteParticipants.count != uuids.count {
-            
-            // Some users didn't exist so we need create the missing users
-            let missingUsers = uuids.subtracting(
-                remoteParticipants.map { $0.remoteIdentifier! }
-            )
-            remoteParticipants.formUnion(missingUsers.map {
-                ZMUser(remoteID: $0, createIfNeeded: true, in: self.managedObjectContext!)!
-            })
-        }
-        return Set(remoteParticipants)
-    }
     
     /// Parse the "members" section
     private func updateMembers(payload: [String: Any]) {
@@ -183,36 +169,14 @@ extension ZMConversation {
         }
         let usersInfos = otherUsersInfos + [selfInfo]
         
-        let remoteUUIDsToRoles: [UUID: String?] = usersInfos.reduce([UUID:String?]()) { (prev, payload) in
-            guard let id = payload.UUID(fromKey: PayloadKeys.IDKey) else { return prev }
-            let role = payload[PayloadKeys.conversationRoleKey] as? String
-            return prev.updated(other: [id: role])
-        }
-        
-        let allParticipants = fetchOrCreateAllUsers(uuids: Set(remoteUUIDsToRoles.keys))
-        // I will "re-add" all participants, just to make sure they have the right role
-        let addedParticipantsWithRoles = allParticipants
-            .map { user -> (ZMUser, Role?) in
-                if let roleEntry = remoteUUIDsToRoles[user.remoteIdentifier!],
-                    let roleName = roleEntry
-                {
-                    let role = fetchOrCreateRoleForConversation(name: roleName)
-                    return (user, role)
-                } else {
-                    return (user, nil)
-                }
-            }
+        let usersAndRoles = self.usersPayloadToUserAndRole(
+            payload: usersInfos,
+            userIdKey: PayloadKeys.IDKey)
+        let allParticipants = Set(usersAndRoles.map { $0.0 })
         let removedParticipants = self.localParticipants.subtracting(allParticipants)
   
-        self.addParticipantsAndUpdateConversationState(usersAndRoles: addedParticipantsWithRoles)
+        self.addParticipantsAndUpdateConversationState(usersAndRoles: usersAndRoles)
         self.removeParticipantsAndUpdateConversationState(users: removedParticipants, initiatingUser: ZMUser.selfUser(in: moc))
-    }
-    
-    private func fetchOrCreateRoleForConversation(name: String) -> Role {
-        return Role.fetchOrCreateRole(
-            with: name,
-            teamOrConversation: self.team != nil ? .team(self.team!) : .conversation(self),
-            in: self.managedObjectContext!)
     }
     
     func updateTeam(identifier: UUID?) {
@@ -268,7 +232,75 @@ extension ZMConversation {
 
 }
 
-fileprivate extension Dictionary where Key == String, Value == Any {
+// MARK: - Payload parsing utils
+
+public struct ConversationParsing {
+    private init() {}
+    
+    public static func parseUsersPayloadToUserAndRole(
+        payload: [[String: Any]],
+        userIdKey: String,
+        conversation: ZMConversation
+        ) -> [(ZMUser, Role?)] {
+        return conversation.usersPayloadToUserAndRole(payload: payload, userIdKey: userIdKey)
+    }
+}
+
+extension ZMConversation {
+    
+    /// Extract user and role from a list of dictionaries
+    func usersPayloadToUserAndRole(
+        payload: [[String: Any]],
+        userIdKey: String
+    ) -> [(ZMUser, Role?)] {
+        
+        let uuidsToRoles = payload.reduce([UUID:String?]()) { (prev, payload) in
+            guard let id = payload.UUID(fromKey: userIdKey) else { return prev }
+            let role = payload[ZMConversation.PayloadKeys.conversationRoleKey] as? String
+            return prev.updated(other: [id: role])
+        }
+        let users = self.fetchOrCreateAllUsers(
+            uuids: Set(uuidsToRoles.keys)
+        )
+        return users.map {
+            user -> (ZMUser, Role?) in
+            if let roleEntry = uuidsToRoles[user.remoteIdentifier!],
+                let roleName = roleEntry
+            {
+                let role = self.fetchOrCreateRoleForConversation(name: roleName)
+                return (user, role)
+            } else {
+                return (user, nil)
+            }
+        }
+    }
+    
+    private func fetchOrCreateRoleForConversation(name: String) -> Role {
+        return Role.fetchOrCreateRole(
+            with: name,
+            teamOrConversation: self.team != nil ? .team(self.team!) : .conversation(self),
+            in: self.managedObjectContext!)
+    }
+    
+    /// Fetch or create all users in the list
+    private func fetchOrCreateAllUsers(uuids: Set<UUID>) -> Set<ZMUser> {
+        var users = ZMUser.users(withRemoteIDs: uuids, in: self.managedObjectContext!)
+        if users.count != uuids.count {
+            
+            // Some users didn't exist so we need create the missing users
+            let missingUsers = uuids.subtracting(
+                users.map { $0.remoteIdentifier! }
+            )
+            users.formUnion(missingUsers.map {
+                ZMUser(remoteID: $0, createIfNeeded: true, in: self.managedObjectContext!)!
+            })
+        }
+        return Set(users)
+    }
+}
+
+
+extension Dictionary where Key == String, Value == Any {
     
     func UUID(fromKey key: String) -> UUID? {
         return (self[key] as? String).flatMap(Foundation.UUID.init)
@@ -279,7 +311,7 @@ fileprivate extension Dictionary where Key == String, Value == Any {
     }
 }
 
-fileprivate extension Dictionary where Key == String, Value == Any? {
+extension Dictionary where Key == String, Value == Any? {
     
     func UUID(fromKey key: String) -> UUID? {
         return (self[key] as? String).flatMap(Foundation.UUID.init)

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -118,7 +118,7 @@ public final class Role: ZMManagedObject {
     
     static func fetchOrCreateRole(with name: String,
                                   teamOrConversation: TeamOrConversation,
-                                  in context: NSManagedObjectContext) -> Role? {
+                                  in context: NSManagedObjectContext) -> Role {
         let existingRole = self.fetchExistingRole(with: name,
                                                   teamOrConversation: teamOrConversation,
                                                   in: context)

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -183,7 +183,6 @@ extension ZMUser {
         }
     }
     
-    ///TODO: need isFromLocal param?
     @objc
     func add(conversation: ZMConversation) {
         guard let moc = self.managedObjectContext else { return }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -256,7 +256,6 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
     }
     
     func testThatActiveParticipantsContainsSelf() {
-        // TODO: review
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.conversationType = .group
@@ -371,6 +370,8 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
         // then
         XCTAssertEqual(conversation.connectedUser, user)
     }
+    
+    // MARK: - Roles
     
     func testThatWeGetAConversationRolesIfItIsAPartOfATeam() {
         // given

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -145,7 +145,7 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
         conversation.conversationType = .group
         
         // when
-        conversation.addParticipantIfMissing(user, date: Date())
+        conversation.addParticipantAndSystemMessageIfMissing(user, date: Date())
         
         // then
         XCTAssertTrue(conversation.localParticipants.contains(user))
@@ -161,7 +161,7 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
         conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         
         // when
-        conversation.addParticipantIfMissing(user, date: Date())
+        conversation.addParticipantAndSystemMessageIfMissing(user, date: Date())
         
         // then
         XCTAssertTrue(conversation.localParticipants.contains(user))

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.m
@@ -82,12 +82,13 @@
         [others addObject:userInfo];
     }
     
+    NSString *selfRemoteId = [ZMUser selfUserInContext:conversation.managedObjectContext].remoteIdentifier.transportString;
     NSDictionary *payload = @{
                               @"name" : [NSNull null],
                               @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
                               @"members" : @{
                                       @"self" : @{
-                                              @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
+                                              @"id" : selfRemoteId,
                                               @"otr_archived" : @(isArchived),
                                               @"otr_archived_ref" : archivedRef ? [archivedRef transportString] : [NSNull null],
                                               @"otr_muted" : @(isSilenced),
@@ -784,12 +785,13 @@
         ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
         NSUUID *uuid = NSUUID.createUUID;
         conversation.remoteIdentifier = uuid;
+        NSString *selfRemoteId = [ZMUser selfUserInContext:conversation.managedObjectContext].remoteIdentifier.transportString;
         NSDictionary *payload = @{
                                   @"name" : [NSNull null],
                                   @"creator" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
                                   @"members" : @{
                                           @"self" : @{
-                                                  @"id" : @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9"
+                                                  @"id" : selfRemoteId
                                                   },
                                           },
                                   @"type" : @1,

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
@@ -75,14 +75,10 @@ extension ZMConversationTransportTests {
                 Set(conversation.localParticipants.map { $0.remoteIdentifier }),
                 Set([user1ID, user2ID, selfUser.remoteIdentifier!])
             )
-            guard let participant1 = conversation.participantRoles
-                .first(where: {$0.user.remoteIdentifier == user1ID}) else {
-                return XCTFail()
-            }
-            guard let participant2 = conversation.participantRoles
-                .first(where: {$0.user.remoteIdentifier == user2ID}) else {
-                    return XCTFail()
-            }
+            guard let participant1 = conversation.participantForUser(id: user1ID),
+                let participant2 = conversation.participantForUser(id: user2ID)
+                else { return XCTFail() }
+            
             XCTAssertNil(participant1.role)
             XCTAssertEqual(participant2.role?.name, "test_role")
             XCTAssertEqual(conversation.nonTeamRoles.count, 1)
@@ -120,14 +116,10 @@ extension ZMConversationTransportTests {
                 Set(conversation.localParticipants.map { $0.remoteIdentifier }),
                 Set([user1ID, user2ID, selfUser.remoteIdentifier!])
             )
-            guard let participant1 = conversation.participantRoles
-                .first(where: {$0.user.remoteIdentifier == user1ID}) else {
-                    return XCTFail()
-            }
-            guard let participant2 = conversation.participantRoles
-                .first(where: {$0.user.remoteIdentifier == user2ID}) else {
-                    return XCTFail()
-            }
+            guard let participant1 = conversation.participantForUser(id: user1ID),
+                let participant2 = conversation.participantForUser(id: user2ID)
+                else { return XCTFail() }
+            
             XCTAssertEqual(participant1.role?.team, team)
             XCTAssertEqual(participant2.role?.team, team)
             XCTAssertEqual(participant1.role?.name, "test_role1")
@@ -136,6 +128,156 @@ extension ZMConversationTransportTests {
             
         }
     }
+    
+    func testThatItChangesRolesFromMetadataInTeam() {
+        
+        syncMOC.performGroupedAndWait() { _ -> () in
+            // given
+            ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+            let user1 = ZMUser.insertNewObject(in: self.syncMOC)
+            user1.name = "U1"
+            user1.remoteIdentifier = UUID.create()
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.remoteIdentifier = UUID.create()
+            conversation.team = team
+            let oldRole = Role.create(managedObjectContext: self.syncMOC, name: "ROLE1", team: team)
+            conversation.addParticipantAndUpdateConversationState(user: user1, role: oldRole)
+            
+            let payload = self.simplePayload(
+                conversation: conversation,
+                team: team,
+                otherActiveUsersAndRoles: [
+                    (user1.remoteIdentifier, "new_role")
+                ]
+            )
+            
+            // when
+            conversation.update(transportData: payload, serverTimeStamp: Date())
+            
+            // then
+            XCTAssertEqual(conversation.localParticipants, Set([user1, selfUser]))
+            guard let newRole = conversation.participantForUser(user1)?.role
+                else { return XCTFail() }
+            
+            XCTAssertNotEqual(oldRole, newRole)
+            XCTAssertEqual(newRole.team, team)
+            XCTAssertEqual(newRole.name, "new_role")
+            XCTAssertEqual(team.roles, Set([newRole, oldRole]))
+        }
+    }
+    
+    func testThatItResuesExistingTeamRolesWhenParsingMetadata() {
+        
+        syncMOC.performGroupedAndWait() { _ -> () in
+            // given
+            ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+            let user1ID = UUID.create()
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.remoteIdentifier = UUID.create()
+            let teamRole = Role.create(managedObjectContext: self.syncMOC, name: "role1", team: team)
+            
+            let payload = self.simplePayload(
+                conversation: conversation,
+                team: team,
+                otherActiveUsersAndRoles: [
+                    (user1ID, "role1")
+                ]
+            )
+            
+            // when
+            conversation.update(transportData: payload, serverTimeStamp: Date())
+            
+            // then
+            XCTAssertEqual(
+                Set(conversation.localParticipants.map { $0.remoteIdentifier }),
+                Set([user1ID, selfUser.remoteIdentifier!])
+            )
+            guard let participant1 = conversation.participantForUser(id: user1ID)
+                else { return XCTFail() }
+            
+            XCTAssertEqual(participant1.role, teamRole)
+            
+        }
+    }
+    
+    func testThatItParserSelfRoleFromConversationMetadataInTeam() {
+        
+        syncMOC.performGroupedAndWait() { _ -> () in
+            // given
+            ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+            let team = Team.insertNewObject(in: self.syncMOC)
+            team.remoteIdentifier = UUID.create()
+            
+            let payload = self.simplePayload(
+                conversation: conversation,
+                team: team,
+                selfRole: "test_role"
+            )
+            
+            // when
+            conversation.update(transportData: payload, serverTimeStamp: Date())
+            
+            // then
+            XCTAssertEqual(conversation.localParticipants, [selfUser])
+            guard let selfRole = conversation.participantForUser(selfUser)?.role else {
+                return XCTFail()
+            }
+            XCTAssertEqual(selfRole.team, team)
+            XCTAssertEqual(selfRole.name, "test_role")
+            XCTAssertEqual(team.roles, Set([selfRole]))
+            
+        }
+    }
+    
+    func testThatItParserSelfRoleFromConversationMetadataNotInTeam() {
+        
+        syncMOC.performGroupedAndWait() { _ -> () in
+            // given
+            ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+            
+            let payload = self.simplePayload(
+                conversation: conversation,
+                team: nil,
+                selfRole: "test_role"
+            )
+            
+            // when
+            conversation.update(transportData: payload, serverTimeStamp: Date())
+            
+            // then
+            XCTAssertEqual(conversation.localParticipants, [selfUser])
+            guard let selfRole = conversation.participantForUser(selfUser)?.role else {
+                return XCTFail()
+            }
+            XCTAssertEqual(selfRole.conversation, conversation)
+            XCTAssertEqual(selfRole.name, "test_role")
+            XCTAssertEqual(conversation.participantRoles.map { $0.role }, [selfRole])
+            
+        }
+    }
+}
+
+extension ZMConversation {
+    
+    fileprivate func participantForUser(_ user: ZMUser) -> ParticipantRole?  {
+        return self.participantForUser(id: user.remoteIdentifier!)
+    }
+    
+    fileprivate func participantForUser(id: UUID) -> ParticipantRole? {
+        return self.participantRoles.first(where: { $0.user.remoteIdentifier == id })
+    }
 }
 
 extension ZMConversationTransportTests {
@@ -143,6 +285,7 @@ extension ZMConversationTransportTests {
     func simplePayload(
         conversation: ZMConversation,
         team: Team?,
+        selfRole: String? = nil,
         conversationType: BackendConversationType = BackendConversationType.group,
         otherActiveUsersAndRoles: [(UUID, String?)] = []
         ) -> [String: Any] {
@@ -160,7 +303,8 @@ extension ZMConversationTransportTests {
             "creator": "3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
             "members": [
                 "self": [
-                    "id" : "3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
+                    "id" : ZMUser.selfUser(in: conversation.managedObjectContext!).remoteIdentifier.transportString(),
+                    "conversation_role": (selfRole ?? NSNull()) as Any
                 ],
                 "others": others,
             ],

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -451,6 +451,9 @@ extension ZMMessageTests_Confirmation {
         }
         
         let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let sender = ZMUser.insertNewObject(in: uiMOC)
+        sender.remoteIdentifier = UUID.create()
+        conversation.addParticipantAndUpdateConversationState(user: sender, role: nil)
         conversation.remoteIdentifier = .create()
         let lastModified = Date(timeIntervalSince1970: 1234567890)
         conversation.lastModifiedDate = lastModified
@@ -467,7 +470,9 @@ extension ZMMessageTests_Confirmation {
         }
         
         // when
-        let updateEvent = createMessageDeliveryConfirmationUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!)
+        let updateEvent = createMessageDeliveryConfirmationUpdateEvent(
+            sut.nonce!,
+            conversationID: conversation.remoteIdentifier!, senderID: sender.remoteIdentifier!)
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: updateEvent, in: self.uiMOC, prefetchResult: nil)
         }

--- a/Tests/Source/Model/ZMTestSession.swift
+++ b/Tests/Source/Model/ZMTestSession.swift
@@ -18,16 +18,15 @@
 
 import Foundation
 
-extension ZMConversation {
+extension ZMTestSession: ZMManagedObjectContextProvider {
     
-    /// Verifies that a sender of an update event is part of the conversation. If they are not,
-    /// it means that our local state is out of sync and we need to update the list of participants.
-    @objc
-    public func verifySender(of updateEvent: ZMUpdateEvent, moc: NSManagedObjectContext) {
-
-        guard let senderUUID = updateEvent.senderUUID(),
-              let user = ZMUser(remoteID: senderUUID, createIfNeeded: true, in: moc) else { return }
-
-        addParticipantAndSystemMessageIfMissing(user, date: updateEvent.timeStamp()?.addingTimeInterval(-0.01))
+    public var managedObjectContext: NSManagedObjectContext! {
+        return self.uiMOC
     }
+    
+    public var syncManagedObjectContext: NSManagedObjectContext! {
+        return self.syncMOC
+    }
+    
+    
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		A923D77E239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923D77D239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift */; };
 		A927F52723A029250058D744 /* ParticipantRoleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A927F52623A029250058D744 /* ParticipantRoleTests.swift */; };
 		A95E7BF5239134E600935B88 /* ZMConversation+Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */; };
+		A9676D7623A30BEF001CD41D /* ZMTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9676D7323A30ABA001CD41D /* ZMTestSession.swift */; };
 		A97FB77023A1225E001A8D34 /* store2-78-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = A97FB76F23A1225E001A8D34 /* store2-78-0.wiredatabase */; };
 		A995F05C23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */; };
 		A995F05E239690B300FAC3CF /* ParticipantRoleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995F05D239690B300FAC3CF /* ParticipantRoleObserverTests.swift */; };
@@ -833,6 +834,7 @@
 		A923D77D239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+SecurityLevel.swift"; sourceTree = "<group>"; };
 		A927F52623A029250058D744 /* ParticipantRoleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRoleTests.swift; sourceTree = "<group>"; };
 		A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Participants.swift"; sourceTree = "<group>"; };
+		A9676D7323A30ABA001CD41D /* ZMTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTestSession.swift; sourceTree = "<group>"; };
 		A97FB76F23A1225E001A8D34 /* store2-78-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-78-0.wiredatabase"; sourceTree = "<group>"; };
 		A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticipantRoleChangeInfo.swift; sourceTree = "<group>"; };
 		A995F05D239690B300FAC3CF /* ParticipantRoleObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticipantRoleObserverTests.swift; sourceTree = "<group>"; };
@@ -1912,6 +1914,7 @@
 				5476BA3D1DEDABCC00D047F8 /* AddressBookEntryTests.swift */,
 				BF0D07F91E4C7B1100B934EB /* TextSearchQueryTests.swift */,
 				F94A2C501F2B20480011ED42 /* ZMTestSession.h */,
+				A9676D7323A30ABA001CD41D /* ZMTestSession.swift */,
 				F94A2C511F2B20480011ED42 /* ZMTestSession.m */,
 			);
 			name = Model;
@@ -1958,7 +1961,6 @@
 				54A885A71F62EEB600AFBA95 /* ZMConversationTests+Messages.swift */,
 				16D5260C20DD1D9400608D8E /* ZMConversationTests+Timestamps.swift */,
 				A9128ACF2398067E0056F591 /* ZMConversationTests+Participants.swift */,
-				A90B3E2E23A2A6E7003EFED4 /* ZMConversationTests+Creation.swift */,
 				EF3510FB22CA0BEE00115B97 /* ZMConversationTests+Transport.h */,
 				F9B71F541CB2BC85001DB03F /* ZMConversationTests+Transport.m */,
 				EF3510F922CA07BB00115B97 /* ZMConversationTests+Transport.swift */,
@@ -2714,6 +2716,7 @@
 				F9331C781CB4165100139ECC /* NSString+ZMPersonName.m in Sources */,
 				BF6EA4D21E2512E800B7BD4B /* ZMConversation+DisplayName.swift in Sources */,
 				F1C867851FAA0D48001505E8 /* ZMUser+Create.swift in Sources */,
+				A9676D7623A30BEF001CD41D /* ZMTestSession.swift in Sources */,
 				A95E7BF5239134E600935B88 /* ZMConversation+Participants.swift in Sources */,
 				546D3DE61CE5D0B100A6047F /* RichAssetFileType.swift in Sources */,
 				F963E9761D9C002000098AD3 /* ZMGenericMessage+Assets.swift in Sources */,
@@ -2972,7 +2975,6 @@
 				BF7D9C491D90286700949267 /* MessagingTest+UUID.swift in Sources */,
 				F929C1721E40D6530018ADA4 /* ZMUserDisplayNameGeneratorTest.m in Sources */,
 				F9B71FA61CB2BF37001DB03F /* ZMConversationTests+Transport.m in Sources */,
-				A90B3E3223A2A9FC003EFED4 /* ZMConversationTests+Creation.swift in Sources */,
 				1621E59220E62BD2006B2D17 /* ZMConversationTests+Silencing.swift in Sources */,
 				F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */,
 				544034341D6DFE8500860F2D /* ZMAddressBookContactTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Adding the ability to parse the self user role. 

Also address the fact that roles are not updated when parsing the metadata for a user that changed role.