### PR TITLE
[Fix] Conversation list observer is out of sync after economical mode

### DIFF
--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -50,8 +50,13 @@ import CoreData
         didSet {
             guard operationMode != oldValue else { return }
 
+            if operationMode == .economical {
+                conversationListObserverCenter.stopObserving()
+            }
+
             if oldValue == .economical {
                 fireAllNotifications()
+                conversationListObserverCenter.startObserving()
             }
 
             changeDetector = changeDetectorBuilder(operationMode)


### PR DESCRIPTION
## What's new in this PR?

### Issues

After the `NotificationDispatcher` leaves `economical` mode, the `ConversationListObserverCenter` doesn't post complete change information. The visual effect of this is the conversation list doesn't display the up to date state.

### Causes

While in `economical` mode, the `NotificationDispatcher` uses the `PotentialChangeDetector` to accumulate change information. Unlike the normal explicit change detector, the potential change detector doesn't report change dependencies as also being changed. In other words, if a message is inserted in the database, the message insertion is detected, but the conversation of that message is not considered changed. The `ConversationListObserverCenter` relies on these transitive changes to post change information to the conversation list.

### Solutions

When the conversation list observer center is restarted, it causes the conversation list to reload its data. We already do this when the app comes to the foreground, however this is happening before we perform a quick sync.

A simple solution to this problem is to restart the conversation list observer center when we transition out of the `economical` state. 

An alternative solution is to extend the `PotentialChangeDetector` to also find transitive changes, but this would increase the complexity and will likely degrade the performance (which was the whole point of it in the first place).

