### PR TITLE
[Refactor] Support calling with GenericMessage

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -34,12 +34,12 @@ extension ZMConversation {
             $0.zoom = location.zoomLevel
         }
 
-        return appendClientMessage(with: GenericMessage.message(content: locationContent, nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
+        return appendClientMessage(with: GenericMessage(content: locationContent, nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
     @discardableResult
     public func appendKnock(nonce: UUID = UUID()) -> ZMConversationMessage? {
-        return appendClientMessage(with: GenericMessage.message(content: Knock.with({ $0.hotKnock = false }), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
+        return appendClientMessage(with: GenericMessage(content: Knock.with({ $0.hotKnock = false }), nonce: nonce, expiresAfter: messageDestructionTimeoutValue))
     }
     
     @discardableResult @objc(appendSelfConversationWithLastReadOfConversation:)
@@ -52,7 +52,7 @@ extension ZMConversation {
         
         let nonce: UUID = UUID()
         let lastRead = LastRead(conversationID: convID, lastReadTimestamp: lastReadTimeStamp)
-        let genericMessage = GenericMessage.message(content: lastRead, nonce: nonce)
+        let genericMessage = GenericMessage(content: lastRead, nonce: nonce)
         let selfConversation = ZMConversation.selfConversation(in: moc)
         
         let clientMessage = selfConversation.appendClientMessage(with: genericMessage, expires: false, hidden: false)
@@ -78,7 +78,7 @@ extension ZMConversation {
         guard !(text as NSString).zmHasOnlyWhitespaceCharacters() else { return nil }
         
         let text = Text(content: text, mentions: mentions, linkPreviews: [], replyingTo: quotedMessage as? ZMOTRMessage)
-        let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
+        let genericMessage = GenericMessage(content: text, nonce: nonce, expiresAfter: messageDestructionTimeoutValue)
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: managedObjectContext!)
         
         do {
@@ -206,7 +206,7 @@ extension ZMConversation {
     
     @nonobjc
     func append(message: MessageCapable, nonce: UUID = UUID(), hidden: Bool = false, expires: Bool = false) -> ZMClientMessage? {
-        return appendClientMessage(with: GenericMessage.message(content: message, nonce: nonce), expires: expires, hidden: hidden)
+        return appendClientMessage(with: GenericMessage(content: message, nonce: nonce), expires: expires, hidden: hidden)
     }
     
 }

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -36,7 +36,7 @@ extension ZMMessage {
         
         let emoji = unicodeValue ?? ""
         let reaction = WireProtos.Reaction(emoji: emoji, messageID: messageID)
-        let genericMessage = GenericMessage.message(content: reaction)
+        let genericMessage = GenericMessage(content: reaction)
         let clientMessage = message.conversation?.appendClientMessage(with: genericMessage, expires: false, hidden: true)
         message.addReaction(unicodeValue, forUser: .selfUser(in: context))
         return clientMessage

--- a/Source/Model/Message/GenericMessage+Encryption.swift
+++ b/Source/Model/Message/GenericMessage+Encryption.swift
@@ -1,0 +1,199 @@
+//
+//  GenericMessage+Encryption.swift
+//  WireDataModel
+//
+//  Created by David Henner on 13.02.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+import WireCryptobox
+
+private var zmLog = ZMSLog(tag: "message encryption")
+
+extension GenericMessage {
+    public func encryptedMessagePayloadData(_ conversation: ZMConversation, externalData: Data?) -> (data: Data, strategy: MissingClientsStrategy)? {
+        guard let context = conversation.managedObjectContext else { return nil }
+        
+        let recipientsAndStrategy = recipientUsersForMessage(in: conversation, selfUser: ZMUser.selfUser(in: context))
+        if let data = encryptedMessagePayloadData(for: recipientsAndStrategy.users, externalData: nil, context: context) {
+            return (data, recipientsAndStrategy.strategy)
+        }
+        
+        return nil
+    }
+    
+    private func encryptedMessagePayloadData(for recipients: Set<ZMUser>, externalData: Data?, context: NSManagedObjectContext) -> Data? {
+        guard let selfClient = ZMUser.selfUser(in: context).selfClient(), selfClient.remoteIdentifier != nil
+            else { return nil }
+        
+        let encryptionContext = selfClient.keysStore.encryptionContext
+        var messageData : Data?
+        
+        encryptionContext.perform { (sessionsDirectory) in
+            let message = otrMessage(selfClient, recipients: recipients, externalData: externalData, sessionDirectory: sessionsDirectory)
+            
+            messageData = message.data()
+            
+            // message too big?
+            if let data = messageData, UInt(data.count) > ZMClientMessageByteSizeExternalThreshold && externalData == nil {
+                // The payload is too big, we therefore rollback the session since we won't use the message we just encrypted.
+                // This will prevent us advancing sender chain multiple time before sending a message, and reduce the risk of TooDistantFuture.
+                sessionsDirectory.discardCache()
+                messageData = encryptedMessageDataWithExternalDataBlob(recipients, context: context)
+            }
+        }
+        
+        // reset all failed sessions
+        for recipient in recipients {
+            recipient.clients.forEach({ $0.failedToEstablishSession = false })
+        }
+        
+        return messageData
+    }
+    
+    private var hasConfirmation: Bool {
+        if case .confirmation? = content {
+            return true
+        }
+        return false
+    }
+    
+    /// Returns a message with recipients
+    private func otrMessage(_ selfClient: UserClient,
+                                recipients: Set<ZMUser>,
+                                externalData: Data?,
+                                sessionDirectory: EncryptionSessionsDirectory) -> ZMNewOtrMessage {
+        
+        let userEntries = recipientsWithEncryptedData(selfClient, recipients: recipients, sessionDirectory: sessionDirectory)
+        let nativePush = !hasConfirmation // We do not want to send pushes for delivery receipts
+        let message = ZMNewOtrMessage.message(withSender: selfClient, nativePush: nativePush, recipients: userEntries, blob: externalData)
+        
+        return message
+    }
+
+    /// Returns the recipients and the encrypted data for each recipient
+    func recipientsWithEncryptedData(_ selfClient: UserClient,
+                                     recipients: Set<ZMUser>,
+                                     sessionDirectory: EncryptionSessionsDirectory) -> [ZMUserEntry]
+    {
+        let userEntries = recipients.compactMap { user -> ZMUserEntry? in
+            guard !user.isAccountDeleted else { return nil }
+            
+            let clientsEntries = user.clients.compactMap { client -> ZMClientEntry? in
+                
+                guard client != selfClient, let clientRemoteIdentifier = client.sessionIdentifier else {
+                    return nil
+                }
+                
+                let hasSessionWithClient = sessionDirectory.hasSession(for: clientRemoteIdentifier)
+                
+                if !hasSessionWithClient {
+                    // if the session is corrupted, we will send a special payload
+                    if client.failedToEstablishSession {
+                        let data = ZMFailedToCreateEncryptedMessagePayloadString.data(using: String.Encoding.utf8)!
+                        return ZMClientEntry.entry(withClient: client, data: data)
+                    }
+                    else {
+                        // if we do not have a session, we need to fetch a prekey and create a new session
+                        return nil
+                    }
+                }
+                guard let data = try? serializedData(),
+                    let encryptedData = try? sessionDirectory.encryptCaching(data, for: clientRemoteIdentifier) else {
+                        return nil
+                }
+                return ZMClientEntry.entry(withClient: client, data: encryptedData)
+            }
+            
+            guard !clientsEntries.isEmpty else { return nil }
+            return ZMUserEntry.entry(withUser: user, clientEntries: clientsEntries)
+        }
+        return userEntries
+    }
+    
+    func recipientUsersForMessage(in conversation: ZMConversation, selfUser: ZMUser) -> (users: Set<ZMUser>, strategy: MissingClientsStrategy) {
+        let (services, otherUsers) = conversation.localParticipants.categorizeServicesAndUser()
+        
+        func recipientForConfirmationMessage() -> Set<ZMUser>? {
+            guard case .confirmation? = content, confirmation.hasFirstMessageID else { return nil }
+            guard let message = ZMMessage.fetch(withNonce:UUID(uuidString:confirmation.firstMessageID), for:conversation, in:conversation.managedObjectContext!) else { return nil }
+            guard let sender = message.sender else { return nil }
+            return Set(arrayLiteral: sender)
+        }
+        
+        func recipientForOtherUsers() -> Set<ZMUser>? {
+            guard conversation.connectedUser != nil || (otherUsers.isEmpty == false) else { return nil }
+            if let connectedUser = conversation.connectedUser { return Set(arrayLiteral:connectedUser) }
+            return Set(otherUsers)
+        }
+        
+        func recipientsForDeletedEphemeral() -> Set<ZMUser>? {
+            guard case .deleted? = content, conversation.conversationType == .group else { return nil}
+            let nonce = UUID(uuidString: deleted.messageID)
+            guard let message = ZMMessage.fetch(withNonce:nonce, for:conversation, in:conversation.managedObjectContext!) else { return nil }
+            guard message.destructionDate != nil else { return nil }
+            guard let sender = message.sender else {
+                zmLog.error("sender of deleted ephemeral message \(String(describing: deleted.messageID)) is already cleared \n ConvID: \(String(describing: conversation.remoteIdentifier)) ConvType: \(conversation.conversationType.rawValue)")
+                return Set(arrayLiteral: selfUser)
+            }
+            
+            // if self deletes their own message, we want to send delete msg
+            // for everyone, so return nil.
+            guard !sender.isSelfUser else { return nil }
+            
+            // otherwise we delete only for self and the sender, all other
+            // recipients are unaffected.
+            return Set(arrayLiteral: sender, selfUser)
+        }
+        
+        func allAuthorizedRecipients() -> Set<ZMUser> {
+            if let connectedUser = conversation.connectedUser { return Set(arrayLiteral: connectedUser, selfUser) }
+            
+            func mentionedServices() -> Set<ZMUser> {
+                return services.filter { service in
+                    textData?.mentions.contains { $0.userID == service.remoteIdentifier?.transportString() } ?? false
+                }
+            }
+            
+            let authorizedServices = ZMUser.servicesMustBeMentioned ? mentionedServices() : services
+            
+            return otherUsers.union(authorizedServices).union([selfUser])
+        }
+        
+        var recipientUsers = Set<ZMUser>()
+        
+        if case .confirmation? = content {
+            guard let recipients = recipientForConfirmationMessage() ?? recipientForOtherUsers() else {
+                let confirmationInfo = ", original message: \(String(describing: confirmation.firstMessageID))"
+                fatal("confirmation need a recipient\n ConvType: \(conversation.conversationType.rawValue) \(confirmationInfo)")
+            }
+            recipientUsers = recipients
+        }
+        else if let deletedEphemeral = recipientsForDeletedEphemeral() {
+            recipientUsers = deletedEphemeral
+        }
+        else {
+            recipientUsers = allAuthorizedRecipients()
+        }
+        
+        let hasRestrictions: Bool = {
+            if conversation.connectedUser != nil { return recipientUsers.count != 2 }
+            return recipientUsers.count != conversation.localParticipants.count
+        }()
+        
+        let strategy : MissingClientsStrategy = hasRestrictions ? .ignoreAllMissingClientsNotFromUsers(users: recipientUsers)
+            : .doNotIgnoreAnyMissingClient
+        
+        return (recipientUsers, strategy)
+    }
+}
+
+// MARK: - External
+extension GenericMessage {
+    private func encryptedMessageDataWithExternalDataBlob(_ recipients: Set<ZMUser>, context: NSManagedObjectContext) -> Data? {
+        guard let encryptedDataWithKeys = GenericMessage.encryptedDataWithKeys(from: self) else { return nil }
+        let externalGenericMessage = GenericMessage(content: External(withKeyWithChecksum: encryptedDataWithKeys.keys))
+        return externalGenericMessage.encryptedMessagePayloadData(for: recipients, externalData: encryptedDataWithKeys.data, context: context)
+    }
+}

--- a/Source/Model/Message/GenericMessage+Encryption.swift
+++ b/Source/Model/Message/GenericMessage+Encryption.swift
@@ -1,9 +1,19 @@
 //
-//  GenericMessage+Encryption.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 13.02.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Source/Model/Message/GenericMessage+External.swift
+++ b/Source/Model/Message/GenericMessage+External.swift
@@ -1,9 +1,19 @@
 //
-//  GenericMessage+External.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 12.02.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Source/Model/Message/GenericMessage+External.swift
+++ b/Source/Model/Message/GenericMessage+External.swift
@@ -1,0 +1,42 @@
+//
+//  GenericMessage+External.swift
+//  WireDataModel
+//
+//  Created by David Henner on 12.02.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+
+private let zmLog = ZMSLog(tag: "GenericMessage")
+
+extension GenericMessage {
+    static func encryptedDataWithKeys(from message: GenericMessage) -> ZMExternalEncryptedDataWithKeys? {
+        guard
+            let aesKey = NSData.randomEncryptionKey(),
+            let messageData = try? message.serializedData()
+        else {
+            return nil
+        }
+        let encryptedData = messageData.zmEncryptPrefixingPlainTextIV(key: aesKey)
+        let keys = ZMEncryptionKeyWithChecksum.key(withAES: aesKey, digest: encryptedData.zmSHA256Digest())
+        return ZMExternalEncryptedDataWithKeys(data: encryptedData, keys: keys)
+    }
+    
+    init?(from updateEvent: ZMUpdateEvent, withExternal external: External) {
+        guard let externalDataString = updateEvent.payload.optionalString(forKey: "external") else { return nil }
+        let externalData = Data(base64Encoded: externalDataString)
+        let externalSha256 = externalData?.zmSHA256Digest()
+        
+        guard externalSha256 == external.sha256 else {
+            zmLog.error("Invalid hash for external data: \(externalSha256 ?? Data()) != \(external.sha256), updateEvent: \(updateEvent)")
+            return nil
+        }
+        
+        let decryptedData = externalData?.zmDecryptPrefixedPlainTextIV(key: external.otrKey)
+        guard let message = GenericMessage(withBase64String: decryptedData?.base64String()) else {
+            return nil
+        }
+        self = message
+    }
+}

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -1,0 +1,49 @@
+//
+//  GenericMessage+UpdateEvent.swift
+//  WireDataModel
+//
+//  Created by David Henner on 11.02.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+
+extension GenericMessage {
+    public init?(from updateEvent: ZMUpdateEvent) {
+        let base64Content: String?
+        
+        switch updateEvent.type {
+        case .conversationClientMessageAdd:
+            base64Content = updateEvent.payload.string(forKey: "data")
+        case .conversationOtrMessageAdd:
+            base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "text")
+        case .conversationOtrAssetAdd:
+            base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "info")
+        default:
+            return nil
+        }
+        
+        var message = GenericMessage(withBase64String: base64Content)
+        
+        if case .external? = message?.content {
+            message = GenericMessage(from: updateEvent, withExternal: message!.external)
+        }
+
+        guard message != nil else { return nil }
+        self = message!
+    }
+}
+
+extension Dictionary {
+    func string(forKey key: String) -> String? {
+        return (self as NSDictionary).string(forKey: key)
+    }
+    
+    func optionalString(forKey key: String) -> String? {
+        return (self as NSDictionary).optionalString(forKey: key)
+    }
+    
+    func dictionary(forKey key: String) -> [String: AnyObject]? {
+        return (self as NSDictionary).dictionary(forKey: key)
+    }
+}

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -1,9 +1,19 @@
 //
-//  GenericMessage+UpdateEvent.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 11.02.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Source/Model/Message/GenericMessageScheduleNotification.swift
+++ b/Source/Model/Message/GenericMessageScheduleNotification.swift
@@ -28,11 +28,11 @@ public struct GenericMessageScheduleNotification {
 
     private init() {}
     
-    public static func post(message: ZMGenericMessage, conversation: ZMConversation) {
-        let userInfo = [
+    public static func post(message: GenericMessage, conversation: ZMConversation) {
+        let userInfo: [String : Any] = [
             UserInfoKey.message.rawValue: message,
             UserInfoKey.conversation.rawValue: conversation
-        ]
+            ]
         NotificationInContext(name: self.name,
                               context: conversation.managedObjectContext!.notificationContext,
                               userInfo: userInfo
@@ -40,12 +40,12 @@ public struct GenericMessageScheduleNotification {
     }
     
     public static func addObserver(managedObjectContext: NSManagedObjectContext,
-                                using block: @escaping (ZMGenericMessage, ZMConversation)->()) -> Any
+                                using block: @escaping (GenericMessage, ZMConversation)->()) -> Any
     {
         return NotificationInContext.addObserver(name: self.name,
                                                  context: managedObjectContext.notificationContext)
         { note in
-            guard let message = note.userInfo[UserInfoKey.message.rawValue] as? ZMGenericMessage,
+            guard let message = note.userInfo[UserInfoKey.message.rawValue] as? GenericMessage,
                 let conversation = note.userInfo[UserInfoKey.conversation.rawValue] as? ZMConversation
                 else { return }
             block(message, conversation)

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -35,7 +35,7 @@ import Foundation
         transferState = .uploading
         version = 3
         
-        let genericMessage = GenericMessage.message(content: asset, nonce: nonce, expiresAfter: timeout)
+        let genericMessage = GenericMessage(content: asset, nonce: nonce, expiresAfter: timeout)
         
         do {
             _ = mergeWithExistingData(data: try genericMessage.serializedData())

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -67,7 +67,7 @@ extension ZMClientMessage: ZMTextMessageData {
         // Quotes are ignored in edits but keep it to mark that the message has quote for us locally
         let editedText = Text(content: text, mentions: mentions, linkPreviews: [], replyingTo: self.quote as? ZMOTRMessage)
         let editNonce = UUID()
-        let updatedMessage = GenericMessage.message(content: MessageEdit(replacingMessageID: nonce, text: editedText), nonce: nonce)
+        let updatedMessage = GenericMessage(content: MessageEdit(replacingMessageID: nonce, text: editedText), nonce: nonce)
         do {
             self.add(try updatedMessage.serializedData())
         } catch {

--- a/Source/Model/Message/ZMGenericMessage+External.h
+++ b/Source/Model/Message/ZMGenericMessage+External.h
@@ -26,6 +26,8 @@
 @property (nonatomic, readonly) NSData *aesKey;
 /// SHA-256 digest
 @property (nonatomic, readonly) NSData *sha256;
+    
++ (ZMEncryptionKeyWithChecksum *)keyWithAES:(NSData *)aesKey digest:(NSData *)sha256;
 
 @end
 
@@ -36,6 +38,8 @@
 @property (nonatomic, readonly) NSData *data;
 /// The AES Key used to encrypt @c data and the sha-256 digest of @c data
 @property (nonatomic, readonly) ZMEncryptionKeyWithChecksum *keys;
+
++ (ZMExternalEncryptedDataWithKeys *)dataWithKeysWithData:(NSData *)data keys:(ZMEncryptionKeyWithChecksum *)keys;
 
 @end
 

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -317,7 +317,8 @@ public class UserClient: ZMManagedObject, UserClientType {
                 guard
                     let user = (try? uiMOC.existingObject(with: userID)) as? ZMUser,
                     let conversation = self.conversation(for: user) else { return }
-                GenericMessageScheduleNotification.post(message: ZMGenericMessage.clientAction(ZMClientAction.RESETSESSION), conversation: conversation)
+                
+                GenericMessageScheduleNotification.post(message: GenericMessage(clientAction: .resetSession), conversation: conversation)
             }
         }
     }

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -86,6 +86,36 @@ extension String {
 
 // MARK: Generic Message
 
+extension GenericMessage {
+    public func validatingFields() -> GenericMessage? {
+        guard UUID.isValid(object: messageID), let content = self.content else { return nil }
+        
+        switch content {
+        case .text:
+            guard text.validatingFields() != nil else { return nil }
+        case .lastRead:
+            guard lastRead.validatingFields() != nil else { return nil }
+        case .cleared:
+            guard cleared.validatingFields() != nil else { return nil }
+        case .hidden:
+            guard hidden.validatingFields() != nil else { return nil }
+        case .deleted:
+            guard deleted.validatingFields() != nil else { return nil }
+        case .edited:
+            guard edited.validatingFields() != nil else { return nil }
+        case .confirmation:
+            guard confirmation.validatingFields() != nil else { return nil }
+        case .reaction:
+            guard reaction.validatingFields() != nil else { return nil }
+        case .asset:
+            guard asset.validatingFields() != nil else { return nil }
+        default:
+            break
+        }
+        return self
+    }
+}
+
 extension ZMGenericMessage {
     @objc public func validatingFields() -> ZMGenericMessage? {
         // Validate the message itself
@@ -148,6 +178,14 @@ extension ZMGenericMessageBuilder {
 
 // MARK: - Text
 
+extension Text {
+    public func validatingFields() -> Text? {
+        let validMentions = mentions.compactMap { $0.validatingFields() }
+        guard validMentions.count == mentions.count else { return nil }
+        return self
+    }
+}
+
 extension ZMText {
     @objc public func validatingFields() -> ZMText? {
 
@@ -157,7 +195,6 @@ extension ZMText {
         }
 
         return self
-
     }
 }
 
@@ -172,6 +209,12 @@ extension ZMQuote {
 
 // MARK: Mention
 
+extension WireProtos.Mention {
+    public func validatingFields() -> WireProtos.Mention? {
+        return UUID.isValid(object: userID) ? self : nil
+    }
+}
+
 extension ZMMention {
     @objc public func validatingFields() -> ZMMention? {
         guard UUID.isValid(object: userId) else { return nil }
@@ -180,6 +223,12 @@ extension ZMMention {
 }
 
 // MARK: Last Read
+
+extension LastRead {
+    public func validatingFields() -> LastRead? {
+        return UUID.isValid(object: conversationID) ? self : nil
+    }
+}
 
 extension ZMLastRead {
     @objc public func validatingFields() -> ZMLastRead? {
@@ -190,6 +239,12 @@ extension ZMLastRead {
 
 // MARK: Cleared
 
+extension Cleared {
+    public func validatingFields() -> Cleared? {
+        return UUID.isValid(object: conversationID) ? self : nil
+    }
+}
+
 extension ZMCleared {
     @objc public func validatingFields() -> ZMCleared? {
         guard UUID.isValid(object: conversationId) else { return nil }
@@ -198,6 +253,14 @@ extension ZMCleared {
 }
 
 // MARK: Message Hide
+
+extension MessageHide {
+    public func validatingFields() -> MessageHide? {
+        guard UUID.isValid(object: conversationID) else { return nil }
+        guard UUID.isValid(object: messageID) else { return nil }
+        return self
+    }
+}
 
 extension ZMMessageHide {
     @objc public func validatingFields() -> ZMMessageHide? {
@@ -209,6 +272,12 @@ extension ZMMessageHide {
 
 // MARK: Message Delete
 
+extension MessageDelete {
+    public func validatingFields() -> MessageDelete? {
+        return UUID.isValid(object: messageID) ? self : nil
+    }
+}
+
 extension ZMMessageDelete {
     @objc public func validatingFields() -> ZMMessageDelete? {
         guard UUID.isValid(object: messageId) else { return nil }
@@ -218,6 +287,12 @@ extension ZMMessageDelete {
 
 // MARK: Message Edit
 
+extension MessageEdit {
+    public func validatingFields() -> MessageEdit? {
+        return UUID.isValid(object: replacingMessageID) ? self : nil
+    }
+}
+
 extension ZMMessageEdit {
     @objc public func validatingFields() -> ZMMessageEdit? {
         guard UUID.isValid(object: replacingMessageId) else { return nil }
@@ -226,6 +301,18 @@ extension ZMMessageEdit {
 }
 
 // MARK: Message Confirmation
+
+extension Confirmation {
+    public func validatingFields() -> Confirmation? {
+        guard UUID.isValid(object: firstMessageID) else { return nil }
+        
+        if !moreMessageIds.isEmpty {
+            guard UUID.isValid(array: moreMessageIds) else { return nil }
+        }
+        
+        return self
+    }
+}
 
 extension ZMConfirmation {
     @objc public func validatingFields() -> ZMConfirmation? {
@@ -241,6 +328,12 @@ extension ZMConfirmation {
 
 // MARK: Reaction
 
+extension WireProtos.Reaction {
+    public func validatingFields() -> WireProtos.Reaction? {
+        return UUID.isValid(object: messageID) ? self : nil
+    }
+}
+
 extension ZMReaction {
     @objc public func validatingFields() -> ZMReaction? {
         guard UUID.isValid(object: messageId) else { return nil }
@@ -250,6 +343,12 @@ extension ZMReaction {
 
 // MARK: User ID
 
+extension WireProtos.UserId {
+    public func validatingFields() -> WireProtos.UserId? {
+        return UUID.isValid(object: uuid) ? self : nil
+    }
+}
+
 extension ZMUserId {
     @objc public func validatingFields() -> ZMUserId? {
         guard UUID.isValid(bytes: uuid) else { return nil }
@@ -258,6 +357,20 @@ extension ZMUserId {
 }
 
 // MARK: - Asset
+
+extension WireProtos.Asset {
+    public func validatingFields() -> WireProtos.Asset? {
+        if hasPreview && preview.hasRemote {
+            guard preview.remote.validatingFields() != nil else { return nil }
+        }
+
+        if case .uploaded? = status {
+            guard uploaded.validatingFields() != nil else { return nil }
+        }
+        
+        return self
+    }
+}
 
 extension ZMAsset {
 
@@ -275,6 +388,14 @@ extension ZMAsset {
 
     }
 
+}
+
+extension WireProtos.Asset.RemoteData {
+    public func validatingFields() -> WireProtos.Asset.RemoteData? {
+        guard assetID.isValidAssetID else { return nil }
+        guard assetToken.isValidBearerToken else { return nil }
+        return self
+    }
 }
 
 extension ZMAssetRemoteData {

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -345,7 +345,7 @@ extension ZMReaction {
 
 extension WireProtos.UserId {
     public func validatingFields() -> WireProtos.UserId? {
-        return UUID.isValid(object: uuid) ? self : nil
+        return UUID.isValid(bytes: uuid) ? self : nil
     }
 }
 

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -207,7 +207,7 @@ extension Knock: EphemeralMessageCapable {
 
 extension Text: EphemeralMessageCapable {
     
-    public init(content: String, mentions: [Mention], linkPreviews: [LinkMetadata], replyingTo: ZMOTRMessage?) {
+    public init(content: String, mentions: [Mention] = [], linkPreviews: [LinkMetadata] = [], replyingTo: ZMOTRMessage? = nil) {
         self = Text.with {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention($0) }
@@ -321,6 +321,39 @@ extension WireProtos.MessageEdit: MessageCapable {
         set {
             
         }
+    }
+}
+
+extension Cleared: MessageCapable {
+    public func setContent(on message: inout GenericMessage) {
+        message.cleared = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get { return false }
+        set {}
+    }
+}
+
+extension MessageHide: MessageCapable {
+    public func setContent(on message: inout GenericMessage) {
+        message.hidden = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get { return false }
+        set {}
+    }
+}
+
+extension MessageDelete: MessageCapable {
+    public func setContent(on message: inout GenericMessage) {
+        message.deleted = self
+    }
+    
+    public var expectsReadConfirmation: Bool {
+        get { return false }
+        set {}
     }
 }
 

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -576,7 +576,6 @@ extension ZMExternal: MessageContentType {
     public func updateLegalHoldStatus(_ value: ZMLegalHoldStatus) -> MessageContentType? {
         return nil
     }
-    
 }
 
 public extension ZMClientEntry {

--- a/Tests/Source/Model/Messages/GenericMessageTests+External.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests+External.swift
@@ -7,3 +7,66 @@
 //
 
 import Foundation
+@testable import WireDataModel
+
+class GenericMessageTests_External: XCTestCase {
+    var sut: GenericMessage!
+    
+    override func setUp() {
+        super.setUp()
+        let text = Text.with() {
+            $0.content = "She sells sea shells"
+        }
+        
+        sut = GenericMessage.with() {
+            $0.text = text
+            $0.messageID = NSUUID.create()!.transportString()
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+    
+    func testThatItEncryptsTheMessageAndReturnsTheCorrectKeyAndDigest() {
+        // given / when
+        let dataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        XCTAssertNotNil(dataWithKeys)
+        
+        let keysWithDigest = dataWithKeys!.keys
+        let data = dataWithKeys!.data
+        
+        // then
+        XCTAssertEqual(data?.zmSHA256Digest(), keysWithDigest?.sha256)
+        XCTAssertEqual(data?.zmDecryptPrefixedPlainTextIV(key: keysWithDigest!.aesKey), try? sut.serializedData())
+    }
+    
+    func testThatItUsesADifferentKeyForEachCall() {
+        // given / when
+        let firstDataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        let secondDataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        XCTAssertNotNil(firstDataWithKeys)
+        XCTAssertNotNil(secondDataWithKeys)
+        let firstEncrypted = firstDataWithKeys?.data.zmDecryptPrefixedPlainTextIV(key: firstDataWithKeys!.keys.aesKey)
+        let secondEncrypted = secondDataWithKeys?.data.zmDecryptPrefixedPlainTextIV(key: secondDataWithKeys!.keys.aesKey)
+        
+        // then
+        XCTAssertNotEqual(firstDataWithKeys?.keys.aesKey, secondDataWithKeys?.keys.aesKey)
+        XCTAssertNotEqual(firstDataWithKeys, secondDataWithKeys)
+        XCTAssertEqual(firstEncrypted, try? sut.serializedData())
+        XCTAssertEqual(secondEncrypted, try? sut.serializedData())
+    }
+    
+    func testThatDifferentKeysAreNotConsideredEqual() {
+        // given / when
+        let firstKeys = GenericMessage.encryptedDataWithKeys(from: sut)?.keys
+        let secondKeys = GenericMessage.encryptedDataWithKeys(from: sut)?.keys
+        
+        // then
+        XCTAssertFalse(firstKeys?.aesKey == secondKeys?.aesKey)
+        XCTAssertFalse(firstKeys?.sha256 == secondKeys?.sha256)
+        XCTAssertEqual(firstKeys, firstKeys)
+        XCTAssertNotEqual(firstKeys, secondKeys)
+    }
+}

--- a/Tests/Source/Model/Messages/GenericMessageTests+External.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests+External.swift
@@ -1,9 +1,19 @@
 //
-//  GenericMessageTests+External.swift
-//  WireDataModelTests
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 14.02.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Tests/Source/Model/Messages/GenericMessageTests+External.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests+External.swift
@@ -1,0 +1,9 @@
+//
+//  GenericMessageTests+External.swift
+//  WireDataModelTests
+//
+//  Created by David Henner on 14.02.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation

--- a/Tests/Source/Model/Messages/GenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests.swift
@@ -1,9 +1,19 @@
 //
-//  GenericMessageTests.swift
-//  WireDataModelTests
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 14.02.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Tests/Source/Model/Messages/GenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests.swift
@@ -1,0 +1,33 @@
+//
+//  GenericMessageTests.swift
+//  WireDataModelTests
+//
+//  Created by David Henner on 14.02.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class GenericMessageTests: XCTestCase {
+    func testThatItChecksTheCommonMessageTypeAsKnownMessage() {
+        let generators: [()->(GenericMessage)] = [
+            { return GenericMessage(content: Text(content: "hello")) },
+            { return GenericMessage(content: Knock()) },
+            { return GenericMessage(content: LastRead(conversationID: UUID.create(), lastReadTimestamp: Date())) },
+            {
+                let sha256 = Data(base64Encoded: "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")!
+                let otrKey = Data(base64Encoded: "4H1nD6bG2sCxC/tZBnIG7avLYhkCsSfv0ATNqnfug7w=")!
+                return GenericMessage(content: External(withOTRKey: otrKey, sha256: sha256))
+            },
+            { return GenericMessage(content: Calling(content: "Calling")) },
+            { return GenericMessage(content: WireProtos.Asset(imageSize: .zero, mimeType: "image/jpeg", size: 0)) },
+            { return GenericMessage(content: WireProtos.Reaction(emoji: "test", messageID: UUID.create())) }
+        ]
+        
+        generators.forEach { generator in
+            let message = generator()
+            XCTAssertTrue(message.knownMessage)
+        }
+    }
+}

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
@@ -33,7 +33,7 @@ class ClientMessageTests_Location: BaseZMMessageTests {
             $0.name = name
             $0.zoom = zoom
         }
-        let message = GenericMessage.message(content: location)
+        let message = GenericMessage(content: location)
         
         // when
         let clientMessage = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)

--- a/Tests/Source/Model/Messages/ZMGenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageTests.swift
@@ -20,7 +20,7 @@ import Foundation
 
 @testable import WireDataModel
 
-class GenericMessageTests: ZMTBaseTest {
+class ZMGenericMessageTests: ZMTBaseTest {
     func testThatItChecksTheCommonMessageTypesAsKnownMessage() {
         let generators: [()->(ZMGenericMessage)] = [
             {

--- a/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -297,7 +297,7 @@ final class UserClientTests: ZMBaseManagedObjectTest {
     }
     
     func testThatItPostsANotificationToSendASessionResetMessageWhenResettingSession() {
-        var (message, conversation): (ZMGenericMessage?, ZMConversation?)
+        var (message, conversation): (GenericMessage?, ZMConversation?)
 
         let noteExpectation = expectation(description: "GenericMessageScheduleNotification should be fired")
         let token = GenericMessageScheduleNotification.addObserver(managedObjectContext:self.uiMOC)
@@ -335,14 +335,14 @@ final class UserClientTests: ZMBaseManagedObjectTest {
             withExtendedLifetime(token) { () -> () in
                 XCTAssertNotNil(message)
                 XCTAssertNotNil(conversation)
-                XCTAssertEqual(message?.hasClientAction(), true)
-                XCTAssertEqual(message?.clientAction, .RESETSESSION)
+                if case .clientAction? = message?.content {} else { XCTFail() }
+                XCTAssertEqual(message?.clientAction, .resetSession)
             }
         }
     }
 
     func testThatItSendsASessionResetMessageForUserInTeamConversation() {
-        var (message, conversation): (ZMGenericMessage?, ZMConversation?)
+        var (message, conversation): (GenericMessage?, ZMConversation?)
 
         let noteExpectation = expectation(description: "GenericMessageScheduleNotification should be fired")
         let token = GenericMessageScheduleNotification.addObserver(managedObjectContext: self.uiMOC)
@@ -391,8 +391,8 @@ final class UserClientTests: ZMBaseManagedObjectTest {
                 XCTAssertNotNil(message)
                 XCTAssertNotNil(conversation)
                 XCTAssertEqual(expectedConversation?.objectID, conversation?.objectID)
-                XCTAssertEqual(message?.hasClientAction(), true)
-                XCTAssertEqual(message?.clientAction, .RESETSESSION)
+                if case .clientAction? = message?.content {} else { XCTFail() }
+                XCTAssertEqual(message?.clientAction, .resetSession)
             }
         }
     }

--- a/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -20,6 +20,295 @@ import Foundation
 import XCTest
 @testable import WireDataModel
 
+class PBMessageValidationTests: XCTestCase {
+    // MARK: Generic Message
+    
+    func testThatItCreatesGenericMessageWithValidFields() {
+        let text = Text.with() {
+            $0.content = "Hello hello hello"
+        }
+        
+        let message = GenericMessage.with() {
+            text.setContent(on: &$0)
+            $0.messageID = "8783C4BD-A5D3-4F6B-8C41-A6E75F12926F"
+        }
+        
+        XCTAssertNotNil(message.validatingFields())
+    }
+    
+    func testThatItDoesNotCreateGenericMessageWithInvalidFields() {
+        let text = Text.with() {
+            $0.content = "Hello hello hello"
+        }
+        
+        let message = GenericMessage.with() {
+            text.setContent(on: &$0)
+            $0.messageID = "nonce"
+        }
+        
+        XCTAssertNil(message.validatingFields())
+    }
+    
+    // MARK: Last Read
+    
+    func testThatItCreatesLastReadWithValidFields() {
+        let lastRead = LastRead.with() {
+            $0.conversationID = "8783C4BD-A5D3-4F6B-8C41-A6E75F12926F"
+            $0.lastReadTimestamp = 25_000
+        }
+        
+        XCTAssertNotNil(GenericMessage(content: lastRead).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateLastReadWithInvalidFields() {
+        let lastRead = LastRead.with() {
+            $0.conversationID = "null"
+            $0.lastReadTimestamp = 25_000
+        }
+
+        XCTAssertNil(GenericMessage(content: lastRead).validatingFields())
+    }
+    
+    // MARK: Cleared
+    
+    func testThatItCreatesClearedWithValidFields() {
+        let cleared = Cleared.with() {
+            $0.conversationID = "8783C4BD-A5D3-4F6B-8C41-A6E75F12926F"
+            $0.clearedTimestamp = 25_000
+        }
+        
+        XCTAssertNotNil(GenericMessage(content: cleared).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateClearedWithInvalidFields() {
+        let cleared = Cleared.with() {
+            $0.conversationID = "wirewire"
+            $0.clearedTimestamp = 25_000
+        }
+        
+        XCTAssertNil(GenericMessage(content: cleared).validatingFields())
+    }
+
+    // MARK: Message Hide
+    
+    func testThatItCreatesHideWithValidFields() {
+        let messageHide = MessageHide.with() {
+            $0.conversationID = "8783C4BD-A5D3-4F6B-8C41-A6E75F12926F"
+            $0.messageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+        }
+      
+        XCTAssertNotNil(GenericMessage(content: messageHide).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateHideWithInvalidFields() {
+        var invalidMessageHide: MessageHide
+        
+        invalidMessageHide = MessageHide.with() {
+            $0.conversationID = ""
+            $0.messageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+        }
+        
+        XCTAssertNil(GenericMessage(content: invalidMessageHide).validatingFields())
+        
+        invalidMessageHide = MessageHide.with() {
+            $0.conversationID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+            $0.messageID = ""
+        }
+        
+        XCTAssertNil(GenericMessage(content: invalidMessageHide).validatingFields())
+
+        invalidMessageHide = MessageHide.with() {
+            $0.conversationID = ""
+            $0.messageID = ""
+        }
+        
+        XCTAssertNil(GenericMessage(content: invalidMessageHide).validatingFields())
+    }
+
+    // MARK: Message Delete
+    
+    func testThatItCreatesMessageDeleteWithValidFields() {
+        let messageDelete = MessageDelete.with() {
+            $0.messageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+        }
+        
+        XCTAssertNotNil(GenericMessage(content: messageDelete).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateMessageDeleteWithInvalidFields() {
+        let messageDelete = MessageDelete.with() {
+            $0.messageID = "invalid"
+        }
+    
+        XCTAssertNil(GenericMessage(content: messageDelete).validatingFields())
+    }
+
+    // MARK: Message Edit
+    
+    func testThatItCreatesMessageEditWithValidFields() {
+        
+        let messageEdit = MessageEdit.with() {
+            $0.text = Text.with({ $0.content = "Hello" })
+            $0.replacingMessageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+        }
+        
+        XCTAssertNotNil(GenericMessage(content: messageEdit).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateMessageEditWithInvalidFields() {
+        let messageEdit = MessageEdit.with() {
+            $0.text = Text.with({ $0.content = "Hello" })
+            $0.replacingMessageID = "N0TAUNIV-ER5A-77YU-NIQU-EID3NTIF1ER!"
+        }
+
+        XCTAssertNil(GenericMessage(content: messageEdit).validatingFields())
+    }
+    
+    // MARK: Confirmation
+    
+    func testThatItCreatesConfirmationWithValidFields() {
+        let confirmation = Confirmation.with() {
+            $0.type = .delivered
+            $0.firstMessageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+            $0.moreMessageIds = ["54A6E947-1321-42C6-BA99-F407FDF1A229"]
+        }
+
+        XCTAssertNotNil(GenericMessage(content: confirmation).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateConfirmationWithInvalidFields() {
+        var confirmation: Confirmation
+        
+        confirmation = Confirmation.with() {
+            $0.type = .delivered
+            $0.firstMessageID = "invalid"
+            $0.moreMessageIds = ["54A6E947-1321-42C6-BA99-F407FDF1A229"]
+        }
+        
+        XCTAssertNil(GenericMessage(content: confirmation).validatingFields())
+
+        confirmation = Confirmation.with() {
+            $0.type = .delivered
+            $0.firstMessageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+            $0.moreMessageIds = ["54A6E947-1321-42C6-BA99-F407FDF1A229", "invalid"]
+        }
+        
+        XCTAssertNil(GenericMessage(content: confirmation).validatingFields())
+    }
+    
+    // MARK: Reaction
+    
+    func testThatItCreatesReactionWithValidFields() {
+        let reaction = WireProtos.Reaction.with() {
+            $0.messageID = "8B496992-E74D-41D2-A2C4-C92EEE777DCE"
+            $0.emoji = "🤩"
+        }
+        
+        XCTAssertNotNil(GenericMessage(content: reaction).validatingFields())
+    }
+    
+    func testThatItDoesNotCreateReactionWithInvalidFields() {
+        let reaction = WireProtos.Reaction.with() {
+            $0.messageID = "Not-A-UUID"
+            $0.emoji = "🤩"
+        }
+
+        XCTAssertNil(GenericMessage(content: reaction).validatingFields())
+    }
+    
+    // MARK: User ID
+    
+    func testThatItCreatesUserIDWithValidFields() {
+        let userId = UserId.with({$0.uuid = NSUUID().data()})
+        
+        XCTAssertNotNil(userId.validatingFields())
+    }
+    
+    func testThatItDoesNotCreateUserIDWithInvalidFields() {
+        let userId = UserId.with({$0.uuid = Data() })
+        
+        XCTAssertNil(userId.validatingFields())
+    }
+
+    // MARK: Assets
+
+    func testThatItCreatesMessageWithValidAsset() {
+        XCTAssertNotNil(genericMessage(assetId: "asset-id", assetToken: "token", preview: true))
+        XCTAssertNotNil(genericMessage(assetId: "asset-id", assetToken: "token=", preview: false))
+        
+        XCTAssertNotNil(genericMessage(assetId: "3-1-C89D16C3-8FB4-48D7-8EE5-F8D69A2068C8", assetToken: "aV0TGxF3ugpawm3wAYPmew==", preview: true))
+        XCTAssertNotNil(genericMessage(assetId: "3-1-c89d16c3-8fb4-48d7-8ee5-f8d69a2068c8", assetToken: "aV0TGxF3ugpawm3wAYPmew==", preview: false))
+        
+        XCTAssertNotNil(genericMessage(assetId: "C89D16C3-8FB4-48D7-8EE5-F8D69A2068C8", assetToken: "", preview: true))
+        XCTAssertNotNil(genericMessage(assetId: "c89d16c3-8fb4-48d7-8ee5-f8d69a2068c8", assetToken: "", preview: false))
+        
+        XCTAssertNotNil(genericMessage(assetId: "", assetToken: "", preview: true))
+        XCTAssertNotNil(genericMessage(assetId: "", assetToken: "", preview: false))
+    }
+    
+    func testThatItDoesNotCreateMessageWithInvalidAsset() {
+        // Invalid asset ID
+        XCTAssertNil(genericMessage(assetId: "asset:id", assetToken: "token", preview: true))
+        XCTAssertNil(genericMessage(assetId: "asset/id", assetToken: "token", preview: false))
+        XCTAssertNil(genericMessage(assetId: "asset.id", assetToken: "token", preview: true))
+        XCTAssertNil(genericMessage(assetId: "asset@id", assetToken: "token", preview: false))
+        XCTAssertNil(genericMessage(assetId: "asset[id", assetToken: "token", preview: true))
+        XCTAssertNil(genericMessage(assetId: "asset`id", assetToken: "token", preview: false))
+        XCTAssertNil(genericMessage(assetId: "asset{id", assetToken: "token", preview: true))
+        
+        // Invalid asset token
+        XCTAssertNil(genericMessage(assetId: "asset-id", assetToken: "5@shay_a3wAY4%$@#$@%)!@-pOe==", preview: true))
+        XCTAssertNil(genericMessage(assetId: "asset-id", assetToken: "aV0TGxF3ugpawm3wAYPmew===", preview: false))
+        XCTAssertNil(genericMessage(assetId: "3-1-C89D16C3-8FB4-48D7-8EE5-F8D69A2068C8", assetToken: "aV0TGxF3ugpawm3wAYPmew=Hello", preview: true))
+        XCTAssertNil(genericMessage(assetId: "3-1-c89d16c3-8fb4-48d7-8ee5-f8d69a2068c8", assetToken: "aV0TGxF3ugpawm3wAYPmew==Hello", preview: false))
+    
+        // Both
+        XCTAssertNil(genericMessage(assetId: "../C89D16C3-8FB4-48D7-8EE5-F8D69A2068C8", assetToken: "token?name=foo", preview: true))
+        XCTAssertNil(genericMessage(assetId: "../C89D16C3-8FB4-48D7-8EE5-F8D69A2068C8", assetToken: "token?name=foo", preview: false))
+    }
+    
+    // MARK: - Utilities
+    
+    private func genericMessage(assetId: String, assetToken: String?, preview: Bool) -> GenericMessage? {
+        var assetPreview: WireProtos.Asset.Preview!
+        
+        if preview {
+            let metadata = WireProtos.Asset.ImageMetaData.with() {
+                $0.width = 1000
+                $0.height = 1000
+                $0.tag = "tag"
+            }
+            
+            assetPreview = WireProtos.Asset.Preview.with() {
+                $0.size = 1000
+                $0.mimeType = "image/png"
+                $0.remote = assetRemoteData(id: assetId, token: assetToken!)
+                $0.image = metadata
+            }
+        }
+        
+        let asset = WireProtos.Asset.with() {
+            if preview {
+                $0.preview = assetPreview
+            }
+            $0.uploaded = assetRemoteData(id: assetId, token: assetToken!)
+        }
+        
+        return GenericMessage(content: asset).validatingFields()
+    }
+    
+    private func assetRemoteData(id: String, token: String) -> WireProtos.Asset.RemoteData {
+        return WireProtos.Asset.RemoteData.with() {
+            $0.assetID = id
+            $0.assetToken = token
+            $0.otrKey = Data("pFHd6iVTvOVP2wFAd2yVlA==".utf8)
+            $0.sha256 = Data("8fab1b98a5b5ac2b07f0f77c739980bd4c895db23a09a3bed9ecec584d3ed3e0".utf8)
+            $0.encryption = .aesCbc
+        }
+    }
+    
+}
+
 class ModelValidationTests: XCTestCase {
 
     // MARK: Generic Message

--- a/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
+++ b/Tests/Source/Model/Utils/ProtobufUtilitiesTests.swift
@@ -256,7 +256,7 @@ extension ProtobufUtilitiesTests {
         // given
         let (assetId, token) = ("id", "token")
         let asset = WireProtos.Asset(imageSize: CGSize(width: 42, height: 12), mimeType: "image/jpeg", size: 123)
-        var sut = GenericMessage.message(content: asset, nonce: UUID.create())
+        var sut = GenericMessage(content: asset, nonce: UUID.create())
         
         // when
         XCTAssertNotEqual(sut.asset.uploaded.assetID, assetId)
@@ -272,7 +272,7 @@ extension ProtobufUtilitiesTests {
         // given
         let (assetId, token) = ("id", "token")
         let asset = WireProtos.Asset(imageSize: CGSize(width: 42, height: 12), mimeType: "image/jpeg", size: 123)
-        var sut = GenericMessage.message(content: asset, nonce: UUID.create(), expiresAfter: 15)
+        var sut = GenericMessage(content: asset, nonce: UUID.create(), expiresAfter: 15)
         
         // when
         XCTAssertNotEqual(sut.ephemeral.asset.uploaded.assetID, assetId)
@@ -301,7 +301,7 @@ extension ProtobufUtilitiesTests {
         }
         
         let (assetId, token) = ("id", "token")
-        var sut = GenericMessage.message(content: asset, nonce: UUID.create())
+        var sut = GenericMessage(content: asset, nonce: UUID.create())
     
         // when
         XCTAssertNotEqual(sut.asset.preview.remote.assetID, assetId)
@@ -332,7 +332,7 @@ extension ProtobufUtilitiesTests {
         }
         
         let (assetId, token) = ("id", "token")
-        var sut = GenericMessage.message(content: asset, nonce: UUID.create(), expiresAfter: 15)
+        var sut = GenericMessage(content: asset, nonce: UUID.create(), expiresAfter: 15)
         
         // when
         XCTAssertNotEqual(sut.ephemeral.asset.preview.remote.assetID, assetId)

--- a/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
+++ b/Tests/Source/Utils/GenericMessageTests+LinkMetaData.swift
@@ -84,7 +84,7 @@ class GenericMessageTests_LinkMetaData: BaseZMMessageTests {
         preview.author = "Author"
         preview.message = name
         let text = Text(content: "Text", mentions: [], linkPreviews: [preview], replyingTo: nil)
-        let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
+        let genericMessage = GenericMessage(content: text, nonce: nonce, expiresAfter: nil)
         do {
             clientMessage.add(try genericMessage.serializedData())
         } catch {
@@ -114,7 +114,7 @@ class GenericMessageTests_LinkMetaData: BaseZMMessageTests {
         article.summary = "summary"
         
         let text = Text(content: "sample text", mentions: [], linkPreviews: [article], replyingTo: nil)
-        let genericMessage = GenericMessage.message(content: text, nonce: nonce, expiresAfter: nil)
+        let genericMessage = GenericMessage(content: text, nonce: nonce, expiresAfter: nil)
         do {
             clientMessage.add(try genericMessage.serializedData())
         } catch {

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -179,6 +179,9 @@
 		5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */; };
 		5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */; };
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
+		63495DDA23F2F8EA002A7C59 /* GenericMessage+UpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DD923F2F8E9002A7C59 /* GenericMessage+UpdateEvent.swift */; };
+		63495DDC23F458D9002A7C59 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DDB23F458D8002A7C59 /* GenericMessage+External.swift */; };
+		63495DEC23F58A87002A7C59 /* GenericMessage+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEB23F58A87002A7C59 /* GenericMessage+Encryption.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
 		7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */; };
 		7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */; };
@@ -789,6 +792,9 @@
 		5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredUserTests.swift; sourceTree = "<group>"; };
 		5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizationResult.swift; sourceTree = "<group>"; };
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
+		63495DD923F2F8E9002A7C59 /* GenericMessage+UpdateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+UpdateEvent.swift"; sourceTree = "<group>"; };
+		63495DDB23F458D8002A7C59 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
+		63495DEB23F58A87002A7C59 /* GenericMessage+Encryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Encryption.swift"; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
 		7C2E467721072A31007E2566 /* zmessaging2.50.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.50.0.xcdatamodel; sourceTree = "<group>"; };
 		7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Replies.swift"; sourceTree = "<group>"; };
@@ -1680,10 +1686,13 @@
 				54363A001D7876200048FD7D /* ZMClientMessage+Encryption.swift */,
 				165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */,
 				165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */,
+				63495DEB23F58A87002A7C59 /* GenericMessage+Encryption.swift */,
 				BFD2E7971CBE796600BF195A /* ZMGenericMessage+UpdateEvent.h */,
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
+				63495DD923F2F8E9002A7C59 /* GenericMessage+UpdateEvent.swift */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
 				F9A705F91CAEE01D00C2F5FE /* ZMGenericMessage+External.m */,
+				63495DDB23F458D8002A7C59 /* GenericMessage+External.swift */,
 				168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */,
 				F9A705FC1CAEE01D00C2F5FE /* ZMGenericMessageData.h */,
 				F9A705FD1CAEE01D00C2F5FE /* ZMGenericMessageData.m */,
@@ -2764,6 +2773,7 @@
 				F1FDF2FE21B1572500E037A1 /* ZMGenericMessageData.swift in Sources */,
 				F118CB921F41D520004DCF96 /* ZMTestSession.m in Sources */,
 				54CD460A1DEDA55C00BA3429 /* AddressBookEntry.swift in Sources */,
+				63495DDC23F458D9002A7C59 /* GenericMessage+External.swift in Sources */,
 				BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */,
 				F1FDF30021B1580400E037A1 /* GenericMessage+Utils.swift in Sources */,
 				F12BD0B01E4DCEC40012ADBA /* ZMMessage+Insert.swift in Sources */,
@@ -2838,6 +2848,7 @@
 				54FB03A31E41E64A000E13DC /* UserClient+Patches.swift in Sources */,
 				F9A706971CAEE01D00C2F5FE /* UserClientTypes.m in Sources */,
 				5E0FB215205176B400FD9867 /* Set+ServiceUser.swift in Sources */,
+				63495DDA23F2F8EA002A7C59 /* GenericMessage+UpdateEvent.swift in Sources */,
 				F9A706A81CAEE01D00C2F5FE /* DependentObjectsKeysForObservedObjectKeysCache.swift in Sources */,
 				1670D01C231823DC003A143B /* ZMUser+Permissions.swift in Sources */,
 				54FB03AA1E41F204000E13DC /* PersistedDataPatches+Directory.swift in Sources */,
@@ -2886,6 +2897,7 @@
 				BF491CE41F063EDB0055EE44 /* Account.swift in Sources */,
 				16DCB6631DDA2715002A7AC2 /* PersistentStoreRelocator.swift in Sources */,
 				F991CE1B1CB561B0004D8465 /* ZMAddressBookContact.m in Sources */,
+				63495DEC23F58A87002A7C59 /* GenericMessage+Encryption.swift in Sources */,
 				87EFA3AC210F52C6004DFA53 /* ZMConversation+LastMessages.swift in Sources */,
 				541D1B351F1FAE3C0078C1F2 /* ManagedObjectContextDirectory.swift in Sources */,
 				EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		63495DDA23F2F8EA002A7C59 /* GenericMessage+UpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DD923F2F8E9002A7C59 /* GenericMessage+UpdateEvent.swift */; };
 		63495DDC23F458D9002A7C59 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DDB23F458D8002A7C59 /* GenericMessage+External.swift */; };
 		63495DEC23F58A87002A7C59 /* GenericMessage+Encryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEB23F58A87002A7C59 /* GenericMessage+Encryption.swift */; };
+		63495DEE23F6B3B2002A7C59 /* GenericMessageTests+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DED23F6B3B1002A7C59 /* GenericMessageTests+External.swift */; };
+		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
 		7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */; };
 		7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */; };
@@ -795,6 +797,8 @@
 		63495DD923F2F8E9002A7C59 /* GenericMessage+UpdateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+UpdateEvent.swift"; sourceTree = "<group>"; };
 		63495DDB23F458D8002A7C59 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
 		63495DEB23F58A87002A7C59 /* GenericMessage+Encryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Encryption.swift"; sourceTree = "<group>"; };
+		63495DED23F6B3B1002A7C59 /* GenericMessageTests+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessageTests+External.swift"; sourceTree = "<group>"; };
+		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
 		7C2E467721072A31007E2566 /* zmessaging2.50.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.50.0.xcdatamodel; sourceTree = "<group>"; };
 		7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Replies.swift"; sourceTree = "<group>"; };
@@ -2052,6 +2056,7 @@
 				F9331C501CB3BC6800139ECC /* CryptoBoxTests.swift */,
 				16C391E1214BD437003AB3AD /* MentionTests.swift */,
 				F9B71FFF1CB2C4FC001DB03F /* ZMGenericMessage_ExternalTests.m */,
+				63495DED23F6B3B1002A7C59 /* GenericMessageTests+External.swift */,
 				F9B71F5D1CB2BC85001DB03F /* ZMAssetClientMessageTests.swift */,
 				168414292228421700FCB9BC /* ZMAssetClientMessageTests+AssetMessage.swift */,
 				F963E9921D9E9D1800098AD3 /* ZMAssetClientMessageTests+Ephemeral.swift */,
@@ -2060,6 +2065,7 @@
 				F9331C591CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift */,
 				F96470091D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m */,
 				87630A051F8FAB6700EEAE11 /* ZMGenericMessageTests.swift */,
+				63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */,
 				BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */,
 				BF794FE41D14425E00E618C6 /* ZMClientMessageTests+Location.swift */,
 				1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */,
@@ -2960,6 +2966,7 @@
 				16E7DA2A1FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift in Sources */,
 				87DF59C01F729FDA00C7B406 /* ZMMovedIndexTests.swift in Sources */,
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
+				63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */,
 				A96524BA23CDE07700303C60 /* String+WordTests.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,
 				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
@@ -2990,6 +2997,7 @@
 				F9331C5A1CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift in Sources */,
 				16127CF522005AAB0020E65C /* InvalidConversationRemovalTests.swift in Sources */,
 				EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */,
+				63495DEE23F6B3B2002A7C59 /* GenericMessageTests+External.swift in Sources */,
 				F1B025621E53500400900C65 /* ZMConversationTests+PrepareToSend.swift in Sources */,
 				54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */,
 				D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Replicated some functionalities of `ZMGenericMessage` within `GenericMessage` in order to support its use in the Calling request strategies.
Updated tests.