### PR TITLE
[Fix] Read receipts not sent for some messages

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Confirmations.swift
+++ b/Source/Model/Conversation/ZMConversation+Confirmations.swift
@@ -24,11 +24,12 @@ extension ZMConversation {
     
     /// Confirm unread received messages as read.
     ///
-    /// - parameter until: unread messages received up until this timestamp will be confirmed as read.
+    /// - Parameters:
+    ///     - range: Unread messages received within this date range will be confirmed as read.
+
     @discardableResult
-    func confirmUnreadMessagesAsRead(until timestamp: Date) -> [ZMClientMessage] {
-        
-        let unreadMessagesNeedingConfirmation = unreadMessages(until: timestamp).filter({ $0.needsReadConfirmation })
+    func confirmUnreadMessagesAsRead(in range: ClosedRange<Date>) -> [ZMClientMessage] {
+        let unreadMessagesNeedingConfirmation = unreadMessages(in: range).filter(\.needsReadConfirmation)
         var confirmationMessages: [ZMClientMessage] = []
         
         for messages in unreadMessagesNeedingConfirmation.partition(by: \.sender).values {

--- a/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/Source/Model/Conversation/ZMConversation+Internal.h
@@ -102,6 +102,7 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic) BOOL internalIsArchived;
 
 @property (nonatomic, nullable) NSDate *pendingLastReadServerTimestamp;
+@property (nonatomic, nullable) NSDate *previousLastReadServerTimestamp;
 @property (nonatomic, nullable) NSDate *lastServerTimeStamp;
 @property (nonatomic, nullable) NSDate *lastReadServerTimeStamp;
 @property (nonatomic, nullable) NSDate *clearedTimeStamp;

--- a/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -261,24 +261,35 @@ extension ZMConversation {
         
         enqueueMarkAsReadUpdate(unreadTimestamp)
     }
-    
+
     /// Enqueue an mark-as-read update.
     ///
     /// - parameter timestamp: Point in time from which all older messages should be considered read.
     ///
     /// This method only has an effect when called from the UI context and it's throttled so it's fine to call it repeatedly.
+
     fileprivate func enqueueMarkAsReadUpdate(_ timestamp: Date) {
         guard let managedObjectContext = managedObjectContext, managedObjectContext.zm_isUserInterfaceContext else { return }
-        
+
         updatePendingLastRead(timestamp)
+
         lastReadTimestampUpdateCounter += 1
         let currentCount: Int64 = lastReadTimestampUpdateCounter
         let groups = managedObjectContext.enterAllGroups()
+
+        // Because we will only send read receipts after an artificial delay, we must
+        // "freeze" the value of the last read server timestamp to ensure that when
+        // we eventually fetch unread messages they are "unread" with respect to this
+        // frozen value.
+        let lastReadServerTimestamp = self.lastReadServerTimeStamp ?? .distantPast
         
         DispatchQueue.main.asyncAfter(deadline: .now() + lastReadTimestampSaveDelay) { [weak self] in
-            guard currentCount == self?.lastReadTimestampUpdateCounter else { return managedObjectContext.leaveAllGroups(groups) }
-            
-            self?.savePendingLastRead()
+            // Only allow the first dispatched block to execute because it has the oldest value
+            // for `currentLastReadTimestamp`. If we use a later block where the timestamp is newer
+            // (e.g a new message is appended by the self user which update the timestamp), then we would
+            // likely not send read receipts for any messages before that updated timestamp.
+            guard currentCount == 1 else { return managedObjectContext.leaveAllGroups(groups) }
+            self?.savePendingLastRead(previousLastReadServerTimestamp: lastReadServerTimestamp)
             managedObjectContext.leaveAllGroups(groups)
         }
     }
@@ -286,11 +297,13 @@ extension ZMConversation {
     /// Perform the an mark-as-read update by updating the last-read timestamp and
     /// create read confirmations for the newly read messages.
     ///
-    /// - parameter timestamp: Point in time from which all older messages should be considered read.
+    /// - Parameters:
+    ///     - range: The range of time in which all messages should be considered read.
     ///
     /// This method can only be run from the UI context but the actual work will happen
     /// on the sync context since that's the context where we update timestamps.
-    fileprivate func performMarkAsReadUpdate(_ timestamp: Date) {
+
+    fileprivate func performMarkAsReadUpdate(in range: ClosedRange<Date>) {
         guard
             managedObjectContext?.zm_isUserInterfaceContext == true,
             let syncMOC = managedObjectContext?.zm_sync
@@ -302,27 +315,35 @@ extension ZMConversation {
         
         syncMOC.performGroupedBlock {
             let conversation = syncMOC.object(with: objectID) as? ZMConversation
-            conversation?.confirmUnreadMessagesAsRead(until: timestamp)
-            conversation?.updateLastRead(timestamp, synchronize: true)
+            conversation?.confirmUnreadMessagesAsRead(in: range)
+            conversation?.updateLastRead(range.upperBound, synchronize: true)
             syncMOC.saveOrRollback()
         }
     }
-    
+
+    /// Triggers the mark-as-read update.
+    ///
+    /// - Parameter previousLastReadServerTimestamp:
+    ///     The last read sever timestamp if provided, else the `lastReadServerTimeStamp` will be used.
+
     @objc
-    public func savePendingLastRead() {
-        guard let timestamp = pendingLastReadServerTimestamp else { return }
-        performMarkAsReadUpdate(timestamp)
+    public func savePendingLastRead(previousLastReadServerTimestamp: Date? = nil) {
+        guard let upperBound = pendingLastReadServerTimestamp else { return }
+        let lowerBound = previousLastReadServerTimestamp ?? lastReadServerTimeStamp ?? .distantPast
+        performMarkAsReadUpdate(in: lowerBound...upperBound)
         pendingLastReadServerTimestamp = nil
         lastReadTimestampUpdateCounter = 0
     }
         
     /// Calculates the the last unread knock, missed call and total unread unread count. This should be re-calculated
     /// when the last read timetamp changes or a message is inserted / deleted.
+
     @objc
     func calculateLastUnreadMessages() {
-        guard let managedObjectContext = managedObjectContext, managedObjectContext.zm_isSyncContext else { return } // We only calculate unread message on the sync MOC
+        // We only calculate unread message on the sync MOC
+        guard let managedObjectContext = managedObjectContext, managedObjectContext.zm_isSyncContext else { return }
         
-        let messages = unreadMessagesIncludingInvisible().filter(ZMMessage.isVisible)
+        let messages = unreadMessages()
         var lastKnockDate: Date? = nil
         var lastMissedCallDate: Date? = nil
         var unreadCount: Int64 = 0
@@ -360,7 +381,9 @@ extension ZMConversation {
         needsToCalculateUnreadMessages = false
     }
     
-    /// Returns the first unread message in a converation. If the first unread message is child message of system message the parent message will be returned.
+    /// Returns the first unread message in a converation. If the first unread message is child message
+    /// of system message the parent message will be returned.
+    
     @objc
     public var firstUnreadMessage: ZMConversationMessage? {
         let replaceChildWithParent: (ZMMessage) -> ZMMessage = { message in
@@ -370,39 +393,55 @@ extension ZMConversation {
                 return message
             }
         }
-        
-        return unreadMessagesIncludingInvisible().lazy.map(replaceChildWithParent).filter({ $0.visibleInConversation != nil }).first(where: { $0.shouldGenerateUnreadCount() })
+
+        return unreadMessagesIncludingInvisible().lazy
+            .map(replaceChildWithParent)
+            .filter { $0.visibleInConversation != nil }
+            .first { $0.shouldGenerateUnreadCount() }
     }
     
-    // Returns first unread message mentioning the self user
+    /// Returns first unread message mentioning the self user.
+
     public var firstUnreadMessageMentioningSelf: ZMConversationMessage? {
         return unreadMessages.first(where: { $0.textMessageData?.isMentioningSelf ?? false })
     }
     
-    /// Returns all unread messages. This may contain unread child messages of a system message which aren't directly visible in the conversation.
+    /// Returns all unread messages. This may contain unread child messages of a system message
+    /// which aren't directly visible in the conversation.
+
     @objc
     public var unreadMessages: [ZMConversationMessage] {
-        return unreadMessagesIncludingInvisible().filter(ZMMessage.isVisible)
+        return unreadMessages()
     }
-    
+
     internal func unreadMessages(until timestamp: Date = .distantFuture) -> [ZMMessage] {
         return unreadMessagesIncludingInvisible(until: timestamp).filter(ZMMessage.isVisible)
     }
+
+    internal func unreadMessagesIncludingInvisible(until timestamp: Date = .distantFuture) -> [ZMMessage] {
+        let range = (lastReadServerTimeStamp ?? .distantPast)...timestamp
+        return unreadMessagesIncludingInvisible(in: range)
+    }
     
-    internal func unreadMessagesIncludingInvisible(until timestamp: Date = Date.distantFuture) -> [ZMMessage] {
+    internal func unreadMessages(in range: ClosedRange<Date>) -> [ZMMessage] {
+        return unreadMessagesIncludingInvisible(in: range).filter(ZMMessage.isVisible)
+    }
+
+    internal func unreadMessagesIncludingInvisible(in range: ClosedRange<Date>) -> [ZMMessage] {
         guard let managedObjectContext = managedObjectContext else { return [] }
-        
-        let lastReadServerTimestamp = lastReadServerTimeStamp ?? Date.distantPast
+
         let selfUser = ZMUser.selfUser(in: managedObjectContext)
         let fetchRequest = NSFetchRequest<ZMMessage>(entityName: ZMMessage.entityName())
         fetchRequest.predicate = NSPredicate(format: "(%K == %@ OR %K == %@) AND %K != %@ AND %K > %@ AND %K <= %@",
                                              ZMMessageConversationKey, self,
                                              ZMMessageHiddenInConversationKey, self,
                                              ZMMessageSenderKey, selfUser,
-                                             ZMMessageServerTimestampKey, lastReadServerTimestamp as NSDate,
-                                             ZMMessageServerTimestampKey, timestamp as NSDate)
+                                             ZMMessageServerTimestampKey, range.lowerBound as NSDate,
+                                             ZMMessageServerTimestampKey, range.upperBound as NSDate)
+
         fetchRequest.sortDescriptors = ZMMessage.defaultSortDescriptors()
         
-        return managedObjectContext.fetchOrAssert(request: fetchRequest).filter({ $0.shouldGenerateUnreadCount() })
+        return managedObjectContext.fetchOrAssert(request: fetchRequest).filter { $0.shouldGenerateUnreadCount() }
     }
 }
+

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -122,6 +122,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @property (nonatomic) BOOL internalIsArchived;
 
 @property (nonatomic) NSDate *pendingLastReadServerTimestamp;
+@property (nonatomic) NSDate *previousLastReadServerTimestamp;
 @property (nonatomic) NSDate *lastReadServerTimeStamp;
 @property (nonatomic) NSDate *lastServerTimeStamp;
 @property (nonatomic) NSDate *clearedTimeStamp;
@@ -163,6 +164,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
 @dynamic nonTeamRoles;
 
 @synthesize pendingLastReadServerTimestamp;
+@synthesize previousLastReadServerTimestamp;
 @synthesize lastReadTimestampSaveDelay;
 @synthesize lastReadTimestampUpdateCounter;
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1656,7 +1656,7 @@
     
     // when
     [conversation markMessagesAsReadUntil:messageToBeMarkedAsRead];
-    [conversation savePendingLastRead];
+    [conversation savePendingLastReadWithPreviousLastReadServerTimestamp:conversation.lastReadServerTimeStamp];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1656,7 +1656,7 @@
     
     // when
     [conversation markMessagesAsReadUntil:messageToBeMarkedAsRead];
-    [conversation savePendingLastReadWithPreviousLastReadServerTimestamp:conversation.lastReadServerTimeStamp];
+    [conversation savePendingLastRead];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then


### PR DESCRIPTION
## What's new in this PR?

An alternate solution for the issue first described in https://github.com/wireapp/wire-ios-data-model/pull/1097 and initially solved in https://github.com/wireapp/wire-ios-data-model/pull/1110 which was later reverted.

### Issues

It can happen that read receipts are not being sent for some messages that expect them. For example, receive a message, but immediately after reading that message, send a new message. If it is sent within 3 seconds, the original message won't receive a read receipt.

### Causes

The method which triggers the generation of read receipts (`enqueueMarkAsReadUpdate()`) uses an artificial delay of 3 seconds to throttle invocations to that method. If the method is called with a timestamp A, and meanwhile that conversation `lastReadServerTimeStamp` is advanced to a value greater than A, then the delayed call to `enqueueMarkAsReadUpdate` would have no effect because it would not find any unread messages within the range `A...lastReadServerTimeStamp` because A is less than `lastReadServerTimeStamp`. This can happen if the self user appends a message in the conversation during this 3 second delay.

The core of the issue here is that last read server timestamp isn't being preserved throughout the 3 second delay because the method used to fetch unread messages (` unreadMessagesIncludingInvisible(until:)`) will always use current value of the last read server timestamp.

### Solutions

Refactor the chain of methods to accept a date range in which we are searching for unread messages. This allows us to "freeze" the conversation's last read server timestamp just before the 3 second delay begins, passing it through the chain of methods until it is finally used in a predicate to fetch the unread messages.

