### PR TITLE
[Fix] app crash when `service` payload is null

### DIFF
--- a/Source/Model/User/ZMUser.m
+++ b/Source/Model/User/ZMUser.m
@@ -515,7 +515,7 @@ static NSString *const AnalyticsIdentifierKey = @"analyticsIdentifier";
 // is received from the notification stream.
 - (void)updateWithTransportData:(NSDictionary *)transportData authoritative:(BOOL)authoritative
 {
-    NSDictionary *serviceData = transportData[@"service"];
+    NSDictionary *serviceData = [transportData optionalDictionaryForKey:@"service"];
     if (serviceData != nil) {
         NSString *serviceIdentifier = [serviceData optionalStringForKey:@"id"];
         if (serviceIdentifier != nil) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes on launch

### Causes

In `[ZMUser updateWithTransportData:(NSDictionary *) authoritative:(Bool)]` we access the value stored in the dictionary at the `service` key.

The value returned is an instance of `NSNull`.
We expect that value to be an instance of `NSDictionary`.
Before we try to access its values, we check that it isn't `nil`.
However, since it is an instance of `NSNull`, it is not `nil`.
Consequently, we treat it as a `NSDictionary` and the app crashes.

### Solutions

use `optionalDictionaryForKey` to get the dictionary 
