### PR TITLE
Parse self user role in conversation JSON fragment for self

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Transport.swift
+++ b/Source/Model/Conversation/ZMConversation+Transport.swift
@@ -162,18 +162,16 @@ extension ZMConversation {
     /// Parse the "members" section
     private func updateMembers(payload: [String: Any]) {
         
-        guard let otherUsersInfos = payload[PayloadKeys.othersKey] as? [[String: Any]],
-            let selfInfo = payload[PayloadKeys.selfKey] as? [String: Any],
+        guard let usersInfos = payload[PayloadKeys.othersKey] as? [[String: Any]],
             let moc = self.managedObjectContext else {
                 return
         }
-        let usersInfos = otherUsersInfos + [selfInfo]
         
         let usersAndRoles = self.usersPayloadToUserAndRole(
             payload: usersInfos,
             userIdKey: PayloadKeys.IDKey)
         let allParticipants = Set(usersAndRoles.map { $0.0 })
-        let removedParticipants = self.localParticipants.subtracting(allParticipants)
+        let removedParticipants = self.localParticipantsExcludingSelf.subtracting(allParticipants)
   
         self.addParticipantsAndUpdateConversationState(usersAndRoles: usersAndRoles)
         self.removeParticipantsAndUpdateConversationState(users: removedParticipants, initiatingUser: ZMUser.selfUser(in: moc))
@@ -201,6 +199,16 @@ extension ZMConversation {
     /// Pass timestamp when the timestamp equals the time of the lastRead / cleared event, otherwise pass nil
     public func updateSelfStatus(dictionary: [String: Any], timeStamp: Date?, previousLastServerTimeStamp: Date?) {
         self.updateMuted(with: dictionary)
+        
+        if let roleName = dictionary[ZMConversation.PayloadKeys.conversationRoleKey] as? String {
+            let role = Role.fetchOrCreateRole(
+                with: roleName,
+                teamOrConversation: TeamOrConversation.matching(self),
+                in: self.managedObjectContext!)
+            let selfUser = ZMUser.selfUser(in: self.managedObjectContext!)
+            self.addParticipantAndUpdateConversationState(user: selfUser, role: role)
+        }
+        
         if  self.updateIsArchived(payload: dictionary) && self.isArchived,
             let previousLastServerTimeStamp = previousLastServerTimeStamp,
             let timeStamp = timeStamp,

--- a/Source/Model/Conversation/ZMConversation+Transport.swift
+++ b/Source/Model/Conversation/ZMConversation+Transport.swift
@@ -200,13 +200,15 @@ extension ZMConversation {
     public func updateSelfStatus(dictionary: [String: Any], timeStamp: Date?, previousLastServerTimeStamp: Date?) {
         self.updateMuted(with: dictionary)
         
+        let selfUser = ZMUser.selfUser(in: self.managedObjectContext!)
         if let roleName = dictionary[ZMConversation.PayloadKeys.conversationRoleKey] as? String {
             let role = Role.fetchOrCreateRole(
                 with: roleName,
                 teamOrConversation: TeamOrConversation.matching(self),
                 in: self.managedObjectContext!)
-            let selfUser = ZMUser.selfUser(in: self.managedObjectContext!)
             self.addParticipantAndUpdateConversationState(user: selfUser, role: role)
+        } else if !self.isSelfAnActiveMember {
+            self.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
         }
         
         if  self.updateIsArchived(payload: dictionary) && self.isArchived,

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -27,11 +27,9 @@ public enum TeamOrConversation {
         return self.fromTeamOrConversation(team: conversation.team, conversation: conversation)
     }
     
-    /// Creates a team or a conversation. One between team and conversation must be nil, the other not nil
+    /// Creates a team or a conversation
     static func fromTeamOrConversation(team: Team?,
                                        conversation: ZMConversation?) -> TeamOrConversation {
-        require(team != nil || conversation != nil) // one must be not nil
-        require(team == nil || conversation == nil) // one must be nil
         if let team = team {
             return .team(team)
             

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -22,6 +22,11 @@ public enum TeamOrConversation {
     case team(Team)
     case conversation(ZMConversation)
     
+    /// Creates a team if the conversation belongs to a team, or a conversation otherwise
+    public static func matching(_ conversation: ZMConversation) -> TeamOrConversation {
+        return self.fromTeamOrConversation(team: conversation.team, conversation: conversation)
+    }
+    
     /// Creates a team or a conversation. One between team and conversation must be nil, the other not nil
     static func fromTeamOrConversation(team: Team?,
                                        conversation: ZMConversation?) -> TeamOrConversation {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
@@ -164,6 +164,7 @@ extension ZMConversationTransportTests {
         
         syncMOC.performGroupedAndWait() { _ -> () in
             // given
+            
             ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
@@ -295,8 +296,29 @@ extension ZMConversationTransportTests {
             XCTAssertEqual(selfRole.conversation, conversation)
             XCTAssertEqual(selfRole.name, "test_role")
             XCTAssertEqual(conversation.participantRoles.map { $0.role }, [selfRole])
-            
         }
+    }
+    
+    func testThatItParsesSelfUserFragmentWithRole() {
+        
+        // given
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        selfUser.remoteIdentifier = UUID.create()
+        conversation.remoteIdentifier = UUID.create()
+        conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
+        
+        // when
+        conversation.updateSelfStatus(
+            dictionary: [
+                "id": selfUser.remoteIdentifier.transportString(),
+                "conversation_role": "boss"
+            ],
+            timeStamp: nil,
+            previousLastServerTimeStamp: nil)
+        
+        // then
+        XCTAssertEqual(conversation.participantRoles.first?.role?.name, "boss")
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Previously we were parsing the self role in the entire JSON payload of a conversation. 

However, we use the `updateSelfStatus` method also to parse member update events JSON fragments, and that method does not parse the self role, relying on the outer method to parse the entire conversation JSON.

This PR moves the self role parsing inside that method, so that it can be used by sync engine to parse the self role also for events.