### PR TITLE
[Feature] Expose decryption error code on system messages

### DIFF
--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.88.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.88.0.xcdatamodel/contents
@@ -214,6 +214,7 @@
     </entity>
     <entity name="SystemMessage" representedClassName="ZMSystemMessage" parentEntity="Message" syncable="YES">
         <attribute name="allTeamUsersAdded" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="decryptionErrorCode" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="messageTimer" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="needsUpdatingUsers" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -346,7 +347,7 @@
         <element name="Reaction" positionX="18" positionY="162" width="128" height="103"/>
         <element name="Role" positionX="-198" positionY="63" width="128" height="120"/>
         <element name="Session" positionX="9" positionY="153" width="128" height="60"/>
-        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="255"/>
+        <element name="SystemMessage" positionX="0" positionY="0" width="128" height="268"/>
         <element name="Team" positionX="9" positionY="153" width="128" height="238"/>
         <element name="TextMessage" positionX="-153" positionY="-117" width="128" height="60"/>
         <element name="User" positionX="-434" positionY="-72" width="128" height="703"/>

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -306,11 +306,13 @@ extension ZMConversation {
         let type = (UInt32(errorCode) == CBOX_REMOTE_IDENTITY_CHANGED.rawValue) ? ZMSystemMessageType.decryptionFailed_RemoteIdentityChanged : ZMSystemMessageType.decryptionFailed
         let clients = client.flatMap { Set(arrayLiteral: $0) } ?? Set<UserClient>()
         let serverTimestamp = date ?? timestampAfterLastMessage()
-        self.appendSystemMessage(type: type,
-                                 sender: sender,
-                                 users: nil,
-                                 clients: clients,
-                                 timestamp: serverTimestamp)
+        let systemMessage = appendSystemMessage(type: type,
+                                               sender: sender,
+                                               users: nil,
+                                               clients: clients,
+                                               timestamp: serverTimestamp)
+        
+        systemMessage.decryptionErrorCode = NSNumber(integerLiteral: errorCode)
     }
 
     /// Adds the user to the list of participants if not already present and inserts a .participantsAdded system message

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -140,7 +140,7 @@ extern NSString * _Nonnull const ZMMessageNeedsLinkAttachmentsUpdateKey;
 @property (nonatomic, readonly) BOOL userIsTheSender; // Set to true if sender is the only user in users array. E.g. when a wireless user joins conversation
 @property (nonatomic) NSNumber * _Nullable messageTimer; // Only filled for .messageTimerUpdate
 @property (nonatomic) BOOL relevantForConversationStatus; // If true (default), the message is considered to be shown inside the conversation list
-
+@property (nonatomic) NSNumber * _Nullable decryptionErrorCode; // If available this will be set for decryption error messages.
 + (ZMSystemMessage * _Nullable)fetchLatestPotentialGapSystemMessageInConversation:(ZMConversation * _Nonnull)conversation;
 - (void)updateNeedsUpdatingUsersIfNeeded;
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -89,6 +89,7 @@ NSString * const ZMMessageLinkAttachmentsKey = @"linkAttachments";
 NSString * const ZMMessageNeedsLinkAttachmentsUpdateKey = @"needsLinkAttachmentsUpdate";
 NSString * const ZMMessageDiscoveredClientsKey = @"discoveredClients";
 NSString * const ZMMessageButtonStatesKey = @"buttonStates";
+NSString * const ZMMessageDecryptionErrorCodeKey = @"decryptionErrorCode";
 
 
 @interface ZMMessage ()
@@ -594,7 +595,8 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
                              ZMMessageLinkAttachmentsKey,
                              ZMMessageNeedsLinkAttachmentsUpdateKey,
                              ZMMessageDiscoveredClientsKey,
-                             ZMMessageButtonStatesKey
+                             ZMMessageButtonStatesKey,
+                             ZMMessageDecryptionErrorCodeKey
                              ];
         ignoredKeys = [keys setByAddingObjectsFromArray:newKeys];
     });

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -760,6 +760,7 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
 @dynamic parentMessage;
 @dynamic messageTimer;
 @dynamic relevantForConversationStatus;
+@dynamic decryptionErrorCode;
 
 - (instancetype)initWithNonce:(NSUUID *)nonce managedObjectContext:(NSManagedObjectContext *)managedObjectContext
 {

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -131,6 +131,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, readonly, copy, nullable) NSString *text;
 @property (nonatomic) BOOL needsUpdatingUsers;
 @property (nonatomic) NSTimeInterval duration;
+@property (nonatomic) NSNumber * _Nullable decryptionErrorCode; // Only filled for ZMSystemMessageTypeDecryptionFailed
 /**
   Only filled for .performedCall & .missedCall
  */

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
@@ -509,15 +509,17 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
         conversation.conversationType = .group
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         user.name = "Fancy One"
+        let decryptionError = CBOX_REMOTE_IDENTITY_CHANGED
         
         // when
-        conversation.appendDecryptionFailedSystemMessage(at: Date(), sender: user, client: nil, errorCode: Int(CBOX_REMOTE_IDENTITY_CHANGED.rawValue))
+        conversation.appendDecryptionFailedSystemMessage(at: Date(), sender: user, client: nil, errorCode: Int(decryptionError.rawValue))
         
         // then
         guard let lastMessage = conversation.lastMessage as? ZMSystemMessage else {
             return XCTFail()
         }
         XCTAssertEqual(lastMessage.systemMessageType, ZMSystemMessageType.decryptionFailed_RemoteIdentityChanged)
+        XCTAssertEqual(lastMessage.decryptionErrorCode?.intValue, Int(decryptionError.rawValue))
     }
     
     func testThatItAppendsASystemMessageOfGeneralTypeForCBErrorCodeInvalidMessage()
@@ -527,15 +529,17 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
         conversation.conversationType = .group
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         user.name = "Fancy One"
+        let decryptionError = CBOX_INVALID_MESSAGE
         
         // when
-        conversation.appendDecryptionFailedSystemMessage(at: Date(), sender: user, client: nil, errorCode: Int(CBOX_INVALID_MESSAGE.rawValue))
+        conversation.appendDecryptionFailedSystemMessage(at: Date(), sender: user, client: nil, errorCode: Int(decryptionError.rawValue))
         
         // then
         guard let lastMessage = conversation.lastMessage as? ZMSystemMessage else {
             return XCTFail()
         }
         XCTAssertEqual(lastMessage.systemMessageType, ZMSystemMessageType.decryptionFailed)
+        XCTAssertEqual(lastMessage.decryptionErrorCode?.intValue, Int(decryptionError.rawValue))
     }
     
     func testThatContinuedUsingDeviceSystemMessageAppendedAfterLastMessage()

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 		1672A6272344F10700380537 /* FolderList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderList.swift; sourceTree = "<group>"; };
 		1672A6292345102400380537 /* ZMConversationListTests+Labels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationListTests+Labels.swift"; sourceTree = "<group>"; };
 		16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ZMImageOwner.swift"; sourceTree = "<group>"; };
+		16824637257A44A9002AF17B /* zmessaging2.88.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.88.0.xcdatamodel; sourceTree = "<group>"; };
 		168413E82225902200FCB9BC /* zmessaging2.65.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.65.0.xcdatamodel; sourceTree = "<group>"; };
 		168413E9222594E600FCB9BC /* store2-65-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-65-0.wiredatabase"; sourceTree = "<group>"; };
 		168413EC2225965500FCB9BC /* TransferStateMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferStateMigration.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## What's new in this PR?

When we insert a decryption error system message we now store the error code on the system message so we can display it to the user.