### PR TITLE
[Refactor] Add phoneNumber to UserType

### DIFF
--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -43,6 +43,9 @@ public protocol UserType: NSObjectProtocol {
     /// Email for the user
     var emailAddress: String? { get }
 
+    /// The phone number of the user
+    var phoneNumber: String? { get }
+
     /// Whether this is the self user
     var isSelfUser: Bool { get }
     

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -139,6 +139,12 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         }
     }
 
+    public var phoneNumber: String? {
+        get {
+            return user?.phoneNumber
+        }
+    }
+
     public var name: String? {
         get {
             return user != nil ? user?.name : internalName


### PR DESCRIPTION
## What's new in this PR?

This PR adds `phoneNumber` to `UserType` to make it conformable to `ZMEditableUser`. After this addition, any object conforming to `UserType` can also conform to `ZMEditableUser` given that the access requirements are met.