### PR TITLE
[HACK] Disable code optimization

### DIFF
--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -3147,6 +3147,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireDataModel;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Currently our tests are crashing when the optimization is enabled. We'll temporarily disable it to unlock the team from writing more tests. We will revert this before the release.
