### PR TITLE
[Fix] Badge count not updating on receiving a push notification

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -233,27 +233,12 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 {
     [super awakeFromFetch];
     self.lastReadTimestampSaveDelay = ZMConversationDefaultLastReadTimestampSaveDelay;
-    if (self.managedObjectContext.zm_isSyncContext) {
-        // From the documentation: The managed object context’s change processing is explicitly disabled around this method so that you can use public setters to establish transient values and other caches without dirtying the object or its context.
-        // Therefore we need to do a dispatch async  here in a performGroupedBlock to update the unread properties outside of awakeFromFetch
-        ZM_WEAK(self);
-        [self.managedObjectContext performGroupedBlock:^{
-            ZM_STRONG(self);
-            [self calculateLastUnreadMessages];
-        }];
-    }
 }
 
 - (void)awakeFromInsert;
 {
     [super awakeFromInsert];
     self.lastReadTimestampSaveDelay = ZMConversationDefaultLastReadTimestampSaveDelay;
-    if (self.managedObjectContext.zm_isSyncContext) {
-        // From the documentation: You are typically discouraged from performing fetches within an implementation of awakeFromInsert. Although it is allowed, execution of the fetch request can trigger the sending of internal Core Data notifications which may have unwanted side-effects. Since we fetch the unread messages here, we should do a dispatch async
-        [self.managedObjectContext performGroupedBlock:^{
-            [self calculateLastUnreadMessages];
-        }];
-    }
 }
 
 -(NSArray <ZMUser *> *)sortedActiveParticipants

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
@@ -766,7 +766,8 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
         let uiConversation = try! self.uiMOC.existingObject(with: conversation.objectID) as! ZMConversation
         uiConversation.acknowledgePrivacyWarning(withResendIntent: false)
         
-        self.syncMOC.performGroupedAndWait { _ in
+        self.syncMOC.performGroupedAndWait { moc in
+            moc.refreshAllObjects()
             
             // THEN
             XCTAssertTrue(message1.isExpired)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Badge count is not updating when receiving a notification in the background.

### Causes

After the EAR refactoring we started to [calculate an estimated unread count](https://github.com/wireapp/wire-ios-sync-engine/pull/1305) when scheduling notifications. This change was relying on the fact this estimated unread count would get updated again when the app put into the foreground and we perform the full event processing and read unread count can be calculated.

This didn't work because the estimated unread count was updated too early because we calculate the unread count when a `ZMConversation` is awoken by a fetch. This was happening before we could update the badge count and was reverting estimated unread count since messages haven't been inserted into the database at this point.

### Solutions

Stop calculating the unread count on fetches and inserts. The fact we were doing this probably is a left over from a time when we were calculating unread counts in a different way. Nowadays we re-calculate unread count on very message insert and  every time a message is read, which should cover all cases when it needs to re-calculated.