### PR TITLE
[Refactor] Add support of External for GenericMessage

### DIFF
--- a/Source/Model/Message/GenericMessage+External.swift
+++ b/Source/Model/Message/GenericMessage+External.swift
@@ -1,0 +1,52 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+private let zmLog = ZMSLog(tag: "GenericMessage")
+
+extension GenericMessage {
+    static func encryptedDataWithKeys(from message: GenericMessage) -> ZMExternalEncryptedDataWithKeys? {
+        guard
+            let aesKey = NSData.randomEncryptionKey(),
+            let messageData = try? message.serializedData()
+            else {
+                return nil
+        }
+        let encryptedData = messageData.zmEncryptPrefixingPlainTextIV(key: aesKey)
+        let keys = ZMEncryptionKeyWithChecksum.key(withAES: aesKey, digest: encryptedData.zmSHA256Digest())
+        return ZMExternalEncryptedDataWithKeys(data: encryptedData, keys: keys)
+    }
+    
+    init?(from updateEvent: ZMUpdateEvent, withExternal external: External) {
+        guard let externalDataString = updateEvent.payload.optionalString(forKey: "external") else { return nil }
+        let externalData = Data(base64Encoded: externalDataString)
+        let externalSha256 = externalData?.zmSHA256Digest()
+        
+        guard externalSha256 == external.sha256 else {
+            zmLog.error("Invalid hash for external data: \(externalSha256 ?? Data()) != \(external.sha256), updateEvent: \(updateEvent)")
+            return nil
+        }
+        
+        let decryptedData = externalData?.zmDecryptPrefixedPlainTextIV(key: external.otrKey)
+        guard let message = GenericMessage(withBase64String: decryptedData?.base64String()) else {
+            return nil
+        }
+        self = message
+    }
+}

--- a/Source/Model/Message/ZMGenericMessage+External.h
+++ b/Source/Model/Message/ZMGenericMessage+External.h
@@ -27,6 +27,8 @@
 /// SHA-256 digest
 @property (nonatomic, readonly) NSData *sha256;
 
++ (ZMEncryptionKeyWithChecksum *)keyWithAES:(NSData *)aesKey digest:(NSData *)sha256;
+
 @end
 
 
@@ -36,6 +38,8 @@
 @property (nonatomic, readonly) NSData *data;
 /// The AES Key used to encrypt @c data and the sha-256 digest of @c data
 @property (nonatomic, readonly) ZMEncryptionKeyWithChecksum *keys;
+
++ (ZMExternalEncryptedDataWithKeys *)dataWithKeysWithData:(NSData *)data keys:(ZMEncryptionKeyWithChecksum *)keys;
 
 @end
 

--- a/Source/Utilis/Dictionary+ObjectForKey.swift
+++ b/Source/Utilis/Dictionary+ObjectForKey.swift
@@ -1,0 +1,23 @@
+//
+//  Dictionary+ObjectForKey.swift
+//  WireDataModel
+//
+//  Created by David Henner on 03.04.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation
+
+public extension Dictionary {
+    func string(forKey key: String) -> String? {
+        return (self as NSDictionary).string(forKey: key)
+    }
+    
+    func optionalString(forKey key: String) -> String? {
+        return (self as NSDictionary).optionalString(forKey: key)
+    }
+    
+    func dictionary(forKey key: String) -> [String: AnyObject]? {
+        return (self as NSDictionary).dictionary(forKey: key)
+    }
+}

--- a/Source/Utilis/Dictionary+ObjectForKey.swift
+++ b/Source/Utilis/Dictionary+ObjectForKey.swift
@@ -1,9 +1,19 @@
 //
-//  Dictionary+ObjectForKey.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
 //
-//  Created by David Henner on 03.04.20.
-//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Tests/Source/Model/Messages/GenericMessageTests+External.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests+External.swift
@@ -1,0 +1,83 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@testable import WireDataModel
+
+class GenericMessageTests_External: XCTestCase {
+    var sut: GenericMessage!
+    
+    override func setUp() {
+        super.setUp()
+        let text = Text.with() {
+            $0.content = "She sells sea shells"
+        }
+        
+        sut = GenericMessage.with() {
+            $0.text = text
+            $0.messageID = NSUUID.create()!.transportString()
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+    
+    func testThatItEncryptsTheMessageAndReturnsTheCorrectKeyAndDigest() {
+        // given / when
+        let dataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        XCTAssertNotNil(dataWithKeys)
+        
+        let keysWithDigest = dataWithKeys!.keys
+        let data = dataWithKeys!.data
+        
+        // then
+        XCTAssertEqual(data?.zmSHA256Digest(), keysWithDigest?.sha256)
+        XCTAssertEqual(data?.zmDecryptPrefixedPlainTextIV(key: keysWithDigest!.aesKey), try? sut.serializedData())
+    }
+    
+    func testThatItUsesADifferentKeyForEachCall() {
+        // given / when
+        let firstDataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        let secondDataWithKeys = GenericMessage.encryptedDataWithKeys(from: sut)
+        XCTAssertNotNil(firstDataWithKeys)
+        XCTAssertNotNil(secondDataWithKeys)
+        let firstEncrypted = firstDataWithKeys?.data.zmDecryptPrefixedPlainTextIV(key: firstDataWithKeys!.keys.aesKey)
+        let secondEncrypted = secondDataWithKeys?.data.zmDecryptPrefixedPlainTextIV(key: secondDataWithKeys!.keys.aesKey)
+        
+        // then
+        XCTAssertNotEqual(firstDataWithKeys?.keys.aesKey, secondDataWithKeys?.keys.aesKey)
+        XCTAssertNotEqual(firstDataWithKeys, secondDataWithKeys)
+        XCTAssertEqual(firstEncrypted, try? sut.serializedData())
+        XCTAssertEqual(secondEncrypted, try? sut.serializedData())
+    }
+    
+    func testThatDifferentKeysAreNotConsideredEqual() {
+        // given / when
+        let firstKeys = GenericMessage.encryptedDataWithKeys(from: sut)?.keys
+        let secondKeys = GenericMessage.encryptedDataWithKeys(from: sut)?.keys
+        
+        // then
+        XCTAssertFalse(firstKeys?.aesKey == secondKeys?.aesKey)
+        XCTAssertFalse(firstKeys?.sha256 == secondKeys?.sha256)
+        XCTAssertEqual(firstKeys, firstKeys)
+        XCTAssertNotEqual(firstKeys, secondKeys)
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -186,6 +186,9 @@
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
 		63340BBD241C2BC5004ED87C /* store2-80-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 63340BBC241C2BC5004ED87C /* store2-80-0.wiredatabase */; };
+		63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D992434D04D006B6018 /* GenericMessage+External.swift */; };
+		63298D9C24374094006B6018 /* GenericMessageTests+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D9B24374094006B6018 /* GenericMessageTests+External.swift */; };
+		63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */; };
 		6334B516238BDA84000470F0 /* UserAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */; };
 		63370CBB242CB84A0072C37F /* CompositeMessageItemContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */; };
 		63370CBD242CBA0A0072C37F /* CompositeMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */; };
@@ -810,6 +813,9 @@
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
 		63340BBC241C2BC5004ED87C /* store2-80-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-80-0.wiredatabase"; sourceTree = "<group>"; };
+		63298D992434D04D006B6018 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
+		63298D9B24374094006B6018 /* GenericMessageTests+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessageTests+External.swift"; sourceTree = "<group>"; };
+		63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+ObjectForKey.swift"; sourceTree = "<group>"; };
 		6334B515238BDA84000470F0 /* UserAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvailabilityTests.swift; sourceTree = "<group>"; };
 		63370CBA242CB84A0072C37F /* CompositeMessageItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContent.swift; sourceTree = "<group>"; };
 		63370CBC242CBA0A0072C37F /* CompositeMessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageData.swift; sourceTree = "<group>"; };
@@ -1746,6 +1752,7 @@
 				BFD2E7981CBE796600BF195A /* ZMGenericMessage+UpdateEvent.m */,
 				F9A705F81CAEE01D00C2F5FE /* ZMGenericMessage+External.h */,
 				F9A705F91CAEE01D00C2F5FE /* ZMGenericMessage+External.m */,
+				63298D992434D04D006B6018 /* GenericMessage+External.swift */,
 				168913DB2085066800F1E98A /* ZMGenericMessage+Debug.swift */,
 				F9A705FC1CAEE01D00C2F5FE /* ZMGenericMessageData.h */,
 				F9A705FD1CAEE01D00C2F5FE /* ZMGenericMessageData.m */,
@@ -1905,6 +1912,7 @@
 				5EFE9C072126BF9D007932A6 /* ZMPropertyNormalizationResult.h */,
 				5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */,
 				5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */,
+				63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */,
 			);
 			name = Utilis;
 			path = Source/Utilis;
@@ -2117,6 +2125,7 @@
 				F96470091D5B5E9D00A81A92 /* ZMClientMessageTests+Editing.m */,
 				87630A051F8FAB6700EEAE11 /* ZMGenericMessageTests.swift */,
 				63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */,
+				63298D9B24374094006B6018 /* GenericMessageTests+External.swift */,
 				BFCF31DA1DA50C650039B3DC /* ZMGenericMessageTests+NativePush.swift */,
 				BF794FE41D14425E00E618C6 /* ZMClientMessageTests+Location.swift */,
 				1651F9BD1D3554C800A9FAE8 /* ZMClientMessageTests+TextMessage.swift */,
@@ -2882,6 +2891,7 @@
 				54FB03A11E41E273000E13DC /* PersistedDataPatches.swift in Sources */,
 				63CA8215240812620073426A /* ZMClientMessage+Composite.swift in Sources */,
 				F9A706A91CAEE01D00C2F5FE /* StringKeyPath.swift in Sources */,
+				63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */,
 				A90676EA238EB05F006417AC /* Action.swift in Sources */,
 				16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */,
 				BF421B2D1EF3F91D0079533A /* Team+Patches.swift in Sources */,
@@ -2897,6 +2907,7 @@
 				BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */,
 				1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */,
 				16626506217F0DA900300F45 /* ZMGenericMessage+Hashing.swift in Sources */,
+				63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */,
 				BF3493F21EC3623200B0C314 /* ZMUser+Teams.swift in Sources */,
 				541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */,
 				165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */,
@@ -3001,6 +3012,7 @@
 			files = (
 				F920AE171E38C547001BC14F /* NotificationObservers.swift in Sources */,
 				F93265291D89648B0076AAD6 /* ZMAssetClientMessageTests.swift in Sources */,
+				63298D9C24374094006B6018 /* GenericMessageTests+External.swift in Sources */,
 				1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */,
 				F19550392040628400338E91 /* ZMUpdateEvent+Helper.swift in Sources */,
 				F9B71F9C1CB2BF18001DB03F /* ZMCallStateTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Add support to init `GenericMessage` with `ZMUpdateEvent` and `External`