### PR TITLE
[Fix] Correct the 'hasReaction' computed  property

### DIFF
--- a/Source/Utilis/Protos/GenericMessage+Content.swift
+++ b/Source/Utilis/Protos/GenericMessage+Content.swift
@@ -30,7 +30,7 @@ public extension GenericMessage {
     }
     
     var hasReaction: Bool {
-        return messageData is Reaction
+        return messageData is WireProtos.Reaction
     }
     
     var hasAsset: Bool {


### PR DESCRIPTION
## What's new in this PR?

Use `WireProtos.Reaction` instead of `Reaction` for the computed property `hasReaction`.