### PR TITLE
[Performance] Optimize conversation type calculation

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -432,18 +432,17 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     // 3. Conversation has only one other participant.
     // 4. This participant is not a service user (bot).
 
+    // Performance note: localParticipantsExcludingSelf will enumerate over all
+    // local participant roles, so check its count first to avoid unncessary iterations.
+
     if (conversationType == ZMConversationTypeGroup &&
         self.teamRemoteIdentifier != nil &&
         self.userDefinedName.length == 0 &&
-        self.localParticipantRoles.count == 1)
+        self.localParticipantRoles.count == 2 &&
+        self.localParticipantsExcludingSelf.count == 1 &&
+        !self.localParticipantsExcludingSelf.anyObject.isServiceUser)
     {
-        // Note: it's more efficient to use localParticipantRoles rather than
-        // localParticipants because we don't convert every role to a user.
-        ZMUser *otherParticipant = self.localParticipantRoles.anyObject.user;
-
-        if (!otherParticipant.isSelfUser && !otherParticipant.isServiceUser) {
-            conversationType = ZMConversationTypeOneOnOne;
-        }
+        conversationType = ZMConversationTypeOneOnOne;
     }
     
     return conversationType;

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -431,12 +431,19 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     // 2. Has no name given.
     // 3. Conversation has only one other participant.
     // 4. This participant is not a service user (bot).
+
     if (conversationType == ZMConversationTypeGroup &&
         self.teamRemoteIdentifier != nil &&
-        self.localParticipantsExcludingSelf.count == 1 &&
-        !self.localParticipantsExcludingSelf.anyObject.isServiceUser &&
-        self.userDefinedName.length == 0) {
-        conversationType = ZMConversationTypeOneOnOne;
+        self.userDefinedName.length == 0 &&
+        self.localParticipantRoles.count == 1)
+    {
+        // Note: it's more efficient to use localParticipantRoles rather than
+        // localParticipants because we don't convert every role to a user.
+        ZMUser *otherParticipant = self.localParticipantRoles.anyObject.user;
+
+        if (!otherParticipant.isSelfUser && !otherParticipant.isServiceUser) {
+            conversationType = ZMConversationTypeOneOnOne;
+        }
     }
     
     return conversationType;

--- a/Tests/Source/Model/Conversation/ZMConversationPerformanceTests.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationPerformanceTests.swift
@@ -1,0 +1,56 @@
+//
+//  ZMConversationPerformanceTests.swift
+//  WireDataModelTests
+//
+//  Created by John Nguyen on 28.09.20.
+//  Copyright © 2020 Wire Swiss GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class ZMConversationPerformanceTests: ZMConversationTestsBase {
+
+    /// There are no true 1:1 conversations in teams, so we check to see if it
+    /// should be considered a 1:1 depending on certain properties. This was
+    /// previously expensive because the conversation participants were iterated
+    /// over several times. The implementation has been optimized to avoid iterating
+    /// over the conversation participants entirely.
+
+    func testPerformanceWhenCalculatingConversationType() {
+        // Given
+        let conversation = createLargeTeamGroupConversation()
+
+        // The typical worst case scenario is where we need to check the local participants
+        // since this is where the bottleneck is most likely to occur. To ensure that
+        // we check the local participants, we assert that all other criteria is satisfied,
+        // otherwise some boolean expressions may return early (due to short circuiting).
+
+        XCTAssertEqual(conversation.conversationType, .group)
+        XCTAssertNotNil(conversation.teamRemoteIdentifier)
+        XCTAssertTrue(conversation.userDefinedName?.isEmpty ?? true)
+
+        measure {
+            // When
+            _ = conversation.conversationType
+        }
+    }
+
+    private func createLargeTeamGroupConversation() -> ZMConversation {
+        let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)
+
+        let users: [ZMUser] = (0..<299).map { _ in
+            let otherUser = ZMUser.insertNewObject(in: uiMOC)
+            let otherMember = Member.insertNewObject(in: uiMOC)
+            otherMember.team = team
+            otherMember.user = otherUser
+            return otherUser
+        }
+
+        let conversation = ZMConversation.insertGroupConversation(moc: uiMOC, participants: users, team: team)!
+        conversation.teamRemoteIdentifier = team.remoteIdentifier
+
+        return conversation
+    }
+
+}

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -896,11 +896,17 @@
 - (void)testThatGroupConversationInTeamWithOnlyTwoParticipantsIsConsideredOneToOne
 {
     // given
-    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
+
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    [conversation addParticipantAndUpdateConversationStateWithUser:selfUser role:nil];
+
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     [conversation addParticipantAndUpdateConversationStateWithUser:user1 role:nil];
+
+    XCTAssertEqual(conversation.localParticipants.count, 2);
     
     // then
     XCTAssertEqual(conversation.conversationType, ZMConversationTypeOneOnOne);
@@ -964,13 +970,17 @@
 - (void)testThatOneToOneConversationInTeamReturnsAConnectedUser
 {
     // given
-    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
     conversation.conversationType = ZMConversationTypeGroup;
     conversation.teamRemoteIdentifier = [NSUUID createUUID];
+    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
+    [conversation addParticipantAndUpdateConversationStateWithUser:selfUser role:nil];
+
+    ZMUser *user1 = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     [conversation addParticipantAndUpdateConversationStateWithUser:user1 role:nil];
     
     // then
+    XCTAssertNotNil(conversation.connectedUser);
     XCTAssertEqual(conversation.connectedUser, user1);
 }
 

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CA2063ECD400716618 /* BackupMetadataTests.swift */; };
 		D5FA30CF2063F8EC00716618 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CE2063F8EC00716618 /* Version.swift */; };
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
+		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
 		EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */; };
 		EE6CB3DC24E2A4E500B0EADD /* store2-83-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */; };
 		EE6CB3DE24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */; };
@@ -1035,6 +1036,7 @@
 		D5FA30CE2063F8EC00716618 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		D5FA30D02063FD3A00716618 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		D5FD9FD32073B94500F6F4FC /* zmessaging2.45.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.45.0.xcdatamodel; sourceTree = "<group>"; };
+		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
 		EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagedObjectContextDirectory+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-83-0.wiredatabase"; sourceTree = "<group>"; };
 		EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMGenericMessageDataTests.swift; sourceTree = "<group>"; };
@@ -1576,6 +1578,7 @@
 		BF491CDE1F0525ED0055EE44 /* Accounts */ = {
 			isa = PBXGroup;
 			children = (
+				EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */,
 				BF491CDA1F0525DC0055EE44 /* AccountTests.swift */,
 				BF491CDC1F0525E50055EE44 /* AccountManagerTests.swift */,
 				BF491CDF1F0529D80055EE44 /* AccountStoreTests.swift */,
@@ -3178,6 +3181,7 @@
 				1645ECC4243B69A1007A82D6 /* UserTypeTests+Materialize.swift in Sources */,
 				16F7341224F9567000AB93B1 /* ZMConversationTests+DraftMessage.swift in Sources */,
 				F9B71FA61CB2BF37001DB03F /* ZMConversationTests+Transport.m in Sources */,
+				EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */,
 				1621E59220E62BD2006B2D17 /* ZMConversationTests+Silencing.swift in Sources */,
 				F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */,
 				544034341D6DFE8500860F2D /* ZMAddressBookContactTests.swift in Sources */,

--- a/WireDataModel.xcodeproj/xcshareddata/xcbaselines/F9C9A5051CAD5DF10039E10C.xcbaseline/55BD42EF-71F0-4CB8-A473-F9E5849C2044.plist
+++ b/WireDataModel.xcodeproj/xcshareddata/xcbaselines/F9C9A5051CAD5DF10039E10C.xcbaseline/55BD42EF-71F0-4CB8-A473-F9E5849C2044.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>ZMConversationPerformanceTests</key>
+		<dict>
+			<key>testPerformanceWhenCalculatingConversationType()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>3.6474e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/WireDataModel.xcodeproj/xcshareddata/xcbaselines/F9C9A5051CAD5DF10039E10C.xcbaseline/Info.plist
+++ b/WireDataModel.xcodeproj/xcshareddata/xcbaselines/F9C9A5051CAD5DF10039E10C.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>55BD42EF-71F0-4CB8-A473-F9E5849C2044</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>6-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>MacBookPro15,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>6</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone12,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## What's new in this PR?

### Issues

Accessing the `conversationType` property on `ZMConversation` is a relatively expensive operation.

### Causes

Although the `conversationType` is a Core Data attribute, we have a custom accessor that will override the value if the conversation is a group conversation in a team but should be considered as a 1:1 conversation. There are certain criteria that must be satisfied to consider the group as a 1:1, and most of these criteria are fast to check. The most expensive check involves querying the conversation participants, and in the worst case scenario the entire set of all participants is enumerated 4 times. This is due to non-lazy sequence transformations over the `participantRoles` property (mapping and filtering).

### Solutions

By checking the count of `localParticipantRoles` (an O(1) expense) before accessing `localParticipantsExcludingSelf`, we can ensure that we would only ever enumerate over two participants. This make check a O(1) expense.
