### PR TITLE
[Fix] Guarantee self user recipient

### DIFF
--- a/Tests/Source/Model/User/ZMUserTests.swift
+++ b/Tests/Source/Model/User/ZMUserTests.swift
@@ -547,7 +547,7 @@ extension ZMUserTests {
         let knownTeamMembers = ZMUser.knownTeamMembers(in: uiMOC)
 
         // then
-        XCTAssertEqual(knownTeamMembers, Set([selfUser, selfTeamUser1, selfTeamUser2]))
+        XCTAssertEqual(knownTeamMembers, Set([selfTeamUser1, selfTeamUser2]))
     }
 
     func testThatReturnsExpectedRecipientsForBroadcast() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When calculating the recipients of a broadcast message, it could happen that the self user is not included as a recipient.

### Causes

The recipient list is determined as follows: 

1. A maximum number of free slots is allocated. 
2. Find all known team members, sort by their id, take as many as possible.
3. If there are still free slots available, repeat step 2 for connected users.

Currently, the self user is considered to be a known team member. If there are more free slots than known team members, then the self user will be a recipient. 

However, if there are more known team members than free slots, it is possible that the self user is not included because their sorted position at the *nth* index, where *n* is greater than the number of available free slots.

### Solutions

1. Add the self user as the first recipient.
2. Exclude the self user from the set of known team members

### Attachments

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-12883
