### PR TITLE
[Refactor] support assets for `GenericMessage`

### DIFF
--- a/Source/Utilis/Protos/GenericMessage+Assets.swift
+++ b/Source/Utilis/Protos/GenericMessage+Assets.swift
@@ -1,0 +1,153 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension WireProtos.Asset {
+    init(_ metadata: ZMFileMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+            })
+        })
+    }
+    
+    init(_ metadata: ZMAudioMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+                $0.audio = WireProtos.Asset.AudioMetaData.with({
+                    let loudnessArray = metadata.normalizedLoudness.map { UInt8(roundf($0 * 255)) }
+                    $0.durationInMillis = UInt64(metadata.duration * 1000)
+                    $0.normalizedLoudness = NSData(bytes: loudnessArray, length: loudnessArray.count) as Data
+                })
+                
+            })
+        })
+    }
+    
+    init(_ metadata: ZMVideoMetadata) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = metadata.size
+                $0.mimeType = metadata.mimeType
+                $0.name = metadata.filename
+                $0.video = WireProtos.Asset.VideoMetaData.with({
+                    $0.durationInMillis = UInt64(metadata.duration * 1000)
+                    $0.width = Int32(metadata.dimensions.width)
+                    $0.height = Int32(metadata.dimensions.height)
+                })
+            })
+        })
+    }
+    
+    init(imageSize: CGSize, mimeType: String, size: UInt64) {
+        self = WireProtos.Asset.with({
+            $0.original = WireProtos.Asset.Original.with({
+                $0.size = size
+                $0.mimeType = mimeType
+                $0.image = WireProtos.Asset.ImageMetaData.with({
+                    $0.width = Int32(imageSize.width)
+                    $0.height = Int32(imageSize.height)
+                })
+            })
+        })
+    }
+    
+    init(original: WireProtos.Asset.Original?, preview: WireProtos.Asset.Preview?) {
+        self = WireProtos.Asset.with({
+            if let original = original {
+                $0.original = original
+            }
+            if let preview = preview {
+                $0.preview = preview
+            }
+        })
+    }
+    
+    init(withUploadedOTRKey otrKey: Data, sha256: Data) {
+        self = WireProtos.Asset.with {
+            $0.uploaded = WireProtos.Asset.RemoteData(withOTRKey: otrKey, sha256: sha256)
+        }
+    }
+    
+    init(withNotUploaded notUploaded: WireProtos.Asset.NotUploaded) {
+        self = WireProtos.Asset.with {
+            $0.notUploaded = notUploaded
+        }
+    }
+}
+
+extension WireProtos.Asset.Original {
+ 
+    init(withSize size: UInt64, mimeType: String, name: String?, imageMetaData: WireProtos.Asset.ImageMetaData? = nil) {
+        self = WireProtos.Asset.Original.with {
+            $0.size = size
+            $0.mimeType = mimeType
+            if let name = name {
+                $0.name = name
+            }
+            if let imageMeta = imageMetaData {
+                $0.image = imageMeta
+            }
+        }
+    }
+}
+
+extension WireProtos.Asset.Preview {
+    
+    init(size: UInt64, mimeType: String, remoteData: WireProtos.Asset.RemoteData?, imageMetadata: WireProtos.Asset.ImageMetaData) {
+        self = WireProtos.Asset.Preview.with({
+            $0.size = size
+            $0.mimeType = mimeType
+            $0.image = imageMetadata
+            if let remoteData = remoteData {
+                $0.remote = remoteData
+            }
+        })
+    }
+}
+
+extension WireProtos.Asset.ImageMetaData {
+    init(width: Int32, height: Int32) {
+        self = WireProtos.Asset.ImageMetaData.with {
+            $0.width = width
+            $0.height = height
+        }
+    }
+}
+
+extension WireProtos.Asset.RemoteData {
+    init(withOTRKey otrKey: Data, sha256: Data, assetId: String? = nil, assetToken: String? = nil) {
+        self = WireProtos.Asset.RemoteData.with {
+            $0.otrKey = otrKey
+            $0.sha256 = sha256
+            if let id = assetId {
+                $0.assetID = id
+            }
+            if let token = assetToken {
+                $0.assetToken = token
+            }
+        }
+    }
+}

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -535,72 +535,6 @@ extension MessageDelete: MessageCapable {
 }
 
 extension WireProtos.Asset: EphemeralMessageCapable {
-    
-    init(_ metadata: ZMFileMetadata) {
-        self = WireProtos.Asset.with({
-            $0.original = WireProtos.Asset.Original.with({
-                $0.size = metadata.size
-                $0.mimeType = metadata.mimeType
-                $0.name = metadata.filename
-            })
-        })
-    }
-    
-    init(_ metadata: ZMAudioMetadata) {
-        self = WireProtos.Asset.with({
-            $0.original = WireProtos.Asset.Original.with({
-                $0.size = metadata.size
-                $0.mimeType = metadata.mimeType
-                $0.name = metadata.filename
-                $0.audio = WireProtos.Asset.AudioMetaData.with({
-                    let loudnessArray = metadata.normalizedLoudness.map { UInt8(roundf($0 * 255)) }
-                    $0.durationInMillis = UInt64(metadata.duration * 1000)
-                    $0.normalizedLoudness = NSData(bytes: loudnessArray, length: loudnessArray.count) as Data
-                })
-                
-            })
-        })
-    }
-    
-    init(_ metadata: ZMVideoMetadata) {
-        self = WireProtos.Asset.with({
-            $0.original = WireProtos.Asset.Original.with({
-                $0.size = metadata.size
-                $0.mimeType = metadata.mimeType
-                $0.name = metadata.filename
-                $0.video = WireProtos.Asset.VideoMetaData.with({
-                    $0.durationInMillis = UInt64(metadata.duration * 1000)
-                    $0.width = Int32(metadata.dimensions.width)
-                    $0.height = Int32(metadata.dimensions.height)
-                })
-            })
-        })
-    }
-    
-    init(imageSize: CGSize, mimeType: String, size: UInt64) {
-        self = WireProtos.Asset.with({
-            $0.original = WireProtos.Asset.Original.with({
-                $0.size = size
-                $0.mimeType = mimeType
-                $0.image = WireProtos.Asset.ImageMetaData.with({
-                    $0.width = Int32(imageSize.width)
-                    $0.height = Int32(imageSize.height)
-                })
-            })
-        })
-    }
-    
-    init(original: WireProtos.Asset.Original?, preview: WireProtos.Asset.Preview?) {
-        self = WireProtos.Asset.with({
-            if let original = original {
-                $0.original = original
-            }
-            if let preview = preview {
-                $0.preview = preview
-            }
-        })
-    }
-
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.asset = self
     }
@@ -663,20 +597,6 @@ extension External: MessageCapable {
     
     public var legalHoldStatus: LegalHoldStatus {
         return defaultLegalHoldStatus
-    }
-}
-
-extension WireProtos.Asset.Preview {
-    
-    init(size: UInt64, mimeType: String, remoteData: WireProtos.Asset.RemoteData?, imageMetadata: WireProtos.Asset.ImageMetaData) {
-        self = WireProtos.Asset.Preview.with({
-            $0.size = size
-            $0.mimeType = mimeType
-            $0.image = imageMetadata
-            if let remoteData = remoteData {
-                $0.remote = remoteData
-            }
-        })
     }
 }
 

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		638805652410FE920043B641 /* ButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638805642410FE920043B641 /* ButtonState.swift */; };
 		63B658DE243754E100EF463F /* GenericMessage+UpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */; };
 		63CA8215240812620073426A /* ZMClientMessage+Composite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CA8214240812620073426A /* ZMClientMessage+Composite.swift */; };
+		63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */; };
 		7C88C5352182FBD90037DD03 /* ZMClientMessagesTests+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */; };
 		7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */; };
 		7CBC3FC120177C3C008D06E4 /* RasterImages+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC3FC020177C3C008D06E4 /* RasterImages+Protobuf.swift */; };
@@ -837,6 +838,7 @@
 		638805642410FE920043B641 /* ButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonState.swift; sourceTree = "<group>"; };
 		63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GenericMessage+UpdateEvent.swift"; sourceTree = "<group>"; };
 		63CA8214240812620073426A /* ZMClientMessage+Composite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Composite.swift"; sourceTree = "<group>"; };
+		63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Assets.swift"; sourceTree = "<group>"; };
 		7C2E467721072A31007E2566 /* zmessaging2.50.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.50.0.xcdatamodel; sourceTree = "<group>"; };
 		7C88C5312182F6150037DD03 /* ZMClientMessagesTests+Replies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessagesTests+Replies.swift"; sourceTree = "<group>"; };
 		7C8BFFDE22FC5E1600B3C8A5 /* ZMUser+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Validation.swift"; sourceTree = "<group>"; };
@@ -1582,6 +1584,7 @@
 				F963E9681D9ADD5A00098AD3 /* ZMGenericMessage+Helper.swift */,
 				F1FDF2F621B152BC00E037A1 /* GenericMessage+Hashing.swift */,
 				16626505217F0DA900300F45 /* ZMGenericMessage+Hashing.swift */,
+				63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */,
 				F963E9751D9C002000098AD3 /* ZMGenericMessage+Assets.swift */,
 				F963E9691D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.h */,
 				F963E96A1D9ADD5A00098AD3 /* ZMGenericMessage+PropertyUtils.m */,
@@ -2819,6 +2822,7 @@
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
 				55C40BCE22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift in Sources */,
 				5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */,
+				63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */,
 				164EB6F3230D987A001BBD4A /* ZMMessage+DataRetention.swift in Sources */,
 				A90D62C823A159B600F680CC /* ZMConversation+Transport.swift in Sources */,
 				F9A706941CAEE01D00C2F5FE /* UserClient+Protobuf.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

- Move `Asset` related protobuf code to its own file
- Add necessary inits