### PR TITLE
[Performance] Change tracking operation mode

### DIFF
--- a/Source/Notifications/NotificationDispatcher.OperationMode.swift
+++ b/Source/Notifications/NotificationDispatcher.OperationMode.swift
@@ -30,7 +30,7 @@ public extension NotificationDispatcher {
 
     enum OperationMode {
 
-        /// Change detection is highly detailed and observers are notified infrequntly.
+        /// Change detection is highly detailed and observers are notified frequently.
 
         case normal
 

--- a/Source/Notifications/NotificationDispatcher.OperationMode.swift
+++ b/Source/Notifications/NotificationDispatcher.OperationMode.swift
@@ -1,0 +1,44 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public extension NotificationDispatcher {
+
+    /// Describes how the `NotificationDispatcher` should behave in relation to the
+    /// expected work load (the number of database changes it must process).
+    ///
+    /// The normal operation mode is a relatively expensive operation and may cause
+    /// a considerably large amount of observer code to be triggered. If several
+    /// changes are made to the database, you may wish to switch to the `econmical` mode.
+    ///
+
+    enum OperationMode {
+
+        /// Change detection is highly detailed and observers are notified infrequntly.
+
+        case normal
+
+        /// Change detection is minimal and observers are notified infrequently.
+
+        case economical
+
+    }
+
+}

--- a/Source/Notifications/NotificationDispatcher.OperationMode.swift
+++ b/Source/Notifications/NotificationDispatcher.OperationMode.swift
@@ -27,7 +27,6 @@ public extension NotificationDispatcher {
     /// The normal operation mode is a relatively expensive operation and may cause
     /// a considerably large amount of observer code to be triggered. If several
     /// changes are made to the database, you may wish to switch to the `econmical` mode.
-    ///
 
     enum OperationMode {
 

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -49,11 +49,12 @@ import CoreData
     public var operationMode: OperationMode {
         didSet {
             guard operationMode != oldValue else { return }
-            changeDetector = changeDetectorBuilder(operationMode)
 
             if oldValue == .economical {
                 fireAllNotifications()
             }
+
+            changeDetector = changeDetectorBuilder(operationMode)
         }
     }
 

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -223,7 +223,6 @@ import CoreData
 
     // MARK: - Methods
 
-    // FIXME: [John] This is only used in Swift test. Either make non objc or remove entirely.
     /// Add the given consumer to receive forwarded `ChangeInfo`s.
 
     @objc public func addChangeInfoConsumer(_ consumer: ChangeInfoConsumer) {

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -193,7 +193,7 @@ import CoreData
 
     @objc func contextDidSave(_ note: Notification) {
         guard isEnabled else { return }
-        fireAllNotifications()
+        fireAllNotificationsIfAllowed()
     }
     
     /// This will be called if a change to an object does not cause a change in Core Data,
@@ -209,6 +209,8 @@ import CoreData
         }
 
         changeDetector.add(changes: Changes(changedKeys: Set(changedKeys)), for: object)
+
+        guard shouldFireNotifications else { return }
 
         if managedObjectContext.zm_hasChanges {
             // Fire notifications via a save.
@@ -238,7 +240,8 @@ import CoreData
         }
 
         changeDetector.detectChanges(for: ModifiedObjects(updated: Set(changedObjects)))
-        fireAllNotifications()
+
+        fireAllNotificationsIfAllowed()
     }
 
     /// This can safely be called from any thread as it will switch to uiContext internally.
@@ -305,6 +308,15 @@ import CoreData
         unreadMessages.unsent.formUnion(unreadUnsent)
         unreadMessages.messages.formUnion(newUnreadMessages)
         unreadMessages.knocks.formUnion(newUnreadKnocks)
+    }
+
+    private func fireAllNotificationsIfAllowed() {
+        guard shouldFireNotifications else { return }
+        fireAllNotifications()
+    }
+
+    private var shouldFireNotifications: Bool {
+        return operationMode != .economical
     }
 
     private func fireAllNotifications() {

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -44,6 +44,14 @@ import CoreData
         }
     }
 
+    /// Determines how detailed and frequent change notifications are fired.
+
+    public var operationMode = OperationMode.normal {
+        didSet {
+            // TODO: [JOHN] switch detectors.
+        }
+    }
+
     // MARK: - Private properties
 
     private unowned var managedObjectContext: NSManagedObjectContext

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -50,6 +50,10 @@ import CoreData
         didSet {
             guard operationMode != oldValue else { return }
             changeDetector = changeDetectorBuilder(operationMode)
+
+            if oldValue == .economical {
+                fireAllNotifications()
+            }
         }
     }
 

--- a/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -520,5 +520,102 @@ class NotificationDispatcherTests : NotificationDispatcherTestBase {
             XCTAssertTrue(changeInfo.nameChanged)
         }
     }
-    
+
+    // MARK: - Operation Mode
+
+    func testThatItCollectsMinimalChangesWhileInEconomicalMode() {
+        // Given
+        sut.operationMode = .economical
+
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        uiMOC.saveOrRollback()
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        withExtendedLifetime(ConversationChangeInfo.add(observer: conversationObserver, for: conversation)) { () -> () in
+            // When the conversation changes
+            conversation.userDefinedName = "foo"
+            conversation.mutedMessageTypes = .mentionsAndReplies
+            uiMOC.saveOrRollback()
+            XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+            // Go back to normal mode to trigger notification.
+            sut.operationMode = .normal
+
+            // Then there is a notification with minimal changes.
+            let changeInfos = conversationObserver.notifications
+            XCTAssertEqual(changeInfos.count, 1)
+
+            guard let changeInfo = changeInfos.first else { return XCTFail() }
+            XCTAssertTrue(changeInfo.changedKeys.isEmpty)
+            XCTAssertTrue(changeInfo.considerAllKeysChanged)
+        }
+    }
+
+    func testThatItOnlyFiresANotificationWhenLeavingEconomicalMode() {
+        // Given
+        sut.operationMode = .economical
+
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        uiMOC.saveOrRollback()
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        withExtendedLifetime(ConversationChangeInfo.add(observer: conversationObserver, for: conversation)) { () -> () in
+            // Make some changes
+            conversation.userDefinedName = "foo"
+            uiMOC.saveOrRollback()
+            XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+            XCTAssertTrue(conversationObserver.notifications.isEmpty)
+
+            // When
+            sut.operationMode = .normal
+
+            // Then
+            let changeInfos = conversationObserver.notifications
+            XCTAssertEqual(changeInfos.count, 1)
+        }
+    }
+
+    func testThatItOperatesNormalWhenAfterReturningToNormalMode() {
+        // Given
+        sut.operationMode = .economical
+
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        uiMOC.saveOrRollback()
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        withExtendedLifetime(ConversationChangeInfo.add(observer: conversationObserver, for: conversation)) { () -> () in
+            // Make some changes
+            conversation.userDefinedName = "foo"
+            uiMOC.saveOrRollback()
+            XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+            // When
+            sut.operationMode = .normal
+
+            // Notification for economical mode is fired.
+            let changeInfos = conversationObserver.notifications
+            XCTAssertEqual(changeInfos.count, 1)
+
+            guard let changeInfo = changeInfos.first else { return XCTFail() }
+            XCTAssertTrue(changeInfo.changedKeys.isEmpty)
+            XCTAssertTrue(changeInfo.considerAllKeysChanged)
+
+            conversationObserver.notifications.removeAll()
+
+            // Make some more changes in normal mode.
+            conversation.userDefinedName = "bar"
+            uiMOC.saveOrRollback()
+            XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+            // Then a normal change notification is received.
+            let newChangeInfos = conversationObserver.notifications
+            XCTAssertEqual(newChangeInfos.count, 1)
+
+            guard let newChangeInfo = newChangeInfos.first else { return XCTFail() }
+            XCTAssertEqual(newChangeInfo.changedKeys, [#keyPath(ZMConversation.displayName)])
+            XCTAssertFalse(newChangeInfo.considerAllKeysChanged)
+        }
+    }
+
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		EE68EECB252DC4730013B242 /* ExplicitChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE68EECA252DC4720013B242 /* ExplicitChangeDetector.swift */; };
 		EE6CB3DC24E2A4E500B0EADD /* store2-83-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */; };
 		EE6CB3DE24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */; };
+		EE770DAF25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE770DAE25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift */; };
 		EE997A1425062295008336D2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A1325062295008336D2 /* Logging.swift */; };
 		EE997A16250629DC008336D2 /* ZMMessage+ProcessingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */; };
 		EEA2B84624DA943200C6659E /* ManagedObjectContextDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */; };
@@ -1072,6 +1073,7 @@
 		EE68EECA252DC4720013B242 /* ExplicitChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitChangeDetector.swift; sourceTree = "<group>"; };
 		EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-83-0.wiredatabase"; sourceTree = "<group>"; };
 		EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMGenericMessageDataTests.swift; sourceTree = "<group>"; };
+		EE770DAE25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationDispatcher.OperationMode.swift; sourceTree = "<group>"; };
 		EE997A1325062295008336D2 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+ProcessingError.swift"; sourceTree = "<group>"; };
 		EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ManagedObjectContextDirectoryTests.swift; path = Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift; sourceTree = SOURCE_ROOT; };
@@ -1954,6 +1956,7 @@
 				F9A706261CAEE01D00C2F5FE /* ObjectObserverTokens */,
 				5451DE361F604CD500C82E75 /* ZMMoveIndex.swift */,
 				F93C4C7C1E24E1B1007E9CEE /* NotificationDispatcher.swift */,
+				EE770DAE25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift */,
 				EE68EECC252DCAB80013B242 /* Change detection */,
 				EEAAD75D252C711800E6A44E /* ZMManagedObject+ClassIdentifier.swift */,
 				EEAAD75F252C713E00E6A44E /* ClassIdentifier.swift */,
@@ -3095,6 +3098,7 @@
 				EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */,
 				54E3EE411F616BA600A261E3 /* ZMAssetClientMessage.swift in Sources */,
 				EE429390252C466500E70670 /* ChangeInfoConsumer.swift in Sources */,
+				EE770DAF25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				16E0FBC923326B72000E3235 /* ConversationDirectory.swift in Sources */,
 				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Context

This PR is part of ongoing work to refactor the NotificationDispatcher such that it can operate in an "economical" mode which favors speed over detail.

### Goal

To be able to change the tracking behavior of `NotificationDispatcher` at runtime so that it uses the `PotentialChangeDetector` and fires notifications less frequently.

### New

Added `public operationMode: OperationMode` to the notification dispatcher to differentiate between normal operation and economical operation.
