### PR TITLE
Fetch conversation roles for conversations in other teams

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -105,6 +105,7 @@ extension ZMConversation {
     static func forceToFetchConversationRoles(in moc: NSManagedObjectContext) {
         
         // Mark group conversation membership to be refetched
+        let selfUser = ZMUser.selfUser(in: moc)
         let groupConversationsFetch = ZMConversation.sortedFetchRequest(
             with: NSPredicate(format: "%K == %d",
                               ZMConversationConversationTypeKey,
@@ -114,11 +115,11 @@ extension ZMConversation {
         (moc.executeFetchRequestOrAssert(groupConversationsFetch) as! [ZMConversation]).forEach {
             guard $0.isSelfAnActiveMember else { return }
             $0.needsToBeUpdatedFromBackend = true
-            $0.needsToDownloadRoles = $0.team == nil
+            $0.needsToDownloadRoles = $0.team == nil || $0.team != selfUser.team
         }
         
         // Mark team as need to download roles
-        ZMUser.selfUser(in: moc).team?.needsToDownloadRoles = true
+        selfUser.team?.needsToDownloadRoles = true
     }
     
     // Model version 2.78.0 adds a `participantRoles` attribute to the `Conversation` entity, and deprecates the `lastServerSyncedActiveParticipants`.

--- a/Tests/Source/Utils/RolesMigrationTests.swift
+++ b/Tests/Source/Utils/RolesMigrationTests.swift
@@ -27,6 +27,7 @@ class RolesMigrationTests: DiskDatabaseTest {
         // Given
         let selfUser = ZMUser.selfUser(in: moc)
         let team = createTeam()
+        team.remoteIdentifier = UUID.create()
         _ = createMembership(user: selfUser, team: team)
         team.needsToDownloadRoles = false
         
@@ -42,6 +43,13 @@ class RolesMigrationTests: DiskDatabaseTest {
         groupConvoInTeam.needsToDownloadRoles = false
         groupConvoInTeam.needsToBeUpdatedFromBackend = false
         groupConvoInTeam.team = team
+        
+        let groupConvoInAnotherTeam = createConversation()
+        groupConvoInAnotherTeam.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
+        groupConvoInAnotherTeam.userDefinedName = "Group"
+        groupConvoInAnotherTeam.needsToDownloadRoles = false
+        groupConvoInAnotherTeam.needsToBeUpdatedFromBackend = false
+        groupConvoInAnotherTeam.teamRemoteIdentifier = UUID.create()
         
         let groupConvoThatUserLeft = createConversation()
         groupConvoThatUserLeft.needsToDownloadRoles = false
@@ -89,6 +97,8 @@ class RolesMigrationTests: DiskDatabaseTest {
         XCTAssertTrue(groupConvoInTeam.needsToBeUpdatedFromBackend)
         XCTAssertTrue(groupConvo.needsToDownloadRoles)
         XCTAssertTrue(groupConvo.needsToBeUpdatedFromBackend)
+        XCTAssertTrue(groupConvoInAnotherTeam.needsToDownloadRoles)
+        XCTAssertTrue(groupConvoInAnotherTeam.needsToBeUpdatedFromBackend)
         XCTAssertTrue(team.needsToDownloadRoles)
     }
     


### PR DESCRIPTION
Roles for a conversation should be fetched from a team or the conversation. When we have access to the team metadata (i.e. we are part of the team), we should fetch roles from the team. If not, then from the conversation.

The code was checking if the conversation is in a team, but not if it's our team. If the conversation is in another team, we should fetch the roles from the conversation, as we won't have access to that team.

This is similar to https://github.com/wireapp/wire-ios-sync-engine/pull/1132, applying the same logic to the migration.
