### PR TITLE
[Feature] Provide additional data when encrypting

### DIFF
--- a/Tests/Source/Model/Messages/ZMGenericMessageDataTests.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageDataTests.swift
@@ -32,6 +32,7 @@ class ZMGenericMessageDataTests: ModelObjectsTests {
         super.setUp()
         uiMOC.encryptMessagesAtRest = false
         uiMOC.databaseKey = nil
+        createSelfClient(onMOC: uiMOC)
     }
 
     // MARK: - Positive Tests


### PR DESCRIPTION
## What's new in this PR?

When encrypting generic message data we now provide additional data which will be bound to the ciphertext. A ciphertext bound to contextual data can only be decrypted with the same contextual data. For this reason, it should not change over the life of the ciphertext. 

The chosen contextual data is a combination of the user id and client id. In the case of restoring a backup on a new device, the client id will change, however we will not be backing up generic message data in its encrypted form.

