### PR TITLE
Fix: Personal group creator (and Admin) should not see Delete Group option

### DIFF
--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -87,7 +87,9 @@ public extension ZMUser {
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
         if conversation.conversationType == .group {
-            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) && conversation.creator == self
+            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) &&
+                   conversation.creator == self &&
+                   isTeamMember
         } else {
             return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
         }

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -89,7 +89,7 @@ public extension ZMUser {
         if conversation.conversationType == .group {
             return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) &&
                    conversation.creator == self &&
-                   isTeamMember
+                   hasTeam
         } else {
             return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
         }


### PR DESCRIPTION
## What's new in this PR?

Only allow user has team to delete a conversation