### PR TITLE
[Feature] Add method for resolving past decryption failed system messages

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+UpdateRequest.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+UpdateRequest.swift
@@ -20,6 +20,12 @@ import Foundation
 
 public extension NSManagedObjectContext {
     
+    /// Execute an NSBatchUpdateRequest and merge the resulting changes into all contexts.
+    ///
+    /// - parameters:
+    ///   - request: NSBatchUpdateRequest to exectute
+    ///
+    /// If the operation can't be performed we intentionally crash the app
     func executeBatchUpdateRequestOrAssert(_ request: NSBatchUpdateRequest) {
         do {
             let result = try execute(request) as? NSBatchUpdateResult

--- a/Source/ManagedObjectContext/NSManagedObjectContext+UpdateRequest.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+UpdateRequest.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public extension NSManagedObjectContext {
+    
+    func executeBatchUpdateRequestOrAssert(_ request: NSBatchUpdateRequest) {
+        do {
+            let result = try execute(request) as? NSBatchUpdateResult
+            let objectIDArray = result?.result as? [NSManagedObjectID] ?? []
+            let changes: [AnyHashable : Any] = [NSUpdatedObjectsKey: objectIDArray]
+            
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes,
+                                                into: [zm_userInterface, zm_sync])
+        } catch {
+            fatal("Error performing batch update \(error.localizedDescription)")
+        }
+    }
+    
+}

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -312,6 +312,7 @@ extension ZMConversation {
                                                clients: clients,
                                                timestamp: serverTimestamp)
         
+        systemMessage.senderClientID = client?.remoteIdentifier
         systemMessage.decryptionErrorCode = NSNumber(integerLiteral: errorCode)
     }
 

--- a/Source/Model/Message/ZMMessage+Internal.h
+++ b/Source/Model/Message/ZMMessage+Internal.h
@@ -48,6 +48,7 @@ extern NSString * _Nonnull const ZMMessageConversationKey;
 extern NSString * _Nonnull const ZMMessageHiddenInConversationKey;
 extern NSString * _Nonnull const ZMMessageExpirationDateKey;
 extern NSString * _Nonnull const ZMMessageNameKey;
+extern NSString * _Nonnull const ZMMessageSenderClientIDKey;
 extern NSString * _Nonnull const ZMMessageNeedsToBeUpdatedFromBackendKey;
 extern NSString * _Nonnull const ZMMessageNonceDataKey;
 extern NSString * _Nonnull const ZMMessageSenderKey;

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -862,6 +862,7 @@ NSString * const ZMMessageDecryptionErrorCodeKey = @"decryptionErrorCode";
             case ZMSystemMessageTypePerformedCall:
             case ZMSystemMessageTypeUsingNewDevice:
             case ZMSystemMessageTypeDecryptionFailed:
+            case ZMSystemMessageTypeDecryptionFailedResolved:
             case ZMSystemMessageTypeReactivatedDevice:
             case ZMSystemMessageTypeConversationIsSecure:
             case ZMSystemMessageTypeMessageDeletedForEveryone:

--- a/Source/Model/UserClient/UserClient.swift
+++ b/Source/Model/UserClient/UserClient.swift
@@ -325,6 +325,19 @@ public class UserClient: ZMManagedObject, UserClientType {
             syncMOC.saveOrRollback()
         }
     }
+    
+    public func resolveDecryptionFailedSystemMessages() {
+        let request = NSBatchUpdateRequest(entityName: ZMSystemMessage.entityName())
+        
+        request.predicate = NSPredicate(format: "%K = %d AND %K = %@",
+                                        ZMMessageSystemMessageTypeKey,
+                                        ZMSystemMessageType.decryptionFailed.rawValue,
+                                        ZMMessageSenderClientIDKey,
+                                        remoteIdentifier!)
+        request.propertiesToUpdate = [ZMMessageSystemMessageTypeKey:  ZMSystemMessageType.decryptionFailedResolved.rawValue]
+        request.resultType = .updatedObjectIDsResultType
+        managedObjectContext?.executeBatchUpdateRequestOrAssert(request)
+    }
 
     private func conversation(for user: ZMUser) -> ZMConversation? {
         if user.isSelfUser {

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -74,6 +74,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
     ZMSystemMessageTypeConversationIsSecure,
     ZMSystemMessageTypePotentialGap,
     ZMSystemMessageTypeDecryptionFailed,
+    ZMSystemMessageTypeDecryptionFailedResolved,
     ZMSystemMessageTypeDecryptionFailed_RemoteIdentityChanged,
     ZMSystemMessageTypeNewConversation,
     ZMSystemMessageTypeReactivatedDevice,

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -134,6 +134,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic) BOOL needsUpdatingUsers;
 @property (nonatomic) NSTimeInterval duration;
 @property (nonatomic) NSNumber * _Nullable decryptionErrorCode; // Only filled for ZMSystemMessageTypeDecryptionFailed
+@property (nonatomic) NSString * _Nullable senderClientID; // Only filled for ZMSystemMessageTypeDecryptionFailed
 /**
   Only filled for .performedCall & .missedCall
  */

--- a/Tests/Source/Model/UserClient/UserClientTests+ResetSession.swift
+++ b/Tests/Source/Model/UserClient/UserClientTests+ResetSession.swift
@@ -1,0 +1,102 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+// 
+
+import XCTest
+import WireTesting
+@testable import WireDataModel
+
+class UserClientTests_ResetSession: DiskDatabaseTest {
+
+    func testThatDecryptionFailedSystemMessageIsUpdated_WhenSessionIsReset() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: moc)
+        let otherUser = self.createUser()
+        _ = self.createClient(user: selfUser)
+        let otherClient = self.createClient(user: otherUser)
+    
+        let connection = ZMConnection.insertNewSentConnection(to: otherUser)!
+        connection.status = .accepted
+        connection.conversation.appendDecryptionFailedSystemMessage(at: Date(),
+                                                                    sender: otherUser,
+                                                                    client: otherClient,
+                                                                    errorCode: Int(CBOX_TOO_DISTANT_FUTURE.rawValue))
+        let systemMessage: ZMSystemMessage = (connection.conversation.lastMessage as! ZMSystemMessage)
+        moc.saveOrRollback()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // when
+        otherClient.resolveDecryptionFailedSystemMessages()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(systemMessage.systemMessageType, ZMSystemMessageType.decryptionFailedResolved)
+    }
+    
+    func testThatDecryptionFailedSystemMessageIsNotUpdated_WhenOfTypeIdentityChanged() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: moc)
+        let otherUser = self.createUser()
+        _ = self.createClient(user: selfUser)
+        let otherClient = self.createClient(user: otherUser)
+        
+        let connection = ZMConnection.insertNewSentConnection(to: otherUser)!
+        connection.status = .accepted
+        connection.conversation.appendDecryptionFailedSystemMessage(at: Date(),
+                                                                    sender: otherUser,
+                                                                    client: otherClient,
+                                                                    errorCode: Int(CBOX_REMOTE_IDENTITY_CHANGED.rawValue))
+        let systemMessage: ZMSystemMessage = (connection.conversation.lastMessage as! ZMSystemMessage)
+        moc.saveOrRollback()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // when
+        otherClient.resolveDecryptionFailedSystemMessages()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // then
+        XCTAssertEqual(systemMessage.systemMessageType, ZMSystemMessageType.decryptionFailed_RemoteIdentityChanged)
+    }
+    
+    func testThatDecryptionFailedSystemMessageIsNotUpdated_WhenUnrelatedSessionIsReset() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: moc)
+        let otherUser = self.createUser()
+        
+        _ = self.createClient(user: selfUser)
+        let otherUserClient1 = self.createClient(user: otherUser)
+        let otherUserClient2 = self.createClient(user: otherUser)
+    
+        let connection = ZMConnection.insertNewSentConnection(to: otherUser)!
+        connection.status = .accepted
+        connection.conversation.appendDecryptionFailedSystemMessage(at: Date(),
+                                                                    sender: otherUser,
+                                                                    client: otherUserClient1,
+                                                                    errorCode: Int(CBOX_TOO_DISTANT_FUTURE.rawValue))
+        let systemMessage: ZMSystemMessage = (connection.conversation.lastMessage as! ZMSystemMessage)
+        moc.saveOrRollback()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // when
+        otherUserClient2.resolveDecryptionFailedSystemMessages()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(systemMessage.systemMessageType, ZMSystemMessageType.decryptionFailed)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */; };
 		168FF330258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168FF32F258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift */; };
 		16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */; };
+		1693155325A30D4E00709F15 /* UserClientTests+ResetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */; };
+		1693155525A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693155425A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift */; };
 		16A86B4A22A6BF5B00A674F8 /* store2-71-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */; };
 		16A9E354220CAB790062CFCD /* store2-60-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */; };
 		16AD86BA1F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */; };
@@ -761,7 +763,6 @@
 		1672A6272344F10700380537 /* FolderList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderList.swift; sourceTree = "<group>"; };
 		1672A6292345102400380537 /* ZMConversationListTests+Labels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationListTests+Labels.swift"; sourceTree = "<group>"; };
 		16746B071D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ZMImageOwner.swift"; sourceTree = "<group>"; };
-		16824637257A44A9002AF17B /* zmessaging2.88.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.88.0.xcdatamodel; sourceTree = "<group>"; };
 		168413E82225902200FCB9BC /* zmessaging2.65.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.65.0.xcdatamodel; sourceTree = "<group>"; };
 		168413E9222594E600FCB9BC /* store2-65-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-65-0.wiredatabase"; sourceTree = "<group>"; };
 		168413EC2225965500FCB9BC /* TransferStateMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferStateMigration.swift; sourceTree = "<group>"; };
@@ -774,6 +775,8 @@
 		168E96C4220B445000FC92FA /* zmessaging2.61.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.61.0.xcdatamodel; sourceTree = "<group>"; };
 		168FF32F258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ResetSession.swift"; sourceTree = "<group>"; };
 		16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationListDirectoryTests+Labels.swift"; sourceTree = "<group>"; };
+		1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+ResetSession.swift"; sourceTree = "<group>"; };
+		1693155425A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+UpdateRequest.swift"; sourceTree = "<group>"; };
 		16A86B23229EC29800A674F8 /* zmessaging2.71.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.71.0.xcdatamodel; sourceTree = "<group>"; };
 		16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-71-0.wiredatabase"; sourceTree = "<group>"; };
 		16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-60-0.wiredatabase"; path = "Tests/Resources/store2-60-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
@@ -1734,6 +1737,7 @@
 				F9A705CD1CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.m */,
 				54FB03AE1E41FC86000E13DC /* NSManagedObjectContext+Patches.swift */,
 				F93265201D8950F10076AAD6 /* NSManagedObjectContext+FetchRequest.swift */,
+				1693155425A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift */,
 				544E8C101E2F76B400F9B8B8 /* NSManagedObjectContext+UserInfoMerge.swift */,
 				87D9CCE81F27606200AA4388 /* NSManagedObjectContext+TearDown.swift */,
 				16460A43206515370096B616 /* NSManagedObjectContext+BackupImport.swift */,
@@ -2362,6 +2366,7 @@
 				F9331C5B1CB3BF9F00139ECC /* UserClientKeyStoreTests.swift */,
 				F9B720021CB2C68B001DB03F /* UserClientTests.swift */,
 				631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */,
+				1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */,
 			);
 			name = UserClient;
 			path = Tests/Source/Model/UserClient;
@@ -2967,6 +2972,7 @@
 				1607AAF2243768D200A93D29 /* UserType+Materialize.swift in Sources */,
 				63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */,
 				164EB6F3230D987A001BBD4A /* ZMMessage+DataRetention.swift in Sources */,
+				1693155525A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift in Sources */,
 				A90D62C823A159B600F680CC /* ZMConversation+Transport.swift in Sources */,
 				F9A706941CAEE01D00C2F5FE /* UserClient+Protobuf.swift in Sources */,
 				63370CBD242CBA0A0072C37F /* CompositeMessageData.swift in Sources */,
@@ -3271,6 +3277,7 @@
 				EEA2B84624DA943200C6659E /* ManagedObjectContextDirectoryTests.swift in Sources */,
 				1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,
+				1693155325A30D4E00709F15 /* UserClientTests+ResetSession.swift in Sources */,
 				F9A7083E1CAEEB7500C2F5FE /* NSFetchRequestTests+ZMRelationshipKeyPaths.m in Sources */,
 				D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */,
 				EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Add a new system message type `.decryptionFailedResolved`. When a session is reset we will update all existing `.decryptionFailed` system messages to `.decryptionFailedResolved` to signal to the user that the decryption error has been fixed and there's no need to reset the session anymore.

## NOTE

The failing tests are due to not updated database migration tests and can be disregarded.