### PR TITLE
add senderUser

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -48,7 +48,10 @@ public protocol ZMConversationMessage : NSObjectProtocol {
         
     /// The user who sent the message
     var sender: ZMUser? { get }
-    
+
+    /// Wrapper for UI mocking ZMConversationMessage without creating ZMUser
+    var senderUser: UserType? { get }
+
     /// The timestamp as received by the server
     var serverTimestamp: Date? { get }
     
@@ -195,6 +198,10 @@ extension ZMMessage {
 // MARK:- Conversation Message protocol implementation
 
 extension ZMMessage : ZMConversationMessage {
+    public var senderUser: UserType? {
+        return sender
+    }
+    
     @NSManaged public var linkAttachments: [LinkAttachment]?
     @NSManaged public var needsLinkAttachmentsUpdate: Bool
     @NSManaged public var replies: Set<ZMMessage>


### PR DESCRIPTION
## What's new in this PR?

rework of https://github.com/wireapp/wire-ios-data-model/pull/1094

### Issues

In UI project, it is not easy to mock a message object without creating a `ZMUser` object.

### Causes

`ZMConversationMessage` has a `sender` property which is `ZMUser` and UI project must create a `ZMUser` to Mock a message.

### Solutions

Add a `senderUser` member with `UserType?` type. 

In https://github.com/wireapp/wire-ios/pull/4798, we can create a mock message with a `senderUser` with `MockUserType`

Adding new property would not affecting data model and downstream components since they do not access it.

When not running the tests,`ZMMessage.senderUser` returns `ZMMessage.sender` in UI Project which would not affect the existing code.

## Discussion

- [ ] a better name of this property?

