### PR TITLE
[Fix]: Path Traversal on Attachments

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -142,18 +142,14 @@ extension ZMAssetClientMessage: ZMFileMessageData {
         guard
             let assetURL = asset?.fileURL,
             let temporaryDirectoryURL = temporaryDirectoryURL,
-            var filename = filename
+            let filename = filename,
+            !(filename as NSString).lastPathComponent.isEmpty
         else {
             return nil
         }
         
-        filename = (filename as NSString).lastPathComponent
-        
-        guard !filename.isEmpty else {
-            return nil
-        }
-        
-        var temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(filename)
+        let secureFilename = (filename as NSString).lastPathComponent
+        var temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(secureFilename)
         
         if let fileExtension = fileExtension,
             richAssetType == .audio,

--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -148,6 +148,11 @@ extension ZMAssetClientMessage: ZMFileMessageData {
         }
         
         filename = (filename as NSString).lastPathComponent
+        
+        guard !filename.isEmpty else {
+            return nil
+        }
+        
         var temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(filename)
         
         if let fileExtension = fileExtension,

--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -139,10 +139,15 @@ extension ZMAssetClientMessage: ZMFileMessageData {
     }
     
     public var fileURL: URL? {
-        guard let assetURL = asset?.fileURL,
-            let filename = filename,
-            let temporaryDirectoryURL = temporaryDirectoryURL else { return nil }
+        guard
+            let assetURL = asset?.fileURL,
+            let temporaryDirectoryURL = temporaryDirectoryURL,
+            var filename = filename
+        else {
+            return nil
+        }
         
+        filename = (filename as NSString).lastPathComponent
         var temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(filename)
         
         if let fileExtension = fileExtension,

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -117,7 +117,13 @@ extension ZMAssetClientMessageTests {
         // then
         XCTAssertNotNil(sut)
         XCTAssertNotNil(sut?.fileURL)
-        XCTAssertTrue(((sut?.fileURL?.absoluteString.contains("../../")) != nil))
+
+        guard let absoluteString = sut?.fileURL?.absoluteString else {
+            XCTFail("asset doesn't have a file URL")
+            return
+        }
+        
+        XCTAssertFalse(absoluteString.contains("../"))
     }
     
     func testThatItCreatesFileAssetMessageInTheRightStateToBeUploaded()

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -40,7 +40,7 @@ class BaseZMAssetClientMessageTests : BaseZMClientMessageTests {
     }
     
     override func createFileMetadata(filename: String? = nil) -> ZMFileMetadata {
-        let metadata = super.createFileMetadata()
+        let metadata = super.createFileMetadata(filename: filename)
         currentTestURL = metadata.fileURL
         return metadata
     }
@@ -107,6 +107,18 @@ class ZMAssetClientMessageTests : BaseZMAssetClientMessageTests {
 // MARK: - ZMAsset / ZMFileMessageData
 
 extension ZMAssetClientMessageTests {
+    
+    func testThatItCreatesFileAssetMessageWithNotRelativePath()
+    {
+        // given
+        let metadata = createFileMetadata(filename: "../../fileName")
+        let sut = appendFileMessage(to: conversation, fileMetaData: metadata)
+        
+        // then
+        XCTAssertNotNil(sut)
+        XCTAssertNotNil(sut?.fileURL)
+        XCTAssertTrue(((sut?.fileURL?.absoluteString.contains("../../")) != nil))
+    }
     
     func testThatItCreatesFileAssetMessageInTheRightStateToBeUploaded()
     {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Someone can send to the user a file in Wire which will be sent as an `Asset`.
The asset contains among other things the name of the file. In the code that I linked to we are creating a path to a file on the file system which has the same name.
An attacker can choose to send a file path in the name like ".../.../secret.txt" this will fool our code which creates the file URL to navigate to place on disk which was not intended.

### Solutions

We should do some validation on name property so that an attacker can't traverse the file system. The easiest way is always taking the lastPathComponent from the file name.

### Attachments

[lastPathComponent.playground.zip](https://github.com/wireapp/wire-ios-data-model/files/5101320/lastPathComponent.playground.zip)

