### PR TITLE
[Feature] Limit status broadcast to known team members and contacts

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -109,14 +109,14 @@ extension ZMGenericMessage {
         return nil
     }
     
-    public func encryptedMessagePayloadDataForBroadcast(context: NSManagedObjectContext) -> (data: Data, strategy: MissingClientsStrategy)? {
-        let recipients = ZMUser.connectionsAndTeamMembers(in: context)
-        
-        if let data = encryptedMessagePayloadData(for: recipients, externalData: nil, context: context) {
-            return (data, MissingClientsStrategy.doNotIgnoreAnyMissingClient)
-        }
-        
-        return nil
+    public func encryptedMessagePayloadDataForBroadcast(recipients: Set<ZMUser>,
+                                                        in context: NSManagedObjectContext) -> (data: Data, strategy: MissingClientsStrategy)? {
+
+        guard let data = encryptedMessagePayloadData(for: recipients, externalData: nil, context: context) else { return nil }
+
+        // It's important to ignore all irrelevant missing clients, because otherwise the backend will enforce that
+        // the message is sent to all team members and contacts.
+        return (data, MissingClientsStrategy.ignoreAllMissingClientsNotFromUsers(users: recipients))
     }
     
     fileprivate func encryptedMessagePayloadData(for recipients: Set<ZMUser>, externalData: Data?, context: NSManagedObjectContext) -> Data? {

--- a/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
+++ b/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
@@ -20,10 +20,12 @@ import Foundation
 
 extension ZMBaseManagedObjectTest {
 
-    func createConversation(in moc: NSManagedObjectContext) -> ZMConversation {
+    @discardableResult
+    func createConversation(in moc: NSManagedObjectContext, with participants: [ZMUser] = [], role: Role? = nil) -> ZMConversation {
         let conversation = ZMConversation.insertNewObject(in: moc)
         conversation.remoteIdentifier = UUID()
         conversation.conversationType = .group
+        conversation.addParticipantsAndUpdateConversationState(users: Set(participants), role: role)
         return conversation
     }
 

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -304,8 +304,9 @@ extension ZMUserTests {
 }
 
 extension ZMUser {
-    static func insert(in moc: NSManagedObjectContext, name: String, handle: String? = nil, connectionStatus: ZMConnectionStatus = .accepted) -> ZMUser {
+    static func insert(in moc: NSManagedObjectContext, id: UUID = .create(), name: String, handle: String? = nil, connectionStatus: ZMConnectionStatus = .accepted) -> ZMUser {
         let user = ZMUser.insertNewObject(in: moc)
+        user.remoteIdentifier = id
         user.name = name
         user.setHandle(handle)
         let connection = ZMConnection.insertNewSentConnection(to: user)
@@ -479,39 +480,7 @@ extension ZMUserTests {
         // then
         XCTAssertEqual(user.availability, .none)
     }
-    
-    func testThatConnectionsAndTeamMembersReturnsExpectedUsers() {
-        // given
-        _ = ZMUser.insert(in: uiMOC, name: "user1", handle: "handl1", connectionStatus: .pending)
-        _ = ZMUser.insert(in: uiMOC, name: "user2", handle: "handl1", connectionStatus: .blocked)
-        _ = ZMUser.insert(in: uiMOC, name: "user3", handle: "handl1", connectionStatus: .cancelled)
-        _ = ZMUser.insert(in: uiMOC, name: "user4", handle: "handl1", connectionStatus: .ignored)
-        _ = ZMUser.insert(in: uiMOC, name: "user5", handle: "handl1", connectionStatus: .sent)
-        _ = ZMUser.insert(in: uiMOC, name: "user6", handle: "handl1", connectionStatus: .invalid)
-        let connectedUser = ZMUser.insert(in: uiMOC, name: "user7", handle: "handl1", connectionStatus: .accepted)
-        let connectedUserWithoutHandle = ZMUser.insert(in: uiMOC, name: "user8", handle: nil, connectionStatus: .accepted)
-        
-        let team = Team.insertNewObject(in: uiMOC)
-        let teamUser = ZMUser.insertNewObject(in: uiMOC)
-        teamUser.remoteIdentifier = .create()
-        
-        let membership = Member.insertNewObject(in: uiMOC)
-        membership.team = team
-        membership.user = teamUser
-        membership.remoteIdentifier = teamUser.remoteIdentifier
-        
-        let selfMembership = Member.insertNewObject(in: uiMOC)
-        selfMembership.team = team
-        selfMembership.user = selfUser
-        selfMembership.remoteIdentifier = selfUser.remoteIdentifier
-        
-        // when
-        let connectionsAndTeamMembers = ZMUser.connectionsAndTeamMembers(in: uiMOC)
 
-        // then
-        XCTAssertEqual(Set<ZMUser>(arrayLiteral: connectedUser, connectedUserWithoutHandle, teamUser, selfUser), connectionsAndTeamMembers)
-    }
-    
     func testThatNeedsToNotifyAvailabilityBehaviourChangeDefaultsToNothing() {
         XCTAssertEqual(selfUser.needsToNotifyAvailabilityBehaviourChange, [])
     }
@@ -524,6 +493,211 @@ extension ZMUserTests {
         XCTAssertEqual(selfUser.needsToNotifyAvailabilityBehaviourChange, .alert)
     }
         
+}
+
+// MARK: - Broadcast Recipients
+
+extension ZMUserTests {
+
+    func testThatItReturnsAllConnections() {
+        // given
+        _ = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
+        _ = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
+        _ = ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
+        _ = ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
+        _ = ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
+        _ = ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
+
+        let connectedUser1 = ZMUser.insert(in: uiMOC, name: "7", handle: "7", connectionStatus: .accepted)
+        let connectedUser2 = ZMUser.insert(in: uiMOC, name: "8", handle: nil, connectionStatus: .accepted)
+
+        let team = createTeam(in: uiMOC)
+        createUserAndAddMember(to: team)
+        createMembership(in: uiMOC, user: selfUser, team: team)
+
+        // when
+        let connections = ZMUser.connections(in: uiMOC)
+
+        // then
+        XCTAssertEqual(connections, Set([connectedUser1, connectedUser2]))
+    }
+
+    func testThatItReturnsAllKnownTeamMembers() {
+        // given
+        let selfUserTeam = createTeam(in: uiMOC)
+        createMembership(in: uiMOC, user: selfUser, team: selfUserTeam)
+
+        let (selfTeamUser1, _) = createUserAndAddMember(to: selfUserTeam)
+        let (selfTeamUser2, _) = createUserAndAddMember(to: selfUserTeam)
+        let (selfTeamUser3, _) = createUserAndAddMember(to: selfUserTeam)
+
+        _ = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .accepted)
+
+        let otherTeam = createTeam(in: uiMOC)
+        let (otherTeamUser, _) = createUserAndAddMember(to: otherTeam)
+
+        // self user and self team member
+        let selfTeamConversation1 = createConversation(in: uiMOC)
+        selfTeamConversation1.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser1]), role: nil)
+
+        // self user and self team member
+        let selfTeamConversation2 = createConversation(in: uiMOC)
+        selfTeamConversation2.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser2]), role: nil)
+
+        // self team members
+        let selfTeamConversation3 = createConversation(in: uiMOC)
+        selfTeamConversation3.addParticipantsAndUpdateConversationState(users: Set([selfTeamUser2, selfTeamUser3]), role: nil)
+
+        // self user and other team member
+        let otherTeamConversation = createConversation(in: uiMOC)
+        otherTeamConversation.addParticipantsAndUpdateConversationState(users: Set([selfUser, otherTeamUser]), role: nil)
+
+        // when
+        let knownTeamMembers = ZMUser.knownTeamMembers(in: uiMOC)
+
+        // then
+        XCTAssertEqual(knownTeamMembers, Set([selfUser, selfTeamUser1, selfTeamUser2]))
+    }
+
+    func testThatReturnsExpectedRecipientsForBroadcast() {
+        // given
+        _ = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
+        _ = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
+        _ = ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
+        _ = ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
+        _ = ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
+        _ = ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
+
+        let connectedUser1 = ZMUser.insert(in: uiMOC, name: "7", handle: "7", connectionStatus: .accepted)
+        let connectedUser2 = ZMUser.insert(in: uiMOC, name: "8", handle: nil, connectionStatus: .accepted)
+
+        let selfUserTeam = createTeam(in: uiMOC)
+        createMembership(in: uiMOC, user: selfUser, team: selfUserTeam)
+
+        let (selfTeamUser1, _) = createUserAndAddMember(to: selfUserTeam)
+        let (selfTeamUser2, _) = createUserAndAddMember(to: selfUserTeam)
+        let (selfTeamUser3, _) = createUserAndAddMember(to: selfUserTeam)
+
+        let otherTeam = createTeam(in: uiMOC)
+        let (otherTeamUser, _) = createUserAndAddMember(to: otherTeam)
+
+        // self user and self team member
+        let selfTeamConversation1 = createConversation(in: uiMOC)
+        selfTeamConversation1.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser1]), role: nil)
+
+        // self user and self team member
+        let selfTeamConversation2 = createConversation(in: uiMOC)
+        selfTeamConversation2.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser2]), role: nil)
+
+        // self team members
+        let selfTeamConversation3 = createConversation(in: uiMOC)
+        selfTeamConversation3.addParticipantsAndUpdateConversationState(users: Set([selfTeamUser2, selfTeamUser3]), role: nil)
+
+        // self user and other team member
+        let otherTeamConversation = createConversation(in: uiMOC)
+        otherTeamConversation.addParticipantsAndUpdateConversationState(users: Set([selfUser, otherTeamUser]), role: nil)
+
+        // when
+        let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 50)
+
+        // then
+        XCTAssertEqual(recipients, Set([selfUser, selfTeamUser1, selfTeamUser2, connectedUser1, connectedUser2]))
+    }
+
+    func testThatItReturnsRecipientsForBroadcastUpToAMaximumCount() {
+        // given
+        let connectedUser1 = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .accepted)
+        let connectedUser2 = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .accepted)
+        let connectedUser3 = ZMUser.insert(in: uiMOC, name: "3", handle: nil, connectionStatus: .accepted)
+
+        let selfUserTeam = createTeam(in: uiMOC)
+        createMembership(in: uiMOC, user: selfUser, team: selfUserTeam)
+
+        let (selfTeamUser1, _) = createUserAndAddMember(to: selfUserTeam)
+        let (selfTeamUser2, _) = createUserAndAddMember(to: selfUserTeam)
+
+        let allRecipients = [
+            selfUser!,
+            connectedUser1,
+            connectedUser2,
+            connectedUser3,
+            selfTeamUser1,
+            selfTeamUser2
+        ]
+
+        let conversation = createConversation(in: uiMOC)
+        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+
+        // when
+        let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)
+
+        // then
+        XCTAssertEqual(recipients.count, 3)
+    }
+
+    func testThatItPrioritiesTeamMembersOverConnectionsForBroadcast() {
+        // given
+        let connectedUser1 = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .accepted)
+        let connectedUser2 = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .accepted)
+        let connectedUser3 = ZMUser.insert(in: uiMOC, name: "3", handle: nil, connectionStatus: .accepted)
+
+        let selfUserTeam = createTeam(in: uiMOC)
+        createMembership(in: uiMOC, user: selfUser, team: selfUserTeam)
+
+        let (teamUser1, _) = createUserAndAddMember(to: selfUserTeam)
+        let (teamUser2, _) = createUserAndAddMember(to: selfUserTeam)
+
+        let allRecipients = [
+            selfUser!,
+            connectedUser1,
+            connectedUser2,
+            connectedUser3,
+            teamUser1,
+            teamUser2
+        ]
+
+        let conversation = createConversation(in: uiMOC)
+        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+
+        // when
+        let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)
+
+        // then
+        XCTAssertEqual(recipients, Set([selfUser, teamUser1, teamUser2]))
+    }
+
+    func testThatItRecipientsForBroadcastIsDeterministic() {
+        // given
+        let selfUserTeam = createTeam(in: uiMOC)
+        createMembership(in: uiMOC, user: selfUser, team: selfUserTeam)
+
+        let (teamUser1, _) = createUserAndAddMember(to: selfUserTeam)
+        let (teamUser2, _) = createUserAndAddMember(to: selfUserTeam)
+        let (teamUser3, _) = createUserAndAddMember(to: selfUserTeam)
+        let (teamUser4, _) = createUserAndAddMember(to: selfUserTeam)
+
+        let allRecipients = [
+            selfUser!,
+            teamUser1,
+            teamUser2,
+            teamUser3,
+            teamUser4
+        ]
+
+        let conversation = createConversation(in: uiMOC)
+        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+
+        // when
+        let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)
+
+        // then
+        let expectedRecipients = allRecipients.sorted {
+            $0.remoteIdentifier.transportString() < $1.remoteIdentifier.transportString()
+        }.prefix(3)
+
+        XCTAssertEqual(recipients, Set(expectedRecipients))
+    }
+
 }
 
 // MARK: - Bot support

--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -304,6 +304,8 @@ extension ZMUserTests {
 }
 
 extension ZMUser {
+
+    @discardableResult
     static func insert(in moc: NSManagedObjectContext, id: UUID = .create(), name: String, handle: String? = nil, connectionStatus: ZMConnectionStatus = .accepted) -> ZMUser {
         let user = ZMUser.insertNewObject(in: moc)
         user.remoteIdentifier = id
@@ -501,12 +503,12 @@ extension ZMUserTests {
 
     func testThatItReturnsAllConnections() {
         // given
-        _ = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
-        _ = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
-        _ = ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
-        _ = ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
-        _ = ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
-        _ = ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
+        ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
+        ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
+        ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
+        ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
+        ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
+        ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
 
         let connectedUser1 = ZMUser.insert(in: uiMOC, name: "7", handle: "7", connectionStatus: .accepted)
         let connectedUser2 = ZMUser.insert(in: uiMOC, name: "8", handle: nil, connectionStatus: .accepted)
@@ -536,21 +538,10 @@ extension ZMUserTests {
         let otherTeam = createTeam(in: uiMOC)
         let (otherTeamUser, _) = createUserAndAddMember(to: otherTeam)
 
-        // self user and self team member
-        let selfTeamConversation1 = createConversation(in: uiMOC)
-        selfTeamConversation1.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser1]), role: nil)
-
-        // self user and self team member
-        let selfTeamConversation2 = createConversation(in: uiMOC)
-        selfTeamConversation2.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser2]), role: nil)
-
-        // self team members
-        let selfTeamConversation3 = createConversation(in: uiMOC)
-        selfTeamConversation3.addParticipantsAndUpdateConversationState(users: Set([selfTeamUser2, selfTeamUser3]), role: nil)
-
-        // self user and other team member
-        let otherTeamConversation = createConversation(in: uiMOC)
-        otherTeamConversation.addParticipantsAndUpdateConversationState(users: Set([selfUser, otherTeamUser]), role: nil)
+        createConversation(in: uiMOC, with: [selfUser, selfTeamUser1])
+        createConversation(in: uiMOC, with: [selfUser, selfTeamUser2])
+        createConversation(in: uiMOC, with: [selfTeamUser2, selfTeamUser3])
+        createConversation(in: uiMOC, with: [selfUser, otherTeamUser])
 
         // when
         let knownTeamMembers = ZMUser.knownTeamMembers(in: uiMOC)
@@ -561,12 +552,12 @@ extension ZMUserTests {
 
     func testThatReturnsExpectedRecipientsForBroadcast() {
         // given
-        _ = ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
-        _ = ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
-        _ = ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
-        _ = ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
-        _ = ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
-        _ = ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
+        ZMUser.insert(in: uiMOC, name: "1", handle: "1", connectionStatus: .pending)
+        ZMUser.insert(in: uiMOC, name: "2", handle: "2", connectionStatus: .blocked)
+        ZMUser.insert(in: uiMOC, name: "3", handle: "3", connectionStatus: .cancelled)
+        ZMUser.insert(in: uiMOC, name: "4", handle: "4", connectionStatus: .ignored)
+        ZMUser.insert(in: uiMOC, name: "5", handle: "5", connectionStatus: .sent)
+        ZMUser.insert(in: uiMOC, name: "6", handle: "6", connectionStatus: .invalid)
 
         let connectedUser1 = ZMUser.insert(in: uiMOC, name: "7", handle: "7", connectionStatus: .accepted)
         let connectedUser2 = ZMUser.insert(in: uiMOC, name: "8", handle: nil, connectionStatus: .accepted)
@@ -581,21 +572,10 @@ extension ZMUserTests {
         let otherTeam = createTeam(in: uiMOC)
         let (otherTeamUser, _) = createUserAndAddMember(to: otherTeam)
 
-        // self user and self team member
-        let selfTeamConversation1 = createConversation(in: uiMOC)
-        selfTeamConversation1.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser1]), role: nil)
-
-        // self user and self team member
-        let selfTeamConversation2 = createConversation(in: uiMOC)
-        selfTeamConversation2.addParticipantsAndUpdateConversationState(users: Set([selfUser, selfTeamUser2]), role: nil)
-
-        // self team members
-        let selfTeamConversation3 = createConversation(in: uiMOC)
-        selfTeamConversation3.addParticipantsAndUpdateConversationState(users: Set([selfTeamUser2, selfTeamUser3]), role: nil)
-
-        // self user and other team member
-        let otherTeamConversation = createConversation(in: uiMOC)
-        otherTeamConversation.addParticipantsAndUpdateConversationState(users: Set([selfUser, otherTeamUser]), role: nil)
+        createConversation(in: uiMOC, with: [selfUser, selfTeamUser1])
+        createConversation(in: uiMOC, with: [selfUser, selfTeamUser2])
+        createConversation(in: uiMOC, with: [selfTeamUser2, selfTeamUser3])
+        createConversation(in: uiMOC, with: [selfUser, otherTeamUser])
 
         // when
         let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 50)
@@ -625,8 +605,7 @@ extension ZMUserTests {
             selfTeamUser2
         ]
 
-        let conversation = createConversation(in: uiMOC)
-        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+        createConversation(in: uiMOC, with: allRecipients)
 
         // when
         let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)
@@ -656,8 +635,7 @@ extension ZMUserTests {
             teamUser2
         ]
 
-        let conversation = createConversation(in: uiMOC)
-        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+        createConversation(in: uiMOC, with: allRecipients)
 
         // when
         let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)
@@ -684,8 +662,7 @@ extension ZMUserTests {
             teamUser4
         ]
 
-        let conversation = createConversation(in: uiMOC)
-        conversation.addParticipantsAndUpdateConversationState(users: Set(allRecipients), role: nil)
+        createConversation(in: uiMOC, with: allRecipients)
 
         // when
         let recipients = ZMUser.recipientsForBroadcast(in: uiMOC, maxCount: 3)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Broadcasting status messages to the entire team is not feasible for unbounded teams. Therefore we must limit the number of recipients who will receive status updates from a member.

### Solutions

Limit the recipients of a broadcast message to known team members and contacts. Known team members are members of the same team of the self user who participate in at least one conversation with the self user. 

Additionally, we limit the maximum number of recipients. We prioritize team member recipients over contacts. This means we take as many known team members as possible, and include any contacts until we meet the specified maximum.

Finally, the return recipients is deterministically calculated. This is means that for any given state of the database, repeated calculations for the recipients will always return the same set. This is achieved by sorting candidate recipients by their remote identifier before filling up the recipient list.