### PR TITLE
[Fix] Broadcast recipients

### DIFF
--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -120,13 +120,13 @@ extension ZMUser {
 
     static func knownTeamUsers(in context: NSManagedObjectContext) -> Set<ZMUser> {
         let connectedPredicate = ZMUser.predicateForUsers(withConnectionStatuses: [ZMConnectionStatus.accepted.rawValue])
-        let teamUserPredicate = NSPredicate(format: "(%K != NULL)", #keyPath(ZMUser.teamIdentifier))
-        let connectedAndTeamUserPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [connectedPredicate, teamUserPredicate])
-
         let request = NSFetchRequest<ZMUser>(entityName: ZMUser.entityName())
-        request.predicate = connectedAndTeamUserPredicate
+        request.predicate = connectedPredicate
 
-        return Set(context.fetchOrAssert(request: request))
+        let connections = Set(context.fetchOrAssert(request: request))
+        let selfUser = ZMUser.selfUser(in: context)
+        let result = connections.filter { $0.hasTeam && !$0.isOnSameTeam(otherUser: selfUser) }
+        return Set(result)
     }
 
     @objc public var availability : Availability {

--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -86,7 +86,7 @@ extension ZMUser {
             .prefix(remainingSlots)
 
         recipients.formUnion(teamMembers)
-        remainingSlots -= recipients.count
+        remainingSlots = maxCount - recipients.count
 
         guard remainingSlots > 0 else { return recipients }
 

--- a/Tests/Source/Model/ModelObjectsTests+Helpers.swift
+++ b/Tests/Source/Model/ModelObjectsTests+Helpers.swift
@@ -41,6 +41,25 @@ extension ModelObjectsTests {
         member.team = team
         return (member.user!, member)
     }
+
+    @objc(userWithClients:trusted:)
+    public func userWithClients(count: Int, trusted: Bool) -> ZMUser {
+        self.createSelfClient()
+        self.uiMOC.refreshAllObjects()
+
+        let selfClient: UserClient? = ZMUser.selfUser(in: self.uiMOC).selfClient()
+        let user: ZMUser = ZMUser.insertNewObject(in: self.uiMOC)
+        [0...count].forEach({ _ in
+            let client: UserClient = UserClient.insertNewObject(in: self.uiMOC)
+            client.user = user
+            if trusted {
+                selfClient?.trustClient(client)
+            } else {
+                selfClient?.ignoreClient(client)
+            }
+        })
+        return user
+    }
     
     // MARK: Files
     
@@ -81,5 +100,5 @@ extension ModelObjectsTests {
             XCTFail("Error removing file: \(error)")
         }
     }
-    
+
 }

--- a/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -20,7 +20,7 @@ import Foundation
 @testable import WireDataModel
 
 // MARK: - Modified keys for profile picture upload
-extension ZMUserTests {
+final class ZMUserTests_Swift: ModelObjectsTests {
     func testThatSettingUserProfileAssetIdentifiersDirectlyDoesNotMarkAsModified() {
         // GIVEN
         let user = ZMUser.selfUser(in: uiMOC)
@@ -67,7 +67,7 @@ extension ZMUserTests {
 
 // MARK: - AssetV3 response parsing
 
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func assetPayload(previewId: String , completeId: String) -> NSArray {
         return [
@@ -185,7 +185,7 @@ extension ZMUserTests {
 }
 
 // MARK: - AssetV3 filter predicates
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     func testThatPreviewImageDownloadFilterPicksUpUser() {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
@@ -252,7 +252,7 @@ extension ZMUserTests {
 }
 
 // MARK: - AssetV3 request notifications
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testThatItPostsPreviewRequestNotifications() {
         let noteExpectation = expectation(description: "PreviewAssetFetchNotification should be fired")
@@ -319,7 +319,7 @@ extension ZMUser {
 }
 
 // MARK: - Predicates
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testPredicateFilteringConnectedUsersByHandle() {
         // Given
@@ -400,7 +400,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Filename
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     /// check the generated filename matches several critirias and a regex pattern
     ///
@@ -447,7 +447,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Availability
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testThatWeCanUpdateAvailabilityFromGenericMessage() {
         let user = ZMUser.insert(in: self.uiMOC, name: "Foo")
@@ -499,7 +499,7 @@ extension ZMUserTests {
 
 // MARK: - Broadcast Recipients
 
-extension ZMUserTests {
+extension ZMUserTests_Swift {
 
     func testThatItReturnsAllKnownTeamUsers() {
         // given
@@ -730,7 +730,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Bot support
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     func testThatServiceIdentifierAndProviderIdentifierAreNilByDefault() {
         // GIVEN
         let sut = ZMUser.insertNewObject(in: self.uiMOC)
@@ -742,7 +742,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Expiration support
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     func testIsWirelessUserCalculation_false() {
         // given
         let sut = ZMUser.insertNewObject(in: self.uiMOC)
@@ -775,7 +775,7 @@ extension ZMUserTests {
 
 // MARK: - Account deletion
 
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testThatUserIsRemovedFromAllConversationsWhenAccountIsDeleted() {
         // given
@@ -814,7 +814,7 @@ extension ZMUserTests {
 
 // MARK: - Active conversations
 
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testActiveConversationsForSelfUser() {
         // given
@@ -840,7 +840,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Self user tests
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     func testThatItIsPossibleToSetReadReceiptsEnabled() {
         // GIVEN
         let sut = ZMUser.selfUser(in: uiMOC)
@@ -922,7 +922,7 @@ extension ZMUserTests {
 }
 
 // MARK: - Verifying user
-extension ZMUserTests {
+extension ZMUserTests_Swift {
     
     func testThatUserIsVerified_WhenSelfUserAndUserIsTrusted() {
         // GIVEN
@@ -953,23 +953,5 @@ extension ZMUserTests {
         XCTAssertFalse(selfUser.isTrusted)
         XCTAssertFalse(user.isVerified)
     }
-    
-    @objc(userWithClients:trusted:)
-    public func userWithClients(count: Int, trusted: Bool) -> ZMUser {
-        self.createSelfClient()
-        self.uiMOC.refreshAllObjects()
-        
-        let selfClient: UserClient? = ZMUser.selfUser(in: self.uiMOC).selfClient()
-        let user: ZMUser = ZMUser.insertNewObject(in: self.uiMOC)
-        [0...count].forEach({ _ in
-            let client: UserClient = UserClient.insertNewObject(in: self.uiMOC)
-            client.user = user
-            if trusted {
-                selfClient?.trustClient(client)
-            } else {
-                selfClient?.ignoreClient(client)
-            }
-        })
-        return user
-    }
+
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 		F188A8992225492400BA53A5 /* store2-63-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = F188A8982225492400BA53A5 /* store2-63-0.wiredatabase */; };
 		F188A89B2225698C00BA53A5 /* store2-64-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = F188A89A2225698C00BA53A5 /* store2-64-0.wiredatabase */; };
 		F18998831E7AC6D900E579A2 /* ZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998821E7AC6D900E579A2 /* ZMUser.swift */; };
-		F18998861E7AEECF00E579A2 /* ZMUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998841E7AEEC900E579A2 /* ZMUserTests.swift */; };
+		F18998861E7AEECF00E579A2 /* ZMUserTests+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18998841E7AEEC900E579A2 /* ZMUserTests+Swift.swift */; };
 		F189988B1E7AF80500E579A2 /* store2-28-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = F189988A1E7AF80500E579A2 /* store2-28-0.wiredatabase */; };
 		F18998A61E7BE03800E579A2 /* zmessaging.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = F189988C1E7BE03800E579A2 /* zmessaging.xcdatamodeld */; };
 		F19550392040628400338E91 /* ZMUpdateEvent+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19550372040628000338E91 /* ZMUpdateEvent+Helper.swift */; };
@@ -1009,7 +1009,7 @@
 		F188A8982225492400BA53A5 /* store2-63-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-63-0.wiredatabase"; sourceTree = "<group>"; };
 		F188A89A2225698C00BA53A5 /* store2-64-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-64-0.wiredatabase"; sourceTree = "<group>"; };
 		F18998821E7AC6D900E579A2 /* ZMUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUser.swift; sourceTree = "<group>"; };
-		F18998841E7AEEC900E579A2 /* ZMUserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMUserTests.swift; sourceTree = "<group>"; };
+		F18998841E7AEEC900E579A2 /* ZMUserTests+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+Swift.swift"; sourceTree = "<group>"; };
 		F18998871E7AF0BE00E579A2 /* ZMUserTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMUserTests.h; sourceTree = "<group>"; };
 		F189988A1E7AF80500E579A2 /* store2-28-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-28-0.wiredatabase"; path = "Tests/Resources/store2-28-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		F189988D1E7BE03800E579A2 /* zmessaging.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging.xcdatamodel; sourceTree = "<group>"; };
@@ -2142,7 +2142,7 @@
 				F9B71F661CB2BC85001DB03F /* ZMPersonNameTests.m */,
 				F18998871E7AF0BE00E579A2 /* ZMUserTests.h */,
 				F9B71F6A1CB2BC85001DB03F /* ZMUserTests.m */,
-				F18998841E7AEEC900E579A2 /* ZMUserTests.swift */,
+				F18998841E7AEEC900E579A2 /* ZMUserTests+Swift.swift */,
 				1670D01D231825BE003A143B /* ZMUserTests+Permissions.swift */,
 				F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */,
 				5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */,
@@ -3027,7 +3027,7 @@
 				87C125F91EF94F2E00D28DC1 /* ZMManagedObjectGroupingTests.swift in Sources */,
 				54DE05DD1CF8711F00C35253 /* ProtobufUtilitiesTests.swift in Sources */,
 				F9C8770B1E015AAF00792613 /* AssetColletionTests.swift in Sources */,
-				F18998861E7AEECF00E579A2 /* ZMUserTests.swift in Sources */,
+				F18998861E7AEECF00E579A2 /* ZMUserTests+Swift.swift in Sources */,
 				16CDEBF72209897D00E74A41 /* ZMMessageTests+ShouldGenerateUnreadCount.swift in Sources */,
 				16EDECB022CA135C00866289 /* ZMGenericMessageTests+LegalHoldStatus.swift in Sources */,
 				162294A5222038FA00A98679 /* CacheAssetTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. The self user is counted as a broadcast recipient twice
2. Connected external team users were not being broadcasted to
3. All tests in `ZMUserTests.swift` were not running

### Causes

1. At the call `remainingSlots -= recipients.count`, `remainingSlots` already includes the self user. On the right hand side, `recipients` also includes the self user.
2. The predicate `%K != NULL` for the `teamIdentifier` was not correct (not sure why though).
3. I believe because they were defined in an extension, and furthermore the base class was in Objc.

### Solutions

1. Calculate the remaining slots from the `maxCount`.
2. Don't rely no the predicate, but instead use standard filtering.
3. Split those swift tests into a separate class.
