### PR TITLE
[Fix] error message delay when service not in conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -294,6 +294,11 @@ extension ZMConversation {
             self.needsToDownloadRoles = true
         }
     }
+    
+    // MARK: - Utils
+    func has(participantWithId userId: UserId?) -> Bool {
+        return localParticipants.contains { $0.userId == userId }
+    }
 }
 
 

--- a/Source/Model/Message/Composite/CompositeMessageItemContent.swift
+++ b/Source/Model/Message/Composite/CompositeMessageItemContent.swift
@@ -109,8 +109,13 @@ extension CompositeMessageItemContent: ButtonMessageData {
             guard let `self` = self else { return }
             let buttonState = self.buttonState ??
                 ButtonState.insert(with: buttonId, message: self.parentMessage, inContext: moc)
-            buttonState.state = .selected
             self.parentMessage.buttonStates?.resetExpired()
+            guard self.parentMessage.isSenderInConversation else {
+                buttonState.isExpired = true
+                moc.saveOrRollback()
+                return
+            }
+            buttonState.state = .selected
             self.parentMessage.conversation?.append(buttonActionWithId: buttonId, referenceMessageId: messageId)
             moc.saveOrRollback()
         }

--- a/Source/Model/Message/ZMMessage+Conversation.swift
+++ b/Source/Model/Message/ZMMessage+Conversation.swift
@@ -1,0 +1,15 @@
+//
+//  ZMMessage+Conversation.swift
+//  WireDataModel
+//
+//  Created by David Henner on 27.03.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+
+extension ZMMessage {
+    var isSenderInConversation: Bool {
+        return conversation?.has(participantWithId: sender?.userId) ?? false
+    }
+}

--- a/Source/Model/Message/ZMMessage+Conversation.swift
+++ b/Source/Model/Message/ZMMessage+Conversation.swift
@@ -1,9 +1,19 @@
 //
-//  ZMMessage+Conversation.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 27.03.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Tests/Source/Model/Messages/Composite/BaseCompositeMessageTests.swift
+++ b/Tests/Source/Model/Messages/Composite/BaseCompositeMessageTests.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class BaseCompositeMessageTests: BaseZMMessageTests {
+    func compositeItemButton(buttonID: String = "1") -> Composite.Item {
+        return Composite.Item.with { $0.button = Button.with {
+            $0.text = "Button text"
+            $0.id = buttonID
+            }}
+    }
+    
+    func compositeItemText() -> Composite.Item {
+        return Composite.Item.with { $0.text = Text.with { $0.content = "Text" } }
+    }
+    
+    func compositeProto(items: Composite.Item...) -> Composite {
+        return Composite.with { $0.items = items }
+    }
+    
+    func compositeMessage(with proto: Composite, nonce: UUID = UUID()) -> ZMClientMessage {
+        let genericMessage = GenericMessage.with {
+            $0.composite = proto
+            $0.messageID = nonce.transportString()
+        }
+        let message = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
+        let data = try! genericMessage.serializedData()
+        message.add(data)
+        return message
+    }
+    
+    func conversation(withMessage message: ZMClientMessage, addSender: Bool = true) -> ZMConversation {
+        let user = ZMUser.insertNewObject(in: uiMOC)
+        user.remoteIdentifier = UUID()
+        message.sender = user
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.append(message)
+        
+        guard addSender else { return conversation }
+
+        let participantRole = ParticipantRole.insertNewObject(in: uiMOC)
+        participantRole.user = user
+        conversation.participantRoles = Set([participantRole])
+        
+        return conversation
+    }
+}

--- a/Tests/Source/Model/Messages/Composite/CompositeMessageItemContentTests.swift
+++ b/Tests/Source/Model/Messages/Composite/CompositeMessageItemContentTests.swift
@@ -1,0 +1,97 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class CompositeMessageItemContentTests: BaseCompositeMessageTests {    
+    
+    func testThatButtonTouchActionInsertsMessageInConversationIfNoneIsSelected() {
+        // GIVEN
+        let message = compositeMessage(with: compositeProto(items: compositeItemButton(), compositeItemText()))
+        guard case .some(.button(let button)) = message.items.first else { return XCTFail() }
+        let conversation = self.conversation(withMessage: message)
+        
+        // WHEN
+        button.touchAction()
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+        
+        // THEN
+        let hiddenMessage = conversation.hiddenMessages.first as? ZMClientMessage
+        guard case .some(.buttonAction) = hiddenMessage?.underlyingMessage?.content else { return XCTFail() }
+    }
+    
+    func testThatButtonTouchActionDoesNotInsertMessageInConversationIfAButtonIsSelected() {
+        // GIVEN
+        let buttonItem = compositeItemButton()
+        let message = compositeMessage(with: compositeProto(items: buttonItem))
+        guard case .some(.button(let button)) = message.items.first else { return XCTFail() }
+        let conversation = self.conversation(withMessage: message)
+
+        uiMOC.performAndWait {
+            let buttonState = WireDataModel.ButtonState.insert(with: buttonItem.button.id, message: message, inContext: self.uiMOC)
+            buttonState.state = .selected
+            self.uiMOC.saveOrRollback()
+            
+            // WHEN
+            button.touchAction()
+            
+            // THEN
+            let lastmessage = conversation.hiddenMessages.first as? ZMClientMessage
+            if case .some(.buttonAction) = lastmessage?.underlyingMessage?.content { XCTFail() }
+        }
+    }
+    
+    func testThatButtonTouchActionCreatesButtonStateIfNeeded() {
+        // GIVEN
+        let id = "123"
+        let buttonItem = compositeItemButton(buttonID: id)
+        let message = compositeMessage(with: compositeProto(items: buttonItem))
+        guard case .some(.button(let button)) = message.items.first else { return XCTFail() }
+        _ = conversation(withMessage: message)
+
+        // WHEN
+        button.touchAction()
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+        
+        // THEN
+        let buttonState = message.buttonStates?.first(where: {$0.remoteIdentifier == id})
+        XCTAssertNotNil(buttonState)
+        XCTAssertEqual(WireDataModel.ButtonState.State.selected, buttonState?.state)
+    }
+    
+    func testThatButtonTouchActionExpiresButtonStateAndDoesntInsertMessage_WhenSenderIsNotInConversation() {
+        // GIVEN
+        let id = "123"
+        let buttonItem = compositeItemButton(buttonID: id)
+        let message = compositeMessage(with: compositeProto(items: buttonItem))
+        guard case .some(.button(let button)) = message.items.first else { return XCTFail() }
+        let conversation = self.conversation(withMessage: message, addSender: false)
+        
+        // WHEN
+        button.touchAction()
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+
+        // THEN
+        let buttonState = message.buttonStates?.first(where: {$0.remoteIdentifier == id})
+        XCTAssertEqual(buttonState?.isExpired, true)
+        XCTAssertEqual(buttonState?.state, WireDataModel.ButtonState.State.unselected)
+        let lastmessage = conversation.hiddenMessages.first as? ZMClientMessage
+        if case .some(.buttonAction) = lastmessage?.underlyingMessage?.content { XCTFail() }
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		63370CBB242CB84A0072C37F /* CompositeMessageItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */; };
 		63370CBD242CBA0A0072C37F /* CompositeMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */; };
+		63370CC9242E3B990072C37F /* ZMMessage+Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
@@ -810,6 +811,7 @@
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContent.swift; sourceTree = "<group>"; };
 		63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageData.swift; sourceTree = "<group>"; };
+		63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Conversation.swift"; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Protobuf.swift"; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
@@ -1740,6 +1742,7 @@
 				EF1F4F532301634500E4872C /* ZMSystemMessage+ChildMessages.swift */,
 				BF5DF5CC20F4EB3E002BCB67 /* ZMSystemMessage+NewConversation.swift */,
 				BF10B58A1E6432ED00E7036E /* Message.swift */,
+				63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */,
 				54563B751E0161730089B1D7 /* ZMMessage+Categorization.swift */,
 				F12BD0AF1E4DCEC40012ADBA /* ZMMessage+Insert.swift */,
 				16CDEBFA2209D13B00E74A41 /* ZMMessage+Quotes.swift */,
@@ -2908,6 +2911,7 @@
 				16460A44206515370096B616 /* NSManagedObjectContext+BackupImport.swift in Sources */,
 				F90D99A51E02DC6B00034070 /* AssetCollectionBatched.swift in Sources */,
 				54FB03AF1E41FC86000E13DC /* NSManagedObjectContext+Patches.swift in Sources */,
+				63370CC9242E3B990072C37F /* ZMMessage+Conversation.swift in Sources */,
 				547E66491F7503A5008CB1FA /* ZMConversation+Notifications.swift in Sources */,
 				EF18C7E61F9E4F8A0085A832 /* ZMUser+Filename.swift in Sources */,
 				F9A706781CAEE01D00C2F5FE /* ZMClientMessage.m in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -190,6 +190,8 @@
 		63370CBB242CB84A0072C37F /* CompositeMessageItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */; };
 		63370CBD242CBA0A0072C37F /* CompositeMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */; };
 		63370CC9242E3B990072C37F /* ZMMessage+Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */; };
+		63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */; };
+		63370CF82431F5DE0072C37F /* BaseCompositeMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */; };
 		636E5754238404D1005B4FD8 /* Team+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E5753238404D1005B4FD8 /* Team+Status.swift */; };
@@ -812,6 +814,8 @@
 		63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContent.swift; sourceTree = "<group>"; };
 		63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageData.swift; sourceTree = "<group>"; };
 		63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Conversation.swift"; sourceTree = "<group>"; };
+		63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContentTests.swift; sourceTree = "<group>"; };
+		63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCompositeMessageTests.swift; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Protobuf.swift"; sourceTree = "<group>"; };
 		636E5753238404D1005B4FD8 /* Team+Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Status.swift"; sourceTree = "<group>"; };
@@ -1423,6 +1427,16 @@
 			children = (
 				63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */,
 				63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */,
+			);
+			path = Composite;
+			sourceTree = "<group>";
+		};
+		63370CF62431F4FA0072C37F /* Composite */ = {
+			isa = PBXGroup;
+			children = (
+				63880548240EA8950043B641 /* ZMClientMessageTests+Composite.swift */,
+				63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */,
+				63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */,
 			);
 			path = Composite;
 			sourceTree = "<group>";
@@ -2087,6 +2101,7 @@
 		F9B71F5C1CB2BC85001DB03F /* Messages */ = {
 			isa = PBXGroup;
 			children = (
+				63370CF62431F4FA0072C37F /* Composite */,
 				EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */,
 				54EDE6811CBBF6260044A17E /* FileAssetCacheTests.swift */,
 				F9331C541CB3BCDA00139ECC /* OtrBaseTest.swift */,
@@ -2103,7 +2118,6 @@
 				87630A051F8FAB6700EEAE11 /* ZMGenericMessageTests.swift */,
 				63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */,
 				BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */,
-				63880548240EA8950043B641 /* ZMClientMessageTests+Composite.swift */,
 				BF794FE41D14425E00E618C6 /* ZMClientMessageTests+Location.swift */,
 				1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */,
 				BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */,
@@ -3129,6 +3143,7 @@
 				16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */,
 				1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */,
 				F9A708341CAEEB7500C2F5FE /* ManagedObjectContextSaveNotificationTests.m in Sources */,
+				63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */,
 				BF491CEC1F063F4B0055EE44 /* AccountStoreTests.swift in Sources */,
 				164A55D320F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift in Sources */,
 				F9B71FA01CB2BF2B001DB03F /* ZMConversationListTests.m in Sources */,
@@ -3142,6 +3157,7 @@
 				F9A708601CAEEF4700C2F5FE /* MessagingTest+EventFactory.m in Sources */,
 				F9DBA5291E29162A00BE23C0 /* MessageObserverTests.swift in Sources */,
 				BF1B980D1EC3410000DE033B /* PermissionsTests.swift in Sources */,
+				63370CF82431F5DE0072C37F /* BaseCompositeMessageTests.swift in Sources */,
 				546D3DE91CE5D24C00A6047F /* RichAssetFileTypeTests.swift in Sources */,
 				F9A708371CAEEB7500C2F5FE /* PersistentStoreCoordinatorTests.m in Sources */,
 				065D7501239FAB1200275114 /* SelfUserParticipantMigrationTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

In a conversation with Poll Bot: 
**a)** Send a poll message 
**b)** Remove Poll Bot from the conversation 
**c)** Tap on any poll button. 

**Expected:** User should see an error immediately. 
**Actual:** It takes 10-20 second before user sees an error.

### Causes

No check to verify if the service is in the conversation before sending the Button Action

### Solutions

Set `ButtonState.isExpired` to true in `buttonAction()` if service is not in conversation

