### PR TITLE
Refetch roles when needed

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -155,6 +155,7 @@ extension ZMConversation {
         
         let addedSelfUser = doesExistsOnBackend && addedRoles.contains(where: {$0.user.isSelfUser})
         if addedSelfUser {
+            self.markToDownloadRolesIfNeeded()
             self.needsToBeUpdatedFromBackend = true
         }
         
@@ -292,6 +293,23 @@ extension ZMConversation {
             return team.roles
         }
         return nonTeamRoles
+    }
+    
+    /// Check if roles are missing, and mark them to download if needed
+    @objc public func markToDownloadRolesIfNeeded() {
+        guard self.conversationType == .group else { return }
+        
+        let selfUser = ZMUser.selfUser(in: self.managedObjectContext!)
+        let notInMyTeam = self.teamRemoteIdentifier == nil ||
+            selfUser.team?.remoteIdentifier != self.teamRemoteIdentifier
+        
+        guard notInMyTeam else { return }
+        
+        if self.nonTeamRoles.isEmpty ||
+            self.nonTeamRoles.first(where: {!$0.actions.isEmpty}) == nil // there are no roles with actions
+        {
+            self.needsToDownloadRoles = true
+        }
     }
 }
 

--- a/Source/Model/Conversation/ZMConversation+Transport.swift
+++ b/Source/Model/Conversation/ZMConversation+Transport.swift
@@ -144,6 +144,7 @@ extension ZMConversation {
             // Backend is sending the miliseconds, we need to convert to seconds.
             self.syncedMessageDestructionTimeout = messageTimerNumber / 1000;
         }
+        self.markToDownloadRolesIfNeeded()
     }
     
     private func updateReceiptMode(_ receiptMode: Int?) {
@@ -219,6 +220,7 @@ extension ZMConversation {
         {
             self.updateCleared(timeStamp, synchronize: false)
         }
+        self.markToDownloadRolesIfNeeded()
     }
     
     private func updateIsArchived(payload: [String: Any]) -> Bool {

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
@@ -320,6 +320,31 @@ extension ZMConversationTransportTests {
         // then
         XCTAssertEqual(conversation.participantRoles.first?.role?.name, "boss")
     }
+    
+    func testThatItRefetchesRolesIfNoRolesAfterUpdate() {
+        
+        syncMOC.performGroupedAndWait() { _ -> () in
+            // given
+            
+            ZMUser.selfUser(in: self.syncMOC).teamIdentifier = UUID()
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+            conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
+            let payload = self.simplePayload(
+                conversation: conversation,
+                team: nil,
+                selfRole: "test_role"
+            )
+            
+            // when
+            conversation.update(transportData: payload, serverTimeStamp: Date())
+            
+            // then
+            XCTAssertTrue(conversation.needsToDownloadRoles)
+        }
+    }
+    
 }
 
 extension ZMConversation {


### PR DESCRIPTION
## What's new in this PR?

Add a method to make sure conversation roles are refetched when needed. This method is called every time a conversation is updated from payload.

This solves the bug when roles are not fetched when a user is added to a conversation. Previously, the check on whether roles should be fetched was done at the sync engine level, when the conversation payload was not yet parsed. At the time of the check, we would not know if the conversation was a group or in a team, and the check would always fail due to incomplete information.