### PR TITLE
[Fix] Make Permissions argument optional

### DIFF
--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -650,7 +650,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
         self.assetKeys = nil
     }
     
-    public func updateWithTeamMembership(permissions: Permissions, createdBy: UUID?) {
+    public func updateWithTeamMembership(permissions: Permissions?, createdBy: UUID?) {
         self.internalTeamPermissions = permissions
         self.internalTeamCreatedBy = createdBy
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We sometimes get into a request loop when fetching members.

### Causes

The permissions field on the member response was incorrectly marked as non-optional, causing the payload decoding to fail if that field was not present.

### Solutions

Mark permissions field as optional.