### PR TITLE
Fix: External(partner) cannot create 1:1 with a person whom External never have 1:1 before

### DIFF
--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -172,7 +172,7 @@ public extension ZMUser {
     }
     
     @objc var canCreateConversation: Bool {
-        return permissions?.contains(.member) ?? true
+        return permissions?.contains(.createConversation) ?? true
     }
     
     @objc var canCreateService: Bool {

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -87,7 +87,9 @@ public extension ZMUser {
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
         if conversation.conversationType == .group {
-            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) && conversation.creator == self
+            return hasRoleWithAction(actionName: ConversationAction.deleteConvesation.name, conversation: conversation) &&
+                   conversation.creator == self &&
+                   hasTeam
         } else {
             return conversation.teamRemoteIdentifier != nil && conversation.isSelfAnActiveMember && conversation.creator == self
         }

--- a/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -218,14 +218,22 @@ class ZMUserTests_Permissions: ModelObjectsTests {
         XCTAssertTrue(selfUser.canCreateConversation)
     }
     
+    func testThatConversationCanBeCreated_ByPartner() {
+        // given
+        makeSelfUserTeamMember(withPermissions: .partner)
+        
+        // then
+        XCTAssert(selfUser.canCreateConversation)
+    }
+
     func testThatConversationCantBeCreated_ByTeamMemberWithInsufficientPermissions() {
         // given
         makeSelfUserTeamMember(withPermissions: .partner)
         
         // then
-        XCTAssertFalse(selfUser.canCreateConversation)
+        XCTAssertFalse(selfUser.canDeleteConversation(conversation))
     }
-    
+
     // MARK: Manage team
     
     func testThatTeamCantBeManaged_ByNonTeamUser() {


### PR DESCRIPTION
## What's new in this PR?

### Issues
Partner can not create a 1-to-1 conversation

### Causes

Partner does not pass permission check

### Solutions

fix with the correct permission check