### PR TITLE
[Chore] Tests for participant role changes

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -180,6 +180,7 @@ extension ZMConversation {
         if let current = self.participantRoles.first(where: {$0.user == user}) {
             if let role = role {
                 current.role = role
+                moc.saveOrRollback()
             }
             
             // If we are already trying to delete this user, abort the deletion
@@ -196,6 +197,7 @@ extension ZMConversation {
             if shouldSyncToBackend {
                 participantRole.operationToSync = .insert
             }
+            moc.saveOrRollback()
             return (.created, participantRole)
         }
     }

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -149,7 +149,7 @@ extension ZMConversation {
                 "Tried to add a role that does not belong to the conversation"
             )
             
-            guard let (result, pr) = fetchOrCreateParticipantRole(user: user, role: role) else { return nil }
+            guard let (result, pr) = updateExistingOrCreateParticipantRole(for: user, with: role) else { return nil }
             return (result == .created) ? pr : nil
         }
         
@@ -168,10 +168,10 @@ extension ZMConversation {
         case fetched
         case created
     }
-    
+
     // Fetch an existing role or create a new one if needed
     // Returns whether it was created or found
-    private func fetchOrCreateParticipantRole(user: ZMUser, role: Role?) -> (FetchOrCreation, ParticipantRole)? {
+    private func updateExistingOrCreateParticipantRole(for user: ZMUser, with role: Role?) -> (FetchOrCreation, ParticipantRole)? {
         
         guard let moc = self.managedObjectContext else { return nil }
         let shouldSyncToBackend = moc.zm_isUserInterfaceContext
@@ -187,7 +187,9 @@ extension ZMConversation {
             if shouldSyncToBackend && current.markedForDeletion {
                 current.operationToSync = .none
             }
+
             return (.fetched, current)
+
         } else {
             // A new participant role
             let participantRole = ParticipantRole.insertNewObject(in: moc)
@@ -197,6 +199,7 @@ extension ZMConversation {
             if shouldSyncToBackend {
                 participantRole.operationToSync = .insert
             }
+
             moc.saveOrRollback()
             return (.created, participantRole)
         }

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -180,7 +180,6 @@ extension ZMConversation {
         if let current = self.participantRoles.first(where: {$0.user == user}) {
             if let role = role {
                 current.role = role
-                moc.saveOrRollback()
             }
             
             // If we are already trying to delete this user, abort the deletion
@@ -200,7 +199,6 @@ extension ZMConversation {
                 participantRole.operationToSync = .insert
             }
 
-            moc.saveOrRollback()
             return (.created, participantRole)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

Added tests to assert that changes to a participant role triggers notifications that the conversation changed. I have also renamed a method for readability.