### PR TITLE
[Feature] Delete user membership they are marked as deleted

### DIFF
--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -57,16 +57,30 @@ public extension ZMUser {
         }
     }
     
-    @objc func createMembershipIfBelongingToTeam() {
+    @objc func createOrDeleteMembershipIfBelongingToTeam() {
         guard
-            !isAccountDeleted,
             let teamIdentifier = self.teamIdentifier,
             let managedObjectContext = self.managedObjectContext,
             let team = Team.fetch(withRemoteIdentifier: teamIdentifier, in: managedObjectContext)
         else {
             return
         }
-        
-        _ = Member.getOrCreateMember(for: self, in: team, context: managedObjectContext)
+
+        if !isAccountDeleted {
+            createMembership(in: team, context: managedObjectContext)
+        } else {
+            deleteMembership(in: managedObjectContext)
+        }
     }
+
+    private func createMembership(in team: Team, context: NSManagedObjectContext) {
+        _ = Member.getOrCreateMember(for: self, in: team, context: context)
+    }
+
+    private func deleteMembership(in context: NSManagedObjectContext) {
+        if let membership = self.membership {
+            context.delete(membership)
+        }
+    }
+
 }

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -562,7 +562,7 @@ static NSString *const ParticipantRolesKey = @"participantRoles";
     
     if ([transportData objectForKey:@"team"] || authoritative) {
         self.teamIdentifier = [transportData optionalUuidForKey:@"team"];
-        [self createMembershipIfBelongingToTeam];
+        [self createOrDeleteMembershipIfBelongingToTeam];
     }
     
     NSString *email = [transportData optionalStringForKey:@"email"];


### PR DESCRIPTION
## What's new in this PR?

### Issues

When processing a `team.member-leave` event we mark the user as deleted and delete their `membership`. In large teams however we will not receive this event.

In this case, we discover if a user has been removed from the team by fetching their metadata and inspecting the `deleted` and `team` keys. Currently, we will only mark the user as deleted, but the local instance of their membership will still exist.

### Solutions

Delete the user membership if the user is deleted and belongs to the self team.

### Attachments

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-12826
