### PR TITLE
[Feature] Add support for team member metadata on the ZMSearchUser

### DIFF
--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -117,6 +117,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     public var assetKeys: SearchUserAssetKeys?
     public var remoteIdentifier: UUID?
     public var teamIdentifier: UUID?
+    public var teamPermissions: Permissions?
     @objc public var contact: ZMAddressBookContact?
     @objc public var user: ZMUser?
     public private(set) var hasDownloadedFullUserProfile: Bool = false
@@ -188,7 +189,9 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     }
     
     public var teamRole: TeamRole {
-        guard let user = user else { return .none }
+        guard let user = user else {
+            return (teamPermissions?.rawValue).flatMap(TeamRole.init(rawPermissions:)) ?? .none
+        }
         
         return user.teamRole
     }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -117,7 +117,6 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     public var assetKeys: SearchUserAssetKeys?
     public var remoteIdentifier: UUID?
     public var teamIdentifier: UUID?
-    public var teamPermissions: Permissions?
     @objc public var contact: ZMAddressBookContact?
     @objc public var user: ZMUser?
     public private(set) var hasDownloadedFullUserProfile: Bool = false
@@ -128,12 +127,19 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     fileprivate var internalHandle: String?
     fileprivate var internalIsConnected: Bool = false
     fileprivate var internalIsTeamMember: Bool = false
+    fileprivate var internalTeamCreatedBy: UUID?
+    fileprivate var internalTeamPermissions: Permissions?
     fileprivate var internalAccentColorValue: ZMAccentColor
     fileprivate var internalPendingApprovalByOtherUser: Bool = false
     fileprivate var internalConnectionRequestMessage: String?
     fileprivate var internalPreviewImageData: Data?
     fileprivate var internalCompleteImageData: Data?
-
+    
+    public var teamCreatedBy: UUID? {
+        get {
+            return user != nil ? user?.membership?.createdBy?.remoteIdentifier : internalTeamCreatedBy
+        }
+    }
 
     public var emailAddress: String? {
         get {
@@ -190,7 +196,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     public var teamRole: TeamRole {
         guard let user = user else {
-            return (teamPermissions?.rawValue).flatMap(TeamRole.init(rawPermissions:)) ?? .none
+            return (internalTeamPermissions?.rawValue).flatMap(TeamRole.init(rawPermissions:)) ?? .none
         }
         
         return user.teamRole
@@ -642,6 +648,11 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     public func reportImageDataHasBeenDeleted() {
         self.assetKeys = nil
+    }
+    
+    public func updateWithTeamMembership(permissions: Permissions, createdBy: UUID?) {
+        self.internalTeamPermissions = permissions
+        self.internalTeamCreatedBy = createdBy
     }
     
 }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -137,7 +137,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     public var teamCreatedBy: UUID? {
         get {
-            return user != nil ? user?.membership?.createdBy?.remoteIdentifier : internalTeamCreatedBy
+            return user?.membership?.createdBy?.remoteIdentifier ?? internalTeamCreatedBy
         }
     }
 

--- a/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
+++ b/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
@@ -95,5 +95,25 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         // then
         XCTAssertNil(searchUser.oneToOneConversation)
     }
+    
+    func testThatSearchUserCanBeUpdatedTeamMembershipDetails() {
+        // given
+        let creator = UUID()
+        let team = createTeam(in: uiMOC)
+        _ = createMembership(in: uiMOC, user: selfUser, team: team)
+        let searchUser = ZMSearchUser(contextProvider: self,
+                                      name: "Foo",
+                                      handle: "foo",
+                                      accentColor: .brightOrange,
+                                      remoteIdentifier: UUID(),
+                                      teamIdentifier: team.remoteIdentifier)
+        
+        // when
+        searchUser.updateWithTeamMembership(permissions: .partner, createdBy: creator)
+        
+        // then
+        XCTAssertEqual(searchUser.teamRole, .partner)
+        XCTAssertEqual(searchUser.teamCreatedBy, creator)
+    }
         
 }


### PR DESCRIPTION
## What's new in this PR?

Add support for team member metadata on the `ZMSearchUser`, which will enable us apply filtering logic to regarding team member in search results.