### PR TITLE
[Fix]Unable to get correct device class on iPad

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -194,7 +194,7 @@ public class UserClient: ZMManagedObject, UserClientType {
         userClient.user = selfUser
         userClient.model = model
         userClient.label = label
-        userClient.deviceClass = model.hasSuffix("iPad") ? .tablet : .phone
+        userClient.deviceClass = model.hasPrefix("iPad") ? .tablet : .phone
         
         return userClient
     }


### PR DESCRIPTION
## What's new in this PR?

Just a bug fix

### Issues

When the user is logged in, Wire will report client information to the server
But under iPad, the device class will be reported as "phone"

It's should be "tablet"

### Causes

userClient.deviceClass = model.hasSurffix("iPad") ? .tablet : .phone
Surffix should be Prefix.

### Solutions

userClient.deviceClass = model.hasPrefix("iPad") ? .tablet : .phone