### PR TITLE
[Feature] Add helper methods to request data refreshes

### DIFF
--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -30,6 +30,7 @@ public protocol TeamType: class {
     var imageData: Data? { get set }
 
     func requestImage()
+    func refreshMetadata()
 }
 
 @objcMembers
@@ -84,6 +85,10 @@ public class Team: ZMManagedObject, TeamType {
         }
 
         return nil
+    }
+
+    public func refreshMetadata() {
+        needsToBeUpdatedFromBackend = true
     }
 }
 

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -116,10 +116,7 @@ public protocol UserType: NSObjectProtocol {
     
     /// The extended metadata for this user, provided by SCIM.
     var richProfile: [UserRichProfileField] { get }
-    
-    /// Used to trigger rich profile download from backend
-    var needsRichProfileUpdate: Bool { get set }
-    
+        
     /// Conversations the user is a currently a participant of
     var activeConversations: Set<ZMConversation> { get }
     
@@ -139,8 +136,19 @@ public protocol UserType: NSObjectProtocol {
     func imageData(for size: ProfileImageSize, queue: DispatchQueue, completion: @escaping (_ imageData: Data?) -> Void)
     
     /// Request a refresh of the user data from the backend.
-    /// This is useful for non-connected user, that we will otherwise never re-fetch
+    ///
+    /// This is useful for non-connected user (that we will otherwise never re-fetch)
+    /// or discovering if the user is still in team.
     func refreshData()
+
+    /// Request a refresh of the rich profile.
+    func refreshRichProfile()
+
+    /// Request a refresh of the user's membership.
+    ///
+    /// This is useful to discover if user is still in a team since clients are not notified
+    /// of team-wide events.
+    func refreshMembership()
     
     /// Sends a connection request to the given user. May be a no-op, eg. if we're already connected.
     /// A ZMUserChangeNotification with the searchUser as object will be sent notifiying about the connection status change

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -313,16 +313,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
             return internalCompleteImageData
         }
     }
-    
-    public var needsRichProfileUpdate: Bool {
-        get {
-            return user?.needsRichProfileUpdate ?? false
-        }
-        set {
-            user?.needsRichProfileUpdate = newValue
-        }
-    }
-    
+
     public var richProfile: [UserRichProfileField] {
         return user?.richProfile ?? []
     }
@@ -501,6 +492,14 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     public func refreshData() {
         user?.refreshData()
+    }
+
+    public func refreshRichProfile() {
+        user?.refreshRichProfile()
+    }
+
+    public func refreshMembership() {
+        user?.refreshMembership()
     }
     
     public func connect(message: String) {

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -79,6 +79,16 @@ extension ZMUser: UserType {
     public var allClients: [UserClientType] {
         return Array(clients)
     }
+
+    // MARK: - Data refresh requests
+
+    public func refreshRichProfile() {
+        needsRichProfileUpdate = true
+    }
+
+    public func refreshMembership() {
+        membership?.needsToBeUpdatedFromBackend = true
+    }
     
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The UI may need to trigger remote data fetches for certain objects. This is typically done by setting flags such as `needsToBeUpdatedFromBackend`, which will automatically schedule downstream requests to the backend.

These properties however are defined on concrete managed objects and are therefore not exposed through the various abstraction protocols, such as `UserType` and `TeamType`.

### Solutions

Extend `UserType` and `TeamType` to include methods to request data refreshes from the backend.
