### PR TITLE
[Fix] Internal debug message for the GenericMessage

### DIFF
--- a/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -45,7 +45,7 @@ extension ZMOTRMessage {
                 appendInvalidSystemMessage(forUpdateEvent: updateEvent, toConversation: conversation, inContext: moc)
                 return nil
         }
-        zmLog.debug("Processing:\n\(message.debugDescription)")
+        zmLog.debug("Processing:\n\(message)")
         
         // Update the legal hold state in the conversation
         conversation.updateSecurityLevelIfNeededAfterReceiving(message: message, timestamp: updateEvent.timeStamp() ?? Date())

--- a/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -45,7 +45,7 @@ extension ZMOTRMessage {
                 appendInvalidSystemMessage(forUpdateEvent: updateEvent, toConversation: conversation, inContext: moc)
                 return nil
         }
-        zmLog.debug("Processing:\n\(message.debugDescription)")
+        zmLog.debug("Processing:\n\(message.debugDescriptionForGenericMessage)")
         
         // Update the legal hold state in the conversation
         conversation.updateSecurityLevelIfNeededAfterReceiving(message: message, timestamp: updateEvent.timeStamp() ?? Date())

--- a/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -45,7 +45,7 @@ extension ZMOTRMessage {
                 appendInvalidSystemMessage(forUpdateEvent: updateEvent, toConversation: conversation, inContext: moc)
                 return nil
         }
-        zmLog.debug("Processing:\n\(message.debugDescriptionForGenericMessage)")
+        zmLog.debug("Processing:\n\(message.debugDescription)")
         
         // Update the legal hold state in the conversation
         conversation.updateSecurityLevelIfNeededAfterReceiving(message: message, timestamp: updateEvent.timeStamp() ?? Date())

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -25,7 +25,8 @@ fileprivate let redactedValue = "<redacted>"
 
 fileprivate extension Text {
     func sanitize() -> Text {
-        var text = Text(content: redactedValue)
+        var text = self
+        text.content = redactedValue
         text.linkPreview = text.linkPreview.map { $0.sanitize() }
         return text
     }
@@ -37,11 +38,11 @@ fileprivate extension LinkPreview {
     func sanitize() -> LinkPreview {
         return LinkPreview(withOriginalURL: redactedValue,
                            permanentURL: redactedValue,
-                           offset: self.urlOffset,
+                           offset: urlOffset,
                            title: redactedValue,
                            summary: redactedValue,
-                           imageAsset: self.image,
-                           article: nil,
+                           imageAsset: image,
+                           article: article.sanitize(),
                            tweet: nil)
     }
 }
@@ -58,42 +59,22 @@ fileprivate extension Article {
     }
 }
 
-
 // MARK: - GenericMessage
 
 public extension GenericMessage {
-    var debugDescription: String {
+    var debugDescriptionForGenericMessage: String {
         var message = self
         guard let content = content else {
             return ""
         }
         switch content {
         case .text:
-            message.text = self.text.sanitize()
+            message.text = text.sanitize()
         case .edited:
-            message.edited.text = self.edited.text.sanitize()
+            message.edited.text = edited.text.sanitize()
         default:
             break
         }
-        let description = NSMutableString()
-//        message.writeDescription(to: description, withIndent: "")
-        return (message as! Message).debugDescription 
-        
-        //        guard let builder = self.toBuilder() else { return "" }
-        //
-        //        if builder.hasText() {
-        //            builder.setText(builder.text().sanitize())
-        //        }
-        //
-        //        if builder.hasEdited(), let editedBuilder = builder.edited().toBuilder(), editedBuilder.hasText() {
-        //            builder.setEdited(editedBuilder.setText(editedBuilder.text().sanitize()))
-        //        }
-        //
-        //        let message = builder.build()!
-        //
-        //        let description = NSMutableString()
-        //        message.writeDescription(to: description, withIndent: "")
-        //        return description as String
-        
+        return message.debugDescription
     }
 }

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireProtos
+import SwiftProtobuf
 
 fileprivate let redactedValue = "<redacted>"
 
@@ -62,7 +63,7 @@ fileprivate extension Article {
 // MARK: - GenericMessage
 
 public extension GenericMessage {
-    var debugDescriptionForGenericMessage: String {
+    var debugDescription: String {
         var message = self
         guard let content = content else {
             return ""
@@ -75,6 +76,6 @@ public extension GenericMessage {
         default:
             break
         }
-        return message.debugDescription
+        return (message as SwiftProtobuf.Message).debugDescription
     }
 }

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -77,7 +77,7 @@ public extension GenericMessage {
         }
         let description = NSMutableString()
 //        message.writeDescription(to: description, withIndent: "")
-        return message.debugDescription //description as String
+        return (message as! Message).debugDescription 
         
         //        guard let builder = self.toBuilder() else { return "" }
         //

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -62,8 +62,8 @@ fileprivate extension Article {
 
 // MARK: - GenericMessage
 
-public extension GenericMessage {
-    var debugDescription: String {
+ extension GenericMessage: CustomStringConvertible {
+    public var description: String {
         var message = self
         guard let content = content else {
             return ""
@@ -76,6 +76,6 @@ public extension GenericMessage {
         default:
             break
         }
-        return (message as SwiftProtobuf.Message).debugDescription
+        return message.debugDescription
     }
 }

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -1,0 +1,99 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireProtos
+
+fileprivate let redactedValue = "<redacted>"
+
+// MARK: - Text
+
+fileprivate extension Text {
+    func sanitize() -> Text {
+        var text = Text(content: redactedValue)
+        text.linkPreview = text.linkPreview.map { $0.sanitize() }
+        return text
+    }
+}
+
+// MARK: - LinkPreview
+
+fileprivate extension LinkPreview {
+    func sanitize() -> LinkPreview {
+        return LinkPreview(withOriginalURL: redactedValue,
+                           permanentURL: redactedValue,
+                           offset: self.urlOffset,
+                           title: redactedValue,
+                           summary: redactedValue,
+                           imageAsset: self.image,
+                           article: nil,
+                           tweet: nil)
+    }
+}
+
+// MARK: - Article
+
+fileprivate extension Article {
+    func sanitize() -> Article {
+        return Article.with {
+            $0.title = redactedValue
+            $0.permanentURL = redactedValue
+            $0.summary = redactedValue
+        }
+    }
+}
+
+
+// MARK: - GenericMessage
+
+public extension GenericMessage {
+    var debugDescription: String {
+        var message = self
+        guard let content = content else {
+            return ""
+        }
+        switch content {
+        case .text:
+            message.text = self.text.sanitize()
+        case .edited:
+            message.edited.text = self.edited.text.sanitize()
+        default:
+            break
+        }
+        let description = NSMutableString()
+//        message.writeDescription(to: description, withIndent: "")
+        return message.debugDescription //description as String
+        
+        //        guard let builder = self.toBuilder() else { return "" }
+        //
+        //        if builder.hasText() {
+        //            builder.setText(builder.text().sanitize())
+        //        }
+        //
+        //        if builder.hasEdited(), let editedBuilder = builder.edited().toBuilder(), editedBuilder.hasText() {
+        //            builder.setEdited(editedBuilder.setText(editedBuilder.text().sanitize()))
+        //        }
+        //
+        //        let message = builder.build()!
+        //
+        //        let description = NSMutableString()
+        //        message.writeDescription(to: description, withIndent: "")
+        //        return description as String
+        
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0680A9C324600306000F80F3 /* ZMClientMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0680A9C1246002DC000F80F3 /* ZMClientMessageTests.swift */; };
 		0680A9C624606288000F80F3 /* ZMMessage+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0680A9C42460627B000F80F3 /* ZMMessage+Reaction.swift */; };
 		068D610324629AB900A110A2 /* ZMBaseManagedObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D610124629AA300A110A2 /* ZMBaseManagedObjectTest.swift */; };
+		06B1C493248F9173007FDA8D /* GenericMessage+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1C492248F9173007FDA8D /* GenericMessage+Debug.swift */; };
 		06B99C79242A293500FEAFDE /* ZMClientMessage+Knock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B99C78242A293500FEAFDE /* ZMClientMessage+Knock.swift */; };
 		06D48735241F930A00881B08 /* GenericMessage+Obfuscation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D48734241F930A00881B08 /* GenericMessage+Obfuscation.swift */; };
 		06D48737241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D48736241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift */; };
@@ -637,6 +638,7 @@
 		0680A9C1246002DC000F80F3 /* ZMClientMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMClientMessageTests.swift; sourceTree = "<group>"; };
 		0680A9C42460627B000F80F3 /* ZMMessage+Reaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Reaction.swift"; sourceTree = "<group>"; };
 		068D610124629AA300A110A2 /* ZMBaseManagedObjectTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMBaseManagedObjectTest.swift; sourceTree = "<group>"; };
+		06B1C492248F9173007FDA8D /* GenericMessage+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Debug.swift"; sourceTree = "<group>"; };
 		06B99C78242A293500FEAFDE /* ZMClientMessage+Knock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Knock.swift"; sourceTree = "<group>"; };
 		06D48734241F930A00881B08 /* GenericMessage+Obfuscation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Obfuscation.swift"; sourceTree = "<group>"; };
 		06D48736241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Obfuscate.swift"; sourceTree = "<group>"; };
@@ -1559,6 +1561,7 @@
 			isa = PBXGroup;
 			children = (
 				F1FDF2F521B152BC00E037A1 /* GenericMessage+Helper.swift */,
+				06B1C492248F9173007FDA8D /* GenericMessage+Debug.swift */,
 				F1FDF2F621B152BC00E037A1 /* GenericMessage+Hashing.swift */,
 				63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */,
 				F1FDF2FF21B1580400E037A1 /* GenericMessage+Utils.swift */,
@@ -2762,6 +2765,7 @@
 				F9DBA5221E28EB4000BE23C0 /* SideEffectSources.swift in Sources */,
 				1672A614234499B500380537 /* LabelChangeInfo.swift in Sources */,
 				06E1C835244F1A2300CA4EF2 /* ZMOTRMessage+Helper.swift in Sources */,
+				06B1C493248F9173007FDA8D /* GenericMessage+Debug.swift in Sources */,
 				1687ABAC20EBE0770007C240 /* UserType.swift in Sources */,
 				16030DB021AD765D00F8032E /* ZMConversation+Confirmations.swift in Sources */,
 				F9A7065C1CAEE01D00C2F5FE /* ZMConnection.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues
We do not remove the text content of protobuf message before logging them. 

### Causes
It was removed during the protobuf refactoring.

### Solutions
Create helper methods that were in objc version.

## Dependencies

**Jira ticket:**
https://wearezeta.atlassian.net/browse/ZIOS-13496

**Old objc code:**
https://github.com/wireapp/wire-ios-data-model/blob/220.0.5/Source/Model/Message/ZMGenericMessage%2BDebug.swift#L73