### PR TITLE
[Fix] Do not increase the security level for the connection

### DIFF
--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -208,9 +208,10 @@ extension ZMConversation {
 
     private func increaseSecurityLevelIfNeeded(for cause: SecurityChangeCause) {
         guard securityLevel != .secure &&
-              allUsersTrusted &&
-              allParticipantsHaveClients else {
-            return
+            allUsersTrusted &&
+            allParticipantsHaveClients &&
+            conversationType != .connection else {
+                return
         }
 
         securityLevel = .secure


### PR DESCRIPTION
## What's new in this PR?

### Issues
In the UI project the verified shield is shown on the connection request page.

### Causes
We increase the security level for the connection when the user verifies all of its own devices.

### Solutions
Do not increase the security level for the connection.
