### PR TITLE
[Fix] AssetId for the digital signature

### DIFF
--- a/Source/Model/Message/File/SignatureStatus.swift
+++ b/Source/Model/Message/File/SignatureStatus.swift
@@ -58,7 +58,7 @@ public final class SignatureStatus : NSObject {
         self.asset = asset
         self.managedObjectContext = managedObjectContext
         
-        documentID = asset?.preview.remote.assetId
+        documentID = asset?.uploaded.assetId
         fileName = asset?.original.name.removingExtremeCombiningCharacters
         
         encodedHash = data?


### PR DESCRIPTION
## What's new in this PR?

Send as a parameter to the BE the assetID instead of the assetID of the preview.