### PR TITLE
[Fix] Don't update name for deleted users

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -546,7 +546,7 @@ static NSString *const ParticipantRolesKey = @"participantRoles";
     }
 
     NSString *name = [transportData optionalStringForKey:@"name"];
-    if (name != nil || authoritative) {
+    if (!self.isAccountDeleted && (name != nil || authoritative)) {
         self.name = name;
     }
     

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -385,6 +385,31 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.membership);
 }
 
+- (void)testThatItDoesNotUpdateNameIfUserIsDeleted
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    team.remoteIdentifier = teamId;
+    user.remoteIdentifier = uuid;
+    user.name = @"bob";
+
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+    payload[@"deleted"] = @YES;
+    payload[@"name"] = @"default";
+
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+
+    // then
+    XCTAssertEqual(user.name, @"bob");
+}
+
 - (void)testThatItDoesNotCreateMembershipIfUserBelongsExternalTeamOnAnExistingUser
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a user is deleted, their name is set to "default".

### Causes

When synchronizing a deleted user with the backend, the backend sets the name field to "default". This is likely to erase metadata for the deleted user. However, when parsing the payload we will set the local user objects name to "default", overwriting their existing username.

### Solutions

Don't update the user name if the user is marked as deleted.

