### PR TITLE
Fix: Application crashes when searching for contacts with symbol

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -54,9 +54,7 @@ extension ZMConversation {
     
     private class func predicateForConversationWithUsers(matchingQuery query: String,
                                                          selfUser: ZMUser) -> NSPredicate {
-        let roleNameMatchingRegexes = query.words.map { word -> String in
-            return ".*\\b\(NSRegularExpression.escapedPattern(for: word).lowercased()).*"
-        }
+        let roleNameMatchingRegexes = query.words.map { ".*\\b\(NSRegularExpression.escapedPattern(for: $0).lowercased()).*" }
         
         let roleNameMatchingConditions = roleNameMatchingRegexes.map { _ in
             "$role.user.normalizedName MATCHES %@"

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -62,8 +62,18 @@ extension ZMConversation {
             "$role.user.normalizedName MATCHES %@"
             }.joined(separator: " OR ")
         
+        if roleNameMatchingConditions.isEmpty {
+            return  NSPredicate(
+                format: "SUBQUERY(%K, $role, $role.user != %@).@count > 0",
+                argumentArray: [
+                    ZMConversationParticipantRolesKey,
+                    selfUser
+                    ] + roleNameMatchingRegexes
+            )
+        }
+        
         return NSPredicate(
-            format: "SUBQUERY(%K, $role, $role.user != %@ AND (\(roleNameMatchingConditions))).@count > 0",
+            format: "SUBQUERY(%K, $role, $role.user != %@ AND (\(roleNameMatchingConditions))",
             argumentArray: [
                 ZMConversationParticipantRolesKey,
                 selfUser

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -182,7 +182,7 @@ extension ZMConversation {
 
 extension String {
     
-    fileprivate var words: [String] {
+    var words: [String] {
         var words: [String] = []
         enumerateSubstrings(in: self.startIndex..., options: .byWords) { substring, _, _, _ in
             words.append(String(substring!))

--- a/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -33,6 +33,20 @@ final class ConversationTests: ZMConversationTestsBase {
         return conversation
     }
 
+    func testThatItFindsConversationByUserDefinedNameDiacriticsWithSymbol() {
+        // given
+        let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
+        
+        // when
+        
+        let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "@Sømebôdy", selfUser: selfUser))
+        let result = uiMOC.executeFetchRequestOrAssert(request)
+        
+        // then
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first as? ZMConversation, conversation)
+    }
+
     func testThatItFindsConversationByUserDefinedNameDiacritics() {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")

--- a/Tests/Source/Model/Utils/String+WordTests.swift
+++ b/Tests/Source/Model/Utils/String+WordTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 final class StringWordsTests: XCTestCase {
     
-    func testThatSetenceIsSplited() {
+    func testThatSentenceIsSplitted() {
         //given
         let sut = "once upon a time"
         

--- a/Tests/Source/Model/Utils/String+WordTests.swift
+++ b/Tests/Source/Model/Utils/String+WordTests.swift
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+final class StringWordsTests: XCTestCase {
+    
+    func testThatSetenceIsSplited() {
+        //given
+        let sut = "once upon a time"
+        
+        //when
+        let words = sut.words
+        
+        //then
+        XCTAssertEqual(words, ["once", "upon", "a", "time"])
+    }
+    
+    func testThatSingleSymbolIsSplitedAsAWord() {
+        //given
+        let sut = "@"
+        
+        //when
+        let words = sut.words
+        
+        //then
+        XCTAssertEqual(words, ["@"])
+    }
+}

--- a/Tests/Source/Model/Utils/String+WordTests.swift
+++ b/Tests/Source/Model/Utils/String+WordTests.swift
@@ -32,7 +32,7 @@ final class StringWordsTests: XCTestCase {
         XCTAssertEqual(words, ["once", "upon", "a", "time"])
     }
     
-    func testThatSingleSymbolIsSplitedAsAWord() {
+    func testThatSingleSymbolIsSplittedAsAWord() {
         //given
         let sut = "@"
         

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		A927F52723A029250058D744 /* ParticipantRoleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A927F52623A029250058D744 /* ParticipantRoleTests.swift */; };
 		A9536FD323ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */; };
 		A95E7BF5239134E600935B88 /* ZMConversation+Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */; };
+		A96524BA23CDE07700303C60 /* String+WordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96524B823CDE07200303C60 /* String+WordTests.swift */; };
 		A9676D7623A30BEF001CD41D /* ZMTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9676D7323A30ABA001CD41D /* ZMTestSession.swift */; };
 		A982B46623BE1B86001828A6 /* ConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A982B46523BE1B86001828A6 /* ConversationTests.swift */; };
 		A995F05C23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */; };
@@ -846,6 +847,7 @@
 		A927F52623A029250058D744 /* ParticipantRoleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRoleTests.swift; sourceTree = "<group>"; };
 		A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+gapsAndWindows.swift"; sourceTree = "<group>"; };
 		A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Participants.swift"; sourceTree = "<group>"; };
+		A96524B823CDE07200303C60 /* String+WordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+WordTests.swift"; sourceTree = "<group>"; };
 		A9676D7323A30ABA001CD41D /* ZMTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTestSession.swift; sourceTree = "<group>"; };
 		A982B46523BE1B86001828A6 /* ConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTests.swift; sourceTree = "<group>"; };
 		A995F05B23968D8500FAC3CF /* ParticipantRoleChangeInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticipantRoleChangeInfo.swift; sourceTree = "<group>"; };
@@ -1354,6 +1356,7 @@
 				87DF59BF1F729FDA00C7B406 /* ZMMovedIndexTests.swift */,
 				F19550372040628000338E91 /* ZMUpdateEvent+Helper.swift */,
 				EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */,
+				A96524B823CDE07200303C60 /* String+WordTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2942,6 +2945,7 @@
 				16E7DA2A1FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift in Sources */,
 				87DF59C01F729FDA00C7B406 /* ZMMovedIndexTests.swift in Sources */,
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
+				A96524BA23CDE07700303C60 /* String+WordTests.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
 				6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Application crashes when searching for contacts with symbol

### Causes

`String.words` methods returns empty string array when the query string is "@"

### Solutions

Append the whole string as a word when the return array is empty. Escape the string for regex.