### PR TITLE
[Performance] Use correct index when fetching ephemeral messages

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -480,9 +480,10 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
 
 + (NSPredicate *)predicateForMessagesThatWillExpire;
 {
-    return [NSPredicate predicateWithFormat:@"%K == 0 && %K != NIL",
+    return [NSPredicate predicateWithFormat:@"%K == 0 && %K > %@",
             ZMMessageIsExpiredKey,
-            ZMMessageExpirationDateKey];
+            ZMMessageExpirationDateKey,
+            [NSDate dateWithTimeIntervalSince1970:0]];
 }
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

As reported in https://github.com/wireapp/wire-ios/issues/4431 when the `MessageExpirationTimer` fetches ephemeral messages it uses the `Z_Message_hiddenInConversation_isExpired_serverTimestamp_delivered` index, which isn't optimal.

### Causes

```
CoreData: details: SQLite: EXPLAIN QUERY PLAN SELECT t0.Z_ENT, t0.Z_PK, t0.Z_OPT, t0.ZCACHEDCATEGORY, t0.ZDELIVERED, t0.ZDESTRUCTIONDATE, t0.ZEXPECTSREADCONFIRMATION, t0.ZEXPIRATIONDATE, t0.ZISEXPIRED, t0.ZISOBFUSCATED, t0.ZLINKATTACHMENTS, t0.ZMODIFIEDKEYS, t0.ZNEEDSLINKATTACHMENTSUPDATE, t0.ZNEEDSTOBEUPDATEDFROMBACKEND, t0.ZNONCE_DATA, t0.ZNORMALIZEDTEXT, t0.ZSENDERCLIENTID, t0.ZSERVERTIMESTAMP, t0.ZHIDDENINCONVERSATION, t0.ZQUOTE, t0.Z10_QUOTE, t0.ZSENDER, t0.ZVISIBLEINCONVERSATION, t0.ZASSETID_DATA, t0.ZASSOCIATEDTASKIDENTIFIER_DATA, t0.ZISDOWNLOADING, t0.ZPREPROCESSEDSIZE_DATA, t0.ZPROGRESS, t0.ZTRANSFERSTATE, t0.ZUPLOADSTATE, t0.ZVERSION, t0.ZLINKPREVIEWSTATE, t0.ZUPDATEDTIMESTAMP, t0.ZIMAGETYPE, t0.ZISANIMATEDGIF, t0.ZMEDIUMDATALOADED, t0.ZMEDIUMREMOTEIDENTIFIER_DATA, t0.ZORIGINALDATAPROCESSED, t0.ZORIGINALSIZE_DATA, t0.ZALLTEAMUSERSADDED, t0.ZDURATION, t0.ZMESSAGETIMER, t0.ZNEEDSUPDATINGUSERS, t0.ZNUMBEROFGUESTSADDED, t0.ZRELEVANTFORCONVERSATIONSTATUS, t0.ZSYSTEMMESSAGETYPE, t0.ZTEXT, t0.ZPARENTMESSAGE, t0.ZTEXT1 FROM ZMESSAGE t0 WHERE ( t0.ZISEXPIRED = ? AND   t0.ZEXPIRATIONDATE IS NOT NULL) ORDER BY t0.ZSERVERTIMESTAMP
     4 0 0 SCAN TABLE ZMESSAGE AS t0 USING INDEX Z_Message_hiddenInConversation_isExpired_serverTimestamp_delivered
     66 0 0 USE TEMP B-TREE FOR ORDER BY
```

### Solutions

As proposed in https://github.com/wireapp/wire-ios-data-model/pull/998 comparing the `expirationDate` with `>` instead of checking if it's non nil, will cause the correct index to be used.

```
CoreData: details: SQLite: EXPLAIN QUERY PLAN SELECT t0.Z_ENT, t0.Z_PK, t0.Z_OPT, t0.ZCACHEDCATEGORY, t0.ZDELIVERED, t0.ZDESTRUCTIONDATE, t0.ZEXPECTSREADCONFIRMATION, t0.ZEXPIRATIONDATE, t0.ZISEXPIRED, t0.ZISOBFUSCATED, t0.ZLINKATTACHMENTS, t0.ZMODIFIEDKEYS, t0.ZNEEDSLINKATTACHMENTSUPDATE, t0.ZNEEDSTOBEUPDATEDFROMBACKEND, t0.ZNONCE_DATA, t0.ZNORMALIZEDTEXT, t0.ZSENDERCLIENTID, t0.ZSERVERTIMESTAMP, t0.ZHIDDENINCONVERSATION, t0.ZQUOTE, t0.Z10_QUOTE, t0.ZSENDER, t0.ZVISIBLEINCONVERSATION, t0.ZASSETID_DATA, t0.ZASSOCIATEDTASKIDENTIFIER_DATA, t0.ZISDOWNLOADING, t0.ZPREPROCESSEDSIZE_DATA, t0.ZPROGRESS, t0.ZTRANSFERSTATE, t0.ZUPLOADSTATE, t0.ZVERSION, t0.ZLINKPREVIEWSTATE, t0.ZUPDATEDTIMESTAMP, t0.ZIMAGETYPE, t0.ZISANIMATEDGIF, t0.ZMEDIUMDATALOADED, t0.ZMEDIUMREMOTEIDENTIFIER_DATA, t0.ZORIGINALDATAPROCESSED, t0.ZORIGINALSIZE_DATA, t0.ZALLTEAMUSERSADDED, t0.ZDURATION, t0.ZMESSAGETIMER, t0.ZNEEDSUPDATINGUSERS, t0.ZNUMBEROFGUESTSADDED, t0.ZRELEVANTFORCONVERSATIONSTATUS, t0.ZSYSTEMMESSAGETYPE, t0.ZTEXT, t0.ZPARENTMESSAGE, t0.ZTEXT1 FROM ZMESSAGE t0 WHERE ( t0.ZISEXPIRED = ? AND  t0.ZEXPIRATIONDATE > ?) ORDER BY t0.ZSERVERTIMESTAMP
     4 0 0 SEARCH TABLE ZMESSAGE AS t0 USING INDEX Z_Message_expirationDate (ZEXPIRATIONDATE>?)
     67 0 0 USE TEMP B-TREE FOR ORDER BY
```