### PR TITLE
[Feature]: SignIn Message Menu Action

### DIFF
--- a/Source/Model/Message/Message.swift
+++ b/Source/Model/Message/Message.swift
@@ -41,6 +41,10 @@ public extension ZMConversationMessage {
         return fileMessageData != nil && !fileMessageData!.v3_isImage
     }
 
+    var isPDF: Bool {
+        return isFile && fileMessageData?.mimeType == "application/pdf"
+    }
+    
     var isPass: Bool {
         return isFile && fileMessageData!.isPass
     }
@@ -121,6 +125,11 @@ public class Message: NSObject {
         return message.isFile
     }
 
+    @objc(isPDFMessage:)
+    public class func isPDF(_ message: ZMConversationMessage) -> Bool {
+        return message.isPDF
+    }
+    
     @objc(isVideoMessage:)
     public class func isVideo(_ message: ZMConversationMessage) -> Bool {
         return message.isVideo


### PR DESCRIPTION
## What's new in this PR?

### Causes

It is necessary add the action menu model logic to check if a message can be digital signed.

### Solutions

Check if the file contained in the message is a pdf

## Dependencies

wire-ios: https://github.com/wireapp/wire-ios/pull/4214
JIRA: https://wearezeta.atlassian.net/browse/ZIOS-12763