### PR TITLE
[Fix] expose text data of CompositeMessageItem for notifications

### DIFF
--- a/Source/Model/Message/Composite/CompositeMessageData.swift
+++ b/Source/Model/Message/Composite/CompositeMessageData.swift
@@ -40,6 +40,13 @@ public enum CompositeMessageItem {
     }
 }
 
+extension CompositeMessageItem {
+    public var textData: ZMTextMessageData? {
+        guard case .text(let data) = self else { return nil }
+        return data
+    }
+}
+
 // MARK: - ButtonMessageData protocol
 
 public protocol ButtonMessageData {


### PR DESCRIPTION
## What's new in this PR?

- Expose optional `ZMTextMessageData` of `CompositeMessageItem` enum

Note: Sync Engine needs this for notifications