### PR TITLE
[Fix] Don't create memberships for deleted users

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -59,6 +59,7 @@ public extension ZMUser {
     
     @objc func createMembershipIfBelongingToTeam() {
         guard
+            !isAccountDeleted,
             let teamIdentifier = self.teamIdentifier,
             let managedObjectContext = self.managedObjectContext,
             let team = Team.fetch(withRemoteIdentifier: teamIdentifier, in: managedObjectContext)

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -362,6 +362,29 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqualObjects(user.membership.team, team);
 }
 
+- (void)testThatItDoesNotCreateMembershipIfUserIsDeleted
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    team.remoteIdentifier = teamId;
+    user.remoteIdentifier = uuid;
+    
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+    payload[@"deleted"] = @YES;
+    
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+    
+    // then
+    XCTAssertNil(user.membership);
+}
+
 - (void)testThatItDoesNotCreateMembershipIfUserBelongsExternalTeamOnAnExistingUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a team member is removed from the team we delete the membership relation, but we would re-create the membership if we ever fetched the user again.

### Causes

When fetching a deleted team member it still includes the `team` property, which will trigger us to create a membership relation if it doesn't already exist.

### Solutions

Don't create memberships for users which are marked as deleted.