### PR TITLE
[Refactor] Add PushToken decoder

### DIFF
--- a/Source/Model/UserClient/PushToken.swift
+++ b/Source/Model/UserClient/PushToken.swift
@@ -38,14 +38,37 @@ public struct PushToken: Equatable, Codable {
     public var isRegistered: Bool
     public var isMarkedForDeletion: Bool = false
     public var isMarkedForDownload: Bool = false
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        deviceToken = try container.decode(Data.self, forKey: .deviceToken)
+        appIdentifier = try container.decode(String.self, forKey: .appIdentifier)
+        transportType = try container.decode(String.self, forKey: .transportType)
+        
+        // Property 'type' was added to use two token types: voip (old) and apns (new). All old clients with voip token did not have this property, so we need to set it by default as .voip.
+        type = try container.decodeIfPresent(TokenType.self, forKey: .type) ?? .voip
+        isRegistered = try container.decode(Bool.self, forKey: .isRegistered)
+        isMarkedForDeletion = try container.decode(Bool.self, forKey: .isMarkedForDeletion)
+        isMarkedForDownload = try container.decode(Bool.self, forKey: .isMarkedForDownload)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deviceToken, appIdentifier, transportType, type, isRegistered, isMarkedForDeletion, isMarkedForDownload
+    }
 }
 
 extension PushToken {
-
+    
     public init(deviceToken: Data, appIdentifier: String, transportType: String, type: TokenType, isRegistered: Bool) {
-        self.init(deviceToken: deviceToken, appIdentifier: appIdentifier, transportType: transportType, type: type, isRegistered: isRegistered, isMarkedForDeletion: false, isMarkedForDownload: false)
+        self.deviceToken = deviceToken
+        self.appIdentifier = appIdentifier
+        self.transportType = transportType
+        self.type = type
+        self.isRegistered = isRegistered
+        self.isMarkedForDeletion = false
+        self.isMarkedForDownload = false
     }
-
+    
     public var deviceTokenString: String {
         return deviceToken.zmHexEncodedString()
     }

--- a/Tests/Source/Model/UserClient/PushTokenTests.swift
+++ b/Tests/Source/Model/UserClient/PushTokenTests.swift
@@ -21,6 +21,15 @@ import XCTest
 
 final class PushTokenTests: XCTestCase {
 
+    struct MockOldPushToken: Encodable {
+        public let deviceToken: Data
+        public let appIdentifier: String
+        public let transportType: String
+        public var isRegistered: Bool
+        public var isMarkedForDeletion: Bool
+        public var isMarkedForDownload: Bool
+    }
+    
     var sut: PushToken!
     
     override func setUp() {
@@ -63,5 +72,52 @@ final class PushTokenTests: XCTestCase {
 
         XCTAssertFalse(reset.isMarkedForDownload)
         XCTAssertFalse(reset.isMarkedForDownload)
+    }
+    
+    func testThatItCreatesAPushTokenWithDefaultVoipTokenType() {
+        // given
+        let mockPushToken = MockOldPushToken(deviceToken: Data([0x01, 0x02, 0x03]),
+                             appIdentifier: "com.wire.zclient",
+                             transportType: "APNS_VOIP",
+                             isRegistered: true,
+                             isMarkedForDeletion: false,
+                             isMarkedForDownload: false)
+        
+        let pushTokenData = try! JSONEncoder().encode(mockPushToken)
+       
+        // when
+        let decodedPushToken = try! JSONDecoder().decode(PushToken.self, from: pushTokenData)
+        
+        // then
+        let expectedPushToken = PushToken(deviceToken: Data([0x01, 0x02, 0x03]),
+                                          appIdentifier: "com.wire.zclient",
+                                          transportType: "APNS_VOIP",
+                                          type: .voip,
+                                          isRegistered: true)
+        
+        XCTAssertEqual(decodedPushToken, expectedPushToken)
+    }
+    
+    func testThatItDecodesPushToken() {
+        // given
+        let mockPushToken = PushToken(deviceToken: Data([0x01, 0x02, 0x03]),
+                                      appIdentifier: "com.wire.zclient",
+                                      transportType: "APNS",
+                                      type: .standard,
+                                      isRegistered: true)
+        
+        let pushTokenData = try! JSONEncoder().encode(mockPushToken)
+        
+        // when
+        let decodedPushToken = try! JSONDecoder().decode(PushToken.self, from: pushTokenData)
+        
+        // then
+        let expectedPushToken = PushToken(deviceToken: Data([0x01, 0x02, 0x03]),
+                                          appIdentifier: "com.wire.zclient",
+                                          transportType: "APNS",
+                                          type: .standard,
+                                          isRegistered: true)
+        
+        XCTAssertEqual(decodedPushToken, expectedPushToken)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

To be able to decoder push token without `type` property we need to have a custom decoder. All old clients will have `type` by default as `.voip`.