### PR TITLE
[Fix] Dont set normalizedText when encrypt messages at rest is enabled

### DIFF
--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -36,9 +36,12 @@ extension ZMClientMessage {
     /// Reccomputes the message's `normalizedText` property if the message
     /// has a message text, otherwise sets it to an empty String.
     override func updateNormalizedText() {
-        // We check if the message is obfuscated first to avoid checking the
-        // protobuf for the textMessageData and return early.
-        if isObfuscated {
+        // We we don't to set or update the normalized text if the message is obfuscated
+        // or if messages are encrypted at rest since that would leak a plain text version
+        // of the message.
+        guard !isObfuscated,
+              managedObjectContext?.encryptMessagesAtRest == false
+        else {
             normalizedText = ""
             return
         }

--- a/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -96,6 +96,8 @@ class BaseZMClientMessageTests : BaseZMMessageTests {
             self.syncMOC.saveOrRollback()
         }
         
+        self.uiMOC.refreshAllObjects()
+        
         self.selfUser = try! self.uiMOC.existingObject(with: self.syncSelfUser.objectID) as! ZMUser
         self.selfClient1 = try! self.uiMOC.existingObject(with: self.syncSelfClient1.objectID) as! UserClient
         self.uiMOC.setPersistentStoreMetadata(self.selfClient1.remoteIdentifier!, key: "PersistedClientId")

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -101,6 +101,21 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         XCTAssertEqual(match, firstMessage)
         verifyAllMessagesAreIndexed(in: conversation)
     }
+    
+    func testThatItDoesntPopulateTheNormalizedTextField_WhenEncryptMessagesAtRestIsEnabled() {
+        uiMOC.encryptMessagesAtRest = true
+        uiMOC.encryptionKeys = validEncryptionKeys
+        
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.remoteIdentifier = .create()
+        
+        // When
+        let message = conversation.append(text: "This is the first message in the conversation") as! ZMMessage
+        XCTAssert(uiMOC.saveOrRollback())
+        
+        // Then
+        XCTAssertEqual(message.normalizedText, "")
+    }
 
     func testThatItPopulatesTheNormalizedTextFieldAndReturnsTheQueryResults() {
         // Given


### PR DESCRIPTION
## What's new in this PR?

### Issues

When inserting a message we update `normalizedText`, which contains a normalised version of the text message suitable for searching. This was also happening when `encryptMessagesAtRest` was enabled which defeats its purpose since we would then store a plain text version of the message in the database. 



### Solutions

Skip updating the `normalizedText` property when `encryptMessagesAtRest` is enabled in the same way we do for obfuscated messages.