### PR TITLE
[Fix] Don't fault users which are likely to be accessed again soon

### DIFF
--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -802,7 +802,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
                 
                 if(conversation.shouldNotBeRefreshed) {
                     [conversationsToKeep addObject:conversation];
-                    [usersToKeep unionSet:conversation.participantRoles];
+                    [usersToKeep unionSet:conversation.localParticipants];
                 }
             } else if ([obj isKindOfClass:ZMOTRMessage.class]) {
                 ZMOTRMessage *message = (ZMOTRMessage *)obj;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Accessing users during event processing was often ending up doing a fetch request which is expensive.

### Causes

All users were faulted on a save even though we have a rule to keep users in memory if they belong to a recently modified conversation. This rule was broken since the introduction of participant roles, it was putting `ParticipantRole` objects in the set of `usersToKeep`, which is expected to only contains `ZMUser` objects.

### Solutions

Call `localParticipants` instead which returns a set of `ZMUser`:s.