### PR TITLE
[Feature] Add (restore) initials property to ZMUser

### DIFF
--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -333,16 +333,7 @@ extension ZMUser {
     
     /// The initials e.g. "JS" for "John Smith"
     @objc public var initials: String? {
-        return personName(for: self).initials
-    }
-    
-    private func personName(for user: ZMUser) -> PersonName {
-        if user.objectID.isTemporaryID {
-            try! managedObjectContext!.obtainPermanentIDs(for: [user])
-        }
-        
-        let personName = PersonName.person(withName: user.name ?? "", schemeTagger: nil)
-        return personName
+        return PersonName.person(withName: self.name ?? "", schemeTagger: nil).initials
     }
 }
 

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -328,3 +328,21 @@ extension ZMUser {
         return !hasUntrustedClients
     }
 }
+
+extension ZMUser {
+    
+    /// The initials e.g. "JS" for "John Smith"
+    @objc public var initials: String? {
+        return personName(for: self).initials
+    }
+    
+    private func personName(for user: ZMUser) -> PersonName {
+        if user.objectID.isTemporaryID {
+            try! managedObjectContext!.obtainPermanentIDs(for: [user])
+        }
+        
+        let personName = PersonName.person(withName: user.name ?? "", schemeTagger: nil)
+        return personName
+    }
+}
+

--- a/Source/Public/ZMUser.h
+++ b/Source/Public/ZMUser.h
@@ -47,8 +47,7 @@ extern NSString * _Nonnull const ZMPersistedClientIdKey;
 
 /// The full name
 @property (nonatomic, readonly, nullable) NSString *name;
-/// The initials e.g. "JS" for "John Smith"
-@property (nonatomic, readonly, nullable) NSString *initials;
+
 /// The "@name" handle
 @property (nonatomic, readonly, nullable) NSString *handle;
 

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -2317,6 +2317,14 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertEqualObjects(user.name, @"User Name");
 }
 
+- (void)testThatItReturnsCorrectInitials
+{
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.name = @"User Name";
+    
+    XCTAssertEqualObjects(user.initials, @"UN");
+}
+
 - (void)testThatTheUserNameIsCopied
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

Add (restore) the `initials` property to the ZMUser since we need it in the UI project.