### PR TITLE
[Fix] Attempt to fix wrong badge count

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1558,6 +1558,7 @@
             messageToBeMarkedAsRead = message;
         }
     }
+    [self.uiMOC saveOrRollback];
     
     // when
     [conversation markMessagesAsReadUntil:messageToBeMarkedAsRead];
@@ -1565,6 +1566,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, messageToBeMarkedAsRead.serverTimestamp);
 }
 
@@ -1580,6 +1582,7 @@
     
     message = [self insertNonUnreadDotGeneratingMessageIntoConversation:conversation];
     conversation.lastServerTimeStamp = message.serverTimestamp;
+    [self.uiMOC saveOrRollback];
     
     // when
     [conversation markMessagesAsReadUntil:message];
@@ -1587,6 +1590,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, message.serverTimestamp);
 }
 
@@ -1605,12 +1609,15 @@
             messageToBeMarkedAsRead = message;
         }
     }
+    [self.uiMOC saveOrRollback];
     
     // when
     [conversation markMessagesAsReadUntil:messageToBeMarkedAsRead];
     [conversation savePendingLastRead];
+    WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, messageToBeMarkedAsRead.serverTimestamp);
 }
 
@@ -1651,12 +1658,14 @@
     for (int i = 0; i < 3; ++i) {
         message = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
     }
+    [self.uiMOC saveOrRollback];
 
     // when
     [conversation markMessagesAsReadUntil:conversation.lastMessage];
     WaitForAllGroupsToBeEmpty(0.5);
 
     // then
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqualObjects(conversation.lastReadServerTimeStamp, message.serverTimestamp);
 }
 
@@ -1678,8 +1687,13 @@
     conversation.remoteIdentifier = NSUUID.createUUID;
     ZMMessage *message = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
     message.sender = self.createUser;
+    [self.uiMOC saveOrRollback];
+    
     [conversation markAsRead];
+    XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
+    
     // WHEN & THEN
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertTrue([conversation canMarkAsUnread]);
 }
 
@@ -1690,12 +1704,18 @@
     conversation.conversationType = ZMConversationTypeConnection;
     conversation.remoteIdentifier = NSUUID.createUUID;
 
-    [self.uiMOC saveOrRollback];
+//    [self.uiMOC saveOrRollback];
 
     ZMMessage* unreadMessage = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
     unreadMessage.sender = self.createUser;
+    [self.uiMOC saveOrRollback];
+    
+    // WHEN
     [conversation markAsRead];
     XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
+    
+    // THEN
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqual(conversation.firstUnreadMessage, nil);
 
     // WHEN
@@ -1703,6 +1723,7 @@
     XCTAssertTrue([self waitForAllGroupsToBeEmptyWithTimeout:0.5]);
     
     // THEN
+    [self.uiMOC refreshObject:conversation mergeChanges:NO];
     XCTAssertEqual(conversation.firstUnreadMessage, unreadMessage);
 }
 
@@ -3219,6 +3240,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:uiConv mergeChanges:NO];
     XCTAssertEqualWithAccuracy([uiConv.lastReadServerTimeStamp timeIntervalSince1970], [firstCallDate timeIntervalSince1970], 0.5);
     
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -3237,6 +3259,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:uiConv mergeChanges:NO];
     XCTAssertEqualWithAccuracy([uiConv.lastReadServerTimeStamp timeIntervalSince1970], [secondCallDate timeIntervalSince1970], 0.5);
     
     [self.syncMOC performGroupedBlockAndWait:^{
@@ -3255,6 +3278,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
+    [self.uiMOC refreshObject:uiConv mergeChanges:NO];
     XCTAssertEqualWithAccuracy([uiConv.lastReadServerTimeStamp timeIntervalSince1970], [thirdCallDate timeIntervalSince1970], 0.5);
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1704,8 +1704,6 @@
     conversation.conversationType = ZMConversationTypeConnection;
     conversation.remoteIdentifier = NSUUID.createUUID;
 
-//    [self.uiMOC saveOrRollback];
-
     ZMMessage* unreadMessage = [self insertDownloadedMessageAfterMessageIntoConversation:conversation];
     unreadMessage.sender = self.createUser;
     [self.uiMOC saveOrRollback];


### PR DESCRIPTION
## What's new in this PR?

### Issues

A badge count is sometimes generated for a conversations where all messages are read.

### Causes

The badge count is calculated by counting the number of conversations which have a `estimatedUnreadCount > 0`. This is a conversation property in the database which is calculated by counting the messages which are newer than `lastReadServerTimestamp`. It's supposed to be re-calculated when a message is inserted, deleted, updated or when the `lastReadServerTimestamp` is changed.

We've observed that sometimes the `lastReadServerTimestamp` had been updated without re-calculating the `estimatedUnreadCount` value. It's unclear exactly why this started to happen now but my guess is that something changed related to when objects are faulted / re-fetched, because we explicitly re-calculate the value when we insert, delete or update a message but when we modify the `lastReadServerTimestamp` we implicitly rely on that the conversation is fetched again on the sync context by doing the unread calculation in `awakeFromFetch()`. This usually happens because we send out a last-read update to sync the read state with other devices.

### Solutions

Don't rely on the implicit re-calculation on the `awakeFromFetch()` but instead do the unread calculation directly after modifying the `lastReadServerTimestamp`. This is a bit complicated since we only do the unread calculation on the sync context but we mark messages as read on the UI context.

The way around this is to dispatch the request to update the `lastReadServerTimestamp` to the sync context.

### Notes

We could in theory remove the unread calculations in `awakeFromFetch()` and `awakeFromInsert()` now as an optimisation.