### PR TITLE
[Refactor] Add method to determine if user type is sender

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -144,6 +144,17 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     var needsLinkAttachmentsUpdate: Bool { get set }
 }
 
+public extension ZMConversationMessage {
+
+    /// Whether the given user is the sender of the message.
+
+    func isUserSender(_ user: UserType) -> Bool {
+        guard let zmUser = user as? ZMUser else { return false }
+        return zmUser == sender
+    }
+
+}
+
 public extension Equatable where Self : ZMConversationMessage { }
 
 public func ==(lhs: ZMConversationMessage, rhs: ZMConversationMessage) -> Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Currently the only way to check if a particular user is the sender of the message is to do a comparison with the `sender: ZMUser` property of `ZMConversationMessage`. Equation with `sender` therefore requires an instance of `ZMUser`.

In order to remove some usages of `ZMUser` from the UI project, we also need a way to check if a given `UserType` is the sender of a message.

### Solutions

Provide a method on `ZMConversationMessage` that checks if a `UserType` instance is the sender of the message.
