### PR TITLE
[Feature]: Avoid Digital Signature Multiple Requests

### DIFF
--- a/Source/Model/Message/File/SignatureStatus.swift
+++ b/Source/Model/Message/File/SignatureStatus.swift
@@ -86,8 +86,9 @@ public final class SignatureStatus: NSObject {
     }
     
     public func retrieveSignature() {
-        state = .waitingForSignature
-        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+         guard case .waitingForCodeVerification = state else { return }
+         state = .waitingForSignature
+         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
     
     public func updateLoadingSignatureState() {

--- a/Source/Model/Message/File/SignatureStatus.swift
+++ b/Source/Model/Message/File/SignatureStatus.swift
@@ -33,6 +33,7 @@ public enum PDFSigningState {
     case waitingForConsentURL
     case waitingForCodeVerification
     case waitingForSignature
+    case loadingSignature
     case signatureInvalid
     case finished
 }
@@ -87,6 +88,10 @@ public final class SignatureStatus: NSObject {
     public func retrieveSignature() {
         state = .waitingForSignature
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+    }
+    
+    public func updateLoadingSignatureState() {
+        state = .loadingSignature
     }
     
     public func didReceiveConsentURL(_ url: URL?) {

--- a/Source/Model/Message/File/SignatureStatus.swift
+++ b/Source/Model/Message/File/SignatureStatus.swift
@@ -33,7 +33,6 @@ public enum PDFSigningState {
     case waitingForConsentURL
     case waitingForCodeVerification
     case waitingForSignature
-    case loadingSignature
     case signatureInvalid
     case finished
 }
@@ -89,10 +88,6 @@ public final class SignatureStatus: NSObject {
          guard case .waitingForCodeVerification = state else { return }
          state = .waitingForSignature
          RequestAvailableNotification.notifyNewRequestsAvailable(nil)
-    }
-    
-    public func updateLoadingSignatureState() {
-        state = .loadingSignature
     }
     
     public func didReceiveConsentURL(_ url: URL?) {

--- a/Tests/Source/Model/DigitalSignature/SignatureStatusTests.swift
+++ b/Tests/Source/Model/DigitalSignature/SignatureStatusTests.swift
@@ -38,8 +38,10 @@ final class SignatureStatusTests: ZMBaseManagedObjectTest {
     }
     
     func testThatItChangesStatusAfterTriggerASignDocumentMethod() {
-        // when
+        // given
         XCTAssertEqual(status.state, .initial)
+        
+        // when
         status.signDocument()
         
         // then
@@ -47,6 +49,9 @@ final class SignatureStatusTests: ZMBaseManagedObjectTest {
     }
     
     func testThatItChangesStatusAfterTriggerARetrieveSignatureMethod() {
+        // given
+        status.state = .waitingForCodeVerification
+        
         // when
         status.retrieveSignature()
         


### PR DESCRIPTION
## What's new in this PR?

The PR try to solve the following issue:
If the user tap multiple time in a super short interval on the "Complete Signing" button before we close the OTP screen the request for the digital signature is made multiple times, this cause we don't have control to enable end disable the button (Swisscom web page).