### PR TITLE
[Fix] Memberships not being downloaded

### DIFF
--- a/Source/Model/Conversation/Member.swift
+++ b/Source/Model/Conversation/Member.swift
@@ -72,6 +72,7 @@
         member.team = team
         member.user = user
         member.remoteIdentifier = user.remoteIdentifier
+        member.needsToBeUpdatedFromBackend = true
         return member
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are are creating memberships when discovering team members but they are not fetched from the backend.

### Causes

`needsToBeUpdatedFromBackend` is `false`

### Solutions

Set `needsToBeUpdatedFromBackend` to true when inserting a new membership.
