### PR TITLE
add userTypes to ZMSystemMessageData

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -956,6 +956,11 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
     // System messages don't support quotes at the moment
 }
 
+-(NSSet <id<UserType>>*)userTypes
+{
+    return [self users];
+}
+
 @end
 
 

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -961,6 +961,16 @@ NSString * const ZMMessageButtonStatesKey = @"buttonStates";
     return [self users];
 }
 
+-(NSSet <id<UserType>>*)addedUserTypes
+{
+    return [self addedUsers];
+}
+
+-(NSSet <id<UserType>>*)removedUserTypes
+{
+    return [self removedUsers];
+}
+
 @end
 
 

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -125,16 +125,17 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 
 @property (nonatomic, readonly) ZMSystemMessageType systemMessageType;
 
-/**
- additional properties with types NSSet <id<UserType>>* for mocking
- */
-@property (nonatomic, readonly, nonnull) NSSet <ZMUser *>*users;
+
+
+@property (nonatomic, readonly, nonnull) NSSet <ZMUser *>*users __attribute__((deprecated("Use `userTypes` instead")));
 @property (nonatomic, readonly, nonnull) NSSet <id<UserType>>*userTypes;
 
-@property (nonatomic, nonnull) NSSet<ZMUser *> *addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+/// Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic, nonnull) NSSet<ZMUser *> *addedUsers __attribute__((deprecated("Use `addedUserTypes` instead")));
 @property (nonatomic, nonnull) NSSet<id<UserClientType>> *addedUserTypes;
 
-@property (nonatomic, nonnull) NSSet<ZMUser *> *removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+/// Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic, nonnull) NSSet<ZMUser *> *removedUsers __attribute__((deprecated("Use `removedUserTypes` instead")));;
 @property (nonatomic, nonnull) NSSet<id<UserClientType>> *removedUserTypes;
 
 @property (nonatomic, readonly, nonnull) NSSet <id<UserClientType>>*clients;

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -129,8 +129,14 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, readonly, nonnull) NSSet <id<UserType>>*userTypes;
 
 @property (nonatomic, readonly, nonnull) NSSet <id<UserClientType>>*clients;
+
 @property (nonatomic, nonnull) NSSet<ZMUser *> *addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic, nonnull) NSSet<id<UserClientType>> *addedUserTypes;
+
 @property (nonatomic, nonnull) NSSet<ZMUser *> *removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
+@property (nonatomic, nonnull) NSSet<id<UserClientType>> *removedUserTypes;
+
+
 @property (nonatomic, readonly, copy, nullable) NSString *text;
 @property (nonatomic) BOOL needsUpdatingUsers;
 @property (nonatomic) NSTimeInterval duration;

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -125,10 +125,11 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 
 @property (nonatomic, readonly) ZMSystemMessageType systemMessageType;
 
+/**
+ additional properties with types NSSet <id<UserType>>* for mocking
+ */
 @property (nonatomic, readonly, nonnull) NSSet <ZMUser *>*users;
 @property (nonatomic, readonly, nonnull) NSSet <id<UserType>>*userTypes;
-
-@property (nonatomic, readonly, nonnull) NSSet <id<UserClientType>>*clients;
 
 @property (nonatomic, nonnull) NSSet<ZMUser *> *addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
 @property (nonatomic, nonnull) NSSet<id<UserClientType>> *addedUserTypes;
@@ -136,6 +137,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, nonnull) NSSet<ZMUser *> *removedUsers; // Only filled for ZMSystemMessageTypePotentialGap
 @property (nonatomic, nonnull) NSSet<id<UserClientType>> *removedUserTypes;
 
+@property (nonatomic, readonly, nonnull) NSSet <id<UserClientType>>*clients;
 
 @property (nonatomic, readonly, copy, nullable) NSString *text;
 @property (nonatomic) BOOL needsUpdatingUsers;

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -32,7 +32,7 @@
 @protocol ZMKnockMessageData;
 @protocol ZMFileMessageData;
 @protocol UserClientType;
-
+@protocol UserType;
 
 #pragma mark - ZMImageMessageData
 
@@ -124,7 +124,10 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @protocol ZMSystemMessageData <NSObject>
 
 @property (nonatomic, readonly) ZMSystemMessageType systemMessageType;
+
 @property (nonatomic, readonly, nonnull) NSSet <ZMUser *>*users;
+@property (nonatomic, readonly, nonnull) NSSet <id<UserType>>*userTypes;
+
 @property (nonatomic, readonly, nonnull) NSSet <id<UserClientType>>*clients;
 @property (nonatomic, nonnull) NSSet<ZMUser *> *addedUsers; // Only filled for ZMSystemMessageTypePotentialGap
 @property (nonatomic, nonnull) NSSet<ZMUser *> *removedUsers; // Only filled for ZMSystemMessageTypePotentialGap


### PR DESCRIPTION
## What's new in this PR?

add `NSSet <id<UserType>>*userTypes` to `ZMSystemMessageData` to allow UI project to mock `ZMSystemMessageData` with `UserType` mocks.