### PR TITLE
add isTrust to UserType protocol

### DIFF
--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -229,4 +229,7 @@ public protocol UserType: NSObjectProtocol {
     /// Whether the user is group admin in the conversation.
     @objc(isGroupAdminInConversation:)
     func isGroupAdmin(in conversation: ZMConversation) -> Bool
+        
+    /// Whether all user's devices are verified by the selfUser
+    var isTrusted: Bool { get }
 }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -137,7 +137,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     
     /// Whether all user's devices are verified by the selfUser
     public var isTrusted: Bool {
-        return false
+        return user?.isTrusted ?? false
     }
     
     public var teamCreatedBy: UUID? {
@@ -148,7 +148,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
 
     public var emailAddress: String? {
         get {
-            return user?.emailAddress
+            return (user as? ZMUser)?.emailAddress
         }
     }
 

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -148,7 +148,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
 
     public var emailAddress: String? {
         get {
-            return (user as? ZMUser)?.emailAddress
+            return user?.emailAddress
         }
     }
 

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -135,6 +135,11 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     fileprivate var internalPreviewImageData: Data?
     fileprivate var internalCompleteImageData: Data?
     
+    /// Whether all user's devices are verified by the selfUser
+    public var isTrusted: Bool {
+        return false
+    }
+    
     public var teamCreatedBy: UUID? {
         get {
             return user?.membership?.createdBy?.remoteIdentifier ?? internalTeamCreatedBy

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -24,6 +24,15 @@ extension ZMUser: UserConnectionType { }
 
 extension ZMUser: UserType {
 
+    /// Whether all user's devices are verified by the selfUser
+    public var isTrusted: Bool {
+        let selfUser = managedObjectContext.map(ZMUser.selfUser)
+        let selfClient = selfUser?.selfClient()
+        let hasUntrustedClients = self.clients.contains(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
+        
+        return !hasUntrustedClients
+    }
+    
     public func isGuest(in conversation: ZMConversation) -> Bool {
         return _isGuest(in: conversation)
     }
@@ -332,18 +341,6 @@ extension NSManagedObject: SafeForLoggingStringConvertible {
         let moc: String = self.managedObjectContext?.description ?? "nil"
         
         return "\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque()): moc=\(moc) objectID=\(self.objectID)"
-    }
-}
-
-extension ZMUser {
-    
-    /// Whether all user's devices are verified by the selfUser
-    @objc public var isTrusted: Bool {
-        let selfUser = managedObjectContext.map(ZMUser.selfUser)
-        let selfClient = selfUser?.selfClient()
-        let hasUntrustedClients = self.clients.contains(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
-        
-        return !hasUntrustedClients
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Add `isTrust` to `Usertype` for easier mocking.

### Discussion

Should `ZMSearchUser` `isTrust` always return false?