### PR TITLE
[Fix] button state changes not observed

### DIFF
--- a/Source/Model/ButtonState/ButtonState.swift
+++ b/Source/Model/ButtonState/ButtonState.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 class ButtonState: ZMManagedObject {
-    @NSManaged private var stateValue: Int16
+    @NSManaged var stateValue: Int16
     @NSManaged var message: ZMMessage?
     @NSManaged var remoteIdentifier: String?
     @NSManaged var isExpired: Bool

--- a/Source/Notifications/DependencyKeyStore.swift
+++ b/Source/Notifications/DependencyKeyStore.swift
@@ -120,6 +120,8 @@ class DependencyKeyStore {
             return Label.observableKeys
         case ParticipantRole.entityName():
             return ParticipantRole.observableKeys
+        case ButtonState.entityName():
+            return Set([#keyPath(ButtonState.stateValue)])
         default:
             zmLog.warn("There are no observable keys defined for \(classIdentifier)")
             return Set()
@@ -158,6 +160,8 @@ class DependencyKeyStore {
             return observableKeys.mapToDictionary{Label.keyPathsForValuesAffectingValue(forKey: $0)}
         case ParticipantRole.entityName():
             return observableKeys.mapToDictionary{ParticipantRole.keyPathsForValuesAffectingValue(forKey: $0)}
+        case ButtonState.entityName():
+            return observableKeys.mapToDictionary{ButtonState.keyPathsForValuesAffectingValue(forKey: $0)}
         default:
             zmLog.warn("There is no path to affecting keys defined for \(classIdentifier)")
             return [:]

--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -99,7 +99,8 @@ extension ZMSystemMessage {
     
     static let UserChangeInfoKey = "userChanges"
     static let ReactionChangeInfoKey = "reactionChanges"
-
+    static let ButtonStateChangeInfoKey = "buttonStateChanges"
+    
     static func changeInfo(for message: ZMMessage, changes: Changes) -> MessageChangeInfo? {
         let originalChanges = changes.originalChanges
         
@@ -204,7 +205,7 @@ extension ZMSystemMessage {
     }
     
     public var buttonStatesChanged: Bool {
-        return changedKeysContain(keys: #keyPath(ZMClientMessage.buttonStates))
+        return changedKeysContain(keys: #keyPath(ZMClientMessage.buttonStates)) || changeInfos[MessageChangeInfo.ButtonStateChangeInfoKey] != nil
     }
     
     public var userChangeInfo : UserChangeInfo? {

--- a/Source/Notifications/SideEffectSources.swift
+++ b/Source/Notifications/SideEffectSources.swift
@@ -210,6 +210,17 @@ extension Reaction : SideEffectSource {
     }
 }
 
+extension ButtonState : SideEffectSource {
+    
+    func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
+        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: MessageChangeInfo.ButtonStateChangeInfoKey, keyMapping: {"\(#keyPath(ZMClientMessage.buttonStates)).\($0)"})
+    }
+    
+    func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
+        return byInsertOrDeletionAffectedKeys(for: message, keyStore: keyStore, affectedKey: #keyPath(ZMClientMessage.buttonStates))
+    }
+}
+
 extension ZMGenericMessageData : SideEffectSource {
     
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {


### PR DESCRIPTION
## What's new in this PR?

### Problem

`MessageChangeInfo` observer was observing changes to the message object, such as insertions and deletions on the `buttonStates` property. But it was not observing updates on the `ButtonState` entities. 

### Solution

- Conform `ButtonState` to `SideEffectSource` protocol
- Add `ButtonState` to the observable keys of `DependencyKeyStore` 
- Update `MessageChangeInfo` to verify if the buttonState key is part of the observed changes 