### PR TITLE
[Feature] Broadcast analytics identifier when generated

### DIFF
--- a/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
+++ b/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
@@ -42,9 +42,11 @@ extension ZMUser {
             if let value = value {
                 return value
             } else {
-                let newIdentifier = UUID().transportString()
-                self.analyticsIdentifier = newIdentifier
-                return newIdentifier
+                let identifier = UUID()
+                let identifierString = identifier.transportString()
+                self.analyticsIdentifier = identifierString
+                broadcast(identifier: identifier)
+                return identifierString
             }
         }
 
@@ -53,6 +55,12 @@ extension ZMUser {
             primitiveAnalyticsIdentifier = newValue
             didChangeValue(forKey: #keyPath(analyticsIdentifier))
         }
+    }
+
+    private func broadcast(identifier: UUID) {
+        guard let moc = managedObjectContext else { return }
+        let message = GenericMessage(content: DataTransfer(trackingIdentifier: identifier))
+        _ = try? ZMConversation.appendMessageToSelfConversation(message, in: moc)
     }
 
 }

--- a/Source/Utilis/Protos/GenericMessage+Content.swift
+++ b/Source/Utilis/Protos/GenericMessage+Content.swift
@@ -80,6 +80,10 @@ public extension GenericMessage {
     var hasLocation: Bool {
         return messageData is Location
     }
+
+    var hasDataTransfer: Bool {
+        return messageData is DataTransfer
+    }
 }
 
 // MARK: - Ephemeral

--- a/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
+++ b/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
 
-    func test_the_analytics_identifier_is_automatically_generated() {
+    func testTheAnalyticsIdentifierIsAutomaticallyGenerated() {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
 
@@ -30,14 +30,14 @@ class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
         XCTAssertNotNil(sut.analyticsIdentifier)
     }
 
-    func test_the_analytics_identifier_is_not_automatically_generated() {
+    func testTheAnalyticsIdentifierIsNotAutomaticallyGenerated() {
         // Given, then
         XCTAssertNil(createUser(selfUser: true, inTeam: false).analyticsIdentifier)
         XCTAssertNil(createUser(selfUser: false, inTeam: false).analyticsIdentifier)
         XCTAssertNil(createUser(selfUser: false, inTeam: true).analyticsIdentifier)
     }
 
-    func test_the_analytics_identifier_is_not_regenerated_if_a_value_exists() {
+    func testTheAnalyticsIdentifierIsNotRegeneratedIfAValueExists() {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
         let existingIdentifier = sut.analyticsIdentifier
@@ -47,7 +47,7 @@ class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
         XCTAssertEqual(sut.analyticsIdentifier, existingIdentifier)
     }
 
-    func test_the_analytics_identifier_is_encoded_as_uuid_transport_string() {
+    func testTheAnalyticsIdentifierIsEncodedAsUUIDTransportString() {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
 

--- a/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
+++ b/Tests/Source/Model/User/ZMUserTests+AnalyticsIdentifier.swift
@@ -60,26 +60,31 @@ class ZMUserTests_AnalyticsIdentifier: ModelObjectsTests {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
 
+        let selfConversation = ZMConversation.selfConversation(in: uiMOC)
+        XCTAssertTrue(selfConversation.allMessages.isEmpty)
+
         // When
         let identifier = sut.analyticsIdentifier
         XCTAssertNotNil(identifier)
 
         // Then
-        let selfConversation = ZMConversation.selfConversation(in: uiMOC)
         XCTAssertEqual(selfConversation.numberOfDataTransferMessagesContaining(analyticsIdentifier: identifier!), 1)
     }
 
     func testTheAnalyticsIdentifierIsNotRebroadcastedInSelfConversation() {
         // Given
         let sut = createUser(selfUser: true, inTeam: true)
+
         let identifier = sut.analyticsIdentifier
         XCTAssertNotNil(identifier)
+
+        let selfConversation = ZMConversation.selfConversation(in: uiMOC)
+        XCTAssertEqual(selfConversation.numberOfDataTransferMessagesContaining(analyticsIdentifier: identifier!), 1)
 
         // When
         _ = sut.analyticsIdentifier
 
         // Then
-        let selfConversation = ZMConversation.selfConversation(in: uiMOC)
         XCTAssertEqual(selfConversation.numberOfDataTransferMessagesContaining(analyticsIdentifier: identifier!), 1)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Goal

When the analytics identifier is generated for the self user, we must send it to the other devices for that user so that they can be notified of the new identifier to use.

### Solutions

To send the identifier within an EE2E payload, we post a `DataTransfer` message containing the identifier to the self conversation.

## Notes

In a future PR, this data transfer message will be received on other clients and processed.