### PR TITLE
[Fix] Edit Message Not Applied

### DIFF
--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -45,7 +45,7 @@ extension ZMClientMessage: ZMTextMessageData {
     public var mentions: [Mention] {
         return Mention.mentions(from: underlyingMessage?.textData?.mentions, messageText: messageText, moc: managedObjectContext)
     }
-        
+    
     public func editText(_ text: String, mentions: [Mention], fetchLinkPreview: Bool) {
         guard let nonce = nonce, isEditableMessage else {
             return
@@ -54,7 +54,9 @@ extension ZMClientMessage: ZMTextMessageData {
         // Quotes are ignored in edits but keep it to mark that the message has quote for us locally
         let editedText = Text(content: text, mentions: mentions, linkPreviews: [], replyingTo: self.quote as? ZMOTRMessage)
         let editNonce = UUID()
-        let updatedMessage = GenericMessage(content: MessageEdit(replacingMessageID: nonce, text: editedText), nonce: nonce)
+        let updatedMessage = GenericMessage(content: MessageEdit(replacingMessageID: nonce,
+                                                                 text: editedText),
+                                            nonce: editNonce)
         do {
             self.add(try updatedMessage.serializedData())
         } catch {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a message was edited and sent, the receiver was not receiving the updated message

### Causes
the generic message object representing the edited message was created with the wrong nonce

### Solutions

Apply the editedNonce to the generic message object representing the edited message
