### PR TITLE
[Refactor] Store all encryption keys in the MOC

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory+EncryptionAtRest.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory+EncryptionAtRest.swift
@@ -20,19 +20,19 @@ import Foundation
 
 public extension ManagedObjectContextDirectory {
 
-    /// Synchronously stores the given database key in each managed object context.
+    /// Synchronously stores the given encryption keys in each managed object context.
 
-    func storeDatabaseKeyInAllContexts(databaseKey: Data) {
+    func storeEncryptionKeysInAllContexts(encryptionKeys: EncryptionKeys) {
         for context in [uiContext, syncContext, searchContext] {
-            context?.performAndWait { context?.databaseKey = databaseKey }
+            context?.performAndWait { context?.encryptionKeys = encryptionKeys }
         }
     }
 
-    /// Synchronously clears the database key in each managed object context.
+    /// Synchronously clears the encryption keys in each managed object context.
 
-    func clearDatabaseKeyInAllContexts() {
+    func clearEncryptionKeysInAllContexts() {
         for context in [uiContext, syncContext, searchContext] {
-            context?.performAndWait { context?.databaseKey = nil }
+            context?.performAndWait { context?.encryptionKeys = nil }
         }
     }
 

--- a/Source/ManagedObjectContext/NSManagedObjectContext+EncryptionAtRest.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+EncryptionAtRest.swift
@@ -32,11 +32,11 @@ extension NSManagedObjectContext {
 
     // MARK: - Database Key
 
-    private static let databaseKeyUserInfoKey = "databaseKey"
+    private static let encryptionKeysUserInfoKey = "encryptionKeys"
 
-    var databaseKey: Data? {
-        set { userInfo[Self.databaseKeyUserInfoKey] = newValue }
-        get { userInfo[Self.databaseKeyUserInfoKey] as? Data }
+    public var encryptionKeys: EncryptionKeys? {
+        set { userInfo[Self.encryptionKeysUserInfoKey] = newValue }
+        get { userInfo[Self.encryptionKeysUserInfoKey] as? EncryptionKeys }
     }
 
 }

--- a/Source/Model/Message/ZMGenericMessageData.swift
+++ b/Source/Model/Message/ZMGenericMessageData.swift
@@ -124,14 +124,14 @@ import WireCryptobox
 
     private func decryptDataIfNeeded(data: Data, in moc: NSManagedObjectContext) throws -> Data {
         guard let nonce = nonce else { return data }
-        guard let key = moc.databaseKey else { throw EncryptionError.missingDatabaseKey }
+        guard let key = moc.encryptionKeys?.databaseKey else { throw EncryptionError.missingDatabaseKey }
         let context = contextData(for: moc)
         return try ChaCha20Poly1305.AEADEncryption.decrypt(ciphertext: data, nonce: nonce, context: context, key: key)
     }
 
     private func encryptDataIfNeeded(data: Data, in moc: NSManagedObjectContext) throws -> (data: Data, nonce: Data?) {
         guard moc.encryptMessagesAtRest else { return (data, nonce: nil) }
-        guard let key = moc.databaseKey else { throw EncryptionError.missingDatabaseKey }
+        guard let key = moc.encryptionKeys?.databaseKey else { throw EncryptionError.missingDatabaseKey }
         let context = contextData(for: moc)
         let (ciphertext, nonce) = try ChaCha20Poly1305.AEADEncryption.encrypt(message: data, context: context, key: key)
         return (ciphertext, nonce)

--- a/Source/Utilis/EncryptionKeys.swift
+++ b/Source/Utilis/EncryptionKeys.swift
@@ -23,7 +23,7 @@ import LocalAuthentication
 /// EncryptionKeys is responsible for creating / deleting the encryptions keys
 /// which are used for supporting encryption at rest
 ///
-public struct EncryptionKeys {
+public struct EncryptionKeys: Equatable {
     
     enum KeychainItem {
         case privateKey(_ account: Account, _ context: LAContext?, _ prompt: String?)

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift
@@ -24,39 +24,43 @@ class ManagedObjectContextDirectoryTests: DatabaseBaseTest {
     func testThatItStoresAndClearsDatabaseKeyOnAllContexts() {
         // Given
         let sut = createStorageStackAndWaitForCompletion()
-        let databaseKey = "abc".data(using: .utf8)!
+        let account = Account(userName: "", userIdentifier: UUID())
+        let encryptionKeys = try! EncryptionKeys.createKeys(for: account)
 
         // When
-        sut.storeDatabaseKeyInAllContexts(databaseKey: databaseKey)
+        sut.storeEncryptionKeysInAllContexts(encryptionKeys: encryptionKeys)
 
         // Then
         sut.uiContext.performGroupedBlockAndWait {
-            XCTAssertEqual(sut.uiContext.databaseKey, databaseKey)
+            XCTAssertEqual(sut.uiContext.encryptionKeys, encryptionKeys)
         }
 
         sut.syncContext.performGroupedBlockAndWait {
-            XCTAssertEqual(sut.syncContext.databaseKey, databaseKey)
+            XCTAssertEqual(sut.syncContext.encryptionKeys, encryptionKeys)
         }
 
         sut.searchContext.performGroupedBlockAndWait {
-            XCTAssertEqual(sut.searchContext.databaseKey, databaseKey)
+            XCTAssertEqual(sut.searchContext.encryptionKeys, encryptionKeys)
         }
 
         // When
-        sut.clearDatabaseKeyInAllContexts()
+        sut.clearEncryptionKeysInAllContexts()
 
         // Then
         sut.uiContext.performGroupedBlockAndWait {
-            XCTAssertNil(sut.uiContext.databaseKey)
+            XCTAssertNil(sut.uiContext.encryptionKeys)
         }
 
         sut.syncContext.performGroupedBlockAndWait {
-            XCTAssertNil(sut.syncContext.databaseKey)
+            XCTAssertNil(sut.syncContext.encryptionKeys)
         }
 
         sut.searchContext.performGroupedBlockAndWait {
-            XCTAssertNil(sut.searchContext.databaseKey)
+            XCTAssertNil(sut.searchContext.encryptionKeys)
         }
+        
+        // Clean up
+        try! EncryptionKeys.deleteKeys(for: account)
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

We are currently storing the database key in the MOCs and also in the `SyncStatus` in SE. This PR attempts to unify these to approaches so that keep all the keys in one place in memory.

- Store all encryption keys instead of only database key
- Update tests