### PR TITLE
[Fix] Sending alarming response button action 

### DIFF
--- a/Source/Model/ButtonState/ButtonState.swift
+++ b/Source/Model/ButtonState/ButtonState.swift
@@ -29,6 +29,7 @@ class ButtonState: ZMManagedObject {
         let buttonState = ButtonState.insertNewObject(in: moc)
         buttonState.remoteIdentifier = id
         buttonState.message = message
+        buttonState.state = .unselected
         return buttonState
     }
     

--- a/Source/Model/ButtonState/ButtonState.swift
+++ b/Source/Model/ButtonState/ButtonState.swift
@@ -24,6 +24,7 @@ class ButtonState: ZMManagedObject {
     @NSManaged var remoteIdentifier: String?
     @NSManaged var isExpired: Bool
 
+    @discardableResult
     static func insert(with id: String, message: ZMMessage, inContext moc: NSManagedObjectContext) -> ButtonState {
         let buttonState = ButtonState.insertNewObject(in: moc)
         buttonState.remoteIdentifier = id

--- a/Source/Model/Message/ZMClientMessage+Composite.swift
+++ b/Source/Model/Message/ZMClientMessage+Composite.swift
@@ -103,10 +103,15 @@ extension ZMClientMessage {
     }
     
     private func updateButtonStates(withConfirmation confirmation: ZMButtonActionConfirmation) {
-        guard let states = buttonStates, states.contains(where: { $0.remoteIdentifier == confirmation.buttonId }) else {
-            return
+        if !containsButtonState(withId: confirmation.buttonId) {
+            guard let moc = managedObjectContext else { return }
+            ButtonState.insert(with: confirmation.buttonId, message: self, inContext: moc)
         }
-        states.confirmButtonState(withId: confirmation.buttonId)
+        buttonStates?.confirmButtonState(withId: confirmation.buttonId)
+    }
+    
+    private func containsButtonState(withId buttonId: String) -> Bool {
+        return buttonStates?.contains(where: { $0.remoteIdentifier == buttonId }) ?? false
     }
     
     @objc static func expireButtonState(forButtonAction buttonAction: ZMButtonAction,

--- a/Source/Model/Message/ZMClientMessage+Composite.swift
+++ b/Source/Model/Message/ZMClientMessage+Composite.swift
@@ -103,8 +103,9 @@ extension ZMClientMessage {
     }
     
     private func updateButtonStates(withConfirmation confirmation: ZMButtonActionConfirmation) {
+        guard let moc = managedObjectContext else { return }
+
         if !containsButtonState(withId: confirmation.buttonId) {
-            guard let moc = managedObjectContext else { return }
             ButtonState.insert(with: confirmation.buttonId, message: self, inContext: moc)
         }
         buttonStates?.confirmButtonState(withId: confirmation.buttonId)

--- a/Source/Utilis/Protos/ZMGenericMessage+Utils.m
+++ b/Source/Utilis/Protos/ZMGenericMessage+Utils.m
@@ -92,7 +92,10 @@
     self.hasEphemeral ||
     self.hasCalling ||
     self.hasExternal ||
-    self.hasAvailability;
+    self.hasAvailability ||
+    self.hasButtonAction ||
+    self.hasButtonActionConfirmation ||
+    self.hasComposite;
 }
 
 @end

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Composite.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Composite.swift
@@ -114,6 +114,29 @@ class ZMClientMessageTests_Composite: BaseZMClientMessageTests {
         XCTAssertEqual(WireDataModel.ButtonState.State.selected, buttonState?.state)
     }
     
+    func testThatItCreatesButtonStateIfNeeded_WhenReceivingButtonActionConfirmation() {
+        // GIVEN
+        let nonce = UUID()
+        let message = compositeMessage(with: compositeProto(items: compositeItemButton()), nonce: nonce)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.append(message)
+        
+        let builder = ZMButtonActionConfirmationBuilder()
+        builder.setReferenceMessageId(nonce.transportString())
+        builder.setButtonId("1")
+        let confirmation = builder.build()
+
+        // WHEN
+        uiMOC.performAndWait { [uiMOC] in
+            ZMClientMessage.updateButtonStates(withConfirmation: confirmation!, forConversation: conversation, inContext: uiMOC)
+            uiMOC.saveOrRollback()
+        }
+        
+        // THEN
+        let buttonState = message.buttonStates?.first
+        XCTAssertEqual(buttonState?.remoteIdentifier, "1")
+    }
+    
     func testThatItUpdatesButtonStates_WhenReceivingButtonActionConfirmation() {
         // GIVEN
         let nonce = UUID()


### PR DESCRIPTION
## What's new in this PR?

- Fix button action not sending 
- Create button state if necessary on confirmation