### PR TITLE
[Feature] Establish team membership if user belongs to the self user team

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -56,4 +56,16 @@ public extension ZMUser {
             return expiresAt.timeIntervalSinceNow
         }
     }
+    
+    @objc func createMembershipIfBelongingToTeam() {
+        guard
+            let teamIdentifier = self.teamIdentifier,
+            let managedObjectContext = self.managedObjectContext,
+            let team = Team.fetch(withRemoteIdentifier: teamIdentifier, in: managedObjectContext)
+        else {
+            return
+        }
+        
+        _ = Member.getOrCreateMember(for: self, in: team, context: managedObjectContext)
+    }
 }

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -562,6 +562,7 @@ static NSString *const ParticipantRolesKey = @"participantRoles";
     
     if ([transportData objectForKey:@"team"] || authoritative) {
         self.teamIdentifier = [transportData optionalUuidForKey:@"team"];
+        [self createMembershipIfBelongingToTeam];
     }
     
     NSString *email = [transportData optionalStringForKey:@"email"];

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -339,6 +339,52 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertFalse(user.hasTeam);
 }
 
+- (void)testThatItCreatesMembershipIfUserBelongsToSelfUserTeamOnAnExistingUser
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    team.remoteIdentifier = teamId;
+    user.remoteIdentifier = uuid;
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+    
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+    
+    // then
+    XCTAssertNotNil(user.membership);
+    XCTAssertEqualObjects(user.membership.team, team);
+}
+
+- (void)testThatItDoesNotCreateMembershipIfUserBelongsExternalTeamOnAnExistingUser
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    NSUUID *externalTeamId = NSUUID.createUUID;
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    team.remoteIdentifier = teamId;
+    user.remoteIdentifier = uuid;
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = externalTeamId.transportString;
+    
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+    
+    // then
+    XCTAssertNil(user.membership);
+}
+
 - (void)testThatItUpdatesBasicDataOnAnExistingUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

Establish team membership, if a user belongs to the same team as the self user.