### PR TITLE
[Fix] Metadata key not always being persisted on backup

### DIFF
--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -152,6 +152,9 @@ extension StorageStack {
         try context.performGroupedAndWait { context in
             try context.save()
         }
+        
+        // Close the store, not doing so could lead to data loss when copying the store files.
+        try coordinator.remove(store)
     }
     
     public enum BackupImportError: Error {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Metadata key not always being persisted on backup leading to issues when importing the backup.

### Causes

The store files still connected to a `NSPersistentStore` when being copied.

### Solutions

Remove `NSPersistentStore` from the `NSPersistentStoreCoordinator` before copying the store files.