### PR TITLE
[Performance] Use correct index when fetching messages by nonce

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -462,13 +462,19 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
     NSPredicate *conversationPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR %K == %@", ZMMessageConversationKey, conversation.objectID, ZMMessageHiddenInConversationKey, conversation.objectID];
     
     NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[noncePredicate, conversationPredicate]];
-    NSFetchRequest *fetchRequest = [self.class sortedFetchRequestWithPredicate:predicate];
+    NSFetchRequest *fetchRequest = [ZMMessage sortedFetchRequestWithPredicate:predicate];
     fetchRequest.fetchLimit = 2;
     fetchRequest.includesSubentities = YES;
     
     NSArray* fetchResult = [moc executeFetchRequestOrAssert:fetchRequest];
     VerifyString([fetchResult count] <= 1, "More than one message with the same nonce in the same conversation");
-    return fetchResult.firstObject;
+    ZMMessage *message = fetchResult.firstObject;
+    
+    if ([message.entity isKindOfEntity:entity]) {
+        return message;
+    } else {
+        return nil;
+    }
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Fetching message by nonce is very slow for users with large databases

### Causes

By turning on the SQL debugging with `-com.apple.CoreData.SQLDebug 4` we can see that fetching a message by nonce ends up using the `ZMESSAGE_Z_ENT_INDEX`, which is indexing messages by their entity type (ClientMessage or AssetMessage). This is not very efficient when looking for a specific message since we search through either all ClientMessage or all AssetMessage messages.

```
EXPLAIN QUERY PLAN SELECT t0.Z_ENT, t0.Z_PK, t0.Z_OPT, t0.ZCACHEDCATEGORY, t0.ZDELIVERED, t0.ZDESTRUCTIONDATE, t0.ZEXPECTSREADCONFIRMATION, t0.ZEXPIRATIONDATE, t0.ZISEXPIRED, t0.ZISOBFUSCATED, t0.ZLINKATTACHMENTS, t0.ZMODIFIEDKEYS, t0.ZNEEDSLINKATTACHMENTSUPDATE, t0.ZNEEDSTOBEUPDATEDFROMBACKEND, t0.ZNONCE_DATA, t0.ZNORMALIZEDTEXT, t0.ZSENDERCLIENTID, t0.ZSERVERTIMESTAMP, t0.ZHIDDENINCONVERSATION, t0.ZQUOTE, t0.Z10_QUOTE, t0.ZSENDER, t0.ZVISIBLEINCONVERSATION, t0.ZASSETID_DATA, t0.ZASSOCIATEDTASKIDENTIFIER_DATA, t0.ZISDOWNLOADING, t0.ZPREPROCESSEDSIZE_DATA, t0.ZPROGRESS, t0.ZTRANSFERSTATE, t0.ZUPLOADSTATE, t0.ZVERSION, t0.ZLINKPREVIEWSTATE, t0.ZUPDATEDTIMESTAMP, t0.ZIMAGETYPE, t0.ZISANIMATEDGIF, t0.ZMEDIUMDATALOADED, t0.ZMEDIUMREMOTEIDENTIFIER_DATA, t0.ZORIGINALDATAPROCESSED, t0.ZORIGINALSIZE_DATA, t0.ZALLTEAMUSERSADDED, t0.ZDURATION, t0.ZMESSAGETIMER, t0.ZNEEDSUPDATINGUSERS, t0.ZNUMBEROFGUESTSADDED, t0.ZRELEVANTFORCONVERSATIONSTATUS, t0.ZSYSTEMMESSAGETYPE, t0.ZTEXT, t0.ZPARENTMESSAGE, t0.ZTEXT1 FROM ZMESSAGE t0 WHERE (( t0.ZNONCE_DATA = ? AND ( t0.ZVISIBLEINCONVERSATION = ? OR  t0.ZHIDDENINCONVERSATION = ?)) AND  t0.Z_ENT = ?) ORDER BY t0.ZSERVERTIMESTAMP LIMIT 2
     5 0 0 SEARCH TABLE ZMESSAGE AS t0 USING INDEX ZMESSAGE_Z_ENT_INDEX (Z_ENT=?)
     78 0 0 USE TEMP B-TREE FOR ORDER BY
CoreData: annotation: total fetch execution time: 0.1092s for 1 rows.
```


### Solutions

By constructing the fetch request from the abstract base entity `Message` instead of `ClientMessage` or `AssetMessage`, Core Data will not include the `AND  t0.Z_ENT = ?` part in query and sqlite will end up searching using the `Z_Message_nonce_data` index instead. 

```
EXPLAIN QUERY PLAN SELECT t0.Z_ENT, t0.Z_PK, t0.Z_OPT, t0.ZCACHEDCATEGORY, t0.ZDELIVERED, t0.ZDESTRUCTIONDATE, t0.ZEXPECTSREADCONFIRMATION, t0.ZEXPIRATIONDATE, t0.ZISEXPIRED, t0.ZISOBFUSCATED, t0.ZLINKATTACHMENTS, t0.ZMODIFIEDKEYS, t0.ZNEEDSLINKATTACHMENTSUPDATE, t0.ZNEEDSTOBEUPDATEDFROMBACKEND, t0.ZNONCE_DATA, t0.ZNORMALIZEDTEXT, t0.ZSENDERCLIENTID, t0.ZSERVERTIMESTAMP, t0.ZHIDDENINCONVERSATION, t0.ZQUOTE, t0.Z10_QUOTE, t0.ZSENDER, t0.ZVISIBLEINCONVERSATION, t0.ZASSETID_DATA, t0.ZASSOCIATEDTASKIDENTIFIER_DATA, t0.ZISDOWNLOADING, t0.ZPREPROCESSEDSIZE_DATA, t0.ZPROGRESS, t0.ZTRANSFERSTATE, t0.ZUPLOADSTATE, t0.ZVERSION, t0.ZLINKPREVIEWSTATE, t0.ZUPDATEDTIMESTAMP, t0.ZIMAGETYPE, t0.ZISANIMATEDGIF, t0.ZMEDIUMDATALOADED, t0.ZMEDIUMREMOTEIDENTIFIER_DATA, t0.ZORIGINALDATAPROCESSED, t0.ZORIGINALSIZE_DATA, t0.ZALLTEAMUSERSADDED, t0.ZDURATION, t0.ZMESSAGETIMER, t0.ZNEEDSUPDATINGUSERS, t0.ZNUMBEROFGUESTSADDED, t0.ZRELEVANTFORCONVERSATIONSTATUS, t0.ZSYSTEMMESSAGETYPE, t0.ZTEXT, t0.ZPARENTMESSAGE, t0.ZTEXT1 FROM ZMESSAGE t0 WHERE ( t0.ZNONCE_DATA = ? AND ( t0.ZVISIBLEINCONVERSATION = ? OR  t0.ZHIDDENINCONVERSATION = ?)) ORDER BY t0.ZSERVERTIMESTAMP LIMIT 2
     5 0 0 SEARCH TABLE ZMESSAGE AS t0 USING INDEX Z_Message_nonce_data (ZNONCE_DATA=?)
     75 0 0 USE TEMP B-TREE FOR ORDER BY
CoreData: annotation: total fetch execution time: 0.0010s for 0 rows.
```