### PR TITLE
[Refactor] Hide Concrete Users in User Classes

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -180,26 +180,20 @@ extension ZMUser : ObjectInSnapshot {
 
 extension UserChangeInfo {
 
-    // MARK: Registering UserObservers
+    // MARK: Registering UserType
 
-    /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
+    /// Adds an observer for the ZMUser or ZMSearchUser. You must hold on to the token and use it to unregister.
     ///
-    public static func add(userObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return add(userObserver: observer, for: nil, managedObjectContext: managedObjectContext)
-    }
-
-    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified. You must hold on to
-    /// the token and use it to unregister.
-    ///
-    private static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .UserChange, managedObjectContext: managedObjectContext, object: user)
-        { [weak observer] (note) in
-            guard let `observer` = observer,
-                let changeInfo = note.changeInfo as? UserChangeInfo
-                else { return }
-            
-            observer.userDidChange(changeInfo)
+    @objc(addObserver:forUser:managedObjectContext:)
+    public static func add(observer: ZMUserObserver, for user: UserType, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol? {
+        if let user = user as? ZMSearchUser {
+            return add(searchUserObserver: observer, for: user, managedObjectContext: managedObjectContext)
         }
+        else if let user = user as? ZMUser {
+            return add(userObserver: observer, for:user, managedObjectContext: managedObjectContext)
+        }
+
+        return nil
     }
     
     // MARK: Registering SearchUserObservers
@@ -213,35 +207,41 @@ extension UserChangeInfo {
     /// Adds an observer for the searchUser if one specified or to all ZMSearchUser is none is specified. You must
     /// hold on to the token and use it to unregister.
     ///
-    private static func add(searchUserObserver observer: ZMUserObserver,
-                           for user: ZMSearchUser?,
-                           managedObjectContext: NSManagedObjectContext
-                           ) -> NSObjectProtocol
-    {
-        return ManagedObjectObserverToken(name: .SearchUserChange, managedObjectContext: managedObjectContext, object: user)
-        { [weak observer] (note) in
-            guard let `observer` = observer,
+    private static func add(searchUserObserver observer: ZMUserObserver, for user: ZMSearchUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+        return ManagedObjectObserverToken(name: .SearchUserChange, managedObjectContext: managedObjectContext, object: user) { [weak observer] (note) in
+            guard
+                let `observer` = observer,
                 let changeInfo = note.changeInfo as? UserChangeInfo
-                else { return }
+            else {
+                return
+            }
             
             observer.userDidChange(changeInfo)
         }
     }
-    
-    // MARK: Registering UserType
-    /// Adds an observer for the ZMUser or ZMSearchUser
-    /// You must hold on to the token and use it to unregister
-    @objc(addObserver:forUser:managedObjectContext:)
-    public static func add(observer: ZMUserObserver,
-                           for user: UserType,
-                           managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol?
-    {
-        if let user = user as? ZMSearchUser {
-            return add(searchUserObserver: observer, for: user, managedObjectContext: managedObjectContext)
-        }
-        else if let user = user as? ZMUser {
-            return add(userObserver: observer, for:user, managedObjectContext: managedObjectContext)
-        }
-        return nil
+
+    // MARK: Registering UserObservers
+
+    /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
+    ///
+    public static func add(userObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+        return add(userObserver: observer, for: nil, managedObjectContext: managedObjectContext)
     }
+
+    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified. You must hold on to
+    /// the token and use it to unregister.
+    ///
+    private static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+        return ManagedObjectObserverToken(name: .UserChange, managedObjectContext: managedObjectContext, object: user) { [weak observer] (note) in
+            guard
+                let `observer` = observer,
+                let changeInfo = note.changeInfo as? UserChangeInfo
+            else {
+                return
+            }
+
+            observer.userDidChange(changeInfo)
+        }
+    }
+
 }

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -181,10 +181,17 @@ extension ZMUser : ObjectInSnapshot {
 extension UserChangeInfo {
 
     // MARK: Registering UserObservers
-    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified
-    /// You must hold on to the token and use it to unregister
-    @objc(addUserObserver:forUser:managedObjectContext:)
-    public static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+
+    /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
+    ///
+    public static func add(userObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+        return add(userObserver: observer, for: nil, managedObjectContext: managedObjectContext)
+    }
+
+    /// Adds an observer for the user if one specified or to all ZMUsers is none is specified. You must hold on to
+    /// the token and use it to unregister.
+    ///
+    private static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
         return ManagedObjectObserverToken(name: .UserChange, managedObjectContext: managedObjectContext, object: user)
         { [weak observer] (note) in
             guard let `observer` = observer,
@@ -196,10 +203,17 @@ extension UserChangeInfo {
     }
     
     // MARK: Registering SearchUserObservers
-    /// Adds an observer for the searchUser if one specified or to all ZMSearchUser is none is specified
-    /// You must hold on to the token and use it to unregister
-    @objc(addSearchUserObserver:forSearchUser:managedObjectContext:)
-    public static func add(searchUserObserver observer: ZMUserObserver,
+
+    /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
+    ///
+    public static func add(searchUserObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+        return add(searchUserObserver: observer, for: nil, managedObjectContext: managedObjectContext)
+    }
+
+    /// Adds an observer for the searchUser if one specified or to all ZMSearchUser is none is specified. You must
+    /// hold on to the token and use it to unregister.
+    ///
+    private static func add(searchUserObserver observer: ZMUserObserver,
                            for user: ZMSearchUser?,
                            managedObjectContext: NSManagedObjectContext
                            ) -> NSObjectProtocol

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -182,7 +182,7 @@ extension UserChangeInfo {
 
     // MARK: Registering UserType
 
-    /// Adds an observer for the ZMUser or ZMSearchUser. You must hold on to the token and use it to unregister.
+    /// Adds an observer for a user conforming to UserType. You must hold on to the token and use it to unregister.
     ///
     @objc(addObserver:forUser:inManagedObjectContext:)
     public static func add(observer: ZMUserObserver, for user: UserType, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol? {

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -198,7 +198,7 @@ extension UserChangeInfo {
     
     // MARK: Registering SearchUserObservers
 
-    /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
+    /// Adds an observer for all ZMSearchUsers in the given context. You must hold on to the token and use it to unregister.
     ///
     public static func add(searchUserObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
         return add(searchUserObserver: observer, for: nil, in: managedObjectContext)

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -184,13 +184,13 @@ extension UserChangeInfo {
 
     /// Adds an observer for the ZMUser or ZMSearchUser. You must hold on to the token and use it to unregister.
     ///
-    @objc(addObserver:forUser:managedObjectContext:)
-    public static func add(observer: ZMUserObserver, for user: UserType, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol? {
+    @objc(addObserver:forUser:inManagedObjectContext:)
+    public static func add(observer: ZMUserObserver, for user: UserType, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol? {
         if let user = user as? ZMSearchUser {
-            return add(searchUserObserver: observer, for: user, managedObjectContext: managedObjectContext)
+            return add(searchUserObserver: observer, for: user, in: managedObjectContext)
         }
         else if let user = user as? ZMUser {
-            return add(userObserver: observer, for:user, managedObjectContext: managedObjectContext)
+            return add(userObserver: observer, for:user, in: managedObjectContext)
         }
 
         return nil
@@ -201,13 +201,13 @@ extension UserChangeInfo {
     /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
     ///
     public static func add(searchUserObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return add(searchUserObserver: observer, for: nil, managedObjectContext: managedObjectContext)
+        return add(searchUserObserver: observer, for: nil, in: managedObjectContext)
     }
 
     /// Adds an observer for the searchUser if one specified or to all ZMSearchUser is none is specified. You must
     /// hold on to the token and use it to unregister.
     ///
-    private static func add(searchUserObserver observer: ZMUserObserver, for user: ZMSearchUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+    private static func add(searchUserObserver observer: ZMUserObserver, for user: ZMSearchUser?, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
         return ManagedObjectObserverToken(name: .SearchUserChange, managedObjectContext: managedObjectContext, object: user) { [weak observer] (note) in
             guard
                 let `observer` = observer,
@@ -225,13 +225,13 @@ extension UserChangeInfo {
     /// Adds an observer for all ZMUsers in the given context. You must hold on to the token and use it to unregister.
     ///
     public static func add(userObserver observer: ZMUserObserver, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return add(userObserver: observer, for: nil, managedObjectContext: managedObjectContext)
+        return add(userObserver: observer, for: nil, in: managedObjectContext)
     }
 
     /// Adds an observer for the user if one specified or to all ZMUsers is none is specified. You must hold on to
     /// the token and use it to unregister.
     ///
-    private static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
+    private static func add(userObserver observer: ZMUserObserver, for user: ZMUser?, in managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
         return ManagedObjectObserverToken(name: .UserChange, managedObjectContext: managedObjectContext, object: user) { [weak observer] (note) in
             guard
                 let `observer` = observer,

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -180,7 +180,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         XCTAssertTrue(user.isFault)
         XCTAssertEqual(user.displayName, "foo")
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
         
             // when
             syncMOC.performGroupedBlockAndWait {
@@ -209,7 +209,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         XCTAssertTrue(user!.isFault)
         let observer = UserObserver()
         
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user!, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user!, in: self.uiMOC)) { () -> () in
         
             // when
             user = nil
@@ -235,7 +235,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC))  { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC))  { () -> () in
         
             // when
             NotificationDispatcher.notifyNonCoreDataChanges(objectID: user.objectID, changedKeys: ["name"], uiContext: uiMOC)
@@ -256,7 +256,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
         
             // when
             user.name = "bar"
@@ -282,7 +282,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
         
             // when
             user.name = "bar"
@@ -311,7 +311,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
             
             // when
             sut.isDisabled = true
@@ -332,7 +332,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         sut.isDisabled = true
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
             
             // when
             sut.isDisabled = false
@@ -355,7 +355,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         uiMOC.saveOrRollback()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
         
             // when
             sut.applicationDidEnterBackground()
@@ -376,7 +376,7 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
         sut.applicationDidEnterBackground()
         
         let observer = UserObserver()
-        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, managedObjectContext: self.uiMOC)) { () -> () in
+        withExtendedLifetime(UserChangeInfo.add(observer: observer, for: user, in: self.uiMOC)) { () -> () in
 
             // when
             sut.applicationWillEnterForeground()

--- a/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -59,7 +59,7 @@ class SearchUserObserverTests : NotificationDispatcherTestBase, ZMManagedObjectC
         let searchUser = ZMSearchUser(contextProvider: self, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
         
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
         
         // when
         searchUser.updateImageData(for: .preview, imageData: verySmallJPEGData())
@@ -80,7 +80,7 @@ class SearchUserObserverTests : NotificationDispatcherTestBase, ZMManagedObjectC
         let searchUser = ZMSearchUser(contextProvider: self, name: "", handle: nil, accentColor: .brightYellow, remoteIdentifier: nil, user: user)
         
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        self.token = UserChangeInfo.add(observer: testObserver, for:searchUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: testObserver, for:searchUser, in: self.uiMOC)
         
         // when
         user.previewProfileAssetIdentifier = UUID.create().transportString()
@@ -101,7 +101,7 @@ class SearchUserObserverTests : NotificationDispatcherTestBase, ZMManagedObjectC
         let searchUser = ZMSearchUser(contextProvider: self, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
         
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
         
         // when
         self.token = nil
@@ -119,7 +119,7 @@ class SearchUserObserverTests : NotificationDispatcherTestBase, ZMManagedObjectC
         
         XCTAssertFalse(searchUser.isPendingApprovalByOtherUser)
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
 
         // when
         searchUser.connect(message: "Hey")
@@ -144,10 +144,10 @@ class SearchUserObserverTests : NotificationDispatcherTestBase, ZMManagedObjectC
         let testObserver2 = TestSearchUserObserver()
         var tokens: [AnyObject] = []
         self.token = tokens
-        tokens.append(UserChangeInfo.add(observer: testObserver, for: user, managedObjectContext: self.uiMOC)!)
+        tokens.append(UserChangeInfo.add(observer: testObserver, for: user, in: self.uiMOC)!)
         
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        tokens.append(UserChangeInfo.add(observer: testObserver2, for: searchUser, managedObjectContext: self.uiMOC)!)
+        tokens.append(UserChangeInfo.add(observer: testObserver2, for: searchUser, in: self.uiMOC)!)
         
         // when
         searchUser.connect(message: "Hey")

--- a/Tests/Source/Model/Observer/UserObserverTests.swift
+++ b/Tests/Source/Model/Observer/UserObserverTests.swift
@@ -69,7 +69,7 @@ extension UserObserverTests {
         self.uiMOC.saveOrRollback()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        self.token = UserChangeInfo.add(observer: userObserver, for: user, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: user, in: self.uiMOC)
 
         // when
         modifier(user)
@@ -114,7 +114,7 @@ extension UserObserverTests {
         let user = ZMUser.insertNewObject(in:self.uiMOC)
         self.uiMOC.saveOrRollback()
 
-        self.token = UserChangeInfo.add(observer: userObserver, for: user, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: user, in: self.uiMOC)
         
         // when
         user.name = "Foo"
@@ -282,7 +282,7 @@ extension UserObserverTests {
         self.setEmailAddress("foo@example.com", on: user)
         self.uiMOC.saveOrRollback()
         
-        self.token = UserChangeInfo.add(observer: userObserver, for: user, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: user, in: self.uiMOC)
         
         // when
         self.token = nil
@@ -346,7 +346,7 @@ extension UserObserverTests {
         let selfClient = UserClient.insertNewObject(in: self.uiMOC)
         selfUser.mutableSetValue(forKey: UserClientsKey).add(selfClient)
         self.uiMOC.saveOrRollback()
-        self.token = UserChangeInfo.add(observer: userObserver, for: selfUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: selfUser, in: self.uiMOC)
         
         // when
         let otherClient = UserClient.insertNewObject(in: self.uiMOC)
@@ -372,7 +372,7 @@ extension UserObserverTests {
         self.uiMOC.saveOrRollback()
         XCTAssertEqual(selfUser.clients.count, 2)
         
-        self.token = UserChangeInfo.add(observer: userObserver, for: selfUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: selfUser, in: self.uiMOC)
         
         // when
         selfUser.mutableSetValue(forKey: UserClientsKey).remove(otherClient)
@@ -404,7 +404,7 @@ extension UserObserverTests {
             return XCTFail("Unable to get user with objectID in uiMOC")
         }
         
-        self.token = UserChangeInfo.add(observer: userObserver, for: uiMOCUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: uiMOCUser, in: self.uiMOC)
         
         // when adding a new client on the syncMOC
         syncMOC.performGroupedBlockAndWait {
@@ -433,7 +433,7 @@ extension UserObserverTests {
         uiMOC.saveOrRollback()
         uiMOC.refresh(user, mergeChanges: true)
         XCTAssertTrue(user.isFault)
-        self.token = UserChangeInfo.add(observer: userObserver, for: user, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: user, in: self.uiMOC)
         
         // when
         let client = UserClient.insertNewObject(in: uiMOC)
@@ -463,7 +463,7 @@ extension UserObserverTests {
         let otherClient = UserClient.insertNewObject(in: uiMOC)
         uiMOC.saveOrRollback()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        self.token = UserChangeInfo.add(observer: userObserver, for: observedUser, managedObjectContext: self.uiMOC)
+        self.token = UserChangeInfo.add(observer: userObserver, for: observedUser, in: self.uiMOC)
         
         // when
         observedUser.mutableSetValue(forKey: UserClientsKey).add(otherClient)


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to remove all concrete user objects from the UI project. See the architecture issues for more info: https://github.com/wireapp/ios-architecture/issues/89

### Changes

`ZMUser` and `ZMSearchUser` references in are now hidden in `UserChangeInfo.swift`. There were three methods to add user observers, one to add an observer for a conforming `UserType`, and one each for adding observers specific to `ZMUser` and `ZMSearchUser`. The latter two methods allowed to observe a single instance or all concrete instances.

Since we can rely on the first method so observe changes in a specific `ZMUser` or `ZMSearchUser` instance, I've removed them. In their place are now two methods to add observers that are interested in changes in all concrete instances, one for each concrete type. In this way, we can avoid exposing `ZMUser` and `ZMSearchUser`.

## Notes

The changes also include minor clean ups and argument label changes.