### PR TITLE
[Fix] Private key can't be retrieved on a real device

### DIFF
--- a/Source/Utilis/EncryptionKeys.swift
+++ b/Source/Utilis/EncryptionKeys.swift
@@ -85,7 +85,7 @@ public struct EncryptionKeys {
                 
                 if let context = context {
                     query[kSecUseAuthenticationContext] = context
-                    query[kSecUseAuthenticationUISkip] = true
+                    query[kSecUseAuthenticationUI] = kSecUseAuthenticationUISkip
                 } else if let prompt = prompt {
                     query[kSecUseOperationPrompt] = prompt
                 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The private key stored in the Secure Enclave can't be fetched on a real device.

### Causes

The fetch request fails with error code -50 indicating that the get query is configured incorrectly. Looking at the properties of the get query when running on a real device we can see that we are trying to set `kSecUseAuthenticationUISkip` to `true`, which is incorrect. `kSecUseAuthenticationUISkip` is value and not a property key.

### Solutions

Correctly configure the `kSecUseAuthenticationUI` property.
