### PR TITLE
[Refactor] Add selfUser to AppLockController initializer

### DIFF
--- a/Source/Model/FeatureConfig/AppLock/AppLockController.swift
+++ b/Source/Model/FeatureConfig/AppLock/AppLockController.swift
@@ -36,7 +36,7 @@ public final class AppLockController {
         var result = baseConfig
         result.forceAppLock = baseConfig.forceAppLock || feature.config.enforceAppLock
         result.appLockTimeout = feature.config.inactivityTimeoutSecs
-        result.isEnabled = (feature.status == .enabled)
+        result.isAvailable = (feature.status == .enabled)
         
         return result
     }
@@ -126,7 +126,7 @@ public final class AppLockController {
         public let useCustomCodeInsteadOfAccountPassword: Bool
         public var forceAppLock: Bool
         public var appLockTimeout: UInt
-        public var isEnabled: Bool
+        public var isAvailable: Bool
         
         public init(useBiometricsOrAccountPassword: Bool,
                     useCustomCodeInsteadOfAccountPassword: Bool,
@@ -136,7 +136,7 @@ public final class AppLockController {
             self.useCustomCodeInsteadOfAccountPassword = useCustomCodeInsteadOfAccountPassword
             self.forceAppLock = forceAppLock
             self.appLockTimeout = timeOut
-            self.isEnabled = true
+            self.isAvailable = true
         }
     }
     

--- a/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
+++ b/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
@@ -111,7 +111,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
         XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isEnabled)
+        XCTAssertTrue(sut.config.isAvailable)
         XCTAssertEqual(sut.config.appLockTimeout, 10)
         
         //when
@@ -130,7 +130,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //then
         XCTAssertTrue(sut.config.forceAppLock)
-        XCTAssertFalse(sut.config.isEnabled)
+        XCTAssertFalse(sut.config.isAvailable)
         XCTAssertEqual(sut.config.appLockTimeout, 30)
     }
     
@@ -173,7 +173,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
         XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isEnabled)
+        XCTAssertTrue(sut.config.isAvailable)
         XCTAssertEqual(sut.config.appLockTimeout, 10)
         
         //when
@@ -192,7 +192,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //then
         XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isEnabled)
+        XCTAssertTrue(sut.config.isAvailable)
         XCTAssertNotEqual(sut.config.appLockTimeout, 30)
     }
 }

--- a/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
+++ b/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
@@ -101,7 +101,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         XCTAssertEqual(context.evaluatedPolicyDomainState, UserDefaults.standard.object(forKey: "DomainStateKey") as? Data)
     }
 
-    func testThatConfigIsUpdatedFromRemovedData_WhenSelfUserIsATeamUser() {
+    func testThatItHonorsTheTeamConfiguration_WhenSelfUserIsATeamUser() {
         
         //given
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
@@ -111,6 +111,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
         XCTAssertFalse(sut.config.forceAppLock)
+        XCTAssertTrue(sut.config.isEnabled)
         XCTAssertEqual(sut.config.appLockTimeout, 10)
         
         //when
@@ -121,7 +122,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         let configData = try? JSONEncoder().encode(config)
         _ = Feature.createOrUpdate(
             name: .appLock,
-            status: .enabled,
+            status: .disabled,
             config: configData,
             team: team,
             context: uiMOC
@@ -129,10 +130,11 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //then
         XCTAssertTrue(sut.config.forceAppLock)
+        XCTAssertFalse(sut.config.isEnabled)
         XCTAssertEqual(sut.config.appLockTimeout, 30)
     }
     
-    func testThatConfigIsNotUpdatedFromRemovedData_WhenSelfUserIsNotATeamUser() {
+    func testThatItDoesNotHonorTheTeamConfiguration_WhenSelfUserIsNotATeamUser() {
         
         //given
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
@@ -142,6 +144,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
         XCTAssertFalse(sut.config.forceAppLock)
+        XCTAssertTrue(sut.config.isEnabled)
         XCTAssertEqual(sut.config.appLockTimeout, 10)
         
         //when
@@ -152,7 +155,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         let configData = try? JSONEncoder().encode(config)
         _ = Feature.createOrUpdate(
             name: .appLock,
-            status: .enabled,
+            status: .disabled,
             config: configData,
             team: team,
             context: uiMOC
@@ -160,6 +163,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //then
         XCTAssertFalse(sut.config.forceAppLock)
+        XCTAssertTrue(sut.config.isEnabled)
         XCTAssertNotEqual(sut.config.appLockTimeout, 30)
     }
 }


### PR DESCRIPTION
## What's new in this PR?
Inject a `selfUser` into the `AppLockController` initializer and combine the AppLock rules from bundle and CoreData.


This PR is one in a series for refactoring for AppLock. Full description of refactoring you can find here:
wireapp/wire-ios-data-model#1078
