### PR TITLE
[Fix] Passcode keychain item creation and deletion

### DIFF
--- a/Source/Model/Account+Keychain.swift
+++ b/Source/Model/Account+Keychain.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+public extension Account {
+
+    /// Delete the keychain items associated with the account.
+
+    func deleteKeychainItems() {
+        let item = AppLockController.PasscodeKeychainItem(userId: userIdentifier)
+        try? Keychain.deleteItem(item)
+    }
+
+}

--- a/Source/Model/FeatureConfig/AppLock/AppLockController.swift
+++ b/Source/Model/FeatureConfig/AppLock/AppLockController.swift
@@ -106,7 +106,7 @@ public final class AppLockController: AppLockType {
     /// a weak reference to LAContext, it should be nil when evaluatePolicy is done.
     private weak var weakLAContext: LAContext? = nil 
 
-    let keychainItem: PasscodeKeychainItem
+    lazy var keychainItem: PasscodeKeychainItem = .init(user: selfUser)
     
     // MARK: - Life cycle
     
@@ -115,7 +115,6 @@ public final class AppLockController: AppLockType {
         
         self.baseConfig = config
         self.selfUser = selfUser
-        keychainItem = PasscodeKeychainItem(user: selfUser)
     }
     
     // MARK: - Methods

--- a/Tests/Source/Model/AccountTests.swift
+++ b/Tests/Source/Model/AccountTests.swift
@@ -130,4 +130,20 @@ final class AccountTests: ZMConversationTestsBase {
         XCTAssertEqual(account, sameAccount)
     }
 
+    func testThatKeychainItemsAreDeleted() throws {
+        // Given
+        let id = UUID.create()
+        let sut = Account(userName: "Alice", userIdentifier: id)
+        let item = AppLockController.PasscodeKeychainItem(userId: id)
+
+        try Keychain.storeItem(item, value: "passscode".data(using: .utf8)!)
+        XCTAssertNoThrow(try Keychain.fetchItem(item))
+
+        // When
+        sut.deleteKeychainItems()
+
+        // Then
+        XCTAssertThrowsError(try Keychain.fetchItem(item))
+    }
+
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		EE4CCA91256BF63A00848212 /* Team+Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CCA90256BF63A00848212 /* Team+Feature.swift */; };
 		EE4CCA95256C558400848212 /* Feature.AppLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CCA94256C558400848212 /* Feature.AppLock.swift */; };
 		EE4CCA97256C563900848212 /* FeatureLike.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CCA96256C563900848212 /* FeatureLike.swift */; };
+		EE5F54CC259B22C400F11F3C /* Account+Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5F54CB259B22C400F11F3C /* Account+Keychain.swift */; };
 		EE68EEC9252DC4450013B242 /* ChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE68EEC8252DC4450013B242 /* ChangeDetector.swift */; };
 		EE68EECB252DC4730013B242 /* ExplicitChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE68EECA252DC4720013B242 /* ExplicitChangeDetector.swift */; };
 		EE6CB3DC24E2A4E500B0EADD /* store2-83-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */; };
@@ -1110,6 +1111,7 @@
 		EE4CCA90256BF63A00848212 /* Team+Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+Feature.swift"; sourceTree = "<group>"; };
 		EE4CCA94256C558400848212 /* Feature.AppLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.AppLock.swift; sourceTree = "<group>"; };
 		EE4CCA96256C563900848212 /* FeatureLike.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureLike.swift; sourceTree = "<group>"; };
+		EE5F54CB259B22C400F11F3C /* Account+Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Keychain.swift"; sourceTree = "<group>"; };
 		EE68EEC8252DC4450013B242 /* ChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeDetector.swift; sourceTree = "<group>"; };
 		EE68EECA252DC4720013B242 /* ExplicitChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplicitChangeDetector.swift; sourceTree = "<group>"; };
 		EE6CB3DB24E2A38500B0EADD /* store2-83-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-83-0.wiredatabase"; sourceTree = "<group>"; };
@@ -1710,6 +1712,7 @@
 			isa = PBXGroup;
 			children = (
 				BF491CE31F063EDB0055EE44 /* Account.swift */,
+				EE5F54CB259B22C400F11F3C /* Account+Keychain.swift */,
 				BF491CE51F063EE50055EE44 /* AccountStore.swift */,
 				BF491CE71F063EEB0055EE44 /* AccountManager.swift */,
 				BF8361D91F0A3C41009AE5AC /* NSSecureCoding+Swift.swift */,
@@ -3168,6 +3171,7 @@
 				63D41E4F2452EA080076826F /* ZMConversation+SelfConversation.swift in Sources */,
 				F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */,
 				5E9EA4E22243E0D300D401B2 /* ConversationMessage+Attachments.swift in Sources */,
+				EE5F54CC259B22C400F11F3C /* Account+Keychain.swift in Sources */,
 				F93C4C7D1E24E1B1007E9CEE /* NotificationDispatcher.swift in Sources */,
 				06D48735241F930A00881B08 /* GenericMessage+Obfuscation.swift in Sources */,
 				0686649F256FB0CA001C8747 /* AppLockController.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Context

We would like to be able to automatically delete the passcode keychain item when deleting an account. 

### Issues

- It can happen that the app crashes when creating the passcode keychain item.
- There is no way to delete the passcode keychain item when deleting an account (in the sync engine).

### Causes

- The keychain item is created when the `AppLockController` is initialized, which happens very early in the app cycle because it is a singleton. It can happen when logging with a new account, the the `remoteIdentifier` is not yet set on the `selfUser`, which is being implicitly forced unwrapped by the keychain item.
- Currently keychain item deletion is only possible through the `AppLockController`, but typically we only have a reference to `Account` when deleting accounts.

### Solutions

- Make the keychain item lazy.
- Add a public extension to `Account` that will delete the keychain item.