### PR TITLE
[Refactor] Modify enqueueBackendRefresh() to refresh  features

### DIFF
--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -64,11 +64,19 @@ extension Team {
     /// To trigger the request immediately, post a `RequestAvailableNotification`.
     ///
     /// - Parameter name: The name of the feature to refresh.
-
+    
     public func enqueueBackendRefresh(for name: Feature.Name) {
         guard let context = managedObjectContext else { return }
-        let feature = Feature.fetch(name: name, context: context)
-        feature?.needsToBeUpdatedFromBackend = true
+        
+        if let feature = Feature.fetch(name: name, context: context) {
+            feature.needsToBeUpdatedFromBackend = true
+        } else {
+            switch name {
+            case .appLock:
+                let defaultInstance = try? Feature.AppLock().store(for: self, in: context)
+                defaultInstance?.needsToBeUpdatedFromBackend = true
+            }
+        }
     }
 
 }

--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -68,15 +68,8 @@ extension Team {
     public func enqueueBackendRefresh(for name: Feature.Name) {
         guard let context = managedObjectContext else { return }
         
-        if let feature = Feature.fetch(name: name, context: context) {
-            feature.needsToBeUpdatedFromBackend = true
-        } else {
-            switch name {
-            case .appLock:
-                let defaultInstance = try? Feature.AppLock().store(for: self, in: context)
-                defaultInstance?.needsToBeUpdatedFromBackend = true
-            }
-        }
+        let feature = Feature.fetchOrCreate(name: name, team: self, context: context)
+        feature.needsToBeUpdatedFromBackend = true
     }
 
 }

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -112,9 +112,13 @@ public class Feature: ZMManagedObject {
             switch name {
             case .appLock:
                 let defaultInstance = Feature.AppLock()
+                guard let defaultConfigData = try? JSONEncoder().encode(defaultInstance.config) else {
+                    fatalError("Failed to encode default config for: \(name)")
+                }
+
                 let feature = insert(name: name,
                                      status: defaultInstance.status,
-                                     config: try? JSONEncoder().encode(defaultInstance.config),
+                                     config: defaultConfigData,
                                      team: team,
                                      context: context)
                 return feature

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -107,7 +107,7 @@ public class Feature: ZMManagedObject {
         fetchRequest.fetchLimit = 2
         
         let results = context.fetchOrAssert(request: fetchRequest)
-        require(results.count <= 1, "More than instance for feature: \(name.rawValue)")
+        require(results.count <= 1, "More than one instance for feature: \(name.rawValue)")
         guard let feature = results.first else {
             switch name {
             case .appLock:

--- a/Source/Model/FeatureConfig/FeatureLike.swift
+++ b/Source/Model/FeatureConfig/FeatureLike.swift
@@ -64,7 +64,8 @@ public extension FeatureLike {
             status: status,
             config: try JSONEncoder().encode(config),
             team: team,
-            context: context)
+            context: context
+        )
     }
 
 }

--- a/Source/Model/FeatureConfig/FeatureLike.swift
+++ b/Source/Model/FeatureConfig/FeatureLike.swift
@@ -59,13 +59,11 @@ public extension FeatureLike {
 
     @discardableResult
     func store(for team: Team, in context: NSManagedObjectContext) throws -> Feature {
-        return Feature.createOrUpdate(
-            name: Self.name,
-            status: status,
-            config: try JSONEncoder().encode(config),
-            team: team,
-            context: context
-        )
+        return Feature.insert(name: Self.name,
+                              status: status,
+                              config: try JSONEncoder().encode(config),
+                              team: team,
+                              context: context)
     }
 
 }

--- a/Source/Model/FeatureConfig/FeatureLike.swift
+++ b/Source/Model/FeatureConfig/FeatureLike.swift
@@ -59,7 +59,7 @@ public extension FeatureLike {
 
     @discardableResult
     func store(for team: Team, in context: NSManagedObjectContext) throws -> Feature {
-        return Feature.insert(name: Self.name,
+        return Feature.createOrUpdate(name: Self.name,
                               status: status,
                               config: try JSONEncoder().encode(config),
                               team: team,

--- a/Source/Model/FeatureConfig/FeatureLike.swift
+++ b/Source/Model/FeatureConfig/FeatureLike.swift
@@ -59,11 +59,12 @@ public extension FeatureLike {
 
     @discardableResult
     func store(for team: Team, in context: NSManagedObjectContext) throws -> Feature {
-        return Feature.createOrUpdate(name: Self.name,
-                              status: status,
-                              config: try JSONEncoder().encode(config),
-                              team: team,
-                              context: context)
+        return Feature.createOrUpdate(
+            name: Self.name,
+            status: status,
+            config: try JSONEncoder().encode(config),
+            team: team,
+            context: context)
     }
 
 }

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -294,7 +294,7 @@ final class TeamTests: ZMConversationTestsBase {
         }
     }
 
-    func testItEnqueuesBackendRefreshForFeature() {
+    func testItEnqueuesBackendRefreshForFeature_WhenFeatureExistsInCoreData() {
         // Given
         let sut = createTeam(in: uiMOC)
 
@@ -312,6 +312,23 @@ final class TeamTests: ZMConversationTestsBase {
         sut.enqueueBackendRefresh(for: .appLock)
 
         // Then
+        XCTAssertTrue(feature.needsToBeUpdatedFromBackend)
+    }
+    
+    func testItEnqueuesBackendRefreshForFeature_WhenThereIsNoFeatureInCoreData() {
+        // Given
+        let sut = createTeam(in: uiMOC)
+        XCTAssertNil(Feature.fetch(name: .appLock, context: uiMOC))
+        
+        // When
+        sut.enqueueBackendRefresh(for: .appLock)
+
+        // Then
+        guard let feature = Feature.fetch(name: .appLock, context: uiMOC) else {
+            XCTFail()
+            return
+        }
+        
         XCTAssertTrue(feature.needsToBeUpdatedFromBackend)
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

We currently have an `enqueueBackendRefresh()` method that can trigger a BE to update the feature. Since we don't have any feature in the new entity of Core data, we should create a new default  feature and then trigger BE to update it.
