### PR TITLE
Expose default member role name

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -19,7 +19,8 @@
 import Foundation
 
 extension ZMConversation {
-    public static let defaultAdminRoleName = "wire_admin"
+    @objc public static let defaultAdminRoleName = "wire_admin"
+    @objc public static let defaultMemberRoleName = "wire_member"
 
     static func predicateSecureWithIgnored() -> NSPredicate {
         return NSPredicate(format: "%K == %d", #keyPath(ZMConversation.securityLevel), ZMConversationSecurityLevel.secureWithIgnored.rawValue)


### PR DESCRIPTION
## What's new in this PR?

Add and expose the default conversation role "member" for use in upstream projects and expose for objective c. 
