### PR TITLE
fix: change sortedFetchRequest return to nonnull

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
@@ -156,8 +156,9 @@ extension NSManagedObjectContext {
     
     // This function setup the user info on the context, the session and self user must be initialised before end.
     fileprivate func setupLocalCachedSessionAndSelfUser() {
-        guard let request = ZMSession.sortedFetchRequest(),
-              let session = fetchOrAssert(request: request).first as? ZMSession else { return }
+        let request = ZMSession.sortedFetchRequest()
+        
+        guard let session = fetchOrAssert(request: request).first as? ZMSession else { return }
         
         userInfo[SessionObjectIDKey] = session.objectID
         ZMUser.boxSelfUser(session.selfUser, inContextUserInfo: self)

--- a/Source/Model/Connection/ZMConnection.swift
+++ b/Source/Model/Connection/ZMConnection.swift
@@ -21,7 +21,8 @@ import Foundation
 extension ZMConnection {
     @objc(connectionsInMangedObjectContext:)
     class func connections(inMangedObjectContext moc: NSManagedObjectContext) -> [NSFetchRequestResult] {
-        guard let request = sortedFetchRequest() else { return [] }
+        
+        let request = sortedFetchRequest()
         
         let result = moc.fetchOrAssert(request: request)
         return result

--- a/Source/Model/Conversation/Team+Patches.swift
+++ b/Source/Model/Conversation/Team+Patches.swift
@@ -26,8 +26,9 @@ extension Team {
     // a multi account setup, we need to delete all local teams. Members will be deleted due to the cascade
     // deletion rule (Team → Member). Conversations will be preserved but their teams realtion will be nullified.
     static func deleteLocalTeamsAndMembers(in context: NSManagedObjectContext) {
-        guard let request = Team.sortedFetchRequest(),
-              let teams = context.fetchOrAssert(request: request) as? [NSManagedObject] else { return                
+        let request = Team.sortedFetchRequest()
+        
+        guard let teams = context.fetchOrAssert(request: request) as? [NSManagedObject] else { return                
         }
         teams.forEach(context.delete)
     }

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -176,9 +176,8 @@ extension ZMConversation {
             sameParticipant
         ])
         
-        guard let request = self.sortedFetchRequest(with: compoundPredicate) else {
-            fatal("fetchOrAssert failed")
-        }
+        let request = self.sortedFetchRequest(with: compoundPredicate)
+
         return moc.fetchOrAssert(request: request).first as? ZMConversation
     }
 }

--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -33,8 +33,9 @@ extension ZMConversation {
     static func migrateAllSecureWithIgnored(in moc: NSManagedObjectContext) {
         let predicate = ZMConversation.predicateSecureWithIgnored()
 
-        guard let request = ZMConversation.sortedFetchRequest(with: predicate),
-              let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
+        let request = ZMConversation.sortedFetchRequest(with: predicate)
+        
+        guard let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
             fatal("fetchOrAssert failed")
         }
 
@@ -56,8 +57,9 @@ extension ZMConversation {
     static func migrateIsSelfAnActiveMemberToTheParticipantRoles(in moc: NSManagedObjectContext) {
         let selfUser = ZMUser.selfUser(in: moc)
         
-        guard let request = ZMConversation.sortedFetchRequest(),
-              let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
+        let request = ZMConversation.sortedFetchRequest()
+        
+        guard let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
             fatal("fetchOrAssert failed")
         }
                 
@@ -116,12 +118,12 @@ extension ZMConversation {
         // Mark group conversation membership to be refetched
         let selfUser = ZMUser.selfUser(in: moc)
         
-        
-        guard let groupConversationsFetch = ZMConversation.sortedFetchRequest(
-                    with: NSPredicate(format: "%K == %d",
+        let groupConversationsFetch = ZMConversation.sortedFetchRequest(
+            with: NSPredicate(format: "%K == %d",
                               ZMConversationConversationTypeKey,
-                              ZMConversationType.group.rawValue)),
-            let conversations = moc.fetchOrAssert(request: groupConversationsFetch) as? [ZMConversation] else {
+                              ZMConversationType.group.rawValue))
+        
+        guard let conversations = moc.fetchOrAssert(request: groupConversationsFetch) as? [ZMConversation] else {
                 fatal("fetchOrAssert failed")
         }
         
@@ -141,8 +143,9 @@ extension ZMConversation {
         
         let oldKey = "lastServerSyncedActiveParticipants"
         
-        guard let request = ZMConversation.sortedFetchRequest(),
-            let conversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
+        let request = ZMConversation.sortedFetchRequest()
+        
+        guard let conversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
                 fatal("fetchOrAssert failed")
         }
         

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -707,9 +707,7 @@ extension ZMSystemMessage {
         let containsSelfClient = NSPredicate(format: "ANY %K == %@", ZMMessageSystemMessageClientsKey, selfClient)
         let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [conversationPredicate, newClientPredicate, containsSelfClient])
         
-        guard let fetchRequest = ZMSystemMessage.sortedFetchRequest(with: compound) else {
-            fatal("fetchOrAssert failed")
-        }
+        let fetchRequest = ZMSystemMessage.sortedFetchRequest(with: compound)
         
         let result = conversation.managedObjectContext!.fetchOrAssert(request: fetchRequest)
         return result.first as? ZMSystemMessage

--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -30,9 +30,7 @@ extension ZMConversation {
         let noUserDefinedName = NSPredicate(format: "%K == nil", #keyPath(ZMConversation.userDefinedName))
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier, noUserDefinedName])
 
-        guard let fetchRequest = sortedFetchRequest(with: predicate) else {
-            return nil
-        }
+        let fetchRequest = sortedFetchRequest(with: predicate)
         
         fetchRequest.fetchLimit = 1
         let result = moc.fetchOrAssert(request: fetchRequest)

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.swift
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.swift
@@ -23,9 +23,7 @@ extension ZMConversation {
     
     ///Fetch all conversation that are marked as needsToCalculateUnreadMessages and calculate unread messages for them
     public static func calculateLastUnreadMessages(in managedObjectContext: NSManagedObjectContext) {
-        guard let fetchRequest = sortedFetchRequest(with: predicateForConversationsNeedingToBeCalculatedUnreadMessages()) else {
-            return
-        }
+        let fetchRequest = sortedFetchRequest(with: predicateForConversationsNeedingToBeCalculatedUnreadMessages())
         
         let conversations = managedObjectContext.fetchOrAssert(request: fetchRequest) as? [ZMConversation]
         conversations?.forEach { $0.calculateLastUnreadMessages() }

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -85,7 +85,7 @@ extension ZMClientMessage {
 
     static func descendingFetchRequest(with predicate: NSPredicate) -> NSFetchRequest<NSFetchRequestResult>? {
         let request = sortedFetchRequest(with: predicate)
-        request?.sortDescriptors = [NSSortDescriptor(key: #keyPath(ZMMessage.serverTimestamp), ascending: false)]
+        request.sortDescriptors = [NSSortDescriptor(key: #keyPath(ZMMessage.serverTimestamp), ascending: false)]
         return request
     }
 
@@ -316,14 +316,16 @@ public class TextSearchQuery: NSObject {
     /// Returns the count of indexed messages in the conversation. 
     /// Needs to be called from the syncMOC's Queue.
     private func countForIndexedMessages() -> Int {
-        guard let request = ZMClientMessage.sortedFetchRequest(with: predicateForIndexedMessages) else { return 0 }
+        let request = ZMClientMessage.sortedFetchRequest(with: predicateForIndexedMessages)
+
         return (try? self.syncMOC.count(for: request)) ?? 0
     }
 
     /// Returns the count of not indexed indexed messages in the conversation. 
     /// Needs to be called from the syncMOC's Queue.
     private func countForNonIndexedMessages() -> Int {
-        guard let request = ZMClientMessage.sortedFetchRequest(with: predicateForNotIndexedMessages) else { return 0 }
+        let request = ZMClientMessage.sortedFetchRequest(with: predicateForNotIndexedMessages)
+
         return (try? self.syncMOC.count(for: request)) ?? 0
     }
 

--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -88,7 +88,7 @@ extension ZMMessage {
             : nil
         
         let finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [orPredicate, excludingPredicate, conversationPredicate].compactMap { $0 })
-        return self.sortedFetchRequest(with: finalPredicate)!
+        return self.sortedFetchRequest(with: finalPredicate)
     }
     
     public static func fetchRequestMatching(matchPairs: [CategoryMatch],
@@ -108,7 +108,7 @@ extension ZMMessage {
             : nil
         
         let finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [categoryPredicate, conversationPredicate].compactMap { $0 })
-        return self.sortedFetchRequest(with: finalPredicate)!
+        return self.sortedFetchRequest(with: finalPredicate)
     }
     
 }
@@ -233,7 +233,7 @@ public struct MessageCategory : OptionSet {
     
     public let rawValue: Int32
     
-    public static let none = MessageCategory(rawValue: 0)
+    public static let none = MessageCategory([])
     public static let undefined = MessageCategory(rawValue: 1 << 0)
     public static let text = MessageCategory(rawValue: 1 << 1)
     public static let link = MessageCategory(rawValue: 1 << 2)

--- a/Source/Model/Message/ZMMessage+Removal.swift
+++ b/Source/Model/Message/ZMMessage+Removal.swift
@@ -27,9 +27,8 @@ extension ZMMessage {
         guard let predicate = ZMClientMessage.predicateForObjectsThatNeedToBeInsertedUpstream() else {
             return
         }
-        guard let requestForInsertedMessages = ZMClientMessage.sortedFetchRequest(with: predicate) else {
-            fatal("fetchOrAssert failed")
-        }
+        
+        let requestForInsertedMessages = ZMClientMessage.sortedFetchRequest(with: predicate)
         
         let possibleMatches = self.managedObjectContext?.executeFetchRequestOrAssert(requestForInsertedMessages) as? [ZMClientMessage]
         let confirmationReceipts = possibleMatches?.filter { candidateConfirmationReceipt in

--- a/Source/Model/UserClient/UserClient+Patches.swift
+++ b/Source/Model/UserClient/UserClient+Patches.swift
@@ -29,9 +29,7 @@ extension UserClient {
             return
         }
         
-        guard let request = UserClient.sortedFetchRequest() else {
-            fatal("fetchOrAssert failed")
-        }
+        let request = UserClient.sortedFetchRequest()
         
         let allClients = moc.fetchOrAssert(request: request) as? [UserClient]
         

--- a/Source/Model/ZMManagedObject+Internal.h
+++ b/Source/Model/ZMManagedObject+Internal.h
@@ -57,9 +57,10 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedKeysKey;
 /// The order in which objects are updated to / from the backend. ZMSyncOperationSet uses this.
 + (nullable NSArray <NSSortDescriptor *> *)sortDescriptorsForUpdating;
 + (nullable NSPredicate *)predicateForFilteringResults;
-+ (nullable NSFetchRequest *)sortedFetchRequest;
-+ (nullable NSFetchRequest *)sortedFetchRequestWithPredicate:(nonnull NSPredicate *)predicate;
-+ (nullable NSFetchRequest *)sortedFetchRequestWithPredicateFormat:(nonnull NSString *)format, ...;
+
++ (nonnull NSFetchRequest *)sortedFetchRequest;
++ (nonnull NSFetchRequest *)sortedFetchRequestWithPredicate:(nonnull NSPredicate *)predicate;
++ (nonnull NSFetchRequest *)sortedFetchRequestWithPredicateFormat:(nonnull NSString *)format, ...;
 
 + (void)enumerateObjectsInContext:(nonnull NSManagedObjectContext *)moc withBlock:(nonnull ObjectsEnumerationBlock)block;
 

--- a/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
@@ -31,7 +31,7 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion()
         
         // THEN
-        let users = try! directory.uiContext.fetch(ZMUser.sortedFetchRequest()!)
+        let users = try! directory.uiContext.fetch(ZMUser.sortedFetchRequest())
         XCTAssertEqual(users.count, 1) // only self user
     }
     
@@ -44,15 +44,15 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMTextMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
-        let helloWorldMessageCount = try! directory.uiContext.count(for: ZMTextMessage.sortedFetchRequest(with: NSPredicate(format: "%K BEGINSWITH[c] %@", "text", "Hello World"))!)
-        let message = directory.uiContext.executeFetchRequestOrAssert(ZMTextMessage.sortedFetchRequest(with: NSPredicate(format: "%K == %@", "text", "You are the best Burno"))!).first as? ZMMessage
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMTextMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
+        let helloWorldMessageCount = try! directory.uiContext.count(for: ZMTextMessage.sortedFetchRequest(with: NSPredicate(format: "%K BEGINSWITH[c] %@", "text", "Hello World")))
+        let message = directory.uiContext.executeFetchRequestOrAssert(ZMTextMessage.sortedFetchRequest(with: NSPredicate(format: "%K == %@", "text", "You are the best Burno"))).first as? ZMMessage
         let messageServerTimestampTransportString = message?.serverTimestamp?.transportString()
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -81,13 +81,13 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -113,13 +113,13 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -145,13 +145,13 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -177,13 +177,13 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -209,14 +209,14 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
-        let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
+        let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -243,14 +243,14 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
         
         // THEN
-        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
-        let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest()!)
+        let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+        let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+        let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+        let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+        let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
+        let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
         
-        let userFetchRequest = ZMUser.sortedFetchRequest()!
+        let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -278,14 +278,14 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             var directory: ManagedObjectContextDirectory! = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
             
             // THEN
-            let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-            let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-            let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-            let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-            let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
-            let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest()!)
+            let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+            let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+            let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+            let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+            let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
+            let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
             
-            let userFetchRequest = ZMUser.sortedFetchRequest()!
+            let userFetchRequest = ZMUser.sortedFetchRequest()
             userFetchRequest.resultType = .dictionaryResultType
             userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
             let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)
@@ -352,17 +352,17 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             var directory: ManagedObjectContextDirectory! = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
 
             // THEN
-            let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest()!)
-            let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
-            let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest()!)
-            let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest()!)
-            let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest()!)
-            let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest()!)
-            let messages = directory.uiContext.executeFetchRequestOrAssert(ZMMessage.sortedFetchRequest()!) as! [ZMMessage]
+            let conversationCount = try! directory.uiContext.count(for: ZMConversation.sortedFetchRequest())
+            let messageCount = try! directory.uiContext.count(for: ZMClientMessage.sortedFetchRequest())
+            let systemMessageCount = try! directory.uiContext.count(for: ZMSystemMessage.sortedFetchRequest())
+            let connectionCount = try! directory.uiContext.count(for: ZMConnection.sortedFetchRequest())
+            let userClientCount = try! directory.uiContext.count(for: UserClient.sortedFetchRequest())
+            let assetClientMessagesCount = try! directory.uiContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
+            let messages = directory.uiContext.executeFetchRequestOrAssert(ZMMessage.sortedFetchRequest()) as! [ZMMessage]
             let users = directory.uiContext.fetchOrAssert(request: NSFetchRequest<ZMUser>(entityName: ZMUser.entityName()))
 
 
-            let userFetchRequest = ZMUser.sortedFetchRequest()!
+            let userFetchRequest = ZMUser.sortedFetchRequest()
             userFetchRequest.resultType = .dictionaryResultType
             userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
             let userDictionaries = directory.uiContext.executeFetchRequestOrAssert(userFetchRequest)

--- a/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
@@ -143,7 +143,7 @@ class StorageStackBackupTests: DatabaseBaseTest {
 
         // then
         guard case .success = result else { return XCTFail() }
-        let fetchConversations = ZMConversation.sortedFetchRequest()!
+        let fetchConversations = ZMConversation.sortedFetchRequest()
         XCTAssertEqual(try directory.uiContext.count(for: fetchConversations), 1)
     }
 
@@ -161,7 +161,7 @@ class StorageStackBackupTests: DatabaseBaseTest {
         // then
         guard case .success = result else { return XCTFail() }
         let anotherDirectory = createStorageStackAndWaitForCompletion(userID: uuid)
-        let fetchConversations = ZMConversation.sortedFetchRequest()!
+        let fetchConversations = ZMConversation.sortedFetchRequest()
         XCTAssertEqual(try anotherDirectory.uiContext.count(for: fetchConversations), 1)
     }
 
@@ -189,7 +189,7 @@ class StorageStackBackupTests: DatabaseBaseTest {
             let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
             context.persistentStoreCoordinator = coordinator
             context.performAndWait {
-                let request = ZMConversation.sortedFetchRequest()!
+                let request = ZMConversation.sortedFetchRequest()
                 let convs = try? context.fetch(request)
                 XCTAssertEqual(convs?.count, 1)
             }
@@ -216,7 +216,7 @@ class StorageStackBackupTests: DatabaseBaseTest {
         // then
         guard case .success = result else { return XCTFail() }
         let directory = createStorageStackAndWaitForCompletion(userID: uuid)
-        let fetchConversations = ZMConversation.sortedFetchRequest()!
+        let fetchConversations = ZMConversation.sortedFetchRequest()
         XCTAssertEqual(try directory.uiContext.count(for: fetchConversations), 1)
     }
     

--- a/Tests/Source/ManagedObjectContext/StorageStackTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackTests.swift
@@ -189,7 +189,7 @@ class StorageStackTests: DatabaseBaseTest {
             XCTFail("No context")
             return
         }
-        let messageCount = try uiContext.count(for: ZMClientMessage.sortedFetchRequest()!)
+        let messageCount = try uiContext.count(for: ZMClientMessage.sortedFetchRequest())
         XCTAssertGreaterThan(messageCount, 0)
         
     }

--- a/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
@@ -66,7 +66,7 @@ final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
         // then
         XCTAssertNotNil(conversation)
         
-        let fetchRequest = ZMConversation.sortedFetchRequest()!
+        let fetchRequest = ZMConversation.sortedFetchRequest()
         let conversations = uiMOC.executeFetchRequestOrAssert(fetchRequest)
         
         XCTAssertEqual(conversations.count, 1)

--- a/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -40,7 +40,7 @@ final class ConversationTests: ZMConversationTestsBase {
         // when
         
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "@Sømebôdy", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request!)
+        let result = uiMOC.executeFetchRequestOrAssert(request)
         
         // then
         XCTAssertEqual(result.count, 1)
@@ -54,7 +54,7 @@ final class ConversationTests: ZMConversationTestsBase {
         // when
         
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request!)
+        let result = uiMOC.executeFetchRequestOrAssert(request)
         
         // then
         XCTAssertEqual(result.count, 1)
@@ -68,7 +68,7 @@ final class ConversationTests: ZMConversationTestsBase {
         // when
         
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy ", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request!)
+        let result = uiMOC.executeFetchRequestOrAssert(request)
         
         // then
         XCTAssertEqual(result.count, 1)
@@ -83,7 +83,7 @@ final class ConversationTests: ZMConversationTestsBase {
         // when
         
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy to", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request!)
+        let result = uiMOC.executeFetchRequestOrAssert(request)
         
         // then
         XCTAssertEqual(result.count, 1)
@@ -218,7 +218,7 @@ extension ConversationTests {
             
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
-            let message = try! conversation.appendImage(from: self.verySmallJPEGData(), nonce: messageID) as! ZMConversationMessage
+            let message = try! conversation.appendImage(from: self.verySmallJPEGData(), nonce: messageID) 
             
             // store asset data
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.original, encrypted: false, data: imageData)

--- a/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/Tests/Source/Model/TextSearchQueryTests.swift
@@ -563,7 +563,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
             ZMClientMessage.predicateForNotIndexedMessages(),
             ZMClientMessage.predicateForMessages(inConversationWith: conversation.remoteIdentifier!)
         ])
-        let request = ZMClientMessage.sortedFetchRequest(with: predicate)!
+        let request = ZMClientMessage.sortedFetchRequest(with: predicate)
         let notIndexedMessageCount = (try? uiMOC.count(for: request)) ?? 0
 
         if notIndexedMessageCount > 0 {

--- a/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
+++ b/Tests/Source/Utils/DuplicatedEntityRemovalTests.swift
@@ -499,7 +499,7 @@ extension DuplicatedEntityRemovalTests {
         self.moc.saveOrRollback()
 
         // THEN
-        let allClients = try self.moc.fetch(UserClient.sortedFetchRequest()!)
+        let allClients = try self.moc.fetch(UserClient.sortedFetchRequest())
         XCTAssertEqual(user1.clients.count, 0)
         XCTAssertEqual(allClients.count, 0)
     }


### PR DESCRIPTION
## What's new in this PR?

change `sortedFetchRequest` and its overrides return type to nonnull