### PR TITLE
[Fix] Add the verified property on the UserType.

### DIFF
--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -126,6 +126,9 @@ public protocol UserType: NSObjectProtocol {
     /// All clients belonging to the user
     var allClients: [UserClientType] { get }
     
+    /// Whether the user verified all own devices plus others
+    var verified: Bool { get }
+    
     func requestPreviewProfileImage()
     func requestCompleteProfileImage()
     

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -127,7 +127,7 @@ public protocol UserType: NSObjectProtocol {
     var allClients: [UserClientType] { get }
     
     /// Whether the user verified all own devices plus others
-    var verified: Bool { get }
+    var isVerified: Bool { get }
     
     func requestPreviewProfileImage()
     func requestCompleteProfileImage()

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -217,7 +217,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     }
     
     public var isVerified: Bool {
-        return user?.isVerified != false
+        return user?.isVerified ?? false
     }
     
     public var managedByWire: Bool {

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -216,6 +216,15 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         return user?.allClients ?? []
     }
     
+    public var verified: Bool {
+        guard let user = user,
+            let selfUser = contextProvider?.managedObjectContext.map(ZMUser.selfUser) else {
+                return false
+        }
+        
+        return user.trusted() && selfUser.trusted()
+    }
+    
     public var managedByWire: Bool {
         return user?.managedByWire != false
     }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -217,12 +217,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     }
     
     public var isVerified: Bool {
-        guard let user = user,
-            let selfUser = contextProvider?.managedObjectContext.map(ZMUser.selfUser) else {
-                return false
-        }
-        
-        return user.trusted() && selfUser.trusted()
+        return user?.isVerified != false
     }
     
     public var managedByWire: Bool {

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -216,7 +216,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         return user?.allClients ?? []
     }
     
-    public var verified: Bool {
+    public var isVerified: Bool {
         guard let user = user,
             let selfUser = contextProvider?.managedObjectContext.map(ZMUser.selfUser) else {
                 return false

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -945,37 +945,6 @@ static NSString *const ParticipantRolesKey = @"participantRoles";
     }
 }
 
-- (BOOL)trusted
-{
-    if (self.clients.count == 0) {
-        return false;
-    }
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-    UserClient *selfClient = selfUser.selfClient;
-    __block BOOL hasOnlyTrustedClients = YES;
-    [self.clients enumerateObjectsUsingBlock:^(UserClient *client, BOOL * _Nonnull stop) {
-        if (client != selfClient && ![selfClient.trustedClients containsObject:client]) {
-            hasOnlyTrustedClients = NO;
-            *stop = YES;
-        }
-    }];
-    return hasOnlyTrustedClients;
-}
-
-- (BOOL)untrusted
-{
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.managedObjectContext];
-    UserClient *selfClient = selfUser.selfClient;
-    __block BOOL hasUntrustedClients = NO;
-    [self.clients enumerateObjectsUsingBlock:^(UserClient *client, BOOL * _Nonnull stop) {
-        if (client != selfClient && ![selfClient.trustedClients containsObject:client]) {
-            hasUntrustedClients = YES;
-            *stop = YES;
-        }
-    }];
-    return hasUntrustedClients;
-}
-
 @end
 
 

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -327,7 +327,7 @@ extension ZMUser {
     
     @objc
     public func trusted() -> Bool {
-        if self.clients.count == 0 {
+        if self.clients.isEmpty {
             return false
         }
 
@@ -349,4 +349,3 @@ extension ZMUser {
         return hasUntrustedClients
     }
 }
-

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -44,7 +44,7 @@ extension ZMUser: UserType {
         return Set(self.participantRoles.compactMap {$0.conversation})
     }
     
-    public var verified: Bool {
+    public var isVerified: Bool {
         guard let selfUser = managedObjectContext.map(ZMUser.selfUser) else {
             return false
         }
@@ -330,22 +330,20 @@ extension ZMUser {
         if self.clients.isEmpty {
             return false
         }
-
+        
         let selfUser = managedObjectContext.map(ZMUser.selfUser)
         let selfClient = selfUser?.selfClient()
-        let untrustedClient = self.clients.first(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
-        let hasOnlyTrustedClients = (untrustedClient == nil)
+        let hasUntrustedClients = self.clients.contains(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
         
-        return hasOnlyTrustedClients
+        return !hasUntrustedClients
     }
     
     @objc
     public func untrusted() -> Bool {
         let selfUser = managedObjectContext.map(ZMUser.selfUser)
         let selfClient = selfUser?.selfClient()
-        let untrustedClient = self.clients.first(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
-        let hasUntrustedClients = (untrustedClient != nil)
-        
+        let hasUntrustedClients = self.clients.contains(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
+
         return hasUntrustedClients
     }
 }

--- a/Source/Public/ZMUser.h
+++ b/Source/Public/ZMUser.h
@@ -110,9 +110,6 @@ extern NSString * _Nonnull const ZMPersistedClientIdKey;
 - (void)ignore;
 - (void)cancelConnectionRequest;
 
-- (BOOL)trusted;
-- (BOOL)untrusted;
-
 @end
 
 

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -2353,25 +2353,6 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
 
 @implementation ZMUserTests (Trust)
 
-- (ZMUser *)userWithClients:(int)count trusted:(BOOL)trusted
-{
-    [self createSelfClient];
-    [self.uiMOC refreshAllObjects];
-    
-    UserClient *selfClient = [ZMUser selfUserInContext:self.uiMOC].selfClient;
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    for (int i = 0; i < count; i++) {
-        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
-        client.user = user;
-        if (trusted) {
-            [selfClient trustClient:client];
-        } else {
-            [selfClient ignoreClient:client];
-        }
-    }
-    return user;
-}
-
 - (void)testThatItReturns_Trusted_NO_WhenThereAreNoClients
 {
     // given

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -718,3 +718,55 @@ extension ZMUserTests {
     }
 }
 
+// MARK: - Verifying user
+extension ZMUserTests {
+    
+    func testThatUserIsVerified() {
+        // GIVEN
+        let user: ZMUser = self.userWithClients(count: 2, trusted: true)
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        
+        // WHEN
+        XCTAssert(user.trusted())
+        XCTAssert(selfUser.trusted())
+        
+        // THEN
+        XCTAssert(user.verified)
+    }
+    
+    func testThatUserIsNotVerified() {
+        // GIVEN
+        let user: ZMUser = self.userWithClients(count: 2, trusted: true)
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        let selfClient: UserClient? = selfUser.selfClient()
+        
+        // WHEN
+        let newClient: UserClient = UserClient.insertNewObject(in: self.uiMOC)
+        newClient.user = selfUser
+        selfClient?.ignoreClient(newClient)
+        
+        // THEN
+        XCTAssert(user.trusted())
+        XCTAssertFalse(selfUser.trusted())
+        XCTAssertFalse(user.verified)
+    }
+    
+    @objc(userWithClients:trusted:)
+    public func userWithClients(count: Int, trusted: Bool) -> ZMUser {
+        self.createSelfClient()
+        self.uiMOC.refreshAllObjects()
+        
+        let selfClient: UserClient? = ZMUser.selfUser(in: self.uiMOC).selfClient()
+        let user: ZMUser = ZMUser.insertNewObject(in: self.uiMOC)
+        [0...count].forEach({ _ in
+            let client: UserClient = UserClient.insertNewObject(in: self.uiMOC)
+            client.user = user
+            if trusted {
+                selfClient?.trustClient(client)
+            } else {
+                selfClient?.ignoreClient(client)
+            }
+        })
+        return user
+    }
+}

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -727,14 +727,14 @@ extension ZMUserTests {
         let selfUser = ZMUser.selfUser(in: uiMOC)
         
         // WHEN
-        XCTAssert(user.trusted())
-        XCTAssert(selfUser.trusted())
+        XCTAssertTrue(user.trusted())
+        XCTAssertTrue(selfUser.trusted())
         
         // THEN
-        XCTAssert(user.verified)
+        XCTAssertTrue(user.isVerified)
     }
     
-    func testThatUserIsNotVerified() {
+    func testThatUserIsNotVerified_WhenSelfUserIsNotTrustedButUserIsTrusted() {
         // GIVEN
         let user: ZMUser = self.userWithClients(count: 2, trusted: true)
         let selfUser = ZMUser.selfUser(in: uiMOC)
@@ -746,9 +746,9 @@ extension ZMUserTests {
         selfClient?.ignoreClient(newClient)
         
         // THEN
-        XCTAssert(user.trusted())
+        XCTAssertTrue(user.trusted())
         XCTAssertFalse(selfUser.trusted())
-        XCTAssertFalse(user.verified)
+        XCTAssertFalse(user.isVerified)
     }
     
     @objc(userWithClients:trusted:)

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -721,7 +721,7 @@ extension ZMUserTests {
 // MARK: - Verifying user
 extension ZMUserTests {
     
-    func testThatUserIsVerified() {
+    func testThatUserIsVerified_WhenSelfUserAndUserIsTrusted() {
         // GIVEN
         let user: ZMUser = self.userWithClients(count: 2, trusted: true)
         let selfUser = ZMUser.selfUser(in: uiMOC)


### PR DESCRIPTION
## What's new in this PR?

Since the rules for displaying the verified shield have changed, we decided to create a new `verified: Bool` property in` UserType`.`verified` property shows whether the user verified own and other devices.

PR also contains the convert of trusted() and untrusted() methods from Objective C to Swift.
