### PR TITLE
Fix: migration to roles failing due to duplicate Roles being inserted

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -79,7 +79,7 @@ extension ZMConversation {
     
     static private func getAParticipantRole(in moc: NSManagedObjectContext, adminRole: Role?, user: ZMUser, conversation: ZMConversation, team: Team?) -> ParticipantRole {
         let participantRoleForUser = ParticipantRole.create(managedObjectContext: moc, user: user, conversation: conversation)
-        let customRole = (team != nil) ? Role.create(managedObjectContext: moc, name: defaultAdminRoleName, team: team!) : Role.create(managedObjectContext: moc, name: defaultAdminRoleName, conversation: conversation)
+        let customRole = Role.fetchOrCreateRole(with: defaultAdminRoleName, teamOrConversation: team != nil ? .team(team!) : .conversation(conversation), in: moc)
         
         if let adminRole = adminRole {
             participantRoleForUser.role = adminRole


### PR DESCRIPTION
## What's new in this PR?

### Issues

Group participants are incorrectly migrated as members instead of admins.

### Causes

During the migration of team group conversations a new `Role` was created for each conversation instead them all sharing the the same `Role` as expected. The duplicate roles would later be deleted when the `TeamRolesDownloadRequestStrategy` syncs the team roles, leaving the participants without a role and thus default to be "members".

### Solutions

Fetch any existing `Role` before creating a new `Role` for a team conversation.