### PR TITLE
[Refactor] Swift protobuf - LinkPreview

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -77,7 +77,7 @@ extension ZMConversation {
         
         guard !(text as NSString).zmHasOnlyWhitespaceCharacters() else { return nil }
         
-        let text = Text(content: text, mentions: mentions, replyingTo: quotedMessage as? ZMOTRMessage)
+        let text = Text(content: text, mentions: mentions, linkPreviews: [], replyingTo: quotedMessage as? ZMOTRMessage)
         let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: managedObjectContext!)
         

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -156,7 +156,7 @@ extension Knock: EphemeralMessageCapable {
 
 extension Text: EphemeralMessageCapable {
     
-    init(content: String, mentions: [Mention], linkPreviews: [LinkPreview], replyingTo: ZMOTRMessage?) {
+    public init(content: String, mentions: [Mention], linkPreviews: [LinkPreview], replyingTo: ZMOTRMessage?) {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -156,10 +156,11 @@ extension Knock: EphemeralMessageCapable {
 
 extension Text: EphemeralMessageCapable {
     
-    init(content: String, mentions: [Mention], replyingTo: ZMOTRMessage?) {
+    init(content: String, mentions: [Mention], linkPreviews: [LinkPreview], replyingTo: ZMOTRMessage?) {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }
+            $0.linkPreview = linkPreviews.compactMap { $0 }
             
             if let quotedMessage = replyingTo,
                let quotedMessageNonce = quotedMessage.nonce,

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -160,7 +160,7 @@ extension Text: EphemeralMessageCapable {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }
-            $0.linkPreview = linkPreviews.compactMap { $0 }
+            $0.linkPreview = linkPreviews
             
             if let quotedMessage = replyingTo,
                let quotedMessageNonce = quotedMessage.nonce,
@@ -370,28 +370,6 @@ public extension LinkPreview {
             
             guard let author = twitterMetadata.author,
                 let username = twitterMetadata.username else { return }
-            
-            $0.tweet = WireProtos.Tweet.with({
-                $0.author = author
-                $0.username = username
-            })
-        }
-    }
-    
-    init(originalURL: String, permanentURL: String, offset: Int32,title: String, summary: String, imageData: Data?, author: String?, username: String?) {
-        
-        self = LinkPreview.with {
-            $0.url = originalURL
-            $0.permanentURL = permanentURL
-            $0.urlOffset = offset
-            $0.title = title
-            $0.summary = summary
-            if let imageData = imageData {
-                $0.image = WireProtos.Asset(imageSize: CGSize(width: 0, height: 0), mimeType: "image/jpeg", size: UInt64(imageData.count))
-            }
-            
-            guard let author = author,
-                let username = username else { return }
             
             $0.tweet = WireProtos.Tweet.with({
                 $0.author = author

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -156,11 +156,11 @@ extension Knock: EphemeralMessageCapable {
 
 extension Text: EphemeralMessageCapable {
     
-    public init(content: String, mentions: [Mention], linkPreviews: [LinkPreview], replyingTo: ZMOTRMessage?) {
+    public init(content: String, mentions: [Mention], linkPreviews: [LinkMetadata], replyingTo: ZMOTRMessage?) {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }
-            $0.linkPreview = linkPreviews
+            $0.linkPreview = linkPreviews.map { WireProtos.LinkPreview($0) }
             
             if let quotedMessage = replyingTo,
                let quotedMessageNonce = quotedMessage.nonce,
@@ -331,7 +331,7 @@ extension WireProtos.Mention {
 
 public extension LinkPreview {
 
-    init(linkMetadata: LinkMetadata) {
+    init(_ linkMetadata: LinkMetadata) {
         if let articleMetadata = linkMetadata as? ArticleMetadata {
             self = LinkPreview(articleMetadata: articleMetadata)
         } else if let twitterMetadata = linkMetadata as? TwitterStatusMetadata {

--- a/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
+++ b/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
@@ -1,0 +1,130 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireTesting
+@testable import WireDataModel
+
+class GenericMessageTests_LinkMetaData: BaseZMMessageTests {
+    
+    func testThatItCreatesAValidLinkPreview_ArticleMetadata() {
+        // given
+        let article = ArticleMetadata(
+            originalURLString: "www.example.com/original",
+            permanentURLString: "www.example.com/permanent",
+            resolvedURLString: "http://www.example.com/article/1",
+            offset: 42
+        )
+        article.title = "title"
+        article.summary = "summary"
+        
+        // when
+        let linkPreview = LinkPreview(articleMetadata: article)
+        
+        // then
+        XCTAssertEqual(linkPreview.title, "title")
+        XCTAssertEqual(linkPreview.summary, "summary")
+        XCTAssertEqual(linkPreview.permanentURL, "www.example.com/permanent")
+        XCTAssertEqual(linkPreview.url, "www.example.com/original")
+        XCTAssertEqual(linkPreview.urlOffset, 42)
+    }
+    
+    func testThatItCreatesAValidLinkPreview_TwitterStatusMetadata() {
+        // given
+        let twitterStatus = TwitterStatusMetadata(
+            originalURLString: "www.example.com/original",
+            permanentURLString: "www.example.com/permanent",
+            resolvedURLString: "http://www.example.com/article/1",
+            offset: 42
+        )
+        twitterStatus.message = "message"
+        twitterStatus.author = "author"
+        twitterStatus.username = "username"
+        
+        // when
+        let linkPreview = LinkPreview(twitterMetadata: twitterStatus)
+        
+        // then
+        XCTAssertEqual(linkPreview.title, "message")
+        XCTAssertEqual(linkPreview.permanentURL, "www.example.com/permanent")
+        XCTAssertEqual(linkPreview.url, "www.example.com/original")
+        XCTAssertEqual(linkPreview.urlOffset, 42)
+        XCTAssertEqual(linkPreview.tweet.author, "author")
+        XCTAssertEqual(linkPreview.tweet.username, "username")
+    }
+    
+    func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage_TwitterStatus() {
+        // given
+        let nonce = UUID.create()
+        let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
+        
+        
+        let preview = TwitterStatusMetadata(
+            originalURLString: "example.com/article/original",
+            permanentURLString: "http://www.example.com/article/1",
+            resolvedURLString: "http://www.example.com/article/1",
+            offset: 42
+        )
+        
+        preview.author = "Author"
+        preview.message = name
+        let text = Text(content: "Text", mentions: [], linkPreviews: [LinkPreview(linkMetadata: preview)], replyingTo: nil)
+        let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
+        do {
+            clientMessage.add(try genericMessage.serializedData())
+        } catch {
+            return
+        }
+        
+        // when
+        let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
+        
+        // then
+        XCTAssertFalse(willHaveAnImage)
+    }
+    
+    func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage_Article() {
+        
+        // given
+        let nonce = UUID()
+        let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
+        
+        let article = ArticleMetadata(
+            originalURLString: "example.com/article/original",
+            permanentURLString: "http://www.example.com/article/1",
+            resolvedURLString: "http://www.example.com/article/1",
+            offset: 12
+        )
+        article.title = "title"
+        article.summary = "summary"
+        
+        let text = Text(content: "sample text", mentions: [], linkPreviews: [LinkPreview(linkMetadata: article)], replyingTo: nil)
+        let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
+        do {
+            clientMessage.add(try genericMessage.serializedData())
+        } catch {
+            return
+        }
+        
+        // when
+        let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
+        
+        // then
+        XCTAssertFalse(willHaveAnImage)
+    }
+}

--- a/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
+++ b/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
@@ -83,7 +83,7 @@ class GenericMessageTests_LinkMetaData: BaseZMMessageTests {
         
         preview.author = "Author"
         preview.message = name
-        let text = Text(content: "Text", mentions: [], linkPreviews: [LinkPreview(linkMetadata: preview)], replyingTo: nil)
+        let text = Text(content: "Text", mentions: [], linkPreviews: [preview], replyingTo: nil)
         let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
         do {
             clientMessage.add(try genericMessage.serializedData())
@@ -113,7 +113,7 @@ class GenericMessageTests_LinkMetaData: BaseZMMessageTests {
         article.title = "title"
         article.summary = "summary"
         
-        let text = Text(content: "sample text", mentions: [], linkPreviews: [LinkPreview(linkMetadata: article)], replyingTo: nil)
+        let text = Text(content: "sample text", mentions: [], linkPreviews: [article], replyingTo: nil)
         let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
         do {
             clientMessage.add(try genericMessage.serializedData())

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0617001123E2FBC0005C262D /* GenericMessageTests+LinkMetaData.swift */; };
 		06392CF923BF9DA9003186E6 /* store2-79-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 06392CF823BF9DA9003186E6 /* store2-79-0.wiredatabase */; };
 		065D7501239FAB1200275114 /* SelfUserParticipantMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065D7500239FAB1200275114 /* SelfUserParticipantMigrationTests.swift */; };
 		16030DB021AD765D00F8032E /* ZMConversation+Confirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DAF21AD765D00F8032E /* ZMConversation+Confirmations.swift */; };
@@ -596,6 +597,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0617001123E2FBC0005C262D /* GenericMessageTests+LinkMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessageTests+LinkMetaData.swift"; sourceTree = "<group>"; };
 		06392CF723BF9C22003186E6 /* zmessaging2.79.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.79.0.xcdatamodel; sourceTree = "<group>"; };
 		06392CF823BF9DA9003186E6 /* store2-79-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-79-0.wiredatabase"; sourceTree = "<group>"; };
 		065D7500239FAB1200275114 /* SelfUserParticipantMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfUserParticipantMigrationTests.swift; sourceTree = "<group>"; };
@@ -1367,6 +1369,7 @@
 				F11F3E8A1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift */,
 				16127CF422005AAA0020E65C /* InvalidConversationRemovalTests.swift */,
 				87C1C260207F812F0083BF6B /* InvalidGenericMessageDataRemovalTests.swift */,
+				0617001123E2FBC0005C262D /* GenericMessageTests+LinkMetaData.swift */,
 				1684141622282A1A00FCB9BC /* TransferStateMigrationTests.swift */,
 				065D7500239FAB1200275114 /* SelfUserParticipantMigrationTests.swift */,
 				A9EEFEF923A6D0CB0007828A /* RolesMigrationTests.swift */,
@@ -3014,6 +3017,7 @@
 				87630A061F8FAB6700EEAE11 /* ZMGenericMessageTests.swift in Sources */,
 				F9A708531CAEEB7500C2F5FE /* ZMManagedObjectTests.m in Sources */,
 				F92C992D1DAFC5AC0034AFDD /* ZMConversationTests+Ephemeral.swift in Sources */,
+				0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */,
 				F9B720051CB2C795001DB03F /* ZMGenericMessage_ExternalTests.m in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,
 				16F6BB3C1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?
This PR is part of a refactoring sending messages using Swift Protobuf API:

- Create methods to convert LinkMetadata to LinkPreview objects.
