### PR TITLE
[Fix] Exporting backups under EAR

### DIFF
--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -225,6 +225,7 @@ extension StorageStack {
             if context.encryptMessagesAtRest {
                 guard let encryptionKeys = encryptionKeys else { throw BackupError.missingEAREncryptionKey }
                 try context.disableEncryptionAtRest(encryptionKeys: encryptionKeys)
+                _ = context.makeMetadataPersistent()
                 try context.save()
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Backups exported when EAR is enabled also have EAR enabled when imported which is not the expected behaviour.

### Causes

When we create a backup we disable EAR for the backup but we were missing to persist the store metadata so the `encryptMessagesAtRest` flag was still set to `true` even though EAR had been disabled.

### Solutions

Persist store metadata.
