### PR TITLE
[Refactor] Change ZMConversationMessage.sender type form ZMUser to UserType

### DIFF
--- a/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
+++ b/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
@@ -68,7 +68,8 @@ public extension ZMConversation {
     private func associatedSystemMessage(of type: ZMSystemMessageType, sender: ZMUser) -> ZMSystemMessage? {
         guard let lastMessage = lastMessage as? ZMSystemMessage,
               lastMessage.systemMessageType == type,
-              lastMessage.sender as? ZMUser == sender
+              lastMessage.sender?.isEqualTo(sender) == true,
+            lastMessage.sender?.isEqual(sender) == true
         else { return nil }
         
         return lastMessage

--- a/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
+++ b/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
@@ -68,7 +68,7 @@ public extension ZMConversation {
     private func associatedSystemMessage(of type: ZMSystemMessageType, sender: ZMUser) -> ZMSystemMessage? {
         guard let lastMessage = lastMessage as? ZMSystemMessage,
               lastMessage.systemMessageType == type,
-              lastMessage.sender == sender
+              lastMessage.sender as? ZMUser == sender
         else { return nil }
         
         return lastMessage

--- a/Source/Model/Conversation/ZMConversation+Confirmations.swift
+++ b/Source/Model/Conversation/ZMConversation+Confirmations.swift
@@ -31,7 +31,7 @@ extension ZMConversation {
         let unreadMessagesNeedingConfirmation = unreadMessages(until: timestamp).filter({ $0.needsReadConfirmation })
         var confirmationMessages: [ZMClientMessage] = []
         
-        for messages in unreadMessagesNeedingConfirmation.partition(by: \.sender).values {
+        for messages in unreadMessagesNeedingConfirmation.partition(by: \.zmSender).values {
             guard
                 !messages.isEmpty,
                 let confirmation = Confirmation(messageIds: messages.compactMap(\.nonce), type: .read)

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -504,7 +504,7 @@ extension ZMConversation {
             
             guard let systemMessage = msg as? ZMSystemMessage,
                 systemMessage.systemMessageType == .newClient,
-                systemMessage.sender as? ZMUser == selfUser else {
+            systemMessage.sender?.isEqualTo(selfUser) == true else {
                     return
             }
             

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -504,7 +504,7 @@ extension ZMConversation {
             
             guard let systemMessage = msg as? ZMSystemMessage,
                 systemMessage.systemMessageType == .newClient,
-                systemMessage.sender == selfUser else {
+                systemMessage.sender as? ZMUser == selfUser else {
                     return
             }
             

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -47,7 +47,7 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     var nonce: UUID? { get }
         
     /// The user who sent the message
-    var sender: ZMUser? { get }
+    var sender: UserType? { get }
     
     /// The timestamp as received by the server
     var serverTimestamp: Date? { get }
@@ -157,7 +157,7 @@ public extension ZMConversationMessage {
 
     func isUserSender(_ user: UserType) -> Bool {
         guard let zmUser = user as? ZMUser else { return false }
-        return zmUser == sender
+        return zmUser == sender as? ZMUser
     }
 }
 
@@ -198,6 +198,10 @@ extension ZMMessage : ZMConversationMessage {
     @NSManaged public var linkAttachments: [LinkAttachment]?
     @NSManaged public var needsLinkAttachmentsUpdate: Bool
     @NSManaged public var replies: Set<ZMMessage>
+    
+    var zmSender: ZMUser? {
+        return sender as? ZMUser
+    }
     
     public var readReceipts: [ReadReceipt] {
         return confirmations.filter({ $0.type == .read }).sorted(by: { a, b in  a.serverTimestamp < b.serverTimestamp })
@@ -250,13 +254,13 @@ extension ZMMessage : ZMConversationMessage {
     }
     
     public var isSilenced: Bool {
-        return conversation?.isMessageSilenced(nil, senderID: sender?.remoteIdentifier) ?? true
+        return conversation?.isMessageSilenced(nil, senderID: (sender as? ZMUser)?.remoteIdentifier) ?? true
     }
 }
 
 extension ZMMessage {
     
-    @NSManaged public var sender : ZMUser?
+    @NSManaged public var sender : UserType?
     @NSManaged public var serverTimestamp : Date?
 
     @objc public var textMessageData : ZMTextMessageData? {

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -156,8 +156,7 @@ public extension ZMConversationMessage {
     /// Whether the given user is the sender of the message.
 
     func isUserSender(_ user: UserType) -> Bool {
-        guard let zmUser = user as? ZMUser else { return false }
-        return zmUser == sender as? ZMUser
+        sender?.isEqualTo(user) == true
     }
 }
 

--- a/Source/Model/Message/FileAssetCache.swift
+++ b/Source/Model/Message/FileAssetCache.swift
@@ -368,7 +368,7 @@ private struct FileCache : Cache {
 
     public static func cacheKeyForAsset(_ message : ZMConversationMessage, identifier: String? = nil, encrypted: Bool = false) -> String? {
         guard let messageId = message.nonce?.transportString(),
-              let senderId = message.sender?.remoteIdentifier?.transportString(),
+              let senderId = (message.sender as? ZMUser)?.remoteIdentifier?.transportString(),
               let conversationId = message.conversation?.remoteIdentifier?.transportString()
         else {
             return nil

--- a/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
@@ -54,7 +54,7 @@ extension ZMAssetClientMessage {
     }
     
     private func markRemoteAssetToBeDeleted() {
-        guard sender == ZMUser.selfUser(in: managedObjectContext!) else {
+        guard sender as? ZMUser == ZMUser.selfUser(in: managedObjectContext!) else {
             return
         }
         

--- a/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
@@ -54,7 +54,7 @@ extension ZMAssetClientMessage {
     }
     
     private func markRemoteAssetToBeDeleted() {
-        guard sender as? ZMUser == ZMUser.selfUser(in: managedObjectContext!) else {
+        guard sender?.isEqualTo(ZMUser.selfUser(in: managedObjectContext!)) == true else {
             return
         }
         

--- a/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage.swift
@@ -232,7 +232,7 @@ import Foundation
     }
     
     public override var isSilenced: Bool {
-        return conversation?.isMessageSilenced(underlyingMessage, senderID: sender?.remoteIdentifier) ?? true
+        return conversation?.isMessageSilenced(underlyingMessage, senderID: (sender as? ZMUser)?.remoteIdentifier) ?? true
     } 
     
     // Private implementation

--- a/Source/Model/Message/ZMClientMessage+Editing.swift
+++ b/Source/Model/Message/ZMClientMessage+Editing.swift
@@ -47,7 +47,7 @@ extension ZMClientMessage {
             let senderUUID = updateEvent.senderUUID,
             let originalText = underlyingMessage?.textData,
             case .text? = messageEdit.content,
-            senderUUID == sender?.remoteIdentifier
+            senderUUID == (sender as? ZMUser)?.remoteIdentifier
         else {
             return false
         }

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -274,7 +274,7 @@ extension GenericMessage {
                 fatal("buttonAction needs a recipient")
             }
 
-            return Set(arrayLiteral: sender)
+            return Set(arrayLiteral: sender as! ZMUser)
         }
 
         func recipientForConfirmationMessage() -> Set<ZMUser>? {
@@ -287,7 +287,7 @@ extension GenericMessage {
                     return nil
             }
 
-            return Set(arrayLiteral: sender)
+            return Set(arrayLiteral: sender as! ZMUser)
         }
 
         func recipientForOtherUsers() -> Set<ZMUser>? {
@@ -323,7 +323,7 @@ extension GenericMessage {
             guard !sender.isSelfUser else { return nil }
 
             // Otherwise we delete only for self and the sender, all other recipients are unaffected.
-            return Set(arrayLiteral: sender, selfUser)
+            return Set(arrayLiteral: sender as! ZMUser, selfUser)
         }
 
         func allAuthorizedRecipients() -> Set<ZMUser> {

--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -94,7 +94,7 @@ extension ZMClientMessage {
             let senderUUID = updateEvent.senderUUID,
             let originalText = underlyingMessage?.textData,
             let updatedText = updatedMessage.textData,
-            senderUUID == sender?.remoteIdentifier,
+            senderUUID == (sender as? ZMUser)?.remoteIdentifier,
             originalText.content == updatedText.content
         else {
             return

--- a/Source/Model/Message/ZMClientMessage.swift
+++ b/Source/Model/Message/ZMClientMessage.swift
@@ -222,6 +222,6 @@ extension ZMClientMessage {
     }
     
     public override var isSilenced: Bool {
-        return conversation?.isMessageSilenced(underlyingMessage, senderID: sender?.remoteIdentifier) ?? true
+        return conversation?.isMessageSilenced(underlyingMessage, senderID: (sender as? ZMUser)?.remoteIdentifier) ?? true
     }
 }

--- a/Source/Model/Message/ZMMessage+Conversation.swift
+++ b/Source/Model/Message/ZMMessage+Conversation.swift
@@ -20,7 +20,7 @@ import Foundation
 
 extension ZMMessage {
     var isSenderInConversation: Bool {
-        return conversation?.has(participantWithId: sender?.userId) ?? false
+        return conversation?.has(participantWithId: (sender as? ZMUser)?.userId) ?? false
     }
 }
 

--- a/Source/Model/Message/ZMMessage+Removal.swift
+++ b/Source/Model/Message/ZMMessage+Removal.swift
@@ -85,7 +85,7 @@ extension ZMMessage {
         }
 
         // Only the sender of the original message can delete it
-        if senderID != message.sender?.remoteIdentifier && !message.isEphemeral {
+        if senderID != (message.sender as? ZMUser)?.remoteIdentifier && !message.isEphemeral {
             return
         }
         
@@ -94,11 +94,11 @@ extension ZMMessage {
         // Only clients other than self should see the system message
         if senderID != selfUser.remoteIdentifier && !message.isEphemeral, let sender = message.sender {
             let timestamp = message.serverTimestamp ?? Date()
-            conversation.appendDeletedForEveryoneSystemMessage(at: timestamp, sender: sender)
+            conversation.appendDeletedForEveryoneSystemMessage(at: timestamp, sender: sender as! ZMUser)
         }
         
         // If we receive a delete for an ephemeral message that was not originally sent by the selfUser, we need to stop the deletion timer
-        if message.isEphemeral && message.sender?.remoteIdentifier != selfUser.remoteIdentifier {
+        if message.isEphemeral && (message.sender as? ZMUser)?.remoteIdentifier != selfUser.remoteIdentifier {
             message.removeClearingSender(true)
             stopDeletionTimer(for: message)
         } else {

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -396,7 +396,7 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
             self.objectID.URIRepresentation.lastPathComponent,
             self.conversation.objectID.URIRepresentation.lastPathComponent,
             [self.nonce.UUIDString.lowercaseString substringToIndex:4],
-            self.sender.objectID.URIRepresentation.lastPathComponent,
+            ((ZMUser *)self.sender).objectID.URIRepresentation.lastPathComponent,
             [formatter stringFromNumber:@(self.serverTimestamp.timeIntervalSinceNow)]
             ];
 }

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -233,5 +233,5 @@ public protocol UserType: NSObjectProtocol {
     /// Whether all user's devices are verified by the selfUser
     var isTrusted: Bool { get }
     
-    func isEqualTo(_ other: UserType) -> Bool
+    func isEqualTo(_ other: UserType?) -> Bool
 }

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -232,4 +232,6 @@ public protocol UserType: NSObjectProtocol {
         
     /// Whether all user's devices are verified by the selfUser
     var isTrusted: Bool { get }
+    
+    func isEqualTo(_ other: UserType) -> Bool
 }

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -136,15 +136,11 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     fileprivate var internalCompleteImageData: Data?
     
     public func isEqualTo(_ other: UserType?) -> Bool {
-        if let otherSearchUser = other as? ZMSearchUser {
-            return user == otherSearchUser.user
-        }
-
-        guard let otherUser = other as? ZMUser else {
+        guard let otherSearchUser = other as? ZMSearchUser else {
             return false
         }
 
-        return user == otherUser
+        return self == otherSearchUser
     }
 
     /// Whether all user's devices are verified by the selfUser

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -135,6 +135,18 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     fileprivate var internalPreviewImageData: Data?
     fileprivate var internalCompleteImageData: Data?
     
+    public func isEqualTo(_ other: UserType) -> Bool {
+        if let otherSearchUser = other as? ZMSearchUser {
+            return user == otherSearchUser.user
+        }
+
+        guard let otherUser = other as? ZMUser else {
+            return false
+        }
+
+        return user == otherUser
+    }
+
     /// Whether all user's devices are verified by the selfUser
     public var isTrusted: Bool {
         return user?.isTrusted ?? false

--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -135,7 +135,7 @@ public class ZMSearchUser: NSObject, UserType, UserConnectionType {
     fileprivate var internalPreviewImageData: Data?
     fileprivate var internalCompleteImageData: Data?
     
-    public func isEqualTo(_ other: UserType) -> Bool {
+    public func isEqualTo(_ other: UserType?) -> Bool {
         if let otherSearchUser = other as? ZMSearchUser {
             return user == otherSearchUser.user
         }

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -23,6 +23,11 @@ import WireSystem
 extension ZMUser: UserConnectionType { }
 
 extension ZMUser: UserType {
+    public func isEqualTo(_ other: UserType) -> Bool {
+        guard let otherUser = other as? ZMUser else { return false }
+        
+        return self == otherUser
+    }
 
     /// Whether all user's devices are verified by the selfUser
     public var isTrusted: Bool {

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -23,7 +23,7 @@ import WireSystem
 extension ZMUser: UserConnectionType { }
 
 extension ZMUser: UserType {
-    public func isEqualTo(_ other: UserType) -> Bool {
+    public func isEqualTo(_ other: UserType?) -> Bool {
         guard let otherUser = other as? ZMUser else { return false }
         
         return self == otherUser

--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -184,7 +184,7 @@ extension ZMSystemMessage {
     }
 
     public var senderChanged : Bool {
-        if self.usersChanged && (self.userChangeInfo?.user as? ZMUser ==  self.message.sender){
+        if self.usersChanged && (self.userChangeInfo?.user as? ZMUser == message.sender as? ZMUser){
             return true
         }
         return false

--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -184,10 +184,8 @@ extension ZMSystemMessage {
     }
 
     public var senderChanged : Bool {
-        if self.usersChanged && (self.userChangeInfo?.user as? ZMUser == message.sender as? ZMUser){
-            return true
-        }
-        return false
+        return usersChanged &&
+           userChangeInfo?.user.isEqualTo(message.sender) == true
     }
     
     public var isObfuscatedChanged : Bool {

--- a/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -110,7 +110,7 @@ extension ConversationTests {
         let genericMessageData = try? genericMessage.serializedData()
         let payload: NSDictionary = [
             "conversation": conversation.remoteIdentifier?.transportString(),
-            "from": message.sender?.remoteIdentifier.transportString(),
+            "from": (message.sender as? ZMUser)?.remoteIdentifier!.transportString(),
             "time": Date().transportString(),
             "data": [
                 "text": genericMessageData?.base64String()

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
@@ -39,7 +39,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
                 return XCTFail("No system message")
             }
 
-            XCTAssertEqual(message.sender as? ZMUser, user)
+            XCTAssert(message.sender?.isEqualTo(user) == true)
             XCTAssertEqual(message.users, [user])
             XCTAssertEqual(message.serverTimestamp, timestamp)
             XCTAssertEqual(message.systemMessageType, .missedCall)
@@ -173,7 +173,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
             return XCTFail("No system message")
         }
 
-        XCTAssertEqual(message.sender as? ZMUser, user)
+        XCTAssert(message.sender?.isEqualTo(user) == true)
         XCTAssertEqual(message.users, [user])
         XCTAssertEqual(message.duration, 42)
         XCTAssertEqual(message.systemMessageType, .performedCall)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
@@ -39,7 +39,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
                 return XCTFail("No system message")
             }
 
-            XCTAssertEqual(message.sender, user)
+            XCTAssertEqual(message.sender as? ZMUser, user)
             XCTAssertEqual(message.users, [user])
             XCTAssertEqual(message.serverTimestamp, timestamp)
             XCTAssertEqual(message.systemMessageType, .missedCall)
@@ -173,7 +173,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
             return XCTFail("No system message")
         }
 
-        XCTAssertEqual(message.sender, user)
+        XCTAssertEqual(message.sender as? ZMUser, user)
         XCTAssertEqual(message.users, [user])
         XCTAssertEqual(message.duration, 42)
         XCTAssertEqual(message.systemMessageType, .performedCall)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -39,7 +39,7 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
             XCTAssertEqual(message.textMessageData?.messageText, messageText)
             XCTAssertEqual(message.conversation, conversation)
             XCTAssertEqual(conversation.lastMessage, message)
-            XCTAssertEqual(selfUser, message.sender)
+            XCTAssertEqual(selfUser, message.sender as? ZMUser)
         }
     }
 
@@ -147,7 +147,7 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
         let expectedData = try! (try! Data(contentsOf: imageFileURL)).wr_removingImageMetadata()
         XCTAssertNotNil(expectedData)
         XCTAssertEqual(message.imageMessageData?.imageData, expectedData)
-        XCTAssertEqual(selfUser, message.sender)
+        XCTAssertEqual(selfUser as? ZMUser, message.sender as? ZMUser)
     }
     
     func testThatNoMessageIsInsertedWhenTheImageFileURLIsPointingToSomethingThatIsNotAnImage()

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -39,7 +39,7 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
             XCTAssertEqual(message.textMessageData?.messageText, messageText)
             XCTAssertEqual(message.conversation, conversation)
             XCTAssertEqual(conversation.lastMessage, message)
-            XCTAssertEqual(selfUser, message.sender as? ZMUser)
+            XCTAssert(selfUser.isEqualTo(message.sender))
         }
     }
 
@@ -147,7 +147,7 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
         let expectedData = try! (try! Data(contentsOf: imageFileURL)).wr_removingImageMetadata()
         XCTAssertNotNil(expectedData)
         XCTAssertEqual(message.imageMessageData?.imageData, expectedData)
-        XCTAssertEqual(selfUser as? ZMUser, message.sender as? ZMUser)
+        XCTAssert(selfUser.isEqualTo(message.sender))
     }
     
     func testThatNoMessageIsInsertedWhenTheImageFileURLIsPointingToSomethingThatIsNotAnImage()

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -236,7 +236,7 @@ extension ConversationTests_Teams {
         guard let message = conversation.lastMessage as? ZMSystemMessage else { XCTFail("Last message should be system message"); return }
         
         XCTAssertEqual(message.systemMessageType, .teamMemberLeave)
-        XCTAssertEqual(message.sender as? ZMUser, otherUser)
+        XCTAssert(message.sender?.isEqualTo(otherUser) == true)
         XCTAssertEqual(message.users, [otherUser])
         XCTAssertEqual(message.serverTimestamp, timestamp)
         XCTAssertFalse(message.shouldGenerateUnreadCount())

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Teams.swift
@@ -236,7 +236,7 @@ extension ConversationTests_Teams {
         guard let message = conversation.lastMessage as? ZMSystemMessage else { XCTFail("Last message should be system message"); return }
         
         XCTAssertEqual(message.systemMessageType, .teamMemberLeave)
-        XCTAssertEqual(message.sender, otherUser)
+        XCTAssertEqual(message.sender as? ZMUser, otherUser)
         XCTAssertEqual(message.users, [otherUser])
         XCTAssertEqual(message.serverTimestamp, timestamp)
         XCTAssertFalse(message.shouldGenerateUnreadCount())

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -357,7 +357,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let message = try! conversation.appendFile(with: fileMetadata) as! ZMAssetClientMessage
         conversation.conversationType = .oneOnOne
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier = UUID.create()
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)
         
@@ -393,7 +393,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.createFileMetadata()
         message = try! self.conversation.appendFile(with: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
-        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier = UUID.create()
         
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)
@@ -425,7 +425,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.createFileMetadata()
         message = try! self.conversation.appendFile(with: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
-        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier = UUID.create()
         
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests+Ephemeral.swift
@@ -357,7 +357,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let message = try! conversation.appendFile(with: fileMetadata) as! ZMAssetClientMessage
         conversation.conversationType = .oneOnOne
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        message.sender?.remoteIdentifier = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)
         
@@ -393,7 +393,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.createFileMetadata()
         message = try! self.conversation.appendFile(with: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
-        message.sender?.remoteIdentifier = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
         
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)
@@ -425,7 +425,7 @@ extension ZMAssetClientMessageTests_Ephemeral {
         let fileMetadata = self.createFileMetadata()
         message = try! self.conversation.appendFile(with: fileMetadata) as? ZMAssetClientMessage
         message.sender = ZMUser.insertNewObject(in: self.uiMOC)
-        message.sender?.remoteIdentifier = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
         
         try message.setUnderlyingMessage(GenericMessage(content: WireProtos.Asset(withUploadedOTRKey: Data(), sha256: Data()), nonce: message.nonce!))
         XCTAssertTrue(message.underlyingMessage!.assetData!.hasUploaded)

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -215,7 +215,7 @@ extension ZMAssetClientMessageTests {
     func testThatItSetsTheGenericAssetMessageWhenCreatingMessage()
     {
         // given
-        let nonce = UUID.create()
+        _ = UUID.create()
         let mimeType = "text/plain"
         let filename = "document.txt"
         let url = testURLWithFilename(filename)
@@ -1018,7 +1018,7 @@ extension ZMAssetClientMessageTests {
         // then
         XCTAssertNotNil(sut)
         XCTAssertEqual(sut.conversation?.remoteIdentifier, conversation.remoteIdentifier)
-        XCTAssertEqual(sut.sender?.remoteIdentifier!.transportString(), payload["from"] as? String)
+        XCTAssertEqual((sut.sender as? ZMUser)?.remoteIdentifier!.transportString(), payload["from"] as? String)
         XCTAssertEqual(sut.serverTimestamp?.transportString(), payload["time"] as? String)
         XCTAssertEqual(sut.nonce, nonce)
         XCTAssertNotNil(sut.fileMessageData)
@@ -1056,7 +1056,7 @@ extension ZMAssetClientMessageTests {
         // then
         XCTAssertNotNil(sut)
         XCTAssertEqual(sut.conversation?.remoteIdentifier, conversation.remoteIdentifier)
-        XCTAssertEqual(sut.sender?.remoteIdentifier!.transportString(), payload["from"] as? String)
+        XCTAssertEqual((sut.sender as? ZMUser)?.remoteIdentifier!.transportString(), payload["from"] as? String)
         XCTAssertEqual(sut.serverTimestamp?.transportString(), payload["time"] as? String)
         XCTAssertEqual(sut.nonce, nonce)
         XCTAssertNotNil(sut.fileMessageData)
@@ -1178,7 +1178,7 @@ extension ZMAssetClientMessageTests {
             message.expire()
         }
         if state == .delivered {
-            _ = ZMMessageConfirmation(type: .delivered, message: message, sender: message.sender!, serverTimestamp: Date(), managedObjectContext: message.managedObjectContext!)
+            _ = ZMMessageConfirmation(type: .delivered, message: message, sender: message.sender! as! ZMUser, serverTimestamp: Date(), managedObjectContext: message.managedObjectContext!)
             message.managedObjectContext?.saveOrRollback()
         }
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -427,7 +427,7 @@ extension ZMClientMessageTests_Deletion {
         }
         
         XCTAssertEqual(systemMessage.serverTimestamp, timestamp)
-        XCTAssertEqual(systemMessage.sender as? ZMUser, otherUser)
+        XCTAssert(systemMessage.sender?.isEqualTo(otherUser) == true)
     }
     
     

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -353,7 +353,7 @@ extension ZMClientMessageTests_Deletion {
         conversation.lastModifiedDate = lastModified
 
         // when
-        let updateEvent = createMessageDeletedUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!, senderID: sut.sender!.remoteIdentifier!)
+        let updateEvent = createMessageDeletedUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!, senderID: (sut.sender as! ZMUser).remoteIdentifier!)
 
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: updateEvent, in: self.uiMOC, prefetchResult: nil)
@@ -380,7 +380,7 @@ extension ZMClientMessageTests_Deletion {
         XCTAssertEqual(sut.cachedCategory, .text)
 
         // when
-        let updateEvent = createMessageDeletedUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!, senderID: sut.sender!.remoteIdentifier!)
+        let updateEvent = createMessageDeletedUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!, senderID: (sut.sender as! ZMUser).remoteIdentifier!)
         
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: updateEvent, in: self.uiMOC, prefetchResult: nil)
@@ -427,7 +427,7 @@ extension ZMClientMessageTests_Deletion {
         }
         
         XCTAssertEqual(systemMessage.serverTimestamp, timestamp)
-        XCTAssertEqual(systemMessage.sender, otherUser)
+        XCTAssertEqual(systemMessage.sender as? ZMUser, otherUser)
     }
     
     
@@ -441,7 +441,7 @@ extension ZMClientMessageTests_Deletion {
         let nonce = sut.nonce!
         
         // when
-        let updateEvent = createMessageDeletedUpdateEvent(nonce, conversationID: conversation.remoteIdentifier!, senderID: sut.sender!.remoteIdentifier!)
+        let updateEvent = createMessageDeletedUpdateEvent(nonce, conversationID: conversation.remoteIdentifier!, senderID: (sut.sender as! ZMUser).remoteIdentifier!)
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: updateEvent, in: self.uiMOC, prefetchResult: nil)
         }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
@@ -45,7 +45,7 @@ class ZMClientMessageTests_Editing: BaseZMClientMessageTests {
         
         let genericMessage = GenericMessage(content: edited)
         
-        let updateEvent = createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier)
+        let updateEvent = createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: (message.sender as? ZMUser)!.remoteIdentifier!)
         
         // WHEN
         var editedMessage: ZMClientMessage?
@@ -126,7 +126,7 @@ extension ZMClientMessageTests_Editing {
             : ZMUser.insertNewObject(in:self.uiMOC)
         
         if !sameSender {
-            sender?.remoteIdentifier = UUID.create()
+            (sender as? ZMUser)?.remoteIdentifier = UUID.create()
         }
         
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
@@ -600,7 +600,7 @@ extension ZMClientMessageTests_Editing {
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
-                                                       senderID: message.sender!.remoteIdentifier!,
+                                                       senderID: (message.sender as? ZMUser)!.remoteIdentifier!,
                                                        newText: "Hello")
         
         // when
@@ -635,7 +635,7 @@ extension ZMClientMessageTests_Editing {
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
-                                                       senderID: message.sender!.remoteIdentifier,
+                                                       senderID: (message.sender as? ZMUser)!.remoteIdentifier!,
                                                        newText: "Hello")
         
         // when
@@ -670,7 +670,7 @@ extension ZMClientMessageTests_Editing {
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
-                                                       senderID: message.sender!.remoteIdentifier!,
+                                                       senderID: (message.sender as? ZMUser)!.remoteIdentifier!,
                                                        newText: newText)
         
         // when

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
@@ -405,7 +405,7 @@ extension ZMClientMessageTests_Ephemeral {
         conversation.conversationType = .oneOnOne
         let message = try! conversation.appendText(content: "foo") as! ZMClientMessage
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier = UUID.create()
 
         // when
         XCTAssertTrue(message.startDestructionIfNeeded())
@@ -457,7 +457,7 @@ extension ZMClientMessageTests_Ephemeral {
         conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeout))
         let message = try! conversation.appendText(content: "foo") as! ZMClientMessage
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier = UUID.create()
         uiMOC.saveOrRollback()
         return message
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Ephemeral.swift
@@ -405,7 +405,7 @@ extension ZMClientMessageTests_Ephemeral {
         conversation.conversationType = .oneOnOne
         let message = try! conversation.appendText(content: "foo") as! ZMClientMessage
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        message.sender?.remoteIdentifier = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
 
         // when
         XCTAssertTrue(message.startDestructionIfNeeded())
@@ -457,7 +457,7 @@ extension ZMClientMessageTests_Ephemeral {
         conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeout))
         let message = try! conversation.appendText(content: "foo") as! ZMClientMessage
         message.sender = ZMUser.insertNewObject(in: uiMOC)
-        message.sender?.remoteIdentifier = UUID.create()
+        (message.sender as? ZMUser)?.remoteIdentifier! = UUID.create()
         uiMOC.saveOrRollback()
         return message
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests.swift
@@ -45,7 +45,7 @@ class ClientMessageTests: BaseZMClientMessageTests {
         XCTAssertNotNil(sut)
         XCTAssertEqual(sut?.conversation, conversation)
         XCTAssertTrue(conversation.needsToCalculateUnreadMessages)
-        XCTAssertEqual(sut?.sender?.remoteIdentifier.transportString(), payload["from"] as? String)
+        XCTAssertEqual((sut?.sender as? ZMUser)?.remoteIdentifier.transportString(), payload["from"] as? String)
         XCTAssertEqual(sut?.serverTimestamp?.transportString(), payload["time"] as? String)
         
         XCTAssertEqual(sut?.nonce, nonce)
@@ -82,7 +82,7 @@ class ClientMessageTests: BaseZMClientMessageTests {
         XCTAssertNotNil(sut)
         XCTAssertEqual(sut?.conversation, conversation)
         XCTAssertTrue(conversation.needsToCalculateUnreadMessages)
-        XCTAssertEqual(sut?.sender?.remoteIdentifier.transportString(), payload["from"] as? String)
+        XCTAssertEqual((sut?.sender as? ZMUser)?.remoteIdentifier.transportString(), payload["from"] as? String)
         XCTAssertEqual(sut?.serverTimestamp?.transportString(), payload["time"] as? String)
         XCTAssertEqual(sut?.senderClientID, senderClientID)
         

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
@@ -38,14 +38,14 @@ extension ZMClientMessageTests_Reaction {
     func updateEventForAddingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
         let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "❤️", messageID: message.nonce!))
-        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
+        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: (sender as! ZMUser).remoteIdentifier!)
         return event
     }
     
     func updateEventForRemovingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
         let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "", messageID: message.nonce!))
-        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
+        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: (sender as! ZMUser).remoteIdentifier!)
         return event
     }
     
@@ -88,7 +88,7 @@ extension ZMClientMessageTests_Reaction {
         
         let message = insertMessage()
         let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "TROP BIEN", messageID: message.nonce!))
-        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier!)
+        let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: (message.sender as? ZMUser)!.remoteIdentifier!)
         
         // when
         performPretendingUiMocIsSyncMoc {
@@ -105,7 +105,7 @@ extension ZMClientMessageTests_Reaction {
     func testThatItRemovesAReactionWhenReceivingUpdateEventWithValidReaction() {
         
         let message = insertMessage()
-        message.addReaction("❤️", forUser: message.sender!)
+        message.addReaction("❤️", forUser: message.sender! as! ZMUser)
         uiMOC.saveOrRollback()
         
         let event = updateEventForRemovingReaction(to: message)

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -490,7 +490,7 @@ extension ZMMessageTests_Confirmation {
         // when
         let updateEvent = createMessageDeliveryConfirmationUpdateEvent(
             sut.nonce!,
-            conversationID: conversation.remoteIdentifier!, senderID: sender.remoteIdentifier!)
+            conversationID: conversation.remoteIdentifier!, senderID: sender .remoteIdentifier!)
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: updateEvent, in: self.uiMOC, prefetchResult: nil)
         }

--- a/Tests/Source/Model/Messages/ZMMessageTests+GenericMessage.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+GenericMessage.swift
@@ -89,7 +89,7 @@ extension ZMMessageTests_GenericMessage {
         // then
         XCTAssertNotNil(message)
         XCTAssertEqual(message?.conversation, conversation)
-        XCTAssertEqual(message?.sender?.remoteIdentifier.transportString(), payload["from"] as? String)
+        XCTAssertEqual((message?.sender as? ZMUser)?.remoteIdentifier.transportString(), payload["from"] as? String)
         XCTAssertEqual(message?.serverTimestamp?.transportString(), payload["time"] as? String)
         XCTAssertEqual(message?.senderClientID, senderClientID)
         XCTAssertEqual(message?.nonce, nonce)

--- a/Tests/Source/Model/Messages/ZMMessageTests+Removal.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Removal.swift
@@ -75,7 +75,7 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         
         // WHEN
         performPretendingUiMocIsSyncMoc {
-            ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: textMessage!.sender!.remoteIdentifier, inContext: self.uiMOC)
+            ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: (textMessage!.sender as? ZMUser)!.remoteIdentifier, inContext: self.uiMOC)
         }
         uiMOC.saveOrRollback()
         
@@ -142,7 +142,7 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         // WHEN
         performPretendingUiMocIsSyncMoc {
             self.performIgnoringZMLogError {
-                ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: textMessage!.sender!.remoteIdentifier, inContext: self.uiMOC)
+                ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: (textMessage!.sender as? ZMUser)!.remoteIdentifier, inContext: self.uiMOC)
             }
         }
         uiMOC.saveOrRollback()

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -262,7 +262,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
 
         ZMMessage *message2 = (id) [self.syncMOC existingObjectWithID:message.objectID error:&errorOnSync];
         XCTAssertNotNil(message2, @"Failed to load into other context: %@", errorOnSync);
-        ZMUser *user2 = message2.sender;
+        ZMUser *user2 = (ZMUser *)message2.sender;
         XCTAssertNotNil(user2);
         XCTAssertEqualObjects(user2.objectID, user.objectID);
     }];

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
@@ -160,7 +160,7 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             conversationID: conversation.remoteIdentifier!,
             timestamp: Date(),
             genericMessage: message,
-            senderID: sender.remoteIdentifier!,
+            senderID: (sender as! ZMUser).remoteIdentifier!,
             eventSource: ZMUpdateEventSource.download
         )
     }

--- a/Tests/Source/Model/User/UserTypeTests.swift
+++ b/Tests/Source/Model/User/UserTypeTests.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class UserTypeTests: ModelObjectsTests {
+    private var searchUser: ZMSearchUser!
+    
+    override func setUp() {
+        super.setUp()
+        
+        searchUser = ZMSearchUser(contextProvider: self,
+                                 name: name.capitalized,
+                                 handle: name.lowercased(),
+                                 accentColor: .brightOrange,
+                                 remoteIdentifier: UUID())
+    }
+    
+    override func tearDown() {
+        
+        super.tearDown()
+    }
+
+    func testThatZMSearchUserCanBeComparedWithIsEqualTo() {
+        XCTAssert(searchUser.isEqualTo(searchUser))
+    }
+
+    func testThatDifferentZMSearchUserReturnFalseWhenComparing() {
+        let anotherSearchUser =  ZMSearchUser(contextProvider: self,
+                                              name: "another search user",
+                                              handle: "another search user",
+                                              accentColor: .softPink,
+                                              remoteIdentifier: UUID())
+        
+        XCTAssertFalse(searchUser.isEqualTo(anotherSearchUser))
+    }
+    
+    func testThatZMUserCanBeComparedWithIsEqualTo() {
+        XCTAssert(selfUser.isEqualTo(selfUser))
+    }
+
+    func testThatIsEqualToReturnFalseForDifferentUsers() {
+        XCTAssertFalse(searchUser.isEqualTo(selfUser))
+    }
+}
+
+extension UserTypeTests: ZMManagedObjectContextProvider {
+    
+    var managedObjectContext: NSManagedObjectContext! {
+        return uiMOC
+    }
+    
+    var syncManagedObjectContext: NSManagedObjectContext! {
+        return syncMOC
+    }
+    
+}

--- a/Tests/Source/Model/User/UserTypeTests.swift
+++ b/Tests/Source/Model/User/UserTypeTests.swift
@@ -54,7 +54,14 @@ final class UserTypeTests: ModelObjectsTests {
         XCTAssert(selfUser.isEqualTo(selfUser))
     }
 
-    func testThatIsEqualToReturnFalseForDifferentUsers() {
+    func testThatDifferentZMUserReturnFalseWhenComparing() {
+        let otherUser = ZMUser.insertNewObject(in: uiMOC)
+        otherUser.remoteIdentifier = UUID()
+        
+        XCTAssertFalse(selfUser.isEqualTo(otherUser))
+    }
+
+    func testThatIsEqualToReturnFalseForDifferentTypesOfUsers() {
         XCTAssertFalse(searchUser.isEqualTo(selfUser))
     }
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		A927F52723A029250058D744 /* ParticipantRoleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A927F52623A029250058D744 /* ParticipantRoleTests.swift */; };
 		A949418F23E1DB79001B0373 /* ZMConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A949418E23E1DB78001B0373 /* ZMConnection.swift */; };
 		A9536FD323ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */; };
+		A95A3593258F785F00BC089A /* UserTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95A3592258F785F00BC089A /* UserTypeTests.swift */; };
 		A95E7BF5239134E600935B88 /* ZMConversation+Participants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */; };
 		A96524BA23CDE07700303C60 /* String+WordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96524B823CDE07200303C60 /* String+WordTests.swift */; };
 		A9676D7623A30BEF001CD41D /* ZMTestSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9676D7323A30ABA001CD41D /* ZMTestSession.swift */; };
@@ -985,6 +986,7 @@
 		A927F52623A029250058D744 /* ParticipantRoleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRoleTests.swift; sourceTree = "<group>"; };
 		A949418E23E1DB78001B0373 /* ZMConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConnection.swift; sourceTree = "<group>"; };
 		A9536FD223ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+gapsAndWindows.swift"; sourceTree = "<group>"; };
+		A95A3592258F785F00BC089A /* UserTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTypeTests.swift; sourceTree = "<group>"; };
 		A95E7BF4239134E600935B88 /* ZMConversation+Participants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Participants.swift"; sourceTree = "<group>"; };
 		A96524B823CDE07200303C60 /* String+WordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+WordTests.swift"; sourceTree = "<group>"; };
 		A9676D7323A30ABA001CD41D /* ZMTestSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTestSession.swift; sourceTree = "<group>"; };
@@ -2296,6 +2298,7 @@
 				1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */,
 				872A2E891FFD2FBF00900B22 /* ZMSearchUserPayloadParsingTests.swift */,
 				F9B71F631CB2BC85001DB03F /* UserImageLocalCacheTests.swift */,
+				A95A3592258F785F00BC089A /* UserTypeTests.swift */,
 				1645ECC3243B69A1007A82D6 /* UserTypeTests+Materialize.swift */,
 				F9B71F661CB2BC85001DB03F /* ZMPersonNameTests.m */,
 				F18998871E7AF0BE00E579A2 /* ZMUserTests.h */,
@@ -3208,6 +3211,7 @@
 				A982B46623BE1B86001828A6 /* ConversationTests.swift in Sources */,
 				F16F8EBF2063E9CC009A9D6F /* StorageStackTests_Backup.swift in Sources */,
 				F929C17B1E423B620018ADA4 /* SnapshotCenterTests.swift in Sources */,
+				A95A3593258F785F00BC089A /* UserTypeTests.swift in Sources */,
 				A995F05E239690B300FAC3CF /* ParticipantRoleObserverTests.swift in Sources */,
 				F9A708521CAEEB7500C2F5FE /* ZMFetchRequestBatchTests.m in Sources */,
 				166E47BD255A98D900C161C8 /* StorageStackTests_Migration.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

In UI project, it is not easy to mock a message object without creating a `ZMUser` object.

### Causes

`ZMConversationMessage` has a `sender` property which is `ZMUser` and UI project must create a `ZMUser` to Mock a message.

### Solutions

Replace `sender` type with `UserType`
Add `isEqualTo` protocol method to `UserType` to prevent casting when comparing 2 `UserType` objects.

### Discussion

- [ ] should we add `remoteIdentifier` property to `UserType` to prevent casting `sender` to `ZMUser`?
- [x] is there any better way to compare 2 `UserType`s, other then casting back to `ZMUser`, e.g. user `HashBox`?