### PR TITLE
[Feature] Support for observing session resets

### DIFF
--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -90,7 +90,8 @@ extension ZMSystemMessage {
 
     public class override var observableKeys : Set<String> {
         let keys = super.observableKeys
-        let additionalKeys = [#keyPath(ZMSystemMessage.childMessages)]
+        let additionalKeys = [#keyPath(ZMSystemMessage.childMessages),
+                              #keyPath(ZMSystemMessage.systemMessageType)]
         return keys.union(additionalKeys)
     }
 

--- a/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
@@ -34,7 +34,8 @@ extension UserClient: ObjectInSnapshot {
         return Set([#keyPath(UserClient.trustedByClients),
                     #keyPath(UserClient.ignoredByClients),
                     #keyPath(UserClient.needsToNotifyUser),
-                    #keyPath(UserClient.fingerprint)])
+                    #keyPath(UserClient.fingerprint),
+                    #keyPath(UserClient.needsToNotifyOtherUserAboutSessionReset)])
     }
     
     public var notificationName : Notification.Name {
@@ -55,20 +56,25 @@ public enum UserClientChangeInfoKey: String {
         super.init(object: object)
     }
 
-    open var trustedByClientsChanged : Bool {
+    open var trustedByClientsChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.trustedByClients))
     }
     
-    open var ignoredByClientsChanged : Bool {
+    open var ignoredByClientsChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.ignoredByClients))
     }
 
-    open var fingerprintChanged : Bool {
+    open var fingerprintChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.fingerprint))
     }
 
-    open var needsToNotifyUserChanged : Bool {
+    open var needsToNotifyUserChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.needsToNotifyUser))
+    }
+    
+    open var sessionHasBeenReset: Bool {
+        return changedKeysContain(keys: #keyPath(UserClient.needsToNotifyOtherUserAboutSessionReset)) &&
+               userClient.needsToNotifyOtherUserAboutSessionReset == false
     }
 
     public let userClient: UserClient


### PR DESCRIPTION
## What's new in this PR?

- In order to enable the UI react to when a session reset is completed I've added `sessionHasBeenReset` to the `UserClientChangeInfo`.
- Since system message will now change their type when a session is reset, I've added `systemMessageType` to the `observableKeys`.

## Note

The failing tests are due to not updated database migration tests and can be disregarded.