### PR TITLE
Refactor/Migrate protobuf invisible messages

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -161,7 +161,6 @@ NS_ASSUME_NONNULL_END
 /// Create and append to self conversation a ClientMessage that has generic message data built with the given data
 + (nullable ZMClientMessage *)appendSelfConversationWithGenericMessage:(nonnull ZMGenericMessage *)genericMessage managedObjectContext:(nonnull NSManagedObjectContext *)moc;
 
-+ (nullable ZMClientMessage *)appendSelfConversationWithLastReadOfConversation:(nonnull ZMConversation *)conversation;
 + (nullable ZMClientMessage *)appendSelfConversationWithClearedOfConversation:(nonnull ZMConversation *)conversation;
 
 + (void)updateConversationWithZMLastReadFromSelfConversation:(nonnull ZMLastRead *)lastRead inContext:(nonnull NSManagedObjectContext *)context;

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -51,7 +51,7 @@ extension ZMConversation {
               convID != ZMConversation.selfConversationIdentifier(in: moc)
             else { return nil }
         
-        let lastRead = LastRead(conversationID: convID.transportString(), lastReadTimestamp: Int64(lastReadTimeStamp.timeIntervalSince1970 * 1000))
+        let lastRead = LastRead(conversationID: convID, lastReadTimestamp: lastReadTimeStamp)
         let genericMessage = GenericMessage.message(content: lastRead, nonce: nonce)
         let selfConversation = ZMConversation.selfConversation(in: moc)
         

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -42,6 +42,23 @@ extension ZMConversation {
         return appendClientMessage(with: GenericMessage.message(content: Knock.with({ $0.hotKnock = false }), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
+    @discardableResult @objc(appendSelfConversationWithLastReadOf:nonce:)
+    static func appendSelfConversation(withLastReadOf conversation: ZMConversation,
+                                       nonce: UUID = UUID()) -> ZMClientMessage? {
+        guard let moc = conversation.managedObjectContext,
+              let lastReadTimeStamp = conversation.lastReadServerTimeStamp,
+              let convID = conversation.remoteIdentifier,
+              convID != ZMConversation.selfConversationIdentifier(in: moc)
+            else { return nil }
+        
+        let lastRead = LastRead(conversationID: convID.transportString(), lastReadTimestamp: Int64(lastReadTimeStamp.timeIntervalSince1970 * 1000))
+        let genericMessage = GenericMessage.message(content: lastRead, nonce: nonce)
+        let selfConversation = ZMConversation.selfConversation(in: moc)
+        
+        let clientMessage = selfConversation.appendClientMessage(with: genericMessage, expires: false, hidden: false)
+        return clientMessage
+    }
+    
     @discardableResult @objc(appendText:mentions:fetchLinkPreview:nonce:)
     public func append(text: String,
                        mentions: [Mention] = [],

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -777,22 +777,6 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     return clientMessage;
 }
 
-
-+ (ZMClientMessage *)appendSelfConversationWithLastReadOfConversation:(ZMConversation *)conversation
-{
-    NSDate *lastRead = conversation.lastReadServerTimeStamp;
-    NSUUID *convID = conversation.remoteIdentifier;
-    if (convID == nil || lastRead == nil || [convID isEqual:[ZMConversation selfConversationIdentifierInContext:conversation.managedObjectContext]]) {
-        return nil;
-    }
-
-    NSUUID *nonce = [NSUUID UUID];
-    ZMGenericMessage *message = [ZMGenericMessage messageWithContent:[ZMLastRead lastReadWithTimestamp:lastRead conversationRemoteID:convID] nonce:nonce];
-    VerifyReturnNil(message != nil);
-    
-    return [self appendSelfConversationWithGenericMessage:message managedObjectContext:conversation.managedObjectContext];
-}
-
 + (void)updateConversationWithZMLastReadFromSelfConversation:(ZMLastRead *)lastRead inContext:(NSManagedObjectContext *)context
 {
     double newTimeStamp = lastRead.lastReadTimestamp;

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -59,19 +59,20 @@ extension ZMMessage {
     
     @objc public func addReaction(_ unicodeValue: String?, forUser user:ZMUser) {
         removeReaction(forUser:user)
-        if let unicodeValue = unicodeValue , unicodeValue.count > 0 {
-            guard let reaction = self.reactions.first(where: {$0.unicodeValue! == unicodeValue}) else {
-                
-                // we didn't find a reaction, need to add a new one
-                let newReaction = Reaction.insertReaction(unicodeValue, users: [user], inMessage: self)
-                self.mutableSetValue(forKey: "reactions").add(newReaction)
+        guard let unicodeValue = unicodeValue,
+            unicodeValue.count > 0 else {
                 updateCategoryCache()
                 return
-            }
-            reaction.mutableSetValue(forKey: ZMReactionUsersValueKey).add(user)
+        }
+        
+        guard let reaction = self.reactions.first(where: {$0.unicodeValue! == unicodeValue}) else {
+            // we didn't find a reaction, need to add a new one
+            let newReaction = Reaction.insertReaction(unicodeValue, users: [user], inMessage: self)
+            self.mutableSetValue(forKey: "reactions").add(newReaction)
+            updateCategoryCache()
             return
         }
-        updateCategoryCache()
+        reaction.mutableSetValue(forKey: ZMReactionUsersValueKey).add(user)
     }
     
     fileprivate func removeReaction(forUser user: ZMUser) {

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -35,7 +35,8 @@ extension ZMMessage {
         guard message.isSent else { return nil }
         
         let emoji = unicodeValue ?? ""
-        let genericMessage = ZMGenericMessage.message(content: ZMReaction(emoji: emoji, messageID: messageID))    
+        let reaction = WireProtos.Reaction(emoji: emoji, messageID: messageID.transportString())
+        let genericMessage = GenericMessage.message(content: reaction)
         let clientMessage = message.conversation?.appendClientMessage(with: genericMessage, expires: false, hidden: true)
         message.addReaction(unicodeValue, forUser: .selfUser(in: context))
         return clientMessage

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -35,7 +35,7 @@ extension ZMMessage {
         guard message.isSent else { return nil }
         
         let emoji = unicodeValue ?? ""
-        let reaction = WireProtos.Reaction(emoji: emoji, messageID: messageID.transportString())
+        let reaction = WireProtos.Reaction(emoji: emoji, messageID: messageID)
         let genericMessage = GenericMessage.message(content: reaction)
         let clientMessage = message.conversation?.appendClientMessage(with: genericMessage, expires: false, hidden: true)
         message.addReaction(unicodeValue, forUser: .selfUser(in: context))

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -62,7 +62,7 @@ extension ZMMessage {
         if let unicodeValue = unicodeValue , unicodeValue.count > 0 {
             guard let reaction = self.reactions.first(where: {$0.unicodeValue! == unicodeValue}) else {
                 
-                //we didn't find a reaction, need to add a new one
+                // we didn't find a reaction, need to add a new one
                 let newReaction = Reaction.insertReaction(unicodeValue, users: [user], inMessage: self)
                 self.mutableSetValue(forKey: "reactions").add(newReaction)
                 updateCategoryCache()

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -183,10 +183,10 @@ extension Text: EphemeralMessageCapable {
 
 extension WireProtos.Reaction: MessageCapable {
     
-    init(emoji: String, messageID: String) {
+    init(emoji: String, messageID: UUID) {
         self = WireProtos.Reaction.with({
             $0.emoji = emoji
-            $0.messageID = messageID
+            $0.messageID = messageID.transportString()
         })
     }
     
@@ -206,10 +206,10 @@ extension WireProtos.Reaction: MessageCapable {
 
 extension LastRead: MessageCapable {
     
-    init(conversationID: String, lastReadTimestamp: Int64) {
+    init(conversationID: UUID, lastReadTimestamp: Date) {
         self = LastRead.with {
-            $0.conversationID = conversationID
-            $0.lastReadTimestamp = lastReadTimestamp
+            $0.conversationID = conversationID.transportString()
+            $0.lastReadTimestamp = Int64(lastReadTimestamp.timeIntervalSince1970 * 1000)
         }
     }
     

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -41,6 +41,14 @@ public extension GenericMessage {
             messageContent.setContent(on: &$0)
         }
     }
+    
+    static func message(content: MessageCapable, nonce: UUID = UUID()) -> GenericMessage {
+        return GenericMessage.with() {
+            $0.messageID = nonce.transportString()
+            let messageContent = content
+            messageContent.setContent(on: &$0)
+        }
+    }
 }
 
 extension GenericMessage {
@@ -170,6 +178,74 @@ extension Text: EphemeralMessageCapable {
     
     public func setContent(on message: inout GenericMessage) {
         message.text = self
+    }
+}
+
+extension WireProtos.Reaction: MessageCapable {
+    
+    init(emoji: String, messageID: String) {
+        self = WireProtos.Reaction.with({
+            $0.emoji = emoji
+            $0.messageID = messageID
+        })
+    }
+    
+    public func setContent(on message: inout GenericMessage) {
+        message.reaction = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get {
+            return false
+        }
+        set {
+            
+        }
+    }
+}
+
+extension LastRead: MessageCapable {
+    
+    init(conversationID: String, lastReadTimestamp: Int64) {
+        self = LastRead.with {
+            $0.conversationID = conversationID
+            $0.lastReadTimestamp = lastReadTimestamp
+        }
+    }
+    
+    public func setContent(on message: inout GenericMessage) {
+        message.lastRead = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get {
+            return false
+        }
+        set {
+            
+        }
+    }
+}
+
+extension Calling: MessageCapable {
+    
+    init(content: String) {
+        self = Calling.with {
+            $0.content = content
+        }
+    }
+    
+    public func setContent(on message: inout GenericMessage) {
+        message.calling = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get {
+            return false
+        }
+        set {
+           
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Refactor the message (Reaction, LastRead) sending methods to use the Swift Protobuf API. 