### PR TITLE
[Fix] Don't add deleted participants to conversation

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -141,6 +141,7 @@ extension ZMConversation {
         let doesExistsOnBackend = self.remoteIdentifier != nil
         
         let addedRoles = usersAndRoles.compactMap { (user, role) -> ParticipantRole? in
+            guard !user.isAccountDeleted else { return nil }
             
             // make sure the role is the right team/conversation role
             require(

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -435,6 +435,31 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
         XCTAssertEqual(conversation.participantRoles.first {$0.user == user1}?.role, role1)
         XCTAssertEqual(conversation.participantRoles.first {$0.user == user2}?.role, role2)
     }
+
+    func testThatItDoesNotAddDeletedParticipants() {
+        // given
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.conversationType = .group
+        let role1 = Role.create(managedObjectContext: uiMOC, name: "role1", conversation: conversation)
+        conversation.nonTeamRoles.insert(role1)
+        let role2 = Role.create(managedObjectContext: uiMOC, name: "role2", conversation: conversation)
+        conversation.nonTeamRoles.insert(role2)
+        let user1 = ZMUser.insertNewObject(in: self.uiMOC)
+        user1.name = "user1"
+        let user2 = ZMUser.insertNewObject(in: self.uiMOC)
+        user2.name = "user2"
+        user2.isAccountDeleted = true
+
+        // when
+        conversation.addParticipantsAndUpdateConversationState(usersAndRoles: [
+            (user1, role1),
+            (user2, role2)
+        ])
+
+        // then
+        XCTAssertEqual(conversation.participantRoles.count, 1)
+        XCTAssertEqual(conversation.participantRoles.first {$0.user == user1}?.role, role1)
+    }
     
     func testThatItUpdateParticipantWithTheGivenRole() {
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a participant is discovered to be deleted, they are removed from the conversation as expected. However, it can happen that at a later point in time they are re-added to the conversation, even though they are deleted. 

### Causes

This happens when the app is restarted and we receive a delayed member join update event (for the deleted user), in which case the user is re-added to the conversation. It may also be possible in other undiscovered cases.

### Solutions

Check whether users have deleted accounts before adding them.

