### PR TITLE
[Feature] Add migration of senderClientID for decryption error system messages

### DIFF
--- a/Patches/MigrateSenderClient.swift
+++ b/Patches/MigrateSenderClient.swift
@@ -1,0 +1,40 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class MigrateSenderClient {
+    
+    
+    /// Populate senderClientID for `.decryptionFailed` system messages.
+    ///
+    /// For `.decryptionFailed` system messages we need to copy the `remoteIdentifier` of
+    /// the user client in the `clients` property into `senderClientID` in order identify
+    /// which session we should reset when initiated directly from the decryption error.
+    static func migrateSenderClientID(in moc: NSManagedObjectContext) {
+        let request = NSFetchRequest<ZMSystemMessage>(entityName: ZMSystemMessage.entityName())
+        request.predicate = NSPredicate(format: "%K = %d", ZMMessageSystemMessageTypeKey, ZMSystemMessageType.decryptionFailed.rawValue)
+        
+        let systemMessages = moc.fetchOrAssert(request: request)
+
+        for systemMessage in systemMessages {
+            let userClient = systemMessage.clients.first as? UserClient
+            systemMessage.senderClientID = userClient?.remoteIdentifier
+        }
+    }
+}

--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -34,7 +34,8 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "167.3.0", block: AvailabilityBehaviourChange.notifyAvailabilityBehaviourChange),
         PersistedDataPatch(version: "198.0.0", block: ZMConversation.introduceParticipantRoles),
         PersistedDataPatch(version: "220.0.4", block: InvalidConnectionRemoval.removeInvalid),
-        PersistedDataPatch(version: "234.0.0", block: TransferApplockKeychain.migrateKeychainItems)
+        PersistedDataPatch(version: "234.0.0", block: TransferApplockKeychain.migrateKeychainItems),
+        PersistedDataPatch(version: "235.0.0", block: MigrateSenderClient.migrateSenderClientID)
     ]
 
 }

--- a/Tests/Source/Utils/MigrateSenderClientTests.swift
+++ b/Tests/Source/Utils/MigrateSenderClientTests.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class MigrateSenderClientTests: DiskDatabaseTest {
+
+    func testSenderClientIDIsMigratedFromClientsSet() throws {
+        // given
+        let clientID = UUID().transportString()
+        let userClient = UserClient(context: contextDirectory.uiContext)
+        userClient.remoteIdentifier = clientID
+        let systemMessage = ZMSystemMessage(context: contextDirectory.uiContext)
+        systemMessage.systemMessageType = .decryptionFailed
+        systemMessage.clients = Set(arrayLiteral: userClient)
+        contextDirectory.uiContext.saveOrRollback()
+        
+        // when
+        MigrateSenderClient.migrateSenderClientID(in: contextDirectory.uiContext)
+        
+        // then
+        XCTAssertEqual(systemMessage.senderClientID, clientID)
+        
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -116,6 +116,8 @@
 		16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */; };
 		1693155325A30D4E00709F15 /* UserClientTests+ResetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */; };
 		1693155525A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693155425A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift */; };
+		169315EF25AC4C8100709F15 /* MigrateSenderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169315EE25AC4C8100709F15 /* MigrateSenderClient.swift */; };
+		169315F125AC501300709F15 /* MigrateSenderClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169315F025AC501300709F15 /* MigrateSenderClientTests.swift */; };
 		16A86B4A22A6BF5B00A674F8 /* store2-71-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */; };
 		16A9E354220CAB790062CFCD /* store2-60-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */; };
 		16AD86BA1F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */; };
@@ -804,6 +806,8 @@
 		1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+ResetSession.swift"; sourceTree = "<group>"; };
 		1693155425A329FE00709F15 /* NSManagedObjectContext+UpdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+UpdateRequest.swift"; sourceTree = "<group>"; };
 		169315DD25A76E4600709F15 /* zmessaging2.89.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.89.0.xcdatamodel; sourceTree = "<group>"; };
+		169315EE25AC4C8100709F15 /* MigrateSenderClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateSenderClient.swift; sourceTree = "<group>"; };
+		169315F025AC501300709F15 /* MigrateSenderClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateSenderClientTests.swift; sourceTree = "<group>"; };
 		16A86B23229EC29800A674F8 /* zmessaging2.71.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.71.0.xcdatamodel; sourceTree = "<group>"; };
 		16A86B4922A6BF5B00A674F8 /* store2-71-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-71-0.wiredatabase"; sourceTree = "<group>"; };
 		16A9E353220CAB790062CFCD /* store2-60-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; name = "store2-60-0.wiredatabase"; path = "Tests/Resources/store2-60-0.wiredatabase"; sourceTree = SOURCE_ROOT; };
@@ -1531,6 +1535,7 @@
 				168413EC2225965500FCB9BC /* TransferStateMigration.swift */,
 				1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */,
 				0660FEBC2580E4A900F4C19F /* TransferApplockKeychain.swift */,
+				169315EE25AC4C8100709F15 /* MigrateSenderClient.swift */,
 			);
 			path = Patches;
 			sourceTree = "<group>";
@@ -1599,6 +1604,7 @@
 				54F84D001F995A1F00ABD7D5 /* DiskDatabaseTests.swift */,
 				16E6F26524B8952F0015B249 /* EncryptionKeysTests.swift */,
 				0630E4BE257FA2BD00C75BFB /* TransferAppLockKeychainTests.swift */,
+				169315F025AC501300709F15 /* MigrateSenderClientTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -3255,6 +3261,7 @@
 				541D1B351F1FAE3C0078C1F2 /* ManagedObjectContextDirectory.swift in Sources */,
 				EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */,
 				F9C877091E000C9D00792613 /* AssetCollection.swift in Sources */,
+				169315EF25AC4C8100709F15 /* MigrateSenderClient.swift in Sources */,
 				BF10B58B1E6432ED00E7036E /* Message.swift in Sources */,
 				BF491CE81F063EEB0055EE44 /* AccountManager.swift in Sources */,
 				16D95A421FCEF87B00C96069 /* ZMUser+Availability.swift in Sources */,
@@ -3346,6 +3353,7 @@
 				631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */,
 				F9A7083B1CAEEB7500C2F5FE /* MockEntity2.m in Sources */,
 				1672A62A2345102400380537 /* ZMConversationListTests+Labels.swift in Sources */,
+				169315F125AC501300709F15 /* MigrateSenderClientTests.swift in Sources */,
 				F9331C5A1CB3BECB00139ECC /* ZMClientMessageTests+OTR.swift in Sources */,
 				16127CF522005AAB0020E65C /* InvalidConversationRemovalTests.swift in Sources */,
 				EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

We now set the `senderClientID` when inserting `.decryptionFailed` system messages since we need it to distinguish which client caused the decryption error. We also need to populate this field on any existing `.decryptionFailed` system messages otherwise they wouldn't get updated when the user resolves the decryption error (See https://github.com/wireapp/wire-ios-data-model/pull/1102)