### PR TITLE
[Feature] Support for team users in ZMSearchUser

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
@@ -35,6 +35,7 @@ import WireUtilities
         self.searchContext = ManagedObjectContextDirectory.createSearchManagedObjectContext(persistentStoreCoordinator: persistentStoreCoordinator, dispatchGroup: dispatchGroup)
         MemoryReferenceDebugger.register(self.searchContext)
         super.init()
+        configureManagedObjectContextReferences()
     }
     
     /// User interface context. It can be used only from the main queue
@@ -55,6 +56,20 @@ import WireUtilities
 }
 
 extension ManagedObjectContextDirectory {
+    
+    func configureManagedObjectContextReferences() {
+        uiContext.performAndWait {
+            uiContext.zm_sync = syncContext
+        }
+        syncContext.performAndWait {
+            syncContext.zm_userInterface = uiContext
+        }
+    }
+    
+}
+
+extension ManagedObjectContextDirectory {
+    
     func tearDown() {
         // this will set all contextes to nil
         // making it crash if used after tearDown
@@ -129,6 +144,7 @@ extension ManagedObjectContextDirectory {
         }
         return moc
     }
+    
 }
 
 extension NSManagedObjectContext {

--- a/Source/Model/Conversation/ConversationCreationOptions.swift
+++ b/Source/Model/Conversation/ConversationCreationOptions.swift
@@ -35,7 +35,7 @@ public struct ConversationCreationOptions {
 public extension ZMManagedObjectContextProvider {
     func insertGroup(with options: ConversationCreationOptions) -> ZMConversation {
         return ZMConversation.insertGroupConversation(session: self,
-                                               participants: options.participants,
+                                               participants: options.participants.materialize(in: managedObjectContext),
                                                name: options.name,
                                                team: options.team,
                                                allowGuests: options.allowGuests,

--- a/Source/Model/Conversation/ConversationCreationOptions.swift
+++ b/Source/Model/Conversation/ConversationCreationOptions.swift
@@ -35,7 +35,7 @@ public struct ConversationCreationOptions {
 public extension ZMManagedObjectContextProvider {
     func insertGroup(with options: ConversationCreationOptions) -> ZMConversation {
         return ZMConversation.insertGroupConversation(session: self,
-                                               participants: options.participants.materialize(in: managedObjectContext),
+                                               participants: options.participants,
                                                name: options.name,
                                                team: options.team,
                                                allowGuests: options.allowGuests,

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -32,7 +32,7 @@ extension ZMConversation {
 
     @objc
     static public func insertGroupConversation(session: ZMManagedObjectContextProvider,
-                                               participants: [ZMUser],
+                                               participants: [UserType],
                                                name: String? = nil,
                                                team: Team? = nil,
                                                allowGuests: Bool = true,
@@ -40,7 +40,7 @@ extension ZMConversation {
                                                participantsRole: Role? = nil) -> ZMConversation?
     {
         return self.insertGroupConversation(moc: session.managedObjectContext!,
-                                            participants: participants,
+                                            participants: participants.materialize(in: session.managedObjectContext),
                                             name: name,
                                             team: team,
                                             allowGuests: allowGuests,

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -23,7 +23,7 @@ extension ZMConversation {
     
     @objc(insertGroupConversationIntoManagedObjectContext:withParticipants:)
     static public func insertGroupConversation(moc: NSManagedObjectContext,
-                                               participants: [UserType]) -> ZMConversation?
+                                               participants: [ZMUser]) -> ZMConversation?
     {
         return self.insertGroupConversation(moc: moc, participants: participants, name: nil)
     }
@@ -32,7 +32,7 @@ extension ZMConversation {
 
     @objc
     static public func insertGroupConversation(session: ZMManagedObjectContextProvider,
-                                               participants: [UserType],
+                                               participants: [ZMUser],
                                                name: String? = nil,
                                                team: Team? = nil,
                                                allowGuests: Bool = true,
@@ -50,7 +50,7 @@ extension ZMConversation {
     
     @objc
     static public func insertGroupConversation(moc: NSManagedObjectContext,
-                                               participants: [UserType],
+                                               participants: [ZMUser],
                                                name: String? = nil,
                                                team: Team? = nil,
                                                allowGuests: Bool = true,
@@ -81,7 +81,7 @@ extension ZMConversation {
     /// - Returns: the created conversation, nullable
 
     static public func insertGroupConversation(moc: NSManagedObjectContext,
-                                               participants: [UserType],
+                                               participants: [ZMUser],
                                                name: String? = nil,
                                                team: Team? = nil,
                                                allowGuests: Bool = true,
@@ -89,7 +89,6 @@ extension ZMConversation {
                                                participantsRole: Role? = nil,
                                                type: ZMConversationType = .group) -> ZMConversation?
     {        
-        let participants = participants.materialize(in: moc)
         let selfUser = ZMUser.selfUser(in: moc)
 
         if (team != nil && !selfUser.canCreateConversation(type: type)) {

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -66,7 +66,7 @@ extension ZMConversation {
                                        participantsRole: participantsRole,
                                        type: .group)
     }
-    
+        
     /// insert a conversation with group type
     ///
     /// - Parameters:
@@ -88,9 +88,8 @@ extension ZMConversation {
                                                readReceipts: Bool = false,
                                                participantsRole: Role? = nil,
                                                type: ZMConversationType = .group) -> ZMConversation?
-    {
-        guard let participants = participants as? [ZMUser] else { return nil }
-
+    {        
+        let participants = participants.materialize(in: moc)
         let selfUser = ZMUser.selfUser(in: moc)
 
         if (team != nil && !selfUser.canCreateConversation(type: type)) {

--- a/Source/Model/User/UserType+Materialize.swift
+++ b/Source/Model/User/UserType+Materialize.swift
@@ -1,0 +1,62 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+fileprivate extension UserType {
+    
+    func materialize(in context: NSManagedObjectContext) -> ZMUser? {
+        if let user = self as? ZMUser {
+            return user
+        } else if let searchUser = self as? ZMSearchUser {
+            if let user = searchUser.user {
+                return user
+            } else if let remoteIdentifier = searchUser.remoteIdentifier {
+                return ZMUser(remoteID: remoteIdentifier, createIfNeeded: false, in: context)
+            }
+        }
+        
+        return nil
+    }
+    
+}
+
+extension Sequence where Element: UserType {
+    
+    /// Materialize a sequence of UserType into concrete ZMUser instances.
+    ///
+    /// - parameter context: NSManagedObjectContext on which users should be created.
+    ///
+    /// - Returns: List of concrete users which could be materialized.
+    
+    func materialize(in context: NSManagedObjectContext) -> [ZMUser] {
+        let nonExistingUsers = self.compactMap({ $0 as? ZMSearchUser }).filter({ $0.user == nil })
+        let syncContext = context.zm_sync!
+        
+        syncContext.performGroupedBlockAndWait {
+            nonExistingUsers.forEach { _ = ZMUser(remoteID: $0.remoteIdentifier!, // TODO jacob make remoteIdentifier non optional
+                                                  createIfNeeded: true,
+                                                  in: syncContext)
+            }
+            syncContext.saveOrRollback()
+        }
+        
+        return self.compactMap({ $0.materialize(in: context) })
+    }
+    
+}

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -243,7 +243,11 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     }
 
     public var oneToOneConversation: ZMConversation? {
-        return user?.oneToOneConversation
+        if isTeamMember, let uiContext = contextProvider?.managedObjectContext {
+            return materialize(in: uiContext)?.oneToOneConversation
+        } else {
+            return user?.oneToOneConversation
+        }
     }
 
     public var isBlocked: Bool {

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -427,7 +427,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
                 handle: String?,
                 accentColor: ZMAccentColor,
                 remoteIdentifier: UUID?,
-                teamIdentifier: UUID?,
+                teamIdentifier: UUID? = nil,
                 user existingUser: ZMUser? = nil,
                 contact: ZMAddressBookContact? = nil) {
                 

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -410,9 +410,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         guard let uuidString = payload["id"] as? String,
             let remoteIdentifier = UUID(uuidString: uuidString),
             let managedObjectContext = contextProvider.managedObjectContext else { return nil }
-        
-        print("search user from payload:", payload)
-        
+                
         let localUser = ZMUser(remoteID: remoteIdentifier, createIfNeeded: false, in: managedObjectContext)
         
         if let searchUser = managedObjectContext.zm_searchUserCache?.object(forKey: remoteIdentifier as NSUUID) {

--- a/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
+++ b/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
@@ -45,6 +45,7 @@ extension ZMBaseManagedObjectTest {
         let member = Member.insertNewObject(in: moc)
         member.user = user
         member.team = team
+        member.user?.teamIdentifier = team.remoteIdentifier
         return member
     }
 

--- a/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
+++ b/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
@@ -63,5 +63,37 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         XCTAssertFalse(searchUser.isTeamMember)
         XCTAssertFalse(searchUser.isConnected)
     }
+    
+    func testThatOneToOneConversationIsCreated_WhenBelongingToTheSameTeam() {
+        // given
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let searchUser = ZMSearchUser(contextProvider: self,
+                                      name: "Foo",
+                                      handle: "foo",
+                                      accentColor: .brightOrange,
+                                      remoteIdentifier: UUID(),
+                                      teamIdentifier: team.remoteIdentifier)
+        uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertNotNil(searchUser.oneToOneConversation)
+    }
+    
+    func testThatOneToOneConversationIsNotCreated_WhenNotBelongingToTheSameTeam() {
+        // given
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let searchUser = ZMSearchUser(contextProvider: self,
+                                      name: "Foo",
+                                      handle: "foo",
+                                      accentColor: .brightOrange,
+                                      remoteIdentifier: UUID(),
+                                      teamIdentifier: UUID())
+        uiMOC.saveOrRollback()
+        
+        // then
+        XCTAssertNil(searchUser.oneToOneConversation)
+    }
         
 }

--- a/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
+++ b/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMSearchUserTests_TeamUser: ZMManagedObjectContextProvider {
+    
+    var managedObjectContext: NSManagedObjectContext! {
+        return uiMOC
+    }
+    
+    var syncManagedObjectContext: NSManagedObjectContext! {
+        return syncMOC
+    }
+    
+}
+
+class ZMSearchUserTests_TeamUser: ModelObjectsTests {
+    
+    func testThatSearchUserIsRecognizedAsTeamMember_WhenBelongingToTheSameTeam() {
+        // given
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let searchUser = ZMSearchUser(contextProvider: self,
+                                      name: "Foo",
+                                      handle: "foo",
+                                      accentColor: .brightOrange,
+                                      remoteIdentifier: UUID(),
+                                      teamIdentifier: team.remoteIdentifier)
+        
+        // then
+        XCTAssertTrue(searchUser.isTeamMember)
+        XCTAssertTrue(searchUser.isConnected)
+    }
+    
+    func testThatSearchUserIsNotRecognizedAsTeamMember_WhenNotBelongingToTheSameTeam() {
+        // given
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let searchUser = ZMSearchUser(contextProvider: self,
+                                      name: "Foo",
+                                      handle: "foo",
+                                      accentColor: .brightOrange,
+                                      remoteIdentifier: UUID(),
+                                      teamIdentifier: UUID())
+        
+        // then
+        XCTAssertFalse(searchUser.isTeamMember)
+        XCTAssertFalse(searchUser.isConnected)
+    }
+        
+}

--- a/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -67,6 +67,7 @@
                                                                  handle:@"a"
                                                             accentColor:ZMAccentColorStrongLimeGreen
                                                        remoteIdentifier:remoteIDA
+                                                         teamIdentifier:nil
                                                                    user:nil
                                                                 contact:nil];
     
@@ -77,6 +78,7 @@
                                                                  handle:@"b"
                                                             accentColor:ZMAccentColorSoftPink
                                                        remoteIdentifier:remoteIDA
+                                                         teamIdentifier:nil
                                                                    user:nil
                                                                 contact:nil];
     
@@ -89,6 +91,7 @@
                                                                  handle:@"b"
                                                             accentColor:ZMAccentColorStrongLimeGreen
                                                        remoteIdentifier:remoteIDB
+                                                         teamIdentifier:nil
                                                                    user:nil
                                                                 contact:nil];
     
@@ -131,6 +134,7 @@
                                                                       handle:handle
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:remoteID
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
 
@@ -168,6 +172,7 @@
                                                                       handle:@"not_my_handle"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:[NSUUID createUUID]
+                                                              teamIdentifier:nil
                                                                         user:user
                                                                      contact:nil];
 
@@ -195,6 +200,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:NSUUID.createUUID
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
     
@@ -223,6 +229,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:nil
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
     
@@ -248,6 +255,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:NSUUID.createUUID
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
     NSString *connectionMessage = @"very unique connection message";
@@ -269,6 +277,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:NSUUID.createUUID
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
 
@@ -286,6 +295,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorStrongLimeGreen
                                                             remoteIdentifier:nil
+                                                              teamIdentifier:nil
                                                                         user:nil
                                                                      contact:nil];
     
@@ -308,6 +318,7 @@
                                                                       handle:@""
                                                                  accentColor:ZMAccentColorUndefined
                                                             remoteIdentifier:nil
+                                                              teamIdentifier:nil
                                                                         user:user
                                                                      contact:nil];
     
@@ -345,6 +356,7 @@
                                                                       handle:@"hans"
                                                                  accentColor:ZMAccentColorUndefined
                                                             remoteIdentifier:[NSUUID createUUID]
+                                                              teamIdentifier:nil
                                                                         user:user
                                                                      contact:nil];
     

--- a/Tests/Source/Model/UserTypeTests+Materialize.swift
+++ b/Tests/Source/Model/UserTypeTests+Materialize.swift
@@ -1,0 +1,95 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+extension UserTypeTests_Materialize: ZMManagedObjectContextProvider {
+    
+    var managedObjectContext: NSManagedObjectContext! {
+        return uiMOC
+    }
+    
+    var syncManagedObjectContext: NSManagedObjectContext! {
+        return syncMOC
+    }
+    
+}
+
+class UserTypeTests_Materialize: ModelObjectsTests {
+    
+    func testThatWeCanMaterializeSearchUsers() {
+        // given
+        let userIDs = [UUID(), UUID(), UUID()]
+        let searchUsers = userIDs.map({ createSearchUser(name: "John Doe", remoteIdentifier: $0) }) as [UserType]
+        
+        // when
+        let materializedUsers = searchUsers.materialize(in: uiMOC)
+        
+        // then
+        XCTAssertEqual(materializedUsers.count, 3)
+        XCTAssertEqual(materializedUsers.map(\.remoteIdentifier), userIDs)
+    }
+    
+    func testThatSearchUserWithoutRemoteIdentifierIsIgnored() {
+        // given
+        let userIDs = [UUID(), UUID(), UUID()]
+        let incompleteSearchUser = ZMSearchUser(contextProvider: self,
+                                                name: "Incomplete",
+                                                handle: "incomplete",
+                                                accentColor: .brightOrange,
+                                                remoteIdentifier: nil)
+        var searchUsers = userIDs.map({ createSearchUser(name: "John Doe", remoteIdentifier: $0) }) as [UserType]
+        searchUsers.append(incompleteSearchUser)
+        
+        // when
+        let materializedUsers = searchUsers.materialize(in: uiMOC)
+        
+        // then
+        XCTAssertEqual(materializedUsers.count, 3)
+        XCTAssertEqual(materializedUsers.map(\.remoteIdentifier), userIDs)
+    }
+    
+    func testThatAlreadyMaterializedUsersAreUntouched() {
+        // given
+        let userIDs = [UUID(), UUID(), UUID()]
+        let concreteUsers = userIDs.map({
+            let user = ZMUser.insertNewObject(in: uiMOC)
+            user.remoteIdentifier = $0
+            return user
+        }) as [ZMUser]
+        
+        // when
+        let materializedUsers = (concreteUsers as [UserType]).materialize(in: uiMOC)
+        
+        // then
+        XCTAssertEqual(materializedUsers, concreteUsers)
+    }
+    
+    
+    // MARK: - Helpers
+    
+    func createSearchUser(name: String, remoteIdentifier: UUID = UUID()) -> ZMSearchUser {
+        return ZMSearchUser(contextProvider: self,
+                            name: name.capitalized,
+                            handle: name.lowercased(),
+                            accentColor: .brightOrange,
+                            remoteIdentifier: remoteIdentifier)
+    }
+    
+}

--- a/Tests/Source/Model/UserTypeTests+Materialize.swift
+++ b/Tests/Source/Model/UserTypeTests+Materialize.swift
@@ -46,6 +46,24 @@ class UserTypeTests_Materialize: ModelObjectsTests {
         XCTAssertEqual(materializedUsers.map(\.remoteIdentifier), userIDs)
     }
     
+    func testThatMaterializedTeamUserHasMembership_WhenBelongingToTheSameTeam() {
+        // given
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let teamSearchUser = ZMSearchUser(contextProvider: self,
+                                                name: "Team",
+                                                handle: "team",
+                                                accentColor: .brightOrange,
+                                                remoteIdentifier: UUID(),
+                                                teamIdentifier: team.remoteIdentifier)
+        
+        // when
+        let materializedUser = teamSearchUser.materialize(in: uiMOC)!
+        
+        // then
+        XCTAssertTrue(materializedUser.isTeamMember)
+    }
+    
     func testThatSearchUserWithoutRemoteIdentifierIsIgnored() {
         // given
         let userIDs = [UUID(), UUID(), UUID()]

--- a/Tests/Source/Model/UserTypeTests+Materialize.swift
+++ b/Tests/Source/Model/UserTypeTests+Materialize.swift
@@ -56,6 +56,7 @@ class UserTypeTests_Materialize: ModelObjectsTests {
                                                 accentColor: .brightOrange,
                                                 remoteIdentifier: UUID(),
                                                 teamIdentifier: team.remoteIdentifier)
+        uiMOC.saveOrRollback()
         
         // when
         let materializedUser = teamSearchUser.materialize(in: uiMOC)!

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		16030DB021AD765D00F8032E /* ZMConversation+Confirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DAF21AD765D00F8032E /* ZMConversation+Confirmations.swift */; };
 		16030DBE21AE8FAB00F8032E /* ZMConversationTests+Confirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DBD21AE8FAB00F8032E /* ZMConversationTests+Confirmations.swift */; };
 		16030DC521AEE25500F8032E /* ZMOTRMessage+Confirmations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DC421AEE25500F8032E /* ZMOTRMessage+Confirmations.swift */; };
+		1607AAF2243768D200A93D29 /* UserType+Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607AAF1243768D200A93D29 /* UserType+Materialize.swift */; };
 		1611CF59203AE6A0004D807B /* FileAssetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EDE6811CBBF6260044A17E /* FileAssetCacheTests.swift */; };
 		16127CF3220058160020E65C /* InvalidConversationRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16127CF2220058160020E65C /* InvalidConversationRemoval.swift */; };
 		16127CF522005AAB0020E65C /* InvalidConversationRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16127CF422005AAA0020E65C /* InvalidConversationRemovalTests.swift */; };
@@ -620,6 +621,7 @@
 		16030DAF21AD765D00F8032E /* ZMConversation+Confirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Confirmations.swift"; sourceTree = "<group>"; };
 		16030DBD21AE8FAB00F8032E /* ZMConversationTests+Confirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Confirmations.swift"; sourceTree = "<group>"; };
 		16030DC421AEE25500F8032E /* ZMOTRMessage+Confirmations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Confirmations.swift"; sourceTree = "<group>"; };
+		1607AAF1243768D200A93D29 /* UserType+Materialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Materialize.swift"; sourceTree = "<group>"; };
 		16127CF2220058160020E65C /* InvalidConversationRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidConversationRemoval.swift; sourceTree = "<group>"; };
 		16127CF422005AAA0020E65C /* InvalidConversationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidConversationRemovalTests.swift; sourceTree = "<group>"; };
 		161541B91E27EBD400AC2FFB /* ZMConversation+Calling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Calling.swift"; sourceTree = "<group>"; };
@@ -1759,6 +1761,7 @@
 			children = (
 				1687ABAB20EBE0770007C240 /* UserType.swift */,
 				EEF4010623A9213B007B1A97 /* UserType+Team.swift */,
+				1607AAF1243768D200A93D29 /* UserType+Materialize.swift */,
 				EF2CBDA620061E2D0004F65E /* ServiceUser.swift */,
 				F9331C751CB4165100139ECC /* NSString+ZMPersonName.h */,
 				F9331C761CB4165100139ECC /* NSString+ZMPersonName.m */,
@@ -2773,6 +2776,7 @@
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
 				55C40BCE22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift in Sources */,
 				5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */,
+				1607AAF2243768D200A93D29 /* UserType+Materialize.swift in Sources */,
 				164EB6F3230D987A001BBD4A /* ZMMessage+DataRetention.swift in Sources */,
 				A90D62C823A159B600F680CC /* ZMConversation+Transport.swift in Sources */,
 				F9A706941CAEE01D00C2F5FE /* UserClient+Protobuf.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1637729C22B3F1F700510B7B /* store2-74-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 1637729B22B3F1F700510B7B /* store2-74-0.wiredatabase */; };
 		1639A8132260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */; };
 		1639A8512264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */; };
+		1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */; };
 		16460A44206515370096B616 /* NSManagedObjectContext+BackupImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */; };
 		16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A45206544B00096B616 /* PersistentMetadataKeys.swift */; };
 		1646D5BB234FA6B500E60F1E /* store2-77-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 1646D5BA234FA6B400E60F1E /* store2-77-0.wiredatabase */; };
@@ -637,6 +638,7 @@
 		1637729B22B3F1F700510B7B /* store2-74-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-74-0.wiredatabase"; sourceTree = "<group>"; };
 		1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertAvailabilityBehaviourChange.swift; sourceTree = "<group>"; };
 		1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityBehaviourChangeTests.swift; sourceTree = "<group>"; };
+		1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+TeamUser.swift"; sourceTree = "<group>"; };
 		16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+BackupImport.swift"; sourceTree = "<group>"; };
 		16460A45206544B00096B616 /* PersistentMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMetadataKeys.swift; sourceTree = "<group>"; };
 		1646D5B9234FA56B00E60F1E /* zmessaging2.77.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.77.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2131,6 +2133,7 @@
 			children = (
 				F991CE181CB55E95004D8465 /* ZMSearchUserTests.m */,
 				164A55D220F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift */,
+				1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */,
 				872A2E891FFD2FBF00900B22 /* ZMSearchUserPayloadParsingTests.swift */,
 				F9B71F631CB2BC85001DB03F /* UserImageLocalCacheTests.swift */,
 				F9B71F661CB2BC85001DB03F /* ZMPersonNameTests.m */,
@@ -3050,6 +3053,7 @@
 				F9AB395B1CB3AED900A7254F /* BaseTestSwiftHelpers.swift in Sources */,
 				A923D77E239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift in Sources */,
 				F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */,
+				1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,
 				F9A7083E1CAEEB7500C2F5FE /* NSFetchRequestTests+ZMRelationshipKeyPaths.m in Sources */,
 				D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		1639A8132260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */; };
 		1639A8512264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */; };
 		1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */; };
+		1645ECC4243B69A1007A82D6 /* UserTypeTests+Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECC3243B69A1007A82D6 /* UserTypeTests+Materialize.swift */; };
 		16460A44206515370096B616 /* NSManagedObjectContext+BackupImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */; };
 		16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16460A45206544B00096B616 /* PersistentMetadataKeys.swift */; };
 		1646D5BB234FA6B500E60F1E /* store2-77-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 1646D5BA234FA6B400E60F1E /* store2-77-0.wiredatabase */; };
@@ -639,6 +640,7 @@
 		1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertAvailabilityBehaviourChange.swift; sourceTree = "<group>"; };
 		1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityBehaviourChangeTests.swift; sourceTree = "<group>"; };
 		1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+TeamUser.swift"; sourceTree = "<group>"; };
+		1645ECC3243B69A1007A82D6 /* UserTypeTests+Materialize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UserTypeTests+Materialize.swift"; path = "Tests/Source/Model/UserTypeTests+Materialize.swift"; sourceTree = SOURCE_ROOT; };
 		16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+BackupImport.swift"; sourceTree = "<group>"; };
 		16460A45206544B00096B616 /* PersistentMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMetadataKeys.swift; sourceTree = "<group>"; };
 		1646D5B9234FA56B00E60F1E /* zmessaging2.77.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.77.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2136,6 +2138,7 @@
 				1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */,
 				872A2E891FFD2FBF00900B22 /* ZMSearchUserPayloadParsingTests.swift */,
 				F9B71F631CB2BC85001DB03F /* UserImageLocalCacheTests.swift */,
+				1645ECC3243B69A1007A82D6 /* UserTypeTests+Materialize.swift */,
 				F9B71F661CB2BC85001DB03F /* ZMPersonNameTests.m */,
 				F18998871E7AF0BE00E579A2 /* ZMUserTests.h */,
 				F9B71F6A1CB2BC85001DB03F /* ZMUserTests.m */,
@@ -3071,6 +3074,7 @@
 				F963E9861D9D485900098AD3 /* ZMClientMessageTests+Ephemeral.swift in Sources */,
 				BFB3BA731E28D38F0032A84F /* SharedObjectStoreTests.swift in Sources */,
 				BF7D9C491D90286700949267 /* MessagingTest+UUID.swift in Sources */,
+				1645ECC4243B69A1007A82D6 /* UserTypeTests+Materialize.swift in Sources */,
 				F9B71FA61CB2BF37001DB03F /* ZMConversationTests+Transport.m in Sources */,
 				1621E59220E62BD2006B2D17 /* ZMConversationTests+Silencing.swift in Sources */,
 				F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- Directory results will now return team users, `ZMSearchUser` has therefore been updated to represent a team user.
- Introduce the `materialize(in:)` method which transform a sequence of ZMSearchUser (UserType) into concrete ZMUser instances. 

We can now search for team members which doesn't exist in our local database, these users will represented by a `ZMSearchUser` until the user decides to perform an action with them (add to conversation, create conversation). At that point we will transform them into concrete `ZMUser` and insert then into the local database using the `materialize(in:)` method.