### PR TITLE
[Feature] Support creating/deleting/accessing encryption keys for EAR

### DIFF
--- a/Source/Utilis/EncryptionKeys.swift
+++ b/Source/Utilis/EncryptionKeys.swift
@@ -1,0 +1,339 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Security
+import LocalAuthentication
+
+/// EncryptionKeys is responsible for creating / deleting the encryptions keys
+/// which are used for supporting encryption at rest
+///
+public struct EncryptionKeys {
+    
+    enum KeychainItem {
+        case privateKey(_ account: Account, _ context: LAContext?, _ prompt: String?)
+        case publicKey(Account)
+        case databaseKey(Account)
+        
+        var tag: Data {
+            uniqueIdentifier.data(using: .utf8)!
+        }
+        
+        var uniqueIdentifier: String {
+            "com.wire.ear.\(label).\(accountIdentifier)"
+        }
+        
+        var accountIdentifier: String {
+            switch self {
+            case .privateKey(let account, _, _):
+                return account.userIdentifier.transportString()
+            case .publicKey(let account):
+                return account.userIdentifier.transportString()
+            case .databaseKey(let account):
+                return account.userIdentifier.transportString()
+            }
+        }
+        
+        var label: String {
+            switch self {
+            case .privateKey:
+                return "private"
+            case .publicKey:
+                return "public"
+            case .databaseKey:
+                return "database"
+            }
+        }
+        
+        var getQuery: [CFString: Any] {
+            var query: [CFString: Any]
+            
+            switch self {
+            case .publicKey:
+                query = [kSecClass: kSecClassKey,
+                         kSecAttrApplicationTag: tag,
+                         kSecReturnRef: true]
+            case .databaseKey:
+                query = [kSecClass: kSecClassGenericPassword,
+                         kSecAttrAccount: uniqueIdentifier,
+                         kSecReturnData: true]
+            case .privateKey(_, let context, let prompt):
+                query = [kSecClass: kSecClassKey,
+                         kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+                         kSecAttrLabel: tag,
+                         kSecReturnRef: true,
+                ]
+                
+                if let context = context {
+                    query[kSecUseAuthenticationContext] = context
+                    query[kSecUseAuthenticationUISkip] = true
+                } else if let prompt = prompt {
+                    query[kSecUseOperationPrompt] = prompt
+                }
+            }
+            
+            return query
+        }
+        
+        func setQuery<T>(value: T) -> [CFString: Any] {
+            var query: [CFString: Any]
+            
+            switch self {
+            case .publicKey:
+                query = [kSecClass: kSecClassKey,
+                         kSecAttrApplicationTag: tag,
+                         kSecValueRef: value]
+            case .databaseKey:
+                query = [kSecClass: kSecClassGenericPassword,
+                         kSecAttrAccount: uniqueIdentifier,
+                         kSecValueData: value]
+            case .privateKey:
+                query = [:]
+            }
+            
+            return query
+        }
+    }
+    
+    public enum EncryptionKeysError: Error {
+        case failedToStoreItemInKeychain(OSStatus)
+        case failedToFetchItemFromKeychain(OSStatus)
+        case failedToDeleteItemFromKeychain(OSStatus)
+        case failedToGenerateDatabaseKey(OSStatus)
+        case failedToCopyPublicAccountKey
+        case failedToGenerateAccountKey(underlyingError: Error)
+        case failedToEncryptDatabaseKey(underlyingError: Error)
+        case failedToDecryptDatabaseKey(underlyingError: Error)
+    }
+    
+    /// Public key associated with an account.
+    ///
+    /// This key is used when sensitive information
+    /// needs to be stored while the application operates in the background.
+    public let publicKey: SecKey
+    
+    /// Private key associated with an account.
+    ///
+    /// This key is used by when the app runs in
+    /// the foreground to decrypt data which was previously stored while the app running
+    /// in the background.
+    public let privateKey: SecKey
+    
+    /// Database key associated with an account.
+    ///
+    /// This key is used to encrypt/decrypt
+    /// messages in the database.
+    public let databaseKey: Data
+    
+    private static let databaseKeyAlgorithm: SecKeyAlgorithm = .eciesEncryptionCofactorX963SHA256AESGCM
+    
+    /// Initialise EncryptionKeys for an account.
+    ///
+    /// The encryption keys can only be retrieved if the user is authenticated, this can be done
+    /// by either supplying an LAContext where the user is already authenticated or by letting
+    /// the system display an authentication prompt. Note that the authentication prompt is blocks
+    /// the current thread until the authentication is completed.
+    ///
+    /// - Parameters:
+    ///   - account: Account for which the encryption keys should fetched
+    ///   - context: An already authenticated LAContext
+    ///   - authenticationMessage: message to which is displayed in authentication prompt.
+    ///
+    /// Supplying an authentication context is the preferred way to initialize the encryption keys
+    /// and takes precedence over the authentication prompt.
+    public init(account: Account, context: LAContext? = nil, authenticationMessage: String? = nil) throws {
+        self.publicKey = try Self.fetchItem(.publicKey(account))
+        self.privateKey = try Self.fetchItem(.privateKey(account, context, authenticationMessage))
+        self.databaseKey = try Self.decryptDatabaseKey(Self.fetchItem(.databaseKey(account)), privateKey: privateKey)
+    }
+    
+    // MARK: Create & Destroy keys
+    
+    /// Create all encryption keys and store them in the keychain.
+    ///
+    /// - Parameters:
+    ///   -  account Account for which the encryption keys should created
+    public static func createKeys(for account: Account) throws {
+        let publicKey = try generateAccountKey(identifier: .privateKey(account, nil, nil))
+        try storeItem(.publicKey(account), value: publicKey)
+        try storeItem(.databaseKey(account), value: generateDatabaseKeyEncryptedWithKey(publicKey))
+    }
+    
+    /// Delete all encryption keys and from the keychain.
+    ///
+    /// - Parameters:
+    ///   -  account Account for which the encryption keys should deleted
+    public static func deleteKeys(for account: Account) throws {
+        try deleteItem(.publicKey(account))
+        try deleteItem(.privateKey(account, nil, nil))
+        try deleteItem(.databaseKey(account))
+    }
+    
+    // MARK: Account key
+    
+    /// Fetch the public key associated with an account
+    public static func publicKey(for account: Account) throws -> SecKey {
+        try fetchItem(.publicKey(account))
+    }
+    
+    private static func generateAccountKey(identifier: KeychainItem) throws -> SecKey {
+        #if targetEnvironment(simulator)
+            return try generateSimulatorAccountKey(identifier: identifier)
+        #else
+            return try generateSecureEnclaveAccountKey(identifier: identifier)
+        #endif
+    }
+    
+    private static func generateSecureEnclaveAccountKey(identifier: KeychainItem) throws -> SecKey {
+        var accessError: Unmanaged<CFError>?
+        guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                     [.privateKeyUsage, .userPresence],
+                                                     &accessError)
+            else {
+                let error = accessError!.takeRetainedValue() as Error
+                throw EncryptionKeysError.failedToGenerateAccountKey(underlyingError: error)
+        }
+        
+        let attributes: [CFString : Any] = [
+          kSecAttrKeyType:            kSecAttrKeyTypeECSECPrimeRandom,
+          kSecAttrKeySizeInBits:      256,
+          kSecAttrTokenID:            kSecAttrTokenIDSecureEnclave,
+          kSecPrivateKeyAttrs: [
+            kSecAttrIsPermanent:      true,
+            kSecAttrAccessControl:    access,
+            kSecAttrLabel:            identifier.tag,
+          ]
+        ]
+        
+        var error: Unmanaged<CFError>?
+        guard let privateKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else {
+            let error = error!.takeRetainedValue() as Error
+            throw EncryptionKeysError.failedToGenerateAccountKey(underlyingError: error)
+        }
+        
+        guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
+            throw EncryptionKeysError.failedToCopyPublicAccountKey
+        }
+        
+        return publicKey
+    }
+    
+    private static func generateSimulatorAccountKey(identifier: KeychainItem) throws -> SecKey {
+        var accessError: Unmanaged<CFError>?
+        guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                           kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                           [.userPresence],
+                                                           &accessError)
+            else {
+                let error = accessError!.takeRetainedValue() as Error
+                throw EncryptionKeysError.failedToGenerateAccountKey(underlyingError: error)
+        }
+        
+        let attributes: [CFString : Any] = [
+          kSecAttrKeyType:            kSecAttrKeyTypeECSECPrimeRandom,
+          kSecAttrKeySizeInBits:      256,
+          kSecPrivateKeyAttrs: [
+            kSecAttrIsPermanent:      true,
+            kSecAttrAccessControl:    access,
+            kSecAttrLabel:            identifier.tag,
+          ]
+        ]
+        
+        var error: Unmanaged<CFError>?
+        guard let privateKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else {
+            let error = accessError!.takeRetainedValue() as Error
+            throw EncryptionKeysError.failedToGenerateAccountKey(underlyingError: error)
+        }
+        
+        guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
+            throw EncryptionKeysError.failedToCopyPublicAccountKey
+        }
+        
+        return publicKey
+    }
+    
+    // MARK: - Database key
+    
+    private static func generateDatabaseKeyEncryptedWithKey(_ key: SecKey) throws -> Data {
+        var databaseKey = [UInt8](repeating: 0, count: 256)
+        let status = SecRandomCopyBytes(kSecRandomDefault, databaseKey.count, &databaseKey)
+        
+        guard status == errSecSuccess else {
+            throw EncryptionKeysError.failedToGenerateDatabaseKey(status)
+        }
+                
+        return try encryptDatabaseKey(Data(databaseKey), publicKey: key)
+    }
+    
+    private static func encryptDatabaseKey(_ databaseKey: Data, publicKey: SecKey) throws -> Data {
+        var error: Unmanaged<CFError>?
+        guard let wrappedDatabaseKey = SecKeyCreateEncryptedData(publicKey,
+                                                                 databaseKeyAlgorithm,
+                                                                 databaseKey as CFData, &error) else {
+            let error = error!.takeRetainedValue() as Error
+            throw EncryptionKeysError.failedToEncryptDatabaseKey(underlyingError: error)
+        }
+        
+        return wrappedDatabaseKey as Data
+    }
+    
+    private static func decryptDatabaseKey(_ wrappedDatabaseKey: Data, privateKey: SecKey) throws -> Data {
+        var error: Unmanaged<CFError>?
+        guard let decryptedDatabaseKey = SecKeyCreateDecryptedData(privateKey,
+                                                                   databaseKeyAlgorithm,
+                                                                   wrappedDatabaseKey as CFData,
+                                                                   &error)
+            else {
+                let error = error!.takeRetainedValue() as Error
+                throw EncryptionKeysError.failedToDecryptDatabaseKey(underlyingError: error)
+        }
+        
+        return decryptedDatabaseKey as Data
+    }
+    
+    // MARK: - Keychain access
+        
+    private static func storeItem<T>(_ item: KeychainItem, value: T) throws {
+        let status = SecItemAdd(item.setQuery(value: value) as CFDictionary, nil)
+        
+        guard status == errSecSuccess else {
+            throw EncryptionKeysError.failedToStoreItemInKeychain(status)
+        }
+    }
+    
+    private static func fetchItem<T>(_ item: KeychainItem) throws -> T {
+        var value: CFTypeRef?
+        let status = SecItemCopyMatching(item.getQuery as CFDictionary, &value)
+        
+        guard status == errSecSuccess else {
+            throw EncryptionKeysError.failedToFetchItemFromKeychain(status)
+        }
+        
+        return value as! T
+    }
+    
+    private static func deleteItem(_ item: KeychainItem) throws {
+        let status = SecItemDelete(item.getQuery as CFDictionary)
+        
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw EncryptionKeysError.failedToDeleteItemFromKeychain(status)
+        }
+    }
+    
+}

--- a/Tests/Source/Utils/EncryptionKeysTests.swift
+++ b/Tests/Source/Utils/EncryptionKeysTests.swift
@@ -1,0 +1,95 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class EncryptionKeysTests: XCTestCase {
+    
+    var account: Account!
+
+    override func setUpWithError() throws {
+        account = Account(userName: "John Doe", userIdentifier: UUID())
+    }
+
+    override func tearDownWithError() throws {
+        try EncryptionKeys.deleteKeys(for: account)
+        account = nil
+    }
+    
+    func testThatEncryptionKeysThrowsIfKeysDontExist() {
+        XCTAssertThrowsError(try EncryptionKeys(account: account))
+    }
+    
+    func testThatPublicAccountKeyThrowsIfItDoesNotExist() throws {
+        XCTAssertThrowsError(try EncryptionKeys.publicKey(for: account))
+    }
+    
+    func testThatPublicAccountKeyIsReturnedIfItExists() throws {
+        // given
+        try EncryptionKeys.createKeys(for: account)
+        
+        // when
+        let publicKey = try EncryptionKeys.publicKey(for: account)
+        
+        // then
+        XCTAssertNotNil(publicKey)
+    }
+
+    func testThatEncryptionKeysAreSuccessfullyCreated() throws {
+        // when
+        try EncryptionKeys.createKeys(for: account)
+        
+        // then
+        let encryptionkeys = try EncryptionKeys(account: account)
+        XCTAssertEqual(encryptionkeys.databaseKey.count, 256)
+    }
+    
+    func testThatEncryptionKeysAreSuccessfullyDeleted() throws {
+        // given
+        try EncryptionKeys.createKeys(for: account)
+        
+        // when
+        try EncryptionKeys.deleteKeys(for: account)
+        
+        // then
+        XCTAssertThrowsError(try EncryptionKeys(account: account))
+    }
+    
+    func testThatAsymmetricKeysWorksWithExpectedAlgorithm() throws {
+        // given
+        let data = "Hello world".data(using: .utf8)!
+        try EncryptionKeys.createKeys(for: account)
+        
+        // when
+        let encryptionkeys = try EncryptionKeys(account: account)
+        
+        let encryptedData = SecKeyCreateEncryptedData(encryptionkeys.publicKey,
+                                                      .eciesEncryptionCofactorX963SHA256AESGCM,
+                                                      data as CFData,
+                                                      nil)!
+        
+        let decryptedData = SecKeyCreateDecryptedData(encryptionkeys.privateKey,
+                                                      .eciesEncryptionCofactorX963SHA256AESGCM,
+                                                      encryptedData,
+                                                      nil)!
+        
+        XCTAssertEqual(decryptedData as Data, data)
+    }
+    
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		16DF3B5F2289510600D09365 /* ZMConversationTests+Legalhold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DF3B5E2289510600D09365 /* ZMConversationTests+Legalhold.swift */; };
 		16E0FBC923326B72000E3235 /* ConversationDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E0FBC823326B72000E3235 /* ConversationDirectory.swift */; };
 		16E6F24824B36D550015B249 /* NSManagedObjectContext+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6F24724B36D550015B249 /* NSManagedObjectContext+EncryptionAtRest.swift */; };
+		16E6F26424B614DC0015B249 /* EncryptionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6F26324B614DC0015B249 /* EncryptionKeys.swift */; };
+		16E6F26624B8952F0015B249 /* EncryptionKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6F26524B8952F0015B249 /* EncryptionKeysTests.swift */; };
 		16E7DA281FD9973B0065B6A6 /* store2-39-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16E7DA261FD995810065B6A6 /* store2-39-0.wiredatabase */; };
 		16E7DA2A1FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E7DA291FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift */; };
 		16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */; };
@@ -740,6 +742,8 @@
 		16DF3B5E2289510600D09365 /* ZMConversationTests+Legalhold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Legalhold.swift"; sourceTree = "<group>"; };
 		16E0FBC823326B72000E3235 /* ConversationDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDirectory.swift; sourceTree = "<group>"; };
 		16E6F24724B36D550015B249 /* NSManagedObjectContext+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+EncryptionAtRest.swift"; sourceTree = "<group>"; };
+		16E6F26324B614DC0015B249 /* EncryptionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeys.swift; sourceTree = "<group>"; };
+		16E6F26524B8952F0015B249 /* EncryptionKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionKeysTests.swift; sourceTree = "<group>"; };
 		16E7DA261FD995810065B6A6 /* store2-39-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-39-0.wiredatabase"; path = "Tests/Resources/store2-39-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
 		16E7DA291FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+SelfConversationUpdateTests.swift"; sourceTree = "<group>"; };
 		16F6BB391EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+ObserverHelper.swift"; sourceTree = "<group>"; };
@@ -1408,6 +1412,7 @@
 				16626507217F4E0B00300F45 /* GenericMessageTests+Hashing.swift */,
 				871DD79E2084A316006B1C56 /* BatchDeleteTests.swift */,
 				54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */,
+				16E6F26524B8952F0015B249 /* EncryptionKeysTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -1913,6 +1918,7 @@
 				5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */,
 				5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */,
 				63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */,
+				16E6F26324B614DC0015B249 /* EncryptionKeys.swift */,
 			);
 			name = Utilis;
 			path = Source/Utilis;
@@ -2887,6 +2893,7 @@
 				165DC52121491D8700090B7B /* ZMClientMessage+TextMessageData.swift in Sources */,
 				541D1B331F1F8D660078C1F2 /* StorageStack.swift in Sources */,
 				BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */,
+				16E6F26424B614DC0015B249 /* EncryptionKeys.swift in Sources */,
 				1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */,
 				63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */,
 				BF3493F21EC3623200B0C314 /* ZMUser+Teams.swift in Sources */,
@@ -3099,6 +3106,7 @@
 				0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */,
 				068D610324629AB900A110A2 /* ZMBaseManagedObjectTest.swift in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,
+				16E6F26624B8952F0015B249 /* EncryptionKeysTests.swift in Sources */,
 				16F6BB3C1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift in Sources */,
 				1639A8512264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift in Sources */,
 				F9DBA5271E28EEBD00BE23C0 /* UserObserverTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Add support for creating encryption keys necessary for EAR. The idea is that the `EncryptionKeys` struct should only be initialised when the application runs in the foreground and the user is authenticated. An attempt to initialise `EncryptionKeys` in any other scenario will throw an error.

**NOTE:** The Secure Enclave is not available in the simulator so when running there the account key is stored in the keychain instead.