### PR TITLE
[Fix] Add more detailed logging when aborting processing of a message

### DIFF
--- a/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -29,15 +29,18 @@ extension ZMOTRMessage {
         guard
             let senderID = updateEvent.senderUUID(),
             let conversation = self.conversation(for: updateEvent, in: moc, prefetchResult: prefetchResult),
-            !isSelf(conversation: conversation, andIsSenderID: senderID, differentFromSelfUserID: selfUser.remoteIdentifier) else {
+            !isSelf(conversation: conversation, andIsSenderID: senderID, differentFromSelfUserID: selfUser.remoteIdentifier)
+        else {
+            zmLog.debug("Illegal sender or conversation, abort processing.")
             return nil
         }
         
         guard let message = ZMGenericMessage(from: updateEvent) else {
+            zmLog.debug("Can't read protobuf, abort processing:\n\(updateEvent.payload)")
             appendInvalidSystemMessage(forUpdateEvent: updateEvent, toConversation: conversation, inContext: moc)
             return nil
         }
-        zmLog.debug("processing:\n\(message.debugDescription)")
+        zmLog.debug("Processing:\n\(message.debugDescription)")
         
         // Update the legal hold state in the conversation
         conversation.updateSecurityLevelIfNeededAfterReceiving(message: message, timestamp: updateEvent.timeStamp() ?? Date())


### PR DESCRIPTION
## What's new in this PR?

Add more detailed logging when we abort processing of a message because we can't decode the protobuf.