### PR TITLE
[Fix] crash by unwrapping optional values before attempting to use them

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -94,7 +94,9 @@ extension ZMConversation {
     static func addUserFromTheConnectionToTheParticipantRoles(in moc: NSManagedObjectContext) {
         let allConnections = ZMConnection.connections(inMangedObjectContext: moc) as! [ZMConnection]
         for connection in allConnections {
-            connection.conversation.addParticipantAndUpdateConversationState(user: connection.to, role: nil)
+            guard let conversation = connection.conversation, let user = connection.to else { continue }
+            
+            conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

We've seen reports that the app crashes while migrating to the new user roles

### Causes

Optional values are force unwrapped

### Solutions

Unwrap optional values before attempting to use them.