### PR TITLE
[Fix] App lock passcode migration 

### DIFF
--- a/Patches/TransferApplockKeychain.swift
+++ b/Patches/TransferApplockKeychain.swift
@@ -22,12 +22,7 @@ struct TransferApplockKeychain {
     
     static func migrateKeychainItems(in moc: NSManagedObjectContext) {
         migrateIsAppLockActiveState(in: moc)
-
-        guard let accountManager = Bundle.main.sharedContainerURL.map(AccountManager.init) else {
-            fatalError("Failed to migrated app lock passcode. Reason: couldn't initialize AccountManager,")
-        }
-
-        migrateAppLockPasscodes(forAccountIds: accountManager.accounts.map(\.userIdentifier))
+        migrateAppLockPasscode(in: moc)
     }
     
     /// Save the enable state of the applock feature in the managedObjectContext instead of the keychain.
@@ -49,7 +44,9 @@ struct TransferApplockKeychain {
     /// Migrate the single legacy passcode (account agnostic) to potentially several (account specific)
     /// keychain entries.
 
-    static func migrateAppLockPasscodes(forAccountIds ids: [UUID]) {
+    static func migrateAppLockPasscode(in moc: NSManagedObjectContext) {
+        guard let selfUserId = ZMUser.selfUser(in: moc).remoteIdentifier else { return }
+
         let legacyKeychainItem = AppLockController.PasscodeKeychainItem.legacyItem
 
         guard
@@ -60,11 +57,8 @@ struct TransferApplockKeychain {
         }
 
         do {
-            for id in ids {
-                let item = AppLockController.PasscodeKeychainItem(userId: id)
-                try Keychain.storeItem(item, value: passcode)
-            }
-
+            let item = AppLockController.PasscodeKeychainItem(userId: selfUserId)
+            try Keychain.storeItem(item, value: passcode)
             try Keychain.deleteItem(legacyKeychainItem)
 
         } catch {

--- a/Patches/TransferApplockKeychain.swift
+++ b/Patches/TransferApplockKeychain.swift
@@ -56,14 +56,8 @@ struct TransferApplockKeychain {
             return
         }
 
-        do {
-            let item = AppLockController.PasscodeKeychainItem(userId: selfUserId)
-            try Keychain.storeItem(item, value: passcode)
-            try Keychain.deleteItem(legacyKeychainItem)
-
-        } catch {
-            fatalError("Failed to migrate app lock passcode. Reason: \(error.localizedDescription)")
-        }
+        let item = AppLockController.PasscodeKeychainItem(userId: selfUserId)
+        try? Keychain.storeItem(item, value: passcode)
     }
 
 }

--- a/Tests/Source/Utils/TransferApplockKeychainTests.swift
+++ b/Tests/Source/Utils/TransferApplockKeychainTests.swift
@@ -70,21 +70,21 @@ class TransferAppLockKeychainTests: DiskDatabaseTest {
         // Given
         let legacyItem = AppLockController.PasscodeKeychainItem.legacyItem
         let passcode = "hello".data(using: .utf8)!
-        let userIds = (1...3).map { _ in UUID.create() }
 
         try Keychain.updateItem(legacyItem, value: passcode)
         XCTAssertEqual(try? Keychain.fetchItem(legacyItem), passcode)
 
         // When
-        TransferApplockKeychain.migrateAppLockPasscodes(forAccountIds: userIds)
+        TransferApplockKeychain.migrateAppLockPasscode(in: moc)
 
         // Then
-        let items = userIds.map(AppLockController.PasscodeKeychainItem.init)
-        for item in items { XCTAssertEqual(try Keychain.fetchItem(item), passcode) }
         XCTAssertNil(try? Keychain.fetchItem(legacyItem))
 
+        let item = AppLockController.PasscodeKeychainItem(user: ZMUser.selfUser(in: moc))
+        XCTAssertEqual(try Keychain.fetchItem(item), passcode)
+
         // Clean up
-        for item in items { try Keychain.deleteItem(item) }
+        try Keychain.deleteItem(item)
     }
 
 }

--- a/Tests/Source/Utils/TransferApplockKeychainTests.swift
+++ b/Tests/Source/Utils/TransferApplockKeychainTests.swift
@@ -78,13 +78,15 @@ class TransferAppLockKeychainTests: DiskDatabaseTest {
         TransferApplockKeychain.migrateAppLockPasscode(in: moc)
 
         // Then
-        XCTAssertNil(try? Keychain.fetchItem(legacyItem))
-
         let item = AppLockController.PasscodeKeychainItem(user: ZMUser.selfUser(in: moc))
         XCTAssertEqual(try Keychain.fetchItem(item), passcode)
 
+        // We shouldn't delete the legacy item because it's shared between all accounts.
+        XCTAssertEqual(try? Keychain.fetchItem(legacyItem), passcode)
+
         // Clean up
         try Keychain.deleteItem(item)
+        try Keychain.deleteItem(legacyItem)
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Patch migration tests were failing on the simulator.

### Causes

The shared container doesn't exist on the simulator and one of the app lock keychain migration tests was relying on it to create the account manager to migrate the custom passcode for all accounts at once.

### Solutions

It's not necessary to migrate all accounts at once, the migration will be performed individually for each account. Therefore, just migrate the passcode for the self user. To do this however, we must not delete the legacy passcode from the keychain.

I also decided not to hard crash if the migration fails. If it does fail, the worst that happens is that the user would need to create a new custom passcode, which isn't so bad.

