### PR TITLE
Fix/make as a public appendSelfConversationWithLastReadOf method

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -43,7 +43,7 @@ extension ZMConversation {
     }
     
     @discardableResult @objc(appendSelfConversationWithLastReadOf:nonce:)
-    static func appendSelfConversation(withLastReadOf conversation: ZMConversation,
+    public static func appendSelfConversation(withLastReadOf conversation: ZMConversation,
                                        nonce: UUID = UUID()) -> ZMClientMessage? {
         guard let moc = conversation.managedObjectContext,
               let lastReadTimeStamp = conversation.lastReadServerTimeStamp,

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -42,11 +42,11 @@ extension ZMConversation {
         return appendClientMessage(with: GenericMessage.message(content: Knock.with({ $0.hotKnock = false }), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
-    @discardableResult @objc(appendSelfConversationWithLastReadOf:)
-    public static func appendSelfConversation(withLastReadOf conversation: ZMConversation) -> ZMClientMessage? {
-        guard let moc = conversation.managedObjectContext,
-              let lastReadTimeStamp = conversation.lastReadServerTimeStamp,
-              let convID = conversation.remoteIdentifier,
+    @discardableResult @objc(appendSelfConversationWithLastReadOfConversation:)
+    public static func appendSelfConversation(withLastReadOf theConversation: ZMConversation) -> ZMClientMessage? {
+        guard let moc = theConversation.managedObjectContext,
+              let lastReadTimeStamp = theConversation.lastReadServerTimeStamp,
+              let convID = theConversation.remoteIdentifier,
               convID != ZMConversation.selfConversationIdentifier(in: moc)
             else { return nil }
         

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -42,15 +42,15 @@ extension ZMConversation {
         return appendClientMessage(with: GenericMessage.message(content: Knock.with({ $0.hotKnock = false }), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
-    @discardableResult @objc(appendSelfConversationWithLastReadOf:nonce:)
-    public static func appendSelfConversation(withLastReadOf conversation: ZMConversation,
-                                       nonce: UUID = UUID()) -> ZMClientMessage? {
+    @discardableResult @objc(appendSelfConversationWithLastReadOf:)
+    public static func appendSelfConversation(withLastReadOf conversation: ZMConversation) -> ZMClientMessage? {
         guard let moc = conversation.managedObjectContext,
               let lastReadTimeStamp = conversation.lastReadServerTimeStamp,
               let convID = conversation.remoteIdentifier,
               convID != ZMConversation.selfConversationIdentifier(in: moc)
             else { return nil }
         
+        let nonce: UUID = UUID()
         let lastRead = LastRead(conversationID: convID, lastReadTimestamp: lastReadTimeStamp)
         let genericMessage = GenericMessage.message(content: lastRead, nonce: nonce)
         let selfConversation = ZMConversation.selfConversation(in: moc)


### PR DESCRIPTION
## What's new in this PR?

Fix a mistake from the previous PR. 
- appendSelfConversationWithLastReadOf() method should be public.
- change a parameter name for appendSelfConversationWithLastReadOf method. 