### PR TITLE
[Feature] Add method to UserType to request team data refresh

### DIFF
--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -149,6 +149,11 @@ public protocol UserType: NSObjectProtocol {
     /// This is useful to discover if user is still in a team since clients are not notified
     /// of team-wide events.
     func refreshMembership()
+
+    /// Request a refresh of the team metadata.
+    ///
+    /// This is useful to discover changes such as team name and logo.
+    func refreshTeamData()
     
     /// Sends a connection request to the given user. May be a no-op, eg. if we're already connected.
     /// A ZMUserChangeNotification with the searchUser as object will be sent notifiying about the connection status change

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -501,6 +501,10 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     public func refreshMembership() {
         user?.refreshMembership()
     }
+
+    public func refreshTeamData() {
+        user?.refreshTeamData()
+    }
     
     public func connect(message: String) {
         

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -89,6 +89,10 @@ extension ZMUser: UserType {
     public func refreshMembership() {
         membership?.needsToBeUpdatedFromBackend = true
     }
+
+    public func refreshTeamData() {
+        team?.refreshMetadata()
+    }
     
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

In https://github.com/wireapp/wire-ios-data-model/pull/932 I introduced some helper methods to request data refreshes from the UI. Unfortunately, access to team objects are not exposed through the `UserType` abstraction, and consequently it is difficult to request a refresh of team metadata.

### Solutions

Add a method to `UserType` to request a refresh of team metadata.
