### PR TITLE
[Feature] Store the database key in each contexts userInfo

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory+EncryptionAtRest.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory+EncryptionAtRest.swift
@@ -18,25 +18,22 @@
 
 import Foundation
 
-extension NSManagedObjectContext {
-    
-    public var encryptMessagesAtRest: Bool {
-        set {
-            setPersistentStoreMetadata(NSNumber(booleanLiteral: newValue),
-                                       key: PersistentMetadataKey.encryptMessagesAtRest.rawValue)
-        }
-        get {
-            (persistentStoreMetadata(forKey: PersistentMetadataKey.encryptMessagesAtRest.rawValue) as? NSNumber)?.boolValue ?? false
+public extension ManagedObjectContextDirectory {
+
+    /// Synchronously stores the given database key in each managed object context.
+
+    func storeDatabaseKeyInAllContexts(databaseKey: Data) {
+        for context in [uiContext, syncContext, searchContext] {
+            context?.performAndWait { context?.databaseKey = databaseKey }
         }
     }
 
-    // MARK: - Database Key
+    /// Synchronously clears the database key in each managed object context.
 
-    private static let databaseKeyUserInfoKey = "databaseKey"
-
-    var databaseKey: Data? {
-        set { userInfo[Self.databaseKeyUserInfoKey] = newValue }
-        get { userInfo[Self.databaseKeyUserInfoKey] as? Data }
+    func clearDatabaseKeyInAllContexts() {
+        for context in [uiContext, syncContext, searchContext] {
+            context?.performAndWait { context?.databaseKey = nil }
+        }
     }
 
 }

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
@@ -30,17 +30,33 @@ class ManagedObjectContextDirectoryTests: DatabaseBaseTest {
         sut.storeDatabaseKeyInAllContexts(databaseKey: databaseKey)
 
         // Then
-        XCTAssertEqual(sut.uiContext.databaseKey, databaseKey)
-        XCTAssertEqual(sut.syncContext.databaseKey, databaseKey)
-        XCTAssertEqual(sut.searchContext.databaseKey, databaseKey)
+        sut.uiContext.performGroupedBlockAndWait {
+            XCTAssertEqual(sut.uiContext.databaseKey, databaseKey)
+        }
+
+        sut.syncContext.performGroupedBlockAndWait {
+            XCTAssertEqual(sut.syncContext.databaseKey, databaseKey)
+        }
+
+        sut.searchContext.performGroupedBlockAndWait {
+            XCTAssertEqual(sut.searchContext.databaseKey, databaseKey)
+        }
 
         // When
         sut.clearDatabaseKeyInAllContexts()
 
         // Then
-        XCTAssertNil(sut.uiContext.databaseKey)
-        XCTAssertNil(sut.syncContext.databaseKey)
-        XCTAssertNil(sut.searchContext.databaseKey)
+        sut.uiContext.performGroupedBlockAndWait {
+            XCTAssertNil(sut.uiContext.databaseKey)
+        }
+
+        sut.syncContext.performGroupedBlockAndWait {
+            XCTAssertNil(sut.syncContext.databaseKey)
+        }
+
+        sut.searchContext.performGroupedBlockAndWait {
+            XCTAssertNil(sut.searchContext.databaseKey)
+        }
     }
 
 }

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
@@ -1,0 +1,46 @@
+////
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class ManagedObjectContextDirectoryTests: DatabaseBaseTest {
+
+    func testThatItStoresAndClearsDatabaseKeyOnAllContexts() {
+        // Given
+        let sut = createStorageStackAndWaitForCompletion()
+        let databaseKey = "abc".data(using: .utf8)!
+
+        // When
+        sut.storeDatabaseKeyInAllContexts(databaseKey: databaseKey)
+
+        // Then
+        XCTAssertEqual(sut.uiContext.databaseKey, databaseKey)
+        XCTAssertEqual(sut.syncContext.databaseKey, databaseKey)
+        XCTAssertEqual(sut.searchContext.databaseKey, databaseKey)
+
+        // When
+        sut.clearDatabaseKeyInAllContexts()
+
+        // Then
+        XCTAssertNil(sut.uiContext.databaseKey)
+        XCTAssertNil(sut.syncContext.databaseKey)
+        XCTAssertNil(sut.searchContext.databaseKey)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -359,6 +359,8 @@
 		D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CA2063ECD400716618 /* BackupMetadataTests.swift */; };
 		D5FA30CF2063F8EC00716618 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CE2063F8EC00716618 /* Version.swift */; };
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
+		EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */; };
+		EEA2B84624DA943200C6659E /* ManagedObjectContextDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */; };
 		EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
@@ -1018,6 +1020,8 @@
 		D5FA30CE2063F8EC00716618 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		D5FA30D02063FD3A00716618 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		D5FD9FD32073B94500F6F4FC /* zmessaging2.45.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.45.0.xcdatamodel; sourceTree = "<group>"; };
+		EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagedObjectContextDirectory+EncryptionAtRest.swift"; sourceTree = "<group>"; };
+		EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ManagedObjectContextDirectoryTests.swift; path = Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift; sourceTree = SOURCE_ROOT; };
 		EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStorageInitialization.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
@@ -1632,6 +1636,7 @@
 				EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */,
 				541D1B361F1FBECE0078C1F2 /* NSPersistentStoreCoordinator+Wire.swift */,
 				541D1B341F1FAE3C0078C1F2 /* ManagedObjectContextDirectory.swift */,
+				EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */,
 				F9A705CB1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging-Internal.h */,
 				F9A705CC1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.h */,
 				F9A705CD1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.m */,
@@ -1971,6 +1976,7 @@
 		F9A708031CAEEB7400C2F5FE /* ManagedObjectContext */ = {
 			isa = PBXGroup;
 			children = (
+				EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */,
 				F9A708041CAEEB7400C2F5FE /* ManagedObjectContextSaveNotificationTests.m */,
 				F9A708051CAEEB7400C2F5FE /* ManagedObjectContextTests.m */,
 				F14FA376221DB05B005E7EF5 /* MockBackgroundActivityManager.swift */,
@@ -2940,6 +2946,7 @@
 				541E4F951CBD182100D82D69 /* FileAssetCache.swift in Sources */,
 				165911551DF054AD007FA847 /* ZMConversation+Predicates.swift in Sources */,
 				0663285E2428CEC3005BB3BE /* ZMClientMessage+Deletion.swift in Sources */,
+				EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */,
 				165124D62188CF66006A3C75 /* ZMClientMessage+Editing.swift in Sources */,
 				165D3A2D1E1D47AB0052E654 /* ZMCallState.swift in Sources */,
 				F9A706731CAEE01D00C2F5FE /* AssetEncryption.swift in Sources */,
@@ -3115,6 +3122,7 @@
 				F9AB395B1CB3AED900A7254F /* BaseTestSwiftHelpers.swift in Sources */,
 				A923D77E239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift in Sources */,
 				F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */,
+				EEA2B84624DA943200C6659E /* ManagedObjectContextDirectoryTests.swift in Sources */,
 				1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,
 				F9A7083E1CAEEB7500C2F5FE /* NSFetchRequestTests+ZMRelationshipKeyPaths.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

In order to encrypt and decrypt message content in the database, we need access to the database key. The database key should never persisted and only live in RAM. We should aim to keep the references to the key to an absolute minimum so as to avoid the key surviving for extended periods of time. Furthermore, keeping the references to the key to a strictly small set of known objects allows us to remove those references when we want, such as when moving to the background.

For these reasons, I believe it's best to avoid passing the database key through all the codepaths from high level business logic to low level database access, where the encryption / decryption takes place. Instead, we can provide access to the database key for all managed objects through their corresponding managed object context.

The key is stored in the `userInfo` of each of the three managed object contexts defined in the `ManagedObjectContextDirectory`. Two helper methods on this directory object allow us to set the key and remove it from all contexts synchronously. The intended use is to store the key when the database is unlocked (after authentication) and remove the key when the database is locked.