### PR TITLE
Update UserType

### DIFF
--- a/Source/Model/User/UserType+ConversationRoles.swift
+++ b/Source/Model/User/UserType+ConversationRoles.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public extension UserType {
+
+    func canManagedGroupRole(of user: UserType, conversation: ZMConversation) -> Bool {
+        guard isAdminGroup(conversation: conversation) else { return false }
+        return !user.isSelfUser && (user.isConnected || isOnSameTeam(otherUser: user))
+    }
+
+    func isAdminGroup(conversation: ZMConversation) -> Bool {
+        return role(in: conversation)?.name == ZMConversation.defaultAdminRoleName
+    }
+
+    func role(in conversation: ZMConversation) -> Role? {
+        return zmUser?.participantRoles.first(where: { $0.conversation == conversation })?.role
+    }
+    
+}

--- a/Source/Model/User/UserType+ConversationRoles.swift
+++ b/Source/Model/User/UserType+ConversationRoles.swift
@@ -29,8 +29,4 @@ public extension UserType {
         return role(in: conversation)?.name == ZMConversation.defaultAdminRoleName
     }
 
-    func role(in conversation: ZMConversation) -> Role? {
-        return zmUser?.participantRoles.first(where: { $0.conversation == conversation })?.role
-    }
-    
 }

--- a/Source/Model/User/UserType+Team.swift
+++ b/Source/Model/User/UserType+Team.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public extension UserType {
+
+    func isOnSameTeam(otherUser: UserType) -> Bool {
+        return canAccessCompanyInformation(of: otherUser)
+    }
+    
+}

--- a/Source/Model/User/UserType+ZMUser.swift
+++ b/Source/Model/User/UserType+ZMUser.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public extension UserType {
+
+    /// Return the ZMUser associated with the generic user, if available.
+    var zmUser: ZMUser? {
+        if let searchUser = self as? ZMSearchUser {
+            return searchUser.user
+        } else if let zmUser = self as? ZMUser {
+            return zmUser
+        } else {
+            return nil
+        }
+    }
+    
+}

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -155,17 +155,17 @@ public protocol UserType: NSObjectProtocol {
     /// Whether the user can create services
     var canCreateService: Bool { get }
     
-    /// Wheather the user can administate the team
+    /// Whether the user can administate the team
     var canManageTeam: Bool { get }
 
     /// Whether the user can access the private company information of the other given user.
     func canAccessCompanyInformation(of user: UserType) -> Bool
     
-    /// Wheather the user can add services to the conversation
+    /// Whether the user can add services to the conversation
     @objc(canAddServiceToConversation:)
     func canAddService(to conversation: ZMConversation) -> Bool
     
-    /// Wheather the user can remove services from the conversation
+    /// Whether the user can remove services from the conversation
     @objc(canRemoveServiceFromConversation:)
     func canRemoveService(from conversation: ZMConversation) -> Bool
 
@@ -177,7 +177,7 @@ public protocol UserType: NSObjectProtocol {
     @objc(canRemoveUserFromConversation:)
     func canRemoveUser(from conversation: ZMConversation) -> Bool
     
-    /// Wheather the user can delete the conversation
+    /// Whether the user can delete the conversation
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool
     

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -201,4 +201,7 @@ public protocol UserType: NSObjectProtocol {
     @objc(canModifyTitleInConversation:)
     func canModifyTitle(in conversation: ZMConversation) -> Bool
 
+    /// The role in the given conversation.
+    @objc(roleInConversation:)
+    func role(in conversation: ZMConversation) -> Role?
 }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -379,6 +379,10 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     public func canModifyAccessControlSettings(in conversation: ZMConversation) -> Bool {
         return user?.canModifyAccessControlSettings(in: conversation) == true
     }
+
+    public func role(in conversation: ZMConversation) -> Role? {
+        return user?.role(in: conversation)
+    }
     
     public override func isEqual(_ object: Any?) -> Bool {
         guard let otherSearchUser = object as? ZMSearchUser else { return false }

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -44,6 +44,10 @@ extension ZMUser: UserType {
         return Set(self.participantRoles.filter{!$0.markedForDeletion}.map{$0.conversation})
     }
 
+    public func role(in conversation: ZMConversation) -> Role? {
+        return zmUser?.participantRoles.first(where: { $0.conversation == conversation })?.role
+    }
+
     // MARK: Legal Hold
 
     @objc public var isUnderLegalHold: Bool {

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -45,7 +45,7 @@ extension ZMUser: UserType {
     }
 
     public func role(in conversation: ZMConversation) -> Role? {
-        return zmUser?.participantRoles.first(where: { $0.conversation == conversation })?.role
+        return participantRoles.first(where: { $0.conversation == conversation })?.role
     }
 
     // MARK: Legal Hold

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -304,6 +304,9 @@
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
 		EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
+		EEF4010523A91F2B007B1A97 /* UserType+ConversationRoles.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010423A91F2B007B1A97 /* UserType+ConversationRoles.swift */; };
+		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
+		EEF4010923A92267007B1A97 /* UserType+ZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010823A92267007B1A97 /* UserType+ZMUser.swift */; };
 		EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */; };
 		EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */; };
 		EF17175B22D4CC8E00697EB0 /* Team+MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */; };
@@ -925,6 +928,9 @@
 		EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStorageInitialization.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
+		EEF4010423A91F2B007B1A97 /* UserType+ConversationRoles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+ConversationRoles.swift"; sourceTree = "<group>"; };
+		EEF4010623A9213B007B1A97 /* UserType+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Team.swift"; sourceTree = "<group>"; };
+		EEF4010823A92267007B1A97 /* UserType+ZMUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+ZMUser.swift"; sourceTree = "<group>"; };
 		EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+HasMessages.swift"; sourceTree = "<group>"; };
 		EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+HasMessages.swift"; sourceTree = "<group>"; };
 		EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+MockTeam.swift"; sourceTree = "<group>"; };
@@ -1698,6 +1704,10 @@
 		F9A706031CAEE01D00C2F5FE /* User */ = {
 			isa = PBXGroup;
 			children = (
+				1687ABAB20EBE0770007C240 /* UserType.swift */,
+				EEF4010823A92267007B1A97 /* UserType+ZMUser.swift */,
+				EEF4010623A9213B007B1A97 /* UserType+Team.swift */,
+				EEF4010423A91F2B007B1A97 /* UserType+ConversationRoles.swift */,
 				EF2CBDA620061E2D0004F65E /* ServiceUser.swift */,
 				F9331C751CB4165100139ECC /* NSString+ZMPersonName.h */,
 				F9331C761CB4165100139ECC /* NSString+ZMPersonName.m */,
@@ -1711,7 +1721,6 @@
 				F110503C2220439900F3EB62 /* ZMUser+RichProfile.swift */,
 				55C40BCD22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift */,
 				F14B7AFE2220302B00458624 /* ZMUser+Predicates.swift */,
-				1687ABAB20EBE0770007C240 /* UserType.swift */,
 				F1C867841FAA0D48001505E8 /* ZMUser+Create.swift */,
 				BF3493F11EC3623200B0C314 /* ZMUser+Teams.swift */,
 				1670D01B231823DC003A143B /* ZMUser+Permissions.swift */,
@@ -2663,6 +2672,7 @@
 				BF5DF5CD20F4EB3E002BCB67 /* ZMSystemMessage+NewConversation.swift in Sources */,
 				F163784F1E5C454C00898F84 /* ZMConversation+Patches.swift in Sources */,
 				1639A8132260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift in Sources */,
+				EEF4010523A91F2B007B1A97 /* UserType+ConversationRoles.swift in Sources */,
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
 				162A81DD202DA4BC00F6200C /* AssetCache.swift in Sources */,
 				16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */,
@@ -2782,6 +2792,7 @@
 				8704676B21513DE900C628D7 /* ZMOTRMessage+Unarchive.swift in Sources */,
 				54FB03A11E41E273000E13DC /* PersistedDataPatches.swift in Sources */,
 				F9A706A91CAEE01D00C2F5FE /* StringKeyPath.swift in Sources */,
+				EEF4010923A92267007B1A97 /* UserType+ZMUser.swift in Sources */,
 				A90676EA238EB05F006417AC /* Action.swift in Sources */,
 				16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */,
 				BF421B2D1EF3F91D0079533A /* Team+Patches.swift in Sources */,
@@ -2834,6 +2845,7 @@
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
 				873B88FC204044AC00FBE254 /* ConversationCreationOptions.swift in Sources */,
 				87E9508B2118B2DA00306AA7 /* ZMConversation+DeleteOlderMessages.swift in Sources */,
+				EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */,
 				54E3EE411F616BA600A261E3 /* ZMAssetClientMessage.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				16E0FBC923326B72000E3235 /* ConversationDirectory.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

This PR adds a new protocol method to `UserType` to return the role in a given conversation. Some functionality has also been moved from the UI project.

This will help facilitate mocking the role for the `MockUser`.