### PR TITLE
Fix: allow partner to create 1-on-1 conversaton but not group conversation

### DIFF
--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -28,7 +28,7 @@ public struct Permissions: OptionSet {
 
     // MARK: - Base Values
     public static let none                        = Permissions(rawValue: 0x0000)
-    public static let createConversation          = Permissions(rawValue: 0x0001)
+    public static let createConversation          = Permissions(rawValue: 0x0001) /// create all kind of conversation
     public static let deleteConversation          = Permissions(rawValue: 0x0002)
     public static let addTeamMember               = Permissions(rawValue: 0x0004)
     public static let removeTeamMember            = Permissions(rawValue: 0x0008)

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -48,6 +48,19 @@ extension ZMConversation {
                                             participantsRole: participantsRole)
     }
     
+    
+    /// insert a conversation with group type
+    ///
+    /// - Parameters:
+    ///   - moc: the NSManagedObjectContext
+    ///   - participants: the participants
+    ///   - name: the name of the convo
+    ///   - team: the team of the convo
+    ///   - allowGuests: allow guest or not
+    ///   - readReceipts: allow read receipts or not
+    ///   - participantsRole: the participants' role
+    ///   - type: the convo type want to be created (for permission check)
+    /// - Returns: the created conversation, nullable
     @objc
     static public func insertGroupConversation(moc: NSManagedObjectContext,
                                        participants: [ZMUser],
@@ -55,9 +68,10 @@ extension ZMConversation {
                                        team: Team? = nil,
                                        allowGuests: Bool = true,
                                        readReceipts: Bool = false,
-                                       participantsRole: Role? = nil) -> ZMConversation? {
+                                       participantsRole: Role? = nil,
+                                       type: ZMConversationType = .group) -> ZMConversation? {
         let selfUser = ZMUser.selfUser(in: moc)
-        if (team != nil && !selfUser.canCreateConversation(type: .group)) { ///TODO: inject 1-to-1
+        if (team != nil && !selfUser.canCreateConversation(type: type)) {
             return nil
         }
         
@@ -87,12 +101,12 @@ extension ZMConversation {
         return conversation
     }
     
-    @objc static func fetchOrCreateOneToOneTeamConversation(
+    @objc
+    static func fetchOrCreateOneToOneTeamConversation(
         moc: NSManagedObjectContext,
         participant: ZMUser,
         team: Team?,
-        participantRole: Role? = nil) -> ZMConversation?
-    {
+        participantRole: Role? = nil) -> ZMConversation? {
         guard let team = team,
             !participant.isSelfUser
         else { return nil }
@@ -105,7 +119,8 @@ extension ZMConversation {
                                        participants: [participant],
                                        name: nil,
                                        team: team,
-                                       participantsRole: participantRole)
+                                       participantsRole: participantRole,
+                                       type:.oneOnOne)
     }
     
     private static func existingTeamConversation(moc: NSManagedObjectContext,

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -55,10 +55,9 @@ extension ZMConversation {
                                        team: Team? = nil,
                                        allowGuests: Bool = true,
                                        readReceipts: Bool = false,
-                                       participantsRole: Role? = nil) -> ZMConversation?
-    {
+                                       participantsRole: Role? = nil) -> ZMConversation? {
         let selfUser = ZMUser.selfUser(in: moc)
-        if (team != nil && !selfUser.canCreateConversation) {
+        if (team != nil && !selfUser.canCreateConversation(type: .group)) { ///TODO: inject 1-to-1
             return nil
         }
         

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -48,6 +48,16 @@ extension ZMConversation {
                                             participantsRole: participantsRole)
     }
     
+    @objc
+    static public func insertGroupConversation(moc: NSManagedObjectContext,
+                                               participants: [ZMUser],
+                                               name: String? = nil,
+                                               team: Team? = nil,
+                                               allowGuests: Bool = true,
+                                               readReceipts: Bool = false,
+                                               participantsRole: Role? = nil) -> ZMConversation? {
+        return insertGroupConversation(moc: moc, participants: participants, name: name, team: team, allowGuests: allowGuests, readReceipts: readReceipts, participantsRole: participantsRole, type: .group)
+    }
     
     /// insert a conversation with group type
     ///
@@ -61,7 +71,6 @@ extension ZMConversation {
     ///   - participantsRole: the participants' role
     ///   - type: the convo type want to be created (for permission check)
     /// - Returns: the created conversation, nullable
-    @objc
     static public func insertGroupConversation(moc: NSManagedObjectContext,
                                        participants: [ZMUser],
                                        name: String? = nil,

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -150,7 +150,8 @@ public protocol UserType: NSObjectProtocol {
     // MARK: - Permissions
     
     /// Whether the user can create conversations.
-    var canCreateConversation: Bool { get }
+    @objc
+    func canCreateConversation(type: ZMConversationType) -> Bool
     
     /// Whether the user can create services
     var canCreateService: Bool { get }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -328,8 +328,8 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         return user?.canAccessCompanyInformation(of: otherUser) ?? false
     }
 
-    public var canCreateConversation: Bool {
-        return user?.canCreateConversation ?? false
+    public func canCreateConversation(type: ZMConversationType) -> Bool {
+        return user?.canCreateConversation(type: type) ?? false
     }
     
     public var canCreateService: Bool {

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -174,9 +174,11 @@ public extension ZMUser {
     @objc
     func canCreateConversation(type: ZMConversationType) -> Bool {
         switch type {
-        case .oneOnOne:///all users are allow to open 1-to-1 conversation
+        case .oneOnOne:
+            ///all users are allow to open 1-on-1 conversation
             return true
         default:
+            /// partner is not allowed to create non 1-on-1 convo
             return permissions?.contains(.member) ?? true
         }
     }

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -171,8 +171,14 @@ public extension ZMUser {
         return hasRoleWithAction(actionName: ConversationAction.leaveConversation.name, conversation: conversation)
     }
     
-    @objc var canCreateConversation: Bool {
-        return permissions?.contains(.createConversation) ?? true
+    @objc
+    func canCreateConversation(type: ZMConversationType) -> Bool {
+        switch type {
+        case .oneOnOne:///all users are allow to open 1-to-1 conversation
+            return true
+        default:
+            return permissions?.contains(.member) ?? true
+        }
     }
     
     @objc var canCreateService: Bool {

--- a/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
+    
+    func testThatItInsertsANewConversation() {
+        // given
+        let user1 = createUser()
+        let user2 = createUser()
+        let user3 = createUser()
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        
+        // when
+        let conversation = ZMConversation.insertGroupConversation(moc: uiMOC,
+                                                                  participants: [user1, user2, user3],
+                                                                  name: nil,
+                                                                  team: nil,
+                                                                  allowGuests: true,
+                                                                  readReceipts: false,
+                                                                  participantsRole: nil)
+        
+        // then
+        let conversations = ZMConversation.conversationsIncludingArchived(in: uiMOC)
+        
+        XCTAssertEqual(conversations.count, 1)
+        let fetchedConversation = conversations[0] as? ZMConversation
+        XCTAssertEqual(fetchedConversation?.conversationType, .group)
+        XCTAssertEqual(conversation?.objectID, fetchedConversation?.objectID)
+        
+        let expectedParticipants = Set<AnyHashable>([user1, user2, user3, selfUser])
+        XCTAssertEqual(expectedParticipants, conversation?.localParticipants)
+    }
+
+    func testThatItInsertsANewConversationInUIContext() {
+        // given
+        
+        let user1 = ZMUser.insertNewObject(in: uiMOC)
+        let user2 = ZMUser.insertNewObject(in: uiMOC)
+        let user3 = ZMUser.insertNewObject(in: uiMOC)
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        
+        // when
+        let conversation = ZMConversation.insertGroupConversation(moc: uiMOC, participants: [user1, user2, user3], name: nil, team: nil, allowGuests: true, readReceipts: false, participantsRole: nil)
+        
+        try! uiMOC.save()
+
+        
+        // then
+        XCTAssertNotNil(conversation)
+        
+        let fetchRequest = ZMConversation.sortedFetchRequest()
+        let conversations = uiMOC.executeFetchRequestOrAssert(fetchRequest)
+        
+        XCTAssertEqual(conversations?.count, 1)
+        let fetchedConversation = conversations?[0] as? ZMConversation
+        XCTAssertEqual(conversation?.objectID, fetchedConversation?.objectID)
+        
+        let expectedParticipants = Set<AnyHashable>([user1, user2, user3, selfUser])
+        XCTAssertEqual(expectedParticipants, conversation?.localParticipants)
+        
+    }
+
+}

--- a/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+gapsAndWindows.m
@@ -27,35 +27,6 @@
 @implementation ZMConversationGapsAndWindowTests
 
 
-- (void)testThatItInsertsANewConversation
-{
-    // given
-    ZMUser *user1 = [self createUser];
-    ZMUser *user2 = [self createUser];
-    ZMUser *user3 = [self createUser];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // when
-    ZMConversation *conversation =
-    [ZMConversation insertGroupConversationWithMoc:self.uiMOC
-                                      participants:@[user1, user2, user3]
-                                              name:NULL
-                                              team:NULL
-                                       allowGuests:YES
-                                      readReceipts:NO
-                                  participantsRole:NULL];
-    
-    // then
-    NSArray *conversations = [ZMConversation conversationsIncludingArchivedInContext:self.uiMOC];
-    
-    XCTAssertEqual(conversations.count, 1u);
-    ZMConversation *fetchedConversation = conversations[0];
-    XCTAssertEqual(fetchedConversation.conversationType, ZMConversationTypeGroup);
-    XCTAssertEqualObjects(conversation.objectID, fetchedConversation.objectID);
-    
-    NSSet *expectedParticipants = [NSSet setWithObjects:user1, user2, user3, selfUser, nil];
-    XCTAssertEqualObjects(expectedParticipants, conversation.localParticipants);
-}
 
 - (void)testThatItInsertsANewConversationInUserSession
 {
@@ -90,42 +61,6 @@
     
 }
 
-- (void)testThatItInsertsANewConversationInUIContext
-{
-    // given
-    
-    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    ZMUser *user2 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    ZMUser *user3 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // when
-    ZMConversation *conversation = [ZMConversation insertGroupConversationWithMoc:self.uiMOC
-                                                                     participants:@[user1, user2, user3]
-                                                                             name:NULL
-                                                                             team:NULL
-                                                                      allowGuests:YES
-                                                                     readReceipts:NO
-                                                                 participantsRole:NULL];
-    
-    NSError *error;
-    XCTAssertTrue([self.uiMOC save:&error], @"Error: %@", error);
-    
-    
-    // then
-    XCTAssertNotNil(conversation);
-    
-    NSFetchRequest *fetchRequest = [ZMConversation sortedFetchRequest];
-    NSArray *conversations = [self.uiMOC executeFetchRequestOrAssert:fetchRequest];
-    
-    XCTAssertEqual(conversations.count, 1u);
-    ZMConversation *fetchedConversation = conversations[0];
-    XCTAssertEqualObjects(conversation.objectID, fetchedConversation.objectID);
-    
-    NSSet *expectedParticipants = [NSSet setWithObjects:user1, user2, user3, selfUser, nil];
-    XCTAssertEqualObjects(expectedParticipants, conversation.localParticipants);
-    
-}
 
 - (void)testThatItReturnsTheListOfAllConversationsInTheUserSession;
 {

--- a/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -18,7 +18,7 @@
 
 import XCTest
 
-class ZMUserTests_Permissions: ModelObjectsTests {
+final class ZMUserTests_Permissions: ModelObjectsTests {
     
     let defaultAdminRoleName = "wire_admin"
     var team: Team!
@@ -206,26 +206,30 @@ class ZMUserTests_Permissions: ModelObjectsTests {
     
     // MARK: Create conversation
     
-    func testThatConversationCanBeCreated_ByNonTeamUser() {
-        XCTAssertTrue(selfUser.canCreateConversation)
+    func testThatOneOnOneConversationCanBeCreated_ByNonTeamUser() {
+        XCTAssert(selfUser.canCreateConversation(type: .oneOnOne))
     }
-    
+
+    func testThatGroupConversationCanBeCreated_ByNonTeamUser() {
+        XCTAssert(selfUser.canCreateConversation(type: .group))
+    }
+
+    func testThatGroupConversationCanNotCreated_ByPartner() {
+        // given
+        makeSelfUserTeamMember(withPermissions: .partner)
+        
+        // then
+        XCTAssertFalse(selfUser.canCreateConversation(type: .group))
+    }
+
     func testThatConversationCanBeCreated_ByTeamMemberWithSufficientPermissions() {
         // given
         makeSelfUserTeamMember(withPermissions: .member)
         
         // then
-        XCTAssertTrue(selfUser.canCreateConversation)
+        XCTAssert((selfUser?.canCreateConversation(type: .group))!)
     }
     
-    func testThatConversationCanBeCreated_ByPartner() {
-        // given
-        makeSelfUserTeamMember(withPermissions: .partner)
-        
-        // then
-        XCTAssert(selfUser.canCreateConversation)
-    }
-
     func testThatConversationCantBeCreated_ByTeamMemberWithInsufficientPermissions() {
         // given
         makeSelfUserTeamMember(withPermissions: .partner)

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		A9128AD02398067E0056F591 /* ZMConversationTests+Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9128ACF2398067E0056F591 /* ZMConversationTests+Participants.swift */; };
 		A923D77E239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923D77D239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift */; };
 		A927F52723A029250058D744 /* ParticipantRoleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A927F52623A029250058D744 /* ParticipantRoleTests.swift */; };
+		A9536FD323ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */; };
 		A95E7BF5239134E600935B88 /* ZMConversation+Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */; };
 		A9676D7623A30BEF001CD41D /* ZMTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9676D7323A30ABA001CD41D /* ZMTestSession.swift */; };
 		A995F05C23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */; };
@@ -840,6 +841,7 @@
 		A9128ACF2398067E0056F591 /* ZMConversationTests+Participants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Participants.swift"; sourceTree = "<group>"; };
 		A923D77D239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+SecurityLevel.swift"; sourceTree = "<group>"; };
 		A927F52623A029250058D744 /* ParticipantRoleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRoleTests.swift; sourceTree = "<group>"; };
+		A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+gapsAndWindows.swift"; sourceTree = "<group>"; };
 		A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Participants.swift"; sourceTree = "<group>"; };
 		A9676D7323A30ABA001CD41D /* ZMTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTestSession.swift; sourceTree = "<group>"; };
 		A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticipantRoleChangeInfo.swift; sourceTree = "<group>"; };
@@ -1973,6 +1975,7 @@
 				A923D77D239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift */,
 				F9B71F4F1CB2BC85001DB03F /* ZMConversation+Testing.m */,
 				F9B71F511CB2BC85001DB03F /* ZMConversationTests+gapsAndWindows.m */,
+				A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */,
 				54A885A71F62EEB600AFBA95 /* ZMConversationTests+Messages.swift */,
 				16D5260C20DD1D9400608D8E /* ZMConversationTests+Timestamps.swift */,
 				A9128ACF2398067E0056F591 /* ZMConversationTests+Participants.swift */,
@@ -3011,6 +3014,7 @@
 				F9DBA5271E28EEBD00BE23C0 /* UserObserverTests.swift in Sources */,
 				1611CF59203AE6A0004D807B /* FileAssetCacheTests.swift in Sources */,
 				5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */,
+				A9536FD323ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift in Sources */,
 				5473CC751E14268600814C03 /* NSManagedObjectContextDebuggingTests.swift in Sources */,
 				F99C5B8C1ED466760049CCD7 /* TeamObserverTests.swift in Sources */,
 				F9A7083C1CAEEB7500C2F5FE /* MockModelObjectContextFactory.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

add `type` parameter to `canCreateConversation` checker. Partner team role can only create 1-on-1 conversation but not other kinds.

add `type` parameter to `insertGroupConversation`.