### PR TITLE
[Refactor] Remove useCustomCodeInsteadOfAccountPassword from the Feature.Config

### DIFF
--- a/Source/Model/FeatureConfig/AppLock/AppLockController.swift
+++ b/Source/Model/FeatureConfig/AppLock/AppLockController.swift
@@ -147,18 +147,15 @@ public final class AppLockController: AppLockType {
     // MARK: - Types
     
     public struct Config {
-        public let useBiometricsOrAccountPassword: Bool
-        public let useCustomCodeInsteadOfAccountPassword: Bool
+        public let useBiometricsOrCustomPasscode: Bool
         public var forceAppLock: Bool
         public var appLockTimeout: UInt
         public var isAvailable: Bool
         
-        public init(useBiometricsOrAccountPassword: Bool,
-                    useCustomCodeInsteadOfAccountPassword: Bool,
+        public init(useBiometricsOrCustomPasscode: Bool,
                     forceAppLock: Bool,
                     timeOut: UInt) {
-            self.useBiometricsOrAccountPassword = useBiometricsOrAccountPassword
-            self.useCustomCodeInsteadOfAccountPassword = useCustomCodeInsteadOfAccountPassword
+            self.useBiometricsOrCustomPasscode = useBiometricsOrCustomPasscode
             self.forceAppLock = forceAppLock
             self.appLockTimeout = timeOut
             self.isAvailable = true

--- a/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
+++ b/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
@@ -28,8 +28,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //given
         let selfUser = ZMUser.selfUser(in: uiMOC)
-        let config = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                              useCustomCodeInsteadOfAccountPassword: false,
+        let config = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                               forceAppLock: true,
                                               timeOut: 900)
         let sut = AppLockController(config: config, selfUser: selfUser)
@@ -47,8 +46,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
 
         //given
         let selfUser = ZMUser.selfUser(in: uiMOC)
-        let config = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                              useCustomCodeInsteadOfAccountPassword: false,
+        let config = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                               forceAppLock: false,
                                               timeOut: 10)
         let sut = AppLockController(config: config, selfUser: selfUser)
@@ -105,8 +103,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //given
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
-        let configFromBundle = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                                        useCustomCodeInsteadOfAccountPassword: false,
+        let configFromBundle = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                                         forceAppLock: false,
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
@@ -138,8 +135,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //given
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
-        let configFromBundle = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                                        useCustomCodeInsteadOfAccountPassword: false,
+        let configFromBundle = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                                         forceAppLock: true,
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)
@@ -167,8 +163,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
         
         //given
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
-        let configFromBundle = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                                        useCustomCodeInsteadOfAccountPassword: false,
+        let configFromBundle = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                                         forceAppLock: false,
                                                         timeOut: 10)
         let sut = AppLockController(config: configFromBundle, selfUser: selfUser)

--- a/Tests/Source/Utils/TransferApplockKeychainTests.swift
+++ b/Tests/Source/Utils/TransferApplockKeychainTests.swift
@@ -36,8 +36,7 @@ class TransferApplockKeychain: DiskDatabaseTest {
     
     func testItMigratesIsActiveStateFromTheKeychainToTheMOC() {
         //given
-        let config = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                              useCustomCodeInsteadOfAccountPassword: false,
+        let config = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                               forceAppLock: false,
                                               timeOut: 900)
         let sut = AppLockController(config: config, selfUser: selfUser)
@@ -55,8 +54,7 @@ class TransferApplockKeychain: DiskDatabaseTest {
     
     func testItDoesNotMigrateIsActiveStateFromTheKeychainToTheMOC_IfKeychainIsEmpty() {
         //given
-        let config = AppLockController.Config(useBiometricsOrAccountPassword: false,
-                                              useCustomCodeInsteadOfAccountPassword: false,
+        let config = AppLockController.Config(useBiometricsOrCustomPasscode: false,
                                               forceAppLock: false,
                                               timeOut: 900)
         let sut = AppLockController(config: config, selfUser: selfUser)


### PR DESCRIPTION
## What's new in this PR?

Remove `useCustomCodeInsteadOfAccountPassword` from the Feature.Config because we don't use it anymore in the UI. The fallback to unlock Wire is always a custom passcode.