### PR TITLE
Using correct version number in migration

### DIFF
--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -32,7 +32,7 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "145.0.3", block: InvalidConversationRemoval.removeInvalid),
         PersistedDataPatch(version: "161.0.1", block: TransferStateMigration.migrateLegacyTransferState),
         PersistedDataPatch(version: "167.3.0", block: AvailabilityBehaviourChange.notifyAvailabilityBehaviourChange),
-        PersistedDataPatch(version: "197.0.0", block: ZMConversation.introduceParticipantRoles)
+        PersistedDataPatch(version: "198.0.0", block: ZMConversation.introduceParticipantRoles)
     ]
 
 }


### PR DESCRIPTION
## What's new in this PR?

The migration for conversation roles was started from the wrong version. The previous released data model version was 197. The migration was set to run if the old version was before 197, which was causing it not to be run at all.