### PR TITLE
[Feature] Trigger user data fetch when a team members last client is deleted

### DIFF
--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -260,13 +260,20 @@ public class UserClient: ZMManagedObject, UserClientType {
         // reset the relationship
         self.user = nil
 
-        // increase securityLevel of affected conversations
         if let previousUser = user {
+            // increase securityLevel of affected conversations
             if isLegalHoldDevice && previousUser.isSelfUser {
                 previousUser.needsToAcknowledgeLegalHoldStatus = true
             }
 
             conversations.forEach{ $0.increaseSecurityLevelIfNeededAfterRemoving(clients: [previousUser: [self]]) }
+
+            // if they have no clients left, it's possible they left the team
+            let userMayHaveLeftTeam = previousUser.isTeamMember && previousUser.clients.isEmpty
+
+            if userMayHaveLeftTeam {
+                previousUser.needsToBeUpdatedFromBackend = true
+            }
         }
 
         // delete the object


### PR DESCRIPTION
## What's new in this PR?

### Issues

To handle missing `team.member-leave` update events, we need to fetch the user metadata if we suspect the user has left the team.

### Solutions

We suspect that a user left the team if all of their clients are deleted. This can happen in response to sending a message in the conversation. The response would tell the sender that they attempted to send a message to clients that have been deleted. The self client would then update the local state by tearing down the encryption sessions for those devices and removing the devices completely. In this process, we can check if the user is a team member and no longer has any clients left, in which case we trigger the data fetch.

### Attachments

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-12825
