### PR TITLE
[Fix] Database key should be 256 bits

### DIFF
--- a/Source/Utilis/EncryptionKeys.swift
+++ b/Source/Utilis/EncryptionKeys.swift
@@ -285,7 +285,7 @@ public struct EncryptionKeys {
     // MARK: - Database key
     
     private static func generateDatabaseKey() throws -> Data {
-        var databaseKey = [UInt8](repeating: 0, count: 256)
+        var databaseKey = [UInt8](repeating: 0, count: 32)
         let status = SecRandomCopyBytes(kSecRandomDefault, databaseKey.count, &databaseKey)
         
         guard status == errSecSuccess else {

--- a/Tests/Source/Utils/EncryptionKeysTests.swift
+++ b/Tests/Source/Utils/EncryptionKeysTests.swift
@@ -56,7 +56,7 @@ class EncryptionKeysTests: XCTestCase {
         let encryptionkeys = try EncryptionKeys.createKeys(for: account)
         
         // then
-        XCTAssertEqual(encryptionkeys.databaseKey.count, 256)
+        XCTAssertEqual(encryptionkeys.databaseKey.count, 32)
     }
     
     func testThatEncryptionKeysAreSuccessfullyFetched() throws {
@@ -67,7 +67,7 @@ class EncryptionKeysTests: XCTestCase {
         let encryptionKeys = try EncryptionKeys(account: account)
         
         // then
-        XCTAssertEqual(encryptionKeys.databaseKey.count, 256)
+        XCTAssertEqual(encryptionKeys.databaseKey.count, 32)
     }
     
     func testThatEncryptionKeysAreSuccessfullyDeleted() throws {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The database key does not work with AES256GCM encryption.

### Causes

The expected key length is 256 bits (32 bytes), but the actual key length is 2048 bits (256 bytes).

### Solutions

Change the key length.

