### PR TITLE
Fix/observe role change

### DIFF
--- a/Tests/Source/Model/Observer/SnapshotCenterTests.swift
+++ b/Tests/Source/Model/Observer/SnapshotCenterTests.swift
@@ -144,7 +144,7 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                            "nonTeamRoles": 0,
                                            "lastServerSyncedActiveParticipants": 0]
         
-        let expectedToOneRelationships: [String: NSManagedObjectID?] =
+        let expectedToOneRelationships: [String: NSManagedObjectID] =
             ["creator": conv.creator.objectID]
         
         expectedAttributes.forEach{

--- a/Tests/Source/Model/Observer/SnapshotCenterTests.swift
+++ b/Tests/Source/Model/Observer/SnapshotCenterTests.swift
@@ -96,6 +96,7 @@ class SnapshotCenterTests : BaseZMMessageTests {
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         conv.conversationType = .group
         conv.userDefinedName = "foo"
+        conv.creator = ZMUser.insertNewObject(in: uiMOC)
         performPretendingUiMocIsSyncMoc {
             conv.lastModifiedDate = Date()
             conv.lastServerTimeStamp = Date()
@@ -143,9 +144,8 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                            "nonTeamRoles": 0,
                                            "lastServerSyncedActiveParticipants": 0]
         
-        let expectedToOneRelationships = ["team": false,
-                                          "connection": false,
-                                          "creator": false]
+        let expectedToOneRelationships: [String: NSManagedObjectID?] =
+            ["creator": conv.creator.objectID]
         
         expectedAttributes.forEach{
             XCTAssertEqual((snapshot.attributes[$0] ?? nil), $1, "values for \($0) don't match")
@@ -198,6 +198,32 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                                                                   "labels",
                                                                                   "nonTeamRoles",
                                                                                   "lastServerSyncedActiveParticipants"]))
+    }
+    
+    func testThatItUpatesTheSnapshotForParticipantRole(){
+        // given
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        let role1 = Role.insertNewObject(in: uiMOC)
+        role1.name = "foo"
+        let role2 = Role.insertNewObject(in: uiMOC)
+        role2.name = "bar"
+        let pr = ParticipantRole.create(managedObjectContext: uiMOC, user: user, conversation: conversation)
+        pr.role = role1
+        uiMOC.saveOrRollback()
+        _ = sut.extractChangedKeysFromSnapshot(for: pr)
+        
+        // when
+        pr.role = role2
+        uiMOC.saveOrRollback()
+        let changedKeys = sut.extractChangedKeysFromSnapshot(for: pr)
+        
+        // then
+        guard let snapshot = sut.snapshots[pr.objectID] else { return XCTFail("did not create snapshot")}
+        
+        // then
+        XCTAssertEqual(snapshot.toOneRelationships["role"], role2.objectID)
+        XCTAssertEqual(changedKeys, Set(["role"]))
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is not possible to observe changes in one-to-one relationships via snapshots, as the snapshot only stores whether the relationship is set to something not `nil`.

Therefore if a relationship changes from object A to object B (as opposed to from `nil` to object B), the snapshot will not report a change.

### Solutions

Store the `objectID` of the `NSManagedObject` that the relationship is pointing to, instead of a boolean. This will allow to detect that the value changed when going from object A to object B.