### PR TITLE
[Fix] Don't create connection with self user

### DIFF
--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -34,7 +34,8 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "167.3.0", block: AvailabilityBehaviourChange.notifyAvailabilityBehaviourChange),
         PersistedDataPatch(version: "198.0.0", block: ZMConversation.introduceParticipantRoles),
         PersistedDataPatch(version: "220.0.4", block: InvalidConnectionRemoval.removeInvalid),
-        PersistedDataPatch(version: "234.0.0", block: TransferApplockKeychain.migrateKeychainItems)
+        PersistedDataPatch(version: "234.0.0", block: TransferApplockKeychain.migrateKeychainItems),
+        PersistedDataPatch(version: "234.1.1", block: InvalidConnectionRemoval.removeInvalid),
     ]
 
 }

--- a/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -321,7 +321,7 @@ extension ZMConversation {
     public func addParticipantAndSystemMessageIfMissing(_ user: ZMUser, date dateOptional: Date?) {
         let date = dateOptional ?? Date()
 
-        guard !localParticipants.contains(user) else { return }
+        guard !user.isSelfUser, !localParticipants.contains(user) else { return }
         
         zmLog.debug("Sender: \(user.remoteIdentifier?.transportString() ?? "n/a") missing from participant list: \(localParticipants.map{ $0.remoteIdentifier} )")
         

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -121,6 +121,23 @@ final class ConversationParticipantsTests : ZMConversationTestsBase {
         XCTAssertEqual(conversation.allMessages.count, 0)
     }
     
+    func testThatItDoesntCreateAConnectionIfSelfUserIsMissing() {
+        // given
+        let selfUser = ZMUser.selfUser(in: self.uiMOC)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        let connection = ZMConnection.insertNewObject(in: self.uiMOC)
+        conversation.conversationType = .oneOnOne
+        conversation.connection = connection
+        conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
+        
+        // when
+        conversation.addParticipantAndSystemMessageIfMissing(selfUser, date: Date())
+        
+        // then
+        XCTAssertNotEqual(selfUser.connection, connection)
+    }
+    
     func testThatItAddsParticipants() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were getting reports that user's would end up with 1:1 conversations with the self user. 

### Causes

This is likely a side effecting of the long existing issue of `localParticipants` relationship sometimes being reported as empty. If this would happen when receiving a message from the self user in a 1:1 conversation we would try re-establish the connection. This never makes for the self user though since he/she should never have a connection.

This bug was probably introduced with the addition of participant roles because then we started to include the self user in the `localParticipants` relationship  (previously named `activeParticipants`).

### Solutions

- Return early in `addParticipantAndSystemMessageIfMissing()` if it's the self user who's missing.
- Re-apply the patch which cleans up invalid connections with the self user