### PR TITLE
[Fix] Restoring a large backup freezes the app

### DIFF
--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -325,6 +325,8 @@ import CoreData
     private func fireAllNotifications() {
         let detectedChanges = changeDetector.consumeChanges()
         var changesByClass = [ClassIdentifier: [ObjectChangeInfo]]()
+        let unreadMessages = self.unreadMessages
+        self.unreadMessages = UnreadMessages()
 
         detectedChanges.forEach { changeInfo in
             guard let objectInSnapshot = changeInfo.object as? ObjectInSnapshot else { return }

--- a/Tests/Source/Helper/NotificationObservers.swift
+++ b/Tests/Source/Helper/NotificationObservers.swift
@@ -63,6 +63,24 @@ class MessageObserver : NSObject, ZMMessageObserver {
     }
 }
 
+class NewUnreadMessageObserver: NSObject, ZMNewUnreadMessagesObserver {
+    
+    var token: NSObjectProtocol?
+    var notifications : [NewUnreadMessagesChangeInfo] = []
+    
+    override init() {}
+    
+    init(context: NSManagedObjectContext) {
+        super.init()
+        token = NewUnreadMessagesChangeInfo.add(observer: self, managedObjectContext: context)
+    }
+    
+    func didReceiveNewUnreadMessages(_ changeInfo: NewUnreadMessagesChangeInfo) {
+        notifications.append(changeInfo)
+    }
+    
+}
+
 
 final class ConversationObserver: NSObject, ZMConversationObserver {
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Restoring a large backup freezes the app

### Causes

After restoring a large backup all messages goes through the observer system and specifically the `NewUnreadMessageChangeObserver`. This change observer relies the `unreadMessages` property in the `NotificationDispatcher` which collects unread messages. These unread messages never gets reset though so we keep reporting more and more message as unread, which causes the UI thread to freeze.

### Solutions

Reset the `unreadMessages` property after firing the notifications.

## Notes

We also don't want to run the all existing messages through observer system when restoring a backup but that will be fixed in a separate PR.