### PR TITLE
[Fix]: User is logged out when a backup is imported

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+BackupImport.swift
@@ -22,9 +22,9 @@ extension NSManagedObjectContext {
     
     /// Prepare a backed up database for being imported, deleting self client, push token etc.
     func prepareToImportBackup() {
+        StorageStack.shared.isImportedFromBackup = false
         require(self.zm_isSyncContext, "Needs to be run on Sync Context to avoid race conditions")
         setPersistentStoreMetadata(nil as Data?, key: ZMPersistedClientIdKey)
-        setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.importedFromBackup.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.pushToken.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.pushKitToken.rawValue)
         setPersistentStoreMetadata(nil as Data?, key: PersistentMetadataKey.lastUpdateEventID.rawValue)

--- a/Source/Model/PersistentMetadataKeys.swift
+++ b/Source/Model/PersistentMetadataKeys.swift
@@ -23,7 +23,6 @@ public enum PersistentMetadataKey: String {
     case lastUpdateEventID = "LastUpdateEventID"
     case pushToken = "pushToken"
     case pushKitToken = "ZMPushKitToken"
-    case importedFromBackup = "importedFromBackup"
     case encryptMessagesAtRest = "encryptMessagesAtRest"
     
 }

--- a/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackBackupTests.swift
@@ -164,44 +164,6 @@ class StorageStackBackupTests: DatabaseBaseTest {
         let fetchConversations = ZMConversation.sortedFetchRequest()
         XCTAssertEqual(try anotherDirectory.uiContext.count(for: fetchConversations), 1)
     }
-
-    func testThatItMarksStoreAsBackupWhenExporting() throws {
-        // given
-        let uuid = UUID()
-        var directory: ManagedObjectContextDirectory? = createStorageStackAndWaitForCompletion(userID: uuid)
-        _ = ZMConversation.insertGroupConversation(moc: directory!.uiContext, participants: [])
-        directory!.uiContext.saveOrRollback()
-
-        // when
-        guard let result = createBackup(accountIdentifier: uuid) else { return XCTFail() }
-        StorageStack.reset()
-        directory = nil
-
-        // then
-        switch result {
-        case let .success(backup):
-            let model = NSManagedObjectModel.loadModel()
-            let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-            let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
-            let storeFile = backup.appendingPathComponent("data").appendingStoreFile()
-            XCTAssert(FileManager.default.fileExists(atPath: storeFile.path))
-            let store = try coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeFile, options: options)
-            let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-            context.persistentStoreCoordinator = coordinator
-            context.performAndWait {
-                let request = ZMConversation.sortedFetchRequest()
-                let convs = try? context.fetch(request)
-                XCTAssertEqual(convs?.count, 1)
-            }
-
-            guard let metadata = store.metadata else { return XCTFail() }
-            guard let imported = metadata[PersistentMetadataKey.importedFromBackup.rawValue] else { return XCTFail() }
-            guard let flag = imported as? NSNumber else { return XCTFail() }
-            XCTAssertTrue(flag.boolValue)
-        case .failure:
-            XCTFail()
-        }
-    }
     
     // MARK: - Import
     

--- a/Tests/Source/ManagedObjectContext/StorageStackTests.swift
+++ b/Tests/Source/ManagedObjectContext/StorageStackTests.swift
@@ -615,7 +615,6 @@ extension StorageStackTests {
         
         // Set metadata on DB which we expect to be cleared when importing from a backup
         contextDirectory.uiContext.setPersistentStoreMetadata("1234567890", key: ZMPersistedClientIdKey)
-        contextDirectory.uiContext.setPersistentStoreMetadata(NSNumber(booleanLiteral: true), key: PersistentMetadataKey.importedFromBackup.rawValue)
         contextDirectory.uiContext.setPersistentStoreMetadata("1234567890", key: PersistentMetadataKey.pushToken.rawValue)
         contextDirectory.uiContext.setPersistentStoreMetadata("1234567890", key: PersistentMetadataKey.pushKitToken.rawValue)
         contextDirectory.uiContext.setPersistentStoreMetadata("1234567890", key: PersistentMetadataKey.lastUpdateEventID.rawValue)


### PR DESCRIPTION
## What's new in this PR?

### Issues

the following ticket is related to the scenario described [here](https://wearezeta.atlassian.net/browse/SQCORE-205) and [here](https://github.com/wireapp/wire-ios/issues/4717)

### Causes

In the current version when a backup is exported the db it is marked (see `func markAsImported`). Basically under the key  `PersistentMetadataKey.importedFromBackup`  a  `bool` is saved as `true` in its persistent metadata of the data base.
Often On iOS14 when the backup is imported  the `bool` stored in the metadata of the database under the `PersistentMetadataKey.importedFromBackup` key is corrupted. Somehow the value not present in the persistent metadata.

P.s :Till now  we didn't understand why the PersistentMetadataKey.importedFromBackup is missing in the metadata.

### Solutions

The following solution is not the cleanest: we added a `bool` `isImportedFromBackup` in the `StorageStack` singleton and we set to `true` when a backup is imported. In this manner we don't relay anymore to to data base metadata that could be corrupted but we relay just on the user flow.  In this manner also old corrupted backup could be loaded with the user is logged out.

