### PR TITLE
[Refactor] Retire ZMNewOTRMessage 

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -129,7 +129,7 @@ extension ZMGenericMessage {
         encryptionContext.perform { (sessionsDirectory) in
             let message = otrMessage(selfClient, recipients: recipients, externalData: externalData, sessionDirectory: sessionsDirectory)
 
-            messageData = message.data()
+            messageData = try? message.serializedData()
             
             // message too big?
             if let data = messageData, UInt(data.count) > ZMClientMessageByteSizeExternalThreshold && externalData == nil {
@@ -228,12 +228,11 @@ extension ZMGenericMessage {
     fileprivate func otrMessage(_ selfClient: UserClient,
                                 recipients: Set<ZMUser>,
                                 externalData: Data?,
-                                sessionDirectory: EncryptionSessionsDirectory) -> ZMNewOtrMessage {
+                                sessionDirectory: EncryptionSessionsDirectory) -> NewOtrMessage {
         
         let userEntries = self.recipientsWithEncryptedData(selfClient, recipients: recipients, sessionDirectory: sessionDirectory)
         let nativePush = !hasConfirmation() // We do not want to send pushes for delivery receipts
-        let message = ZMNewOtrMessage.message(withSender: selfClient, nativePush: nativePush, recipients: userEntries, blob: externalData)
-        
+        let message = NewOtrMessage(withSender: selfClient, nativePush: nativePush, recipients: userEntries, blob: externalData)
         return message
     }
     
@@ -241,12 +240,12 @@ extension ZMGenericMessage {
     func recipientsWithEncryptedData(_ selfClient: UserClient,
                                      recipients: Set<ZMUser>,
                                      sessionDirectory: EncryptionSessionsDirectory
-        ) -> [ZMUserEntry]
+        ) -> [UserEntry]
     {
-        let userEntries = recipients.compactMap { user -> ZMUserEntry? in
+        let userEntries = recipients.compactMap { user -> UserEntry? in
                 guard !user.isAccountDeleted else { return nil }
             
-                let clientsEntries = user.clients.compactMap { client -> ZMClientEntry? in
+                let clientsEntries = user.clients.compactMap { client -> ClientEntry? in
                     
                 if client != selfClient {
                     guard let clientRemoteIdentifier = client.sessionIdentifier else {
@@ -259,7 +258,7 @@ extension ZMGenericMessage {
                         // if the session is corrupted, we will send a special payload
                         if client.failedToEstablishSession {
                             let data = ZMFailedToCreateEncryptedMessagePayloadString.data(using: String.Encoding.utf8)!
-                            return ZMClientEntry.entry(withClient: client, data: data)
+                            return ClientEntry(withClient: client, data: data)
                         }
                         else {
                             // if we do not have a session, we need to fetch a prekey and create a new session
@@ -270,7 +269,7 @@ extension ZMGenericMessage {
                     guard let encryptedData = try? sessionDirectory.encryptCaching(self.data(), for: clientRemoteIdentifier) else {
                         return nil
                     }
-                    return ZMClientEntry.entry(withClient: client, data: encryptedData)
+                    return ClientEntry(withClient: client, data: encryptedData)
                 } else {
                     return nil
                 }
@@ -279,7 +278,7 @@ extension ZMGenericMessage {
             if clientsEntries.isEmpty {
                 return nil
             }
-            return ZMUserEntry.entry(withUser: user, clientEntries: clientsEntries)
+            return UserEntry(withUser: user, clientEntries: clientsEntries)
         }
         return userEntries
     }

--- a/Source/Model/Message/ZMClientMessage.h
+++ b/Source/Model/Message/ZMClientMessage.h
@@ -41,15 +41,3 @@ extern NSString * _Nonnull const ZMClientMessageLinkPreviewKey;
 - (BOOL)hasDownloadedImage;
 
 @end
-
-
-
-@interface ZMClientMessage (Testing)
-
-+ (ZMNewOtrMessage * _Nullable)otrMessageForGenericMessage:(ZMGenericMessage * _Nonnull)genericMessage
-                                                selfClient:(UserClient * _Nonnull)selfClient
-                                              conversation:(ZMConversation * _Nonnull)conversation
-                                              externalData:(NSData * _Nullable)externalData
-                                         sessionsDirectory:(EncryptionSessionsDirectory * _Nonnull)sessionsDirectory;
-
-@end

--- a/Source/Model/User/ZMUser+Internal.h
+++ b/Source/Model/User/ZMUser+Internal.h
@@ -132,7 +132,7 @@ extern NSString * __nonnull const ReadReceiptsEnabledKey;
 
 @interface ZMUser (Protobuf)
 
-- (nonnull ZMUserId *)userId;
-
+- (nonnull ZMUserId *)zmUserId;
+    
 @end
 

--- a/Source/Model/User/ZMUser+Protobuf.swift
+++ b/Source/Model/User/ZMUser+Protobuf.swift
@@ -1,44 +1,27 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2020 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 import Foundation
-import WireProtos
 
-extension UserClient {
-    
-    var hexRemoteIdentifier: UInt64 {
-        let pointer = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
-        defer { pointer.deallocate() }
-        Scanner(string: self.remoteIdentifier!).scanHexInt64(pointer)
-        return UInt64(pointer.pointee)
-    }
-    
-    public var clientId: ClientId {
-        return ClientId.with {
-            $0.client = self.hexRemoteIdentifier
+extension ZMUser {
+    var userId: UserId {
+        return UserId.with {
+            $0.uuid = remoteIdentifier.uuidData
         }
     }
-    
-    public var zmClientId: ZMClientId {
-        let builder = ZMClientIdBuilder()
-        builder.setClient(self.hexRemoteIdentifier)
-        return builder.build()
-    }
-
 }

--- a/Source/Model/User/ZMUser+Protobuf.swift
+++ b/Source/Model/User/ZMUser+Protobuf.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-extension ZMUser {
+public extension ZMUser {
     var userId: UserId {
         return UserId.with {
             $0.uuid = remoteIdentifier.uuidData

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -1075,7 +1075,7 @@ static NSString *const ParticipantRolesKey = @"participantRoles";
 
 @implementation ZMUser (Protobuf)
 
-- (ZMUserId *)userId
+- (ZMUserId *)zmUserId
 {
     ZMUserIdBuilder *userIdBuilder = [ZMUserId builder];
     [userIdBuilder setUuid:[self.remoteIdentifier data]];

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -192,6 +192,37 @@ extension Ephemeral: MessageCapable {
     }
 }
 
+public extension ClientEntry {
+    init(withClient client: UserClient, data: Data) {
+        self = ClientEntry.with {
+            $0.client = client.clientId
+            $0.text = data
+        }
+    }
+}
+
+public extension UserEntry {
+    init(withUser user: ZMUser, clientEntries: [ClientEntry]) {
+        self = UserEntry.with {
+            $0.user = user.userId
+            $0.clients = clientEntries
+        }
+    }
+}
+
+public extension NewOtrMessage {
+    init(withSender sender: UserClient, nativePush: Bool, recipients: [UserEntry], blob: Data? = nil) {
+        self = NewOtrMessage.with {
+            $0.nativePush = nativePush
+            $0.sender = sender.clientId
+            $0.recipients = recipients
+            if blob != nil {
+                $0.blob = blob!
+            }
+        }
+    }
+}
+
 extension Location: EphemeralMessageCapable {
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.location = self

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -587,28 +587,6 @@ extension ZMExternal: MessageContentType {
     }
 }
 
-public extension ZMClientEntry {
-    
-    @objc static func entry(withClient client: UserClient, data: Data) -> ZMClientEntry {
-        let builder = ZMClientEntry.builder()!
-        builder.setClient(client.zmClientId)
-        builder.setText(data)
-        return builder.build()
-    }
-    
-}
-
-public extension ZMUserEntry {
-    
-    @objc static func entry(withUser user: ZMUser, clientEntries: [ZMClientEntry]) -> ZMUserEntry {
-        let builder = ZMUserEntry.builder()!
-        builder.setUser(user.zmUserId())
-        builder.setClientsArray(clientEntries)
-        return builder.build()
-    }
-    
-}
-
 @objc
 extension ZMAsset: EphemeralMessageContentType {
     

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -609,21 +609,6 @@ public extension ZMUserEntry {
     
 }
 
-public extension ZMNewOtrMessage {
-    
-    @objc static func message(withSender sender: UserClient, nativePush: Bool, recipients: [ZMUserEntry], blob: Data? = nil) -> ZMNewOtrMessage {
-        let builder = ZMNewOtrMessage.builder()!
-        builder.setNativePush(nativePush)
-        builder.setSender(sender.zmClientId)
-        builder.setRecipientsArray(recipients)
-        if nil != blob {
-            builder.setBlob(blob)
-        }
-        return builder.build()
-    }
-    
-}
-
 @objc
 extension ZMAsset: EphemeralMessageContentType {
     

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -591,7 +591,7 @@ public extension ZMClientEntry {
     
     @objc static func entry(withClient client: UserClient, data: Data) -> ZMClientEntry {
         let builder = ZMClientEntry.builder()!
-        builder.setClient(client.clientId)
+        builder.setClient(client.zmClientId)
         builder.setText(data)
         return builder.build()
     }
@@ -602,7 +602,7 @@ public extension ZMUserEntry {
     
     @objc static func entry(withUser user: ZMUser, clientEntries: [ZMClientEntry]) -> ZMUserEntry {
         let builder = ZMUserEntry.builder()!
-        builder.setUser(user.userId())
+        builder.setUser(user.zmUserId())
         builder.setClientsArray(clientEntries)
         return builder.build()
     }

--- a/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/ZMGenericMessage+Helper.swift
@@ -614,7 +614,7 @@ public extension ZMNewOtrMessage {
     @objc static func message(withSender sender: UserClient, nativePush: Bool, recipients: [ZMUserEntry], blob: Data? = nil) -> ZMNewOtrMessage {
         let builder = ZMNewOtrMessage.builder()!
         builder.setNativePush(nativePush)
-        builder.setSender(sender.clientId)
+        builder.setSender(sender.zmClientId)
         builder.setRecipientsArray(recipients)
         if nil != blob {
             builder.setBlob(blob)

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -167,7 +167,7 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
         super.tearDown()
     }
     
-    func assertRecipients(_ recipients: [ZMUserEntry], file: StaticString = #file, line: UInt = #line) {
+    func assertRecipients(_ recipients: [UserEntry], file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(recipients.count, expectedRecipients.count, file: file, line: line)
         
         for recipientEntry in recipients {
@@ -181,7 +181,7 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
             }
             let clientIds = (recipientEntry.clients).map { String(format: "%llx", $0.client.client) }.sorted()
             XCTAssertEqual(clientIds, expectedClientsIds, file: file, line: line)
-            let hasTexts = (recipientEntry.clients).map { $0.hasText() }
+            let hasTexts = (recipientEntry.clients).map { $0.hasText }
             XCTAssertFalse(hasTexts.contains(false), file: file, line: line)
             
         }

--- a/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageTests+NativePush.swift
@@ -48,13 +48,13 @@ class GenericMessageTests_NativePush: BaseZMMessageTests {
 
             // when
             let (data, _) = message.encryptedMessagePayloadData(conversation, externalData: nil)!
-            let builder = ZMNewOtrMessage.builder()!
-            builder.merge(from: data)
-            guard let otrMessage = builder.build() else { return XCTFail("Unable to build ZMNewOTRMessage", line: line) }
+            let otrMessage = NewOtrMessage.with {
+               try? $0.merge(serializedData: data)
+            }
 
             // then
-            XCTAssertTrue(otrMessage.hasNativePush(), line: line)
-            XCTAssertEqual(otrMessage.nativePush(), nativePush, "Wrong value for nativePush", line: line)
+            XCTAssertTrue(otrMessage.hasNativePush, line: line)
+            XCTAssertEqual(otrMessage.nativePush, nativePush, "Wrong value for nativePush", line: line)
         }
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), line: line)

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
+		63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
 		7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */; };
 		7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */; };
@@ -792,6 +793,7 @@
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
+		63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Protobuf.swift"; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
 		7C2E467721072A31007E2566 /* zmessaging2.50.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.50.0.xcdatamodel; sourceTree = "<group>"; };
 		7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Replies.swift"; sourceTree = "<group>"; };
@@ -1740,6 +1742,7 @@
 				5EFE9C052125CD3F007932A6 /* UnregisteredUser.swift */,
 				5E36B45D21CA5BBA00B7063B /* UnverifiedCredentials.swift */,
 				7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */,
+				63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -2861,6 +2864,7 @@
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
 				873B88FC204044AC00FBE254 /* ConversationCreationOptions.swift in Sources */,
 				87E9508B2118B2DA00306AA7 /* ZMConversation+DeleteOlderMessages.swift in Sources */,
+				63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */,
 				EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */,
 				54E3EE411F616BA600A261E3 /* ZMAssetClientMessage.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- Retire `ZMNewOTRMessage` protobuf and use `NewOTRMessage` instead