### PR TITLE
[Refactor] Generate analytics identifier

### DIFF
--- a/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
+++ b/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+extension ZMUser {
+
+    /// Underlying storage of the analytics identifier.
+
+    @NSManaged private var primitiveAnalyticsIdentifier: String?
+
+    /// The analytics identifier used for tag analytic events.
+    ///
+    /// This identifier should only exist for the self user and only if they are a team member.
+    /// A new identifier will be automatically generated the very first time this is accessed.
+
+    @objc
+    public private(set) var analyticsIdentifier: String? {
+        get {
+            guard isSelfUser && isTeamMember else { return nil }
+
+            willAccessValue(forKey: #keyPath(analyticsIdentifier))
+            let value = primitiveAnalyticsIdentifier
+            didAccessValue(forKey: #keyPath(analyticsIdentifier))
+
+            if let value = value {
+                return value
+            } else {
+                let newIdentifier = UUID().transportString()
+                self.analyticsIdentifier = newIdentifier
+                return newIdentifier
+            }
+        }
+
+        set {
+            willChangeValue(forKey: #keyPath(analyticsIdentifier))
+            primitiveAnalyticsIdentifier = newValue
+            didChangeValue(forKey: #keyPath(analyticsIdentifier))
+        }
+    }
+
+}

--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -707,7 +707,6 @@ static NSString *const AnalyticsIdentifierKey = @"analyticsIdentifier";
     
     if (selfUser == nil) {
         selfUser = [ZMUser insertNewObjectInManagedObjectContext:moc];
-        selfUser.analyticsIdentifier = [[NSUUID UUID] transportString];
         RequireString([moc obtainPermanentIDsForObjects:@[selfUser] error:&error],
                       "Failed to get ID for self user: %lu", (long) error.code);
     }

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -177,9 +177,6 @@ extension ZMUser {
     
     @objc static let previewProfileAssetIdentifierKey = #keyPath(ZMUser.previewProfileAssetIdentifier)
     @objc static let completeProfileAssetIdentifierKey = #keyPath(ZMUser.completeProfileAssetIdentifier)
-    
-    /// Analytics
-    @NSManaged public var analyticsIdentifier: String?
 
     @NSManaged public var previewProfileAssetIdentifier: String?
     @NSManaged public var completeProfileAssetIdentifier: String?

--- a/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
+++ b/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+
+class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
+
+    func test_the_analytics_identifier_is_automatically_generated() {
+        // Given
+        let sut = createUser(selfUser: true, inTeam: true)
+
+        // Then
+        XCTAssertNotNil(sut.analyticsIdentifier)
+    }
+
+    func test_the_analytics_identifier_is_not_automatically_generated() {
+        // Given, then
+        XCTAssertNil(createUser(selfUser: true, inTeam: false).analyticsIdentifier)
+        XCTAssertNil(createUser(selfUser: false, inTeam: false).analyticsIdentifier)
+        XCTAssertNil(createUser(selfUser: false, inTeam: true).analyticsIdentifier)
+    }
+
+    func test_the_analytics_identifier_is_not_regenerated_if_a_value_exists() {
+        // Given
+        let sut = createUser(selfUser: true, inTeam: true)
+        let existingIdentifier = UUID.create().transportString()
+
+        // Then
+        XCTAssertEqual(sut.analyticsIdentifier, existingIdentifier)
+    }
+
+    // MARK: - Helpers
+
+    private func createUser(selfUser: Bool, inTeam: Bool) -> ZMUser {
+        let user = selfUser ? self.selfUser! : createUser(in: uiMOC)
+        guard inTeam else { return user }
+        createMembership(in: uiMOC, user: user, team: createTeam(in: uiMOC))
+        return user
+    }
+    
+}

--- a/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
+++ b/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
@@ -40,10 +40,20 @@ class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
     func test_the_analytics_identifier_is_not_regenerated_if_a_value_exists() {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
-        let existingIdentifier = UUID.create().transportString()
+        let existingIdentifier = sut.analyticsIdentifier
+        XCTAssertNotNil(existingIdentifier)
 
         // Then
         XCTAssertEqual(sut.analyticsIdentifier, existingIdentifier)
+    }
+
+    func test_the_analytics_identifier_is_encoded_as_uuid_transport_string() {
+        // Given
+        let sut = createUser(selfUser: true, inTeam: true)
+
+        // Then
+        XCTAssertNotNil(sut.analyticsIdentifier)
+        XCTAssertNotNil(UUID(uuidString: sut.analyticsIdentifier!))
     }
 
     // MARK: - Helpers

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -2545,19 +2545,5 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertFalse(untrusted);
 }
 
-- (void)testThatAnalyticsIdentifierIsEncodedAsUUIDTransportString
-{
-    // given
-    ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
-    
-    // when
-    NSUUID *sut = [NSUUID uuidWithTransportString:user.analyticsIdentifier];
-    
-    // then
-    XCTAssertNotNil(user.analyticsIdentifier);
-    XCTAssertNotNil(sut);
-}
-
-
 @end
 

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		EE997A1425062295008336D2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A1325062295008336D2 /* Logging.swift */; };
 		EE997A16250629DC008336D2 /* ZMMessage+ProcessingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */; };
 		EEA2B84624DA943200C6659E /* ManagedObjectContextDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */; };
+		EEA985982555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA985972555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift */; };
 		EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */; };
 		EEAAD75A252C6D2700E6A44E /* UnreadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAAD759252C6D2700E6A44E /* UnreadMessages.swift */; };
 		EEAAD75C252C6DAE00E6A44E /* ModifiedObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAAD75B252C6DAE00E6A44E /* ModifiedObjects.swift */; };
@@ -1078,6 +1079,7 @@
 		EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+ProcessingError.swift"; sourceTree = "<group>"; };
 		EEA2B84524DA943100C6659E /* ManagedObjectContextDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ManagedObjectContextDirectoryTests.swift; path = Tests/Source/ManagedObjectContext/ManagedObjectContextDirectoryTests.swift; sourceTree = SOURCE_ROOT; };
 		EEA2B87524DD7B8B00C6659E /* zmessaging2.83.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.83.0.xcdatamodel; sourceTree = "<group>"; };
+		EEA985972555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EEA9C5061F3C9F3500DC39EC /* PersistentStorageInitialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentStorageInitialization.swift; sourceTree = "<group>"; };
 		EEAAD759252C6D2700E6A44E /* UnreadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnreadMessages.swift; sourceTree = "<group>"; };
 		EEAAD75B252C6DAE00E6A44E /* ModifiedObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifiedObjects.swift; sourceTree = "<group>"; };
@@ -1916,6 +1918,7 @@
 				F9A7060D1CAEE01D00C2F5FE /* ZMUser+Internal.h */,
 				F9A706101CAEE01D00C2F5FE /* ZMUser.m */,
 				F18998821E7AC6D900E579A2 /* ZMUser.swift */,
+				EEA985972555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift */,
 				F110503C2220439900F3EB62 /* ZMUser+RichProfile.swift */,
 				55C40BCD22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift */,
 				F14B7AFE2220302B00458624 /* ZMUser+Predicates.swift */,
@@ -2974,6 +2977,7 @@
 				EE42938E252C460000E70670 /* Changes.swift in Sources */,
 				D5FA30CF2063F8EC00716618 /* Version.swift in Sources */,
 				F9DBA5201E28EA8B00BE23C0 /* DependencyKeyStore.swift in Sources */,
+				EEA985982555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift in Sources */,
 				F125BAD71EE9849B0018C2F8 /* ZMConversation+SystemMessages.swift in Sources */,
 				54F84CFD1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift in Sources */,
 				A90B3E2D23A255D5003EFED4 /* ZMConversation+Creation.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CA2063ECD400716618 /* BackupMetadataTests.swift */; };
 		D5FA30CF2063F8EC00716618 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CE2063F8EC00716618 /* Version.swift */; };
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
+		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
 		EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */; };
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
@@ -1061,6 +1062,7 @@
 		D5FA30CE2063F8EC00716618 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		D5FA30D02063FD3A00716618 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		D5FD9FD32073B94500F6F4FC /* zmessaging2.45.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.45.0.xcdatamodel; sourceTree = "<group>"; };
+		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
 		EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagedObjectContextDirectory+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
@@ -2281,6 +2283,7 @@
 				F18998871E7AF0BE00E579A2 /* ZMUserTests.h */,
 				F9B71F6A1CB2BC85001DB03F /* ZMUserTests.m */,
 				F18998841E7AEEC900E579A2 /* ZMUserTests+Swift.swift */,
+				EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */,
 				1670D01D231825BE003A143B /* ZMUserTests+Permissions.swift */,
 				F1549D491FB0A6E000A251BF /* ZMUserFetchAndMergeTests.swift */,
 				5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */,
@@ -3366,6 +3369,7 @@
 				6388054A240EA8990043B641 /* ZMClientMessageTests+Composite.swift in Sources */,
 				F11F3E8B1FA32AA0007B6D3D /* InvalidClientsRemovalTests.swift in Sources */,
 				060D194F2462A9EC00623376 /* ZMMessageTests+GenericMessage.swift in Sources */,
+				EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */,
 				BFFBFD951D59E49D0079773E /* ZMClientMessageTests+Deletion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## What's new in this PR?

### Context

When the analytics id is first generated, we want to append it to the self conversation so that the other devices of the self user can receive it and use it when sending events.

### Issues

Appending the analytics id to the self conversation when it is generated leads to a stack overflow.

### Causes

The id is generated when accessing the self user for the first time. Accessing the self conversation depends on accessing the self user, so an infinite recursion of the self user and self conversation occurs.

### Solutions

Lazily generate the analytics id when it is accessed, if needed. By using custom accessor methods, we can also enforce which kind of users should have an analytics id.

