### PR TITLE
Fix: Update predicateForTeamOneToOneConversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -141,7 +141,7 @@ extension ZMConversation {
         let isTeamConversation = NSPredicate(format: "team != NULL")
         let isGroupConversation = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
         let hasNoUserDefinedName = NSPredicate(format: "\(ZMConversationUserDefinedNameKey) == NULL")
-        let hasOnlyOneParticipant = NSPredicate(format: "\(ZMConversationParticipantRolesKey).@count == 1")
+        let hasOnlyOneParticipant = NSPredicate(format: "\(ZMConversationParticipantRolesKey).@count == 2")
         
         return NSCompoundPredicate(andPredicateWithSubpredicates: [isTeamConversation, isGroupConversation, hasNoUserDefinedName, hasOnlyOneParticipant])
     }

--- a/Tests/Source/Model/Conversation/ParticipantRoleTests.swift
+++ b/Tests/Source/Model/Conversation/ParticipantRoleTests.swift
@@ -125,4 +125,25 @@ class ParticipantRoleTests: ZMBaseManagedObjectTest {
         XCTAssertFalse(ParticipantRole.predicateForObjectsThatNeedToBeUpdatedUpstream()!.evaluate(with: participant2))
     }
     
+    func testThatServicesBelongToOneToOneConversations() {
+        
+        // GIVEN
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        let service = createService(in: uiMOC, named: "Bob the Robot")
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.remoteIdentifier = UUID()
+        conversation.conversationType = .group
+        
+        let team = Team.insertNewObject(in: self.uiMOC)
+        team.remoteIdentifier = UUID.create()
+        conversation.team = team
+        
+        // WHEN
+        conversation.addParticipantAndUpdateConversationState(user: service as! ZMUser, role: nil)
+        conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
+        
+        // THEN
+        XCTAssertTrue(ZMConversation.predicateForOneToOneConversations().evaluate(with: conversation))
+    }
 }

--- a/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -68,6 +68,9 @@
     ZMUser *otherUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     otherUser.remoteIdentifier = [NSUUID createUUID];
     
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    selfUser.remoteIdentifier = [NSUUID createUUID];
+    
     ZMUser *serviceUser = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     serviceUser.serviceIdentifier = @"serviceA";
     serviceUser.providerIdentifier = @"providerA";
@@ -127,6 +130,7 @@
     self.oneToOneConversationInTeam.userDefinedName = nil;
     self.oneToOneConversationInTeam.team = team;
     [self.oneToOneConversationInTeam addParticipantAndUpdateConversationStateWithUser:otherUser role:nil];
+    [self.oneToOneConversationInTeam addParticipantAndUpdateConversationStateWithUser:selfUser role:nil];
 
     self.invalidConversation = [self createConversation];
     self.invalidConversation.conversationType = ZMConversationTypeInvalid;
@@ -150,6 +154,7 @@
     self.serviceConversation.userDefinedName = nil;
     self.serviceConversation.team = team;
     [self.serviceConversation addParticipantAndUpdateConversationStateWithUser:serviceUser role:nil];
+    [self.serviceConversation addParticipantAndUpdateConversationStateWithUser:selfUser role:nil];
 
     [self.uiMOC saveOrRollback];
 }


### PR DESCRIPTION
## What's new in this PR?

Services now contain 2 members, so the predicate must be changed.