### PR TITLE
Fix: Add check to the delete conversation permission

### DIFF
--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -87,7 +87,7 @@ public extension ZMUser {
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
         if conversation.conversationType == .group {
-            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation)
+            return (hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) && conversation.creator == self)
         } else {
             return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
         }
@@ -216,7 +216,7 @@ public extension ZMUser {
     }
     
     private func hasRoleWithAction(actionName: String, conversation: ZMConversation) -> Bool {
-        let canModifyConversation = self.participantRoles.filter({$0.conversation == conversation}).first?.role?.actions.contains(where: {$0.name == actionName})
+        let canModifyConversation = self.role(in: conversation)?.actions.contains(where: {$0.name == actionName})
         return canModifyConversation ?? false
     }
 }

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -87,7 +87,7 @@ public extension ZMUser {
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
         if conversation.conversationType == .group {
-            return (hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) && conversation.creator == self)
+            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) && conversation.creator == self
         } else {
             return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
         }

--- a/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -630,14 +630,25 @@ extension ZMUserTests_Permissions {
         XCTAssertFalse(selfUser.canModifyOtherMember(in: conversation))
     }
     
-    func testThatGroupParticipantCanDeleteConvesation() {
+    func testThatConvesationCreatorWithAdminRoleCanDeleteConvesation() {
+        // given
+        makeSelfUserTeamMember(withPermissions: .addRemoveConversationMember)
+        conversation.conversationType = .group
+        conversation.creator = selfUser
+        createARoleForSelfUserWith("delete_conversation")
+        
+        // then
+        XCTAssertTrue(selfUser.canDeleteConversation(conversation))
+    }
+    
+    func testThatNoConvesationCreatorWithAdminRoleCantDeleteConvesation() {
         // given
         makeSelfUserTeamMember(withPermissions: .addRemoveConversationMember)
         conversation.conversationType = .group
         createARoleForSelfUserWith("delete_conversation")
         
         // then
-        XCTAssertTrue(selfUser.canDeleteConversation(conversation))
+        XCTAssertFalse(selfUser.canDeleteConversation(conversation))
     }
     
     func testThatGroupParticipantCantDeleteConvesation() {


### PR DESCRIPTION

## What's new in this PR?

Add check to the delete conversation permission (only creator with admin role can delete the conversation).