### PR TITLE
[Refactor] Send regular messages using Swift Protobuf API

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -95,13 +95,20 @@ extension ZMConversation {
     
     @discardableResult @objc(appendImageFromData:nonce:)
     public func append(imageFromData imageData: Data, nonce: UUID = UUID()) -> ZMConversationMessage? {
-        do {
-            let imageDataWithoutMetadata = try imageData.wr_removingImageMetadata()
-            return appendAssetClientMessage(withNonce: nonce, imageData: imageDataWithoutMetadata)
-        } catch let error {
-            log.error("Cannot remove image metadata: \(error)")
-            return nil
-        }
+        guard let managedObjectContext = managedObjectContext,
+              let imageData = try? imageData.wr_removingImageMetadata() else { return nil }
+        
+        
+        // mimeType is assigned first, to make sure UI can handle animated GIF file correctly
+        let mimeType = ZMAssetMetaDataEncoder.contentType(forImageData: imageData) ?? ""
+        // We update the size again when the the preprocessing is done
+        let imageSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: imageData)
+        
+        let asset = WireProtos.Asset(imageSize: imageSize, mimeType: mimeType, size: UInt64(imageData.count))
+        
+        return append(asset: asset, nonce: nonce, expires: true, prepareMessage: { message in
+            managedObjectContext.zm_fileAssetCache.storeAssetData(message, format: .original, encrypted: false, data: imageData)
+        })
     }
     
     @discardableResult @objc(appendFile:nonce:)
@@ -109,22 +116,33 @@ extension ZMConversation {
         guard let data = try? Data.init(contentsOf: fileMetadata.fileURL, options: .mappedIfSafe),
               let managedObjectContext = managedObjectContext else { return nil }
         
-        guard let message = ZMAssetClientMessage(with: fileMetadata,
+        return append(asset: fileMetadata.asset, nonce: nonce, expires: false) { (message) in
+            managedObjectContext.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: data)
+            
+            if let thumbnailData = fileMetadata.thumbnail {
+                managedObjectContext.zm_fileAssetCache.storeAssetData(message, format: .original, encrypted: false, data: thumbnailData)
+            }
+        }
+    }
+    
+    @nonobjc
+    private func append(asset: WireProtos.Asset, nonce: UUID, expires: Bool, prepareMessage: (ZMAssetClientMessage) -> Void) -> ZMAssetClientMessage? {
+        guard let managedObjectContext = managedObjectContext,
+              let message = ZMAssetClientMessage(asset: asset,
                                                  nonce: nonce,
                                                  managedObjectContext: managedObjectContext,
-                                                 expiresAfter: messageDestructionTimeoutValue) else { return  nil}
+                                                 expiresAfter: messageDestructionTimeoutValue)
+        else { return nil }
         
         message.sender = ZMUser.selfUser(in: managedObjectContext)
         
-        append(message)
-        unarchiveIfNeeded()
-        
-        managedObjectContext.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: data)
-        
-        if let thumbnailData = fileMetadata.thumbnail {
-            managedObjectContext.zm_fileAssetCache.storeAssetData(message, format: .original, encrypted: false, data: thumbnailData)
+        if expires {
+            message.setExpirationDate()
         }
         
+        append(message)
+        unarchiveIfNeeded()
+        prepareMessage(message)
         message.updateCategoryCache()
         message.prepareToSend()
         

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -742,27 +742,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return message;
 }
 
-- (ZMAssetClientMessage *)appendAssetClientMessageWithNonce:(NSUUID *)nonce imageData:(NSData *)imageData
-{
-    ZMAssetClientMessage *message =
-    [[ZMAssetClientMessage alloc] initWithOriginalImage:imageData
-                                                  nonce:nonce
-                                   managedObjectContext:self.managedObjectContext
-                                           expiresAfter:self.messageDestructionTimeoutValue];
-
-    message.sender = [ZMUser selfUserInContext:self.managedObjectContext];
-    
-    [message setExpirationDate];
-    [self appendMessage:message];
-
-    [self unarchiveIfNeeded];
-    [self.managedObjectContext.zm_fileAssetCache storeAssetData:message format:ZMImageFormatOriginal encrypted:NO data:imageData];
-    [message updateCategoryCache];
-    [message prepareToSend];
-    
-    return message;
-}
-
 - (void)appendMessage:(ZMMessage *)message;
 {
     Require(message != nil);

--- a/Source/Model/Message/ZMFileMetadata.swift
+++ b/Source/Model/Message/ZMFileMetadata.swift
@@ -44,13 +44,8 @@ private let zmLog = ZMSLog(tag: "ZMFileMetadata")
         self.init(fileURL: fileURL, thumbnail: thumbnail, name: nil)
     }
     
-    var asset : ZMAsset {
-        get {
-            return ZMAsset.asset(withOriginal: .original(withSize: size,
-                mimeType: mimeType,
-                name: filename)
-            )
-        }
+    var asset: WireProtos.Asset {
+        return WireProtos.Asset(self)
     }
 }
 
@@ -73,15 +68,8 @@ open class ZMAudioMetadata : ZMFileMetadata {
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: name)
     }
     
-    override var asset : ZMAsset {
-        get {
-            return ZMAsset.asset(withOriginal: .original(withSize: size,
-                mimeType: mimeType,
-                name: filename,
-                audioDurationInMillis: UInt(duration * 1000),
-                normalizedLoudness: normalizedLoudness)
-            )
-        }
+    override var asset: WireProtos.Asset {
+        return WireProtos.Asset(self)
     }
     
 }
@@ -105,15 +93,8 @@ open class ZMVideoMetadata : ZMFileMetadata {
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: name)
     }
     
-    override var asset : ZMAsset {
-        get {
-            return ZMAsset.asset(withOriginal: .original(withSize: size,
-                mimeType: mimeType,
-                name: filename,
-                videoDurationInMillis: UInt(duration * 1000),
-                videoDimensions: dimensions)
-            )
-        }
+    override var asset: WireProtos.Asset {
+        return WireProtos.Asset(self)
     }
     
 }

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -173,6 +173,71 @@ extension Text: EphemeralMessageCapable {
     }
 }
 
+extension WireProtos.Asset: EphemeralMessageCapable {
+    
+    init(_ metadata: ZMFileMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+            })
+        })
+    }
+    
+    init(_ metadata: ZMAudioMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+                $0.audio = WireProtos.Asset.AudioMetaData.with({
+                    let loudnessArray = metadata.normalizedLoudness.map { UInt8(roundf($0 * 255)) }
+                    $0.durationInMillis = UInt64(metadata.duration * 1000)
+                    $0.normalizedLoudness = NSData(bytes: loudnessArray, length: loudnessArray.count) as Data
+                })
+                
+            })
+        })
+    }
+    
+    init(_ metadata: ZMVideoMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+                $0.video = WireProtos.Asset.VideoMetaData.with({
+                    $0.durationInMillis = UInt64(metadata.duration * 1000)
+                    $0.width = Int32(metadata.dimensions.width)
+                    $0.height = Int32(metadata.dimensions.height)
+                })
+            })
+        })
+    }
+    
+    init(imageSize: CGSize, mimeType: String, size: UInt64) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = size
+                $0.mimeType = mimeType
+                $0.image = WireProtos.Asset.ImageMetaData.with({
+                    $0.width = Int32(imageSize.width)
+                    $0.height = Int32(imageSize.height)
+                })
+            })
+        })
+    }
+    
+    public func setEphemeralContent(on ephemeral: inout Ephemeral) {
+        ephemeral.asset = self
+    }
+    
+    public func setContent(on message: inout GenericMessage) {
+        message.asset = self
+    }
+}
+
 extension WireProtos.Mention {
     
     init?(_ mention: WireDataModel.Mention) {


### PR DESCRIPTION
## What's new in this PR?

Refactor the message sending methods to use the the Swift Protobuf API. This is compatible with the existing Objective-C implementation since we serialize and store the protobufs as a data blob.