### PR TITLE
[Fix] Guard against connections referring to the self user

### DIFF
--- a/Source/Model/Connection/ZMConnection.m
+++ b/Source/Model/Connection/ZMConnection.m
@@ -304,6 +304,9 @@ struct stringAndStatus {
     if(toUUID == nil) {
         ZMLogError(@"Invalid 'to'-UUID in connection: %@", transportData);
         return nil;
+    } else if ([toUUID isEqual:[ZMUser selfUserInContext:moc].remoteIdentifier]) {
+        ZMLogError(@"Invalid 'to'-UUID in connection referencing self user: %@", transportData);
+        return nil;
     }
     
     NSDate *lastUpdateDate = [transportData dateFor:@"last_update"];

--- a/Tests/Source/Model/ZMConnectionTests.m
+++ b/Tests/Source/Model/ZMConnectionTests.m
@@ -492,6 +492,33 @@
     }];
 }
 
+- (void)testThatItReturnsNilForInvalidToUUID_ReferringToSelfUser
+{
+
+    // given
+    NSUUID *selfUserUUID = [ZMUser selfUserInContext:self.uiMOC].remoteIdentifier;
+    
+    NSDictionary *payload =     // expected JSON response
+    @{
+      @"status": @"accepted",
+      @"from": @"3bc5750a-b965-40f8-aff2-831e9b5ac2e9",
+      @"conversation": @"fef60427-3c53-4ac5-b971-ad5088f5a4c2",
+      @"to": selfUserUUID.transportString,
+      @"last_update": @"2014-04-16T15:01:45.762Z",
+      };
+    
+    [self.syncMOC performGroupedBlockAndWait:^{
+        [self performIgnoringZMLogError:^{
+            
+            // when
+            ZMConnection *connection = [ZMConnection connectionFromTransportData:payload managedObjectContext:self.syncMOC];
+            
+            // then
+            XCTAssertNil(connection);
+        }];
+    }];
+}
+
 
 
 - (void)testThatItReturnsNilForInvalidConversationUUID


### PR DESCRIPTION
## What's new in this PR?

### Issues

We have seen clients reporting to have a connection with itself.

### Causes

It's unclear exactly when such connection can be created.

### Solutions

Guard against such connection being created by validating that the `to` field is not referring to the self user.