### PR TITLE
[Fix] make alarming messages not silenced

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Mute.swift
+++ b/Source/Model/Conversation/ZMConversation+Mute.swift
@@ -141,8 +141,7 @@ extension ZMConversationMessage {
         }
         
         // We assume that all composite messages are alarming messages
-        let compositeMessage = self as? ConversationCompositeMessage
-        guard compositeMessage?.compositeMessageData == nil else {
+        guard (self as? ConversationCompositeMessage)?.compositeMessageData == nil else {
             return false
         }
         

--- a/Source/Model/Conversation/ZMConversation+Mute.swift
+++ b/Source/Model/Conversation/ZMConversation+Mute.swift
@@ -140,6 +140,12 @@ extension ZMConversationMessage {
             return false
         }
         
+        // We assume that all composite messages are alarming messages
+        let compositeMessage = self as? ConversationCompositeMessage
+        guard compositeMessage?.compositeMessageData == nil else {
+            return false
+        }
+        
         guard let textMessageData = self.textMessageData else {
             return true
         }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Mute.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Mute.swift
@@ -277,3 +277,59 @@ extension ZMConversationTests_Mute {
     }
     
 }
+
+// MARK: - Alarming messages
+class ZMConversationTest_Mute_Alarming: BaseCompositeMessageTests {
+    
+    func testCompositeMessageShouldCreateNotification_AvailabilityBusy() {
+        // GIVEN
+        selfUser.availability = .busy
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let message = compositeMessage(with: compositeProto(items: compositeItemText()))
+        conversation.append(message)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
+        message.sender = user
+        
+        // WHEN / THEN
+        XCTAssertFalse(message.isSilenced)
+    }
+    
+    func testCompositeMessageShouldCreateNotification_AvailabilityAway() {
+        // GIVEN
+        selfUser.availability = .away
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let message = compositeMessage(with: compositeProto(items: compositeItemText()))
+        conversation.append(message)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
+        message.sender = user
+        
+        // WHEN / THEN
+        XCTAssertFalse(message.isSilenced)
+    }
+    
+    func testCompositeMessageShouldCreateNotification_FullySilenced() {
+        // GIVEN
+        let message = compositeMessage(with: compositeProto(items: compositeItemText()))
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.mutedMessageTypes = .all
+        conversation.append(message)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
+        message.sender = user
+
+        // WHEN / THEN
+        XCTAssertFalse(message.isSilenced)
+    }
+    
+    func testCompositeMessageShouldCreateNotification_RegularSilenced() {
+        // GIVEN
+        let message = compositeMessage(with: compositeProto(items: compositeItemText()))
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.mutedMessageTypes = .regular
+        conversation.append(message)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
+        message.sender = user
+        
+        // WHEN / THEN
+        XCTAssertFalse(message.isSilenced)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Alarming messages are silenced, but they should override all notifications preferences

### Solutions

Do not silence if message is an alarming message (composite message)
