### PR TITLE
Use primitive value `isSelfAnActiveMember` for migration

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -56,7 +56,13 @@ extension ZMConversation {
         let allConversations = moc.executeFetchRequestOrAssert(request) as! [ZMConversation]
         
         for conversation in allConversations {
-            if conversation.isSelfAnActiveMember {
+            
+            let oldKey = "isSelfAnActiveMember"
+            conversation.willAccessValue(forKey: oldKey)
+            let isSelfAnActiveMember = (conversation.primitiveValue(forKey: oldKey) as! NSNumber).boolValue
+            conversation.didAccessValue(forKey: oldKey)
+            
+            if isSelfAnActiveMember {
                 var participantRoleForSelfUser: ParticipantRole
                 let adminRole = conversation.getRoles().first(where: {$0.name == defaultAdminRoleName} )
                 

--- a/Tests/Source/Utils/SelfUserParticipantMigrationTests.swift
+++ b/Tests/Source/Utils/SelfUserParticipantMigrationTests.swift
@@ -23,9 +23,13 @@ import XCTest
 class SelfUserParticipantMigrationTests: DiskDatabaseTest {
     
     func testMigrationIsSelfAnActiveMemberToTheParticipantRoles() {
+        
         // Given
+        let oldKey = "isSelfAnActiveMember"
         let conversation = createConversation()
-        conversation.addParticipantAndUpdateConversationState(user: ZMUser.selfUser(in: moc), role: nil)
+        conversation.willAccessValue(forKey: oldKey)
+        conversation.setPrimitiveValue(NSNumber(value: true), forKey: oldKey)
+        conversation.didAccessValue(forKey: oldKey)
         self.moc.saveOrRollback()
         
         // When


### PR DESCRIPTION
## What's new in this PR?

With version 2.78 of the data model, the `isSelfAnActiveMember` properties is now a computed property based on the `participantRoles`. In 2.77, `isSelfAnActiveMember`  was an actual core data (boolean) property.

There is a migration step that reads the old value for `isSelfAnActiveMember`  and update `participantRole`. However the migration step uses the new computed property (based on `participantRoles` rather than reading from the Core Data property. Therefore it would never migrate property, as there is never any `participantRoles` at the beginning of the migration.

This PR reads from the proper Core Data value during migration.

