### PR TITLE
[Fix] Do not show an unread messages badge if a conversation is blocked

### DIFF
--- a/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -118,11 +118,9 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     NSPredicate *pendingConnection = [NSPredicate predicateWithFormat:@"%K != nil AND %K.status == %d", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusPending];
     NSPredicate *acceptablePredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[pendingConnection, [self predicateForUnreadConversation]]];
     
-    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"%K != nil AND %K.status != %d", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
-    NSPredicate *notConnection = [NSPredicate predicateWithFormat:@"%K == nil", ZMConversationConnectionKey];
-    NSPredicate *groupConversationOrNotBlocked = [NSCompoundPredicate orPredicateWithSubpredicates:@[notBlockedConnection, notConnection]];
+    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"(%K == nil) OR (%K != nil AND %K.status != %d)", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
     
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, acceptablePredicate, groupConversationOrNotBlocked]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, acceptablePredicate, notBlockedConnection]];
 }
 
 + (NSPredicate *)predicateForUnreadConversation
@@ -142,11 +140,9 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     NSPredicate *notSelfConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeSelf];
     NSPredicate *notInvalidConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeInvalid];
 
-    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"%K != nil AND %K.status != %d", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
-    NSPredicate *notConnection = [NSPredicate predicateWithFormat:@"%K == nil", ZMConversationConnectionKey];
-    NSPredicate *groupConversationOrNotBlocked = [NSCompoundPredicate orPredicateWithSubpredicates:@[notBlockedConnection, notConnection]];
+    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"(%K == nil) OR (%K != nil AND %K.status != %d)", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
 
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, [self predicateForUnreadConversation], groupConversationOrNotBlocked]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, [self predicateForUnreadConversation], notBlockedConnection]];
 }
 
 - (void)setInternalEstimatedUnreadCount:(int64_t)internalEstimatedUnreadCount

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -120,7 +120,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     
     NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"(%K == nil) OR (%K != nil AND %K.status != %d)", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
     
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, acceptablePredicate, notBlockedConnection]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, notBlockedConnection, acceptablePredicate]];
 }
 
 + (NSPredicate *)predicateForUnreadConversation
@@ -142,7 +142,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
     NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"(%K == nil) OR (%K != nil AND %K.status != %d)", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
 
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, [self predicateForUnreadConversation], notBlockedConnection]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, notBlockedConnection, [self predicateForUnreadConversation]]];
 }
 
 - (void)setInternalEstimatedUnreadCount:(int64_t)internalEstimatedUnreadCount

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -115,9 +115,10 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
     NSPredicate *notSelfConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeSelf];
     NSPredicate *notInvalidConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeInvalid];
     NSPredicate *pendingConnection = [NSPredicate predicateWithFormat:@"%K != nil AND %K.status == %d", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusPending];
+    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"%K.status != %d", ZMConversationConnectionKey, ZMConnectionStatusBlocked];
     NSPredicate *acceptablePredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[pendingConnection, [self predicateForUnreadConversation]]];
     
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, acceptablePredicate]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, acceptablePredicate, notBlockedConnection]];
 }
 
 + (NSPredicate *)predicateForUnreadConversation
@@ -136,8 +137,9 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 {
     NSPredicate *notSelfConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeSelf];
     NSPredicate *notInvalidConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeInvalid];
+    NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"%K.status != %d", ZMConversationConnectionKey, ZMConnectionStatusBlocked];
     
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, [self predicateForUnreadConversation]]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, [self predicateForUnreadConversation], notBlockedConnection]];
 }
 
 - (void)setInternalEstimatedUnreadCount:(int64_t)internalEstimatedUnreadCount

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2463,8 +2463,8 @@
     [self.syncMOC performGroupedBlockAndWait:^{
         XCTAssertEqual([ZMConversation unreadConversationCountInContext:self.syncMOC], 0lu);
     
-        ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
-        conversation.conversationType = ZMConversationTypeConnection;
+        ZMConversation *conversation = [self insertConversationWithUnread:YES];
+        conversation.conversationType = ZMConversationTypeOneOnOne;
         ZMConnection *connection = [ZMConnection insertNewObjectInManagedObjectContext:self.syncMOC];
         connection.conversation = conversation;
         connection.status = ZMConnectionStatusBlocked;


### PR DESCRIPTION
## What's new in this PR?

### Issues
The unread messages badge contains a blocked conversation. 

### Causes
There is no check for the predicate if the conversation is blocked.

### Solutions
Add a check.
