### PR TITLE
[Fix] image quotes are getting lost

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -60,7 +60,7 @@ extension ZMConversation {
         
         guard !(text as NSString).zmHasOnlyWhitespaceCharacters() else { return nil }
         
-        let text = Text(content: text, mentions: mentions, replyingTo: quotedMessage as? ZMClientMessage)
+        let text = Text(content: text, mentions: mentions, replyingTo: quotedMessage as? ZMOTRMessage)
         let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: managedObjectContext!)
         

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -148,7 +148,7 @@ extension Knock: EphemeralMessageCapable {
 
 extension Text: EphemeralMessageCapable {
     
-    init(content: String, mentions: [Mention], replyingTo: ZMClientMessage?) {
+    init(content: String, mentions: [Mention], replyingTo: ZMOTRMessage?) {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -324,6 +324,21 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
         XCTAssertFalse(fileMessage.fileMessageData!.isVideo)
         XCTAssertFalse(fileMessage.fileMessageData!.isAudio)
     }
+    
+    func testThatWeCanInsertATextMessageWithImageQuote() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.remoteIdentifier = UUID()
+        let imageMessage = conversation.append(imageFromData: verySmallJPEGData())
+        
+        // when
+        let textMessage = conversation.append(text: "Hello World", replyingTo: imageMessage)
+        
+        // then
+        XCTAssertNotNil(textMessage?.textMessageData?.quote)
+        XCTAssertEqual(textMessage?.textMessageData?.quote?.nonce, imageMessage?.nonce)
+        
+    }
 
     func testThatWeCanInsertAPassFileMessage() {
         // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you reply to an image it's not included as quote.

### Causes

The quoted image message was casted to a `ZMClientMessage`, which fails since image messages are of type `ZMAssetClientMessage`.

### Solutions

Cast quoted messages the base class `ZMOTRMessage` instead.