### PR TITLE
[Fix] Add safeRemoteIdentifier to UserClient

### DIFF
--- a/Source/Model/UserClient/UserClient+SafeLogging.swift
+++ b/Source/Model/UserClient/UserClient+SafeLogging.swift
@@ -20,6 +20,6 @@ import Foundation
 
 extension UserClient {
     public var safeRemoteIdentifier: SanitizedString {
-        return SanitizedString(stringLiteral: self.remoteIdentifier?.readableHash ?? "nil")
+        return SafeValueForLogging(self.remoteIdentifier?.readableHash ?? "nil")
     }
 }

--- a/Source/Model/UserClient/UserClient+SafeLogging.swift
+++ b/Source/Model/UserClient/UserClient+SafeLogging.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension UserClient {
-    public var safeRemoteIdentifier: SanitizedString {
+    public var safeRemoteIdentifier: SafeForLoggingStringConvertible {
         return SafeValueForLogging(self.remoteIdentifier?.readableHash ?? "nil")
     }
 }

--- a/Source/Model/UserClient/UserClient+SafeLogging.swift
+++ b/Source/Model/UserClient/UserClient+SafeLogging.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension UserClient {
-    public var safeRemoteIdentifier: SafeForLoggingStringConvertible {
+    public var safeRemoteIdentifier: SafeValueForLogging<String> {
         return SafeValueForLogging(self.remoteIdentifier?.readableHash ?? "nil")
     }
 }

--- a/Source/Model/UserClient/UserClient+SafeLogging.swift
+++ b/Source/Model/UserClient/UserClient+SafeLogging.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension UserClient {
+    public var safeRemoteIdentifier: SanitizedString {
+        return SanitizedString(stringLiteral: self.remoteIdentifier?.readableHash ?? "nil")
+    }
+}

--- a/Tests/Source/Model/UserClient/UserClientTests+SafeLogging.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests+SafeLogging.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class UserClientTestsSafeLogging:  ZMBaseManagedObjectTest {
+    func testThatSafeRemoteIdentifierReturnsReadableHashOfRemoteIdentifier() {
+        let uuid =  UUID.create().transportString()
+        self.syncMOC.performGroupedBlockAndWait {
+            let client = UserClient.insertNewObject(in: self.syncMOC)
+            client.remoteIdentifier = uuid
+            XCTAssertEqual(uuid.readableHash, client.safeRemoteIdentifier.safeForLoggingDescription)
+
+        }
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+    
+    func testThatSafeRemoteIdentifierReturnsNilStringIfRemoteIdentifierIsNil() {
+        self.syncMOC.performGroupedBlockAndWait {
+            let client = UserClient.insertNewObject(in: self.syncMOC)
+            XCTAssertEqual("nil", client.safeRemoteIdentifier.safeForLoggingDescription)
+        }
+        XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+}
+

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */; };
 		5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */; };
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
+		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
@@ -788,6 +789,7 @@
 		5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredUserTests.swift; sourceTree = "<group>"; };
 		5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizationResult.swift; sourceTree = "<group>"; };
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
+		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
@@ -2145,6 +2147,7 @@
 				F13A89D22106293000AB40CB /* PushTokenTests.swift */,
 				F9331C5B1CB3BF9F00139ECC /* UserClientKeyStoreTests.swift */,
 				F9B720021CB2C68B001DB03F /* UserClientTests.swift */,
+				631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */,
 			);
 			name = UserClient;
 			path = Tests/Source/Model/UserClient;
@@ -2971,6 +2974,7 @@
 				A9EEFEFA23A6D0CB0007828A /* RolesMigrationTests.swift in Sources */,
 				A9128AD02398067E0056F591 /* ZMConversationTests+Participants.swift in Sources */,
 				BF3493F01EC3569800B0C314 /* MemberTests.swift in Sources */,
+				631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */,
 				F9A7083B1CAEEB7500C2F5FE /* MockEntity2.m in Sources */,
 				1672A62A2345102400380537 /* ZMConversationListTests+Labels.swift in Sources */,
 				F9331C5A1CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */; };
 		5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */; };
 		5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */; };
+		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
@@ -786,6 +787,7 @@
 		5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMPropertyNormalizationResult.m; sourceTree = "<group>"; };
 		5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredUserTests.swift; sourceTree = "<group>"; };
 		5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizationResult.swift; sourceTree = "<group>"; };
+		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
@@ -1744,6 +1746,7 @@
 			isa = PBXGroup;
 			children = (
 				F13A89D0210628F600AB40CB /* PushToken.swift */,
+				631A0577240420380062B387 /* UserClient+SafeLogging.swift */,
 				F9A706151CAEE01D00C2F5FE /* UserClient+Protobuf.swift */,
 				F9A706161CAEE01D00C2F5FE /* UserClient.swift */,
 				54FB03A21E41E64A000E13DC /* UserClient+Patches.swift */,
@@ -2811,6 +2814,7 @@
 				EF1F850422FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift in Sources */,
 				165DC523214A614100090B7B /* ZMConversation+Message.swift in Sources */,
 				F9A706811CAEE01D00C2F5FE /* ZMMessage.m in Sources */,
+				631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */,
 				165DC52121491D8700090B7B /* ZMClientMessage+TextMessageData.swift in Sources */,
 				541D1B331F1F8D660078C1F2 /* StorageStack.swift in Sources */,
 				BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- Added `safeRemoteIdentifier` to `UserClient`
- Added tests