### PR TITLE
[Improvement] Normalize asset filenames

### DIFF
--- a/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+FileMessageData.swift
@@ -199,7 +199,7 @@ extension ZMAssetClientMessage: ZMFileMessageData {
     
     /// File name as was sent or `nil` in case of an image asset
     public var filename: String? {
-        return underlyingMessage?.assetData?.original.name.removingExtremeCombiningCharacters
+        return underlyingMessage?.assetData?.original.name.normalizedFilename
     }
     
     public var thumbnailAssetID: String? {

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -294,6 +294,7 @@ extension ZMAssetClientMessageTests {
         let sut = ZMAssetClientMessage(nonce: UUID.create(), managedObjectContext: uiMOC)
         sut.sender = selfUser
         let mimeType = "text/plain"
+        let name = "example.txt"
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertNotNil(sut)
         


### PR DESCRIPTION
## What's new in this PR?

## Issue

Asset filenames currently have excessing diacritics stripped from them, but it would be better to normalize the filename to contain only characters from the POSIX fully portable character set.

## Solution

Fortunately we already have a `String` extension that handles this, we just have to use it.

