### PR TITLE
[Fix] Can't import backups from old versions of Wire

### DIFF
--- a/Source/ManagedObjectContext/StorageStack+Backup.swift
+++ b/Source/ManagedObjectContext/StorageStack+Backup.swift
@@ -188,7 +188,7 @@ extension StorageStack {
                 
                 // Create target directory
                 try fileManager.createDirectory(at: accountStoreFile.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-                let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
+                let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: true)
                 
                 try prepareStoreForBackupImport(coordinator: coordinator, location: backupStoreFile, options: options)
                 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When trying to import an old Wire build it will sometimes fail with the message:
"Something went wrong: your history couldn't be restored"

### Causes

Since https://github.com/wireapp/wire-ios-data-model/pull/1071 we open the backup db to prepare it for importing before we perform the actual import. When opening an old core data store it might need to be migrated before we can make any changes but we tried to open it with the following options:
```
let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
```

This means that any backed up store which needs migration will fail to import.

### Solutions

Allow migration when opening store.