### PR TITLE
[Revert] Preventing last read update for updated messages

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -202,6 +202,11 @@ extension ZMConversation {
         if message.shouldGenerateUnreadCount() {
             updateLastModified(timestamp)
         }
+
+        if let sender = message.sender, sender.isSelfUser {
+            // if the message was sent by the self user we don't want to send a lastRead event, since we consider this message to be already read
+            updateLastRead(timestamp, synchronize: false)
+        }
         
         self.needsToCalculateUnreadMessages = true
     }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+UnreadMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+UnreadMessages.swift
@@ -52,26 +52,4 @@ class ZMConversationTests_UnreadMessages: ZMConversationTestsBase {
         }
     }
 
-    func testThat_ItDoesNotUpdateLastReadTimestamp_AfterUpdatingMessage() {
-        syncMOC.performGroupedBlockAndWait {
-            // Given
-            let conversation = ZMConversation.insertNewObject(in:self.syncMOC)
-            conversation.conversationType = .group
-            conversation.remoteIdentifier = .create()
-            conversation.lastServerTimeStamp = .distantPast
-            conversation.lastReadServerTimeStamp = .distantPast
-
-            let message = ZMClientMessage(nonce: .create(), managedObjectContext: self.syncMOC)
-            let messageTimestamp = Date()
-            message.serverTimestamp = messageTimestamp
-
-            // When
-            conversation.updateTimestampsAfterUpdatingMessage(message)
-
-            // Then
-            XCTAssertEqual(conversation.lastServerTimeStamp, messageTimestamp)
-            XCTAssertEqual(conversation.lastReadServerTimeStamp, .distantPast)
-        }
-    }
-
 }


### PR DESCRIPTION
## What's new in this PR?

There are some sync engine test failing due to the change in https://github.com/wireapp/wire-ios-data-model/pull/1097 that removed the optimization to update the last read server timestamp when a message was updated.

I'm reverting these changes now to unblock a release train and will address the fix in a separate PR.