### PR TITLE
Fix optional field for core data

### DIFF
--- a/Patches/DuplicatedEntityRemoval.swift
+++ b/Patches/DuplicatedEntityRemoval.swift
@@ -118,7 +118,7 @@ extension ZMUser {
             $0.delete(from: context)
         }
         firstUser.needsToBeUpdatedFromBackend = true
-        firstUser.participantRoles.forEach { $0.conversation.needsToBeUpdatedFromBackend = true }
+        firstUser.participantRoles.forEach { $0.conversation?.needsToBeUpdatedFromBackend = true }
         return firstUser
     }
 
@@ -136,7 +136,7 @@ extension ZMUser {
         self.addressBookEntry = ZMManagedObject.firstNonNullAndDeleteSecond(self.addressBookEntry, user.addressBookEntry)
        
         user.participantRoles.forEach {
-            $0.conversation.addParticipantAndUpdateConversationState(user: self, role: $0.role)
+            $0.conversation?.addParticipantAndUpdateConversationState(user: self, role: $0.role)
         }
     
         self.conversationsCreated = self.conversationsCreated.union(user.conversationsCreated)

--- a/Source/Model/ConversationRole/ParticipantRole.swift
+++ b/Source/Model/ConversationRole/ParticipantRole.swift
@@ -26,7 +26,7 @@ let ZMParticipantRoleModificationToSyncKey  = #keyPath(ParticipantRole.rawOperat
 final public class ParticipantRole: ZMManagedObject {
     
     @objc @NSManaged var rawOperationToSync: Int16
-    @NSManaged public var conversation: ZMConversation
+    @NSManaged public var conversation: ZMConversation?
     @NSManaged public var user: ZMUser
     @NSManaged public var role: Role?
     

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -41,7 +41,7 @@ extension ZMUser: UserType {
     }
     
     public var activeConversations: Set<ZMConversation> {
-        return Set(self.participantRoles.filter{!$0.markedForDeletion}.map{$0.conversation})
+        return Set(self.participantRoles.filter{!$0.markedForDeletion}.compactMap {$0.conversation})
     }
 
     public func role(in conversation: ZMConversation) -> Role? {
@@ -266,8 +266,8 @@ extension ZMUser {
     /// Remove user from all group conversations he is a participant of
     fileprivate func removeFromAllConversations(at timestamp: Date) {
         let allGroupConversations: [ZMConversation] = participantRoles.compactMap {
-            let convo = $0.conversation
-            guard convo.conversationType == .group else { return nil}
+            guard let convo = $0.conversation,
+                convo.conversationType == .group else { return nil}
             return convo
         }
         

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -691,7 +691,7 @@ extension UserClient {
             guard user.isSelfUser else {
                 return $0.formUnion(user.participantRoles
                     .filter { !$0.markedForDeletion}
-                    .map { $0.conversation})
+                    .compactMap { $0.conversation})
             }
             let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
             fetchRequest.predicate = ZMConversation.predicateForConversationsIncludingArchived()

--- a/Source/Notifications/SideEffectSources.swift
+++ b/Source/Notifications/SideEffectSources.swift
@@ -82,7 +82,7 @@ extension ZMManagedObject {
 extension ZMUser : SideEffectSource {
     
     var allConversations : [ZMConversation] {
-        var conversations = self.participantRoles.filter { !$0.markedForDeletion }.map { $0.conversation }
+        var conversations = self.participantRoles.filter { !$0.markedForDeletion }.compactMap { $0.conversation }
         if let connectedConversation = connection?.conversation {
             conversations.append(connectedConversation)
         }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -3159,7 +3159,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
 				MOMC_NO_INVERSE_RELATIONSHIP_WARNINGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireDataModel;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## What's new in this PR?

Fix crash when optimization is turned on. This was caused by `ParticipantRole.conversation` being optional in the Core Data schema but not in the Swift class.