### PR TITLE
[Fix] Introduce isDecryptionErrorRecoverable

### DIFF
--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -33,6 +33,7 @@
 #import "ZMUpdateEvent+WireDataModel.h"
 
 #import <WireDataModel/WireDataModel-Swift.h>
+#import <WireCryptobox/cbox.h>
 
 
 static NSString *ZMLogTag ZM_UNUSED = @"ephemeral";
@@ -900,6 +901,22 @@ NSString * const ZMMessageDecryptionErrorCodeKey = @"decryptionErrorCode";
         self.needsUpdatingUsers = [self.addedUsers anyObjectMatchingWithBlock:matchUnfetchedUserBlock] ||
                                   [self.removedUsers anyObjectMatchingWithBlock:matchUnfetchedUserBlock];
     }
+}
+
+- (BOOL)isDecryptionErrorRecoverable {
+    if (self.decryptionErrorCode == nil) {
+        return NO;
+    }
+    
+    NSInteger errorCode = self.decryptionErrorCode.integerValue;
+    
+    if (errorCode == CBOX_TOO_DISTANT_FUTURE ||
+        errorCode == CBOX_DEGENERATED_KEY ||
+        errorCode == CBOX_PREKEY_NOT_FOUND) {
+        return YES;
+    }
+    
+    return NO;
 }
 
 + (ZMSystemMessageType)systemMessageTypeFromEventType:(ZMUpdateEventType)type

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -144,6 +144,7 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 
 @property (nonatomic, readonly, copy, nullable) NSString *text;
 @property (nonatomic) BOOL needsUpdatingUsers;
+@property (nonatomic) BOOL isDecryptionErrorRecoverable;
 @property (nonatomic) NSTimeInterval duration;
 @property (nonatomic) NSNumber * _Nullable decryptionErrorCode; // Only filled for ZMSystemMessageTypeDecryptionFailed
 @property (nonatomic) NSString * _Nullable senderClientID; // Only filled for ZMSystemMessageTypeDecryptionFailed

--- a/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
@@ -1,0 +1,71 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class ZMMessageTests_SystemMessages: BaseZMMessageTests {
+
+    func testThatOnlyRecoverableDecryptionErrorsAreReportedAsRecoverable() throws {
+        let allEncryptionErrors = [
+            CBOX_STORAGE_ERROR,
+            CBOX_SESSION_NOT_FOUND,
+            CBOX_DECODE_ERROR,
+            CBOX_REMOTE_IDENTITY_CHANGED,
+            CBOX_INVALID_SIGNATURE,
+            CBOX_INVALID_MESSAGE,
+            CBOX_DUPLICATE_MESSAGE,
+            CBOX_TOO_DISTANT_FUTURE,
+            CBOX_OUTDATED_MESSAGE,
+            CBOX_UTF8_ERROR,
+            CBOX_NUL_ERROR,
+            CBOX_ENCODE_ERROR,
+            CBOX_IDENTITY_ERROR,
+            CBOX_PREKEY_NOT_FOUND,
+            CBOX_PANIC,
+            CBOX_INIT_ERROR,
+            CBOX_DEGENERATED_KEY
+        ]
+        
+        let recoverableEncryptionErrors = [
+            CBOX_TOO_DISTANT_FUTURE,
+            CBOX_DEGENERATED_KEY,
+            CBOX_PREKEY_NOT_FOUND
+        ]
+        
+        for encryptionError in allEncryptionErrors {
+            assertDecryptionErrorIsReportedAsRecoverable(
+                encryptionError,
+                recoverable: recoverableEncryptionErrors.contains(encryptionError))
+        }
+    }
+    
+    private func assertDecryptionErrorIsReportedAsRecoverable(_ decryptionError: CBoxResult,
+                                                              recoverable: Bool,
+                                                              file: StaticString = #file,
+                                                              line: UInt = #line) {
+        // given
+        let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
+        systemMessage.systemMessageType = .decryptionFailed
+        systemMessage.decryptionErrorCode = NSNumber(value: decryptionError.rawValue)
+        
+        // then
+        XCTAssertEqual(systemMessage.isDecryptionErrorRecoverable, recoverable, file: file, line: line)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		1639A8132260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */; };
 		1639A8512264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */; };
 		163CE64E25ACE5DB0013C12D /* store2-89-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 163CE64D25ACE57B0013C12D /* store2-89-0.wiredatabase */; };
+		163CE6AF25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163CE6AE25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift */; };
 		163D01E02472DE6200984999 /* InvalidConnectionRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163D01DF2472DE6200984999 /* InvalidConnectionRemoval.swift */; };
 		163D01E22472E44000984999 /* InvalidConnectionRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163D01E12472E44000984999 /* InvalidConnectionRemovalTests.swift */; };
 		1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */; };
@@ -750,6 +751,7 @@
 		1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertAvailabilityBehaviourChange.swift; sourceTree = "<group>"; };
 		1639A8502264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityBehaviourChangeTests.swift; sourceTree = "<group>"; };
 		163CE64D25ACE57B0013C12D /* store2-89-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-89-0.wiredatabase"; sourceTree = "<group>"; };
+		163CE6AE25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessageTests+SystemMessages.swift"; sourceTree = "<group>"; };
 		163D01DF2472DE6200984999 /* InvalidConnectionRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidConnectionRemoval.swift; sourceTree = "<group>"; };
 		163D01E12472E44000984999 /* InvalidConnectionRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidConnectionRemovalTests.swift; sourceTree = "<group>"; };
 		1645ECC1243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMSearchUserTests+TeamUser.swift"; sourceTree = "<group>"; };
@@ -2359,6 +2361,7 @@
 				F9B71F5F1CB2BC85001DB03F /* BaseClientMessageTests.swift */,
 				F9B71F601CB2BC85001DB03F /* ZMMessageTests.h */,
 				F9B71F611CB2BC85001DB03F /* ZMMessageTests.m */,
+				163CE6AE25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift */,
 				63D41E6C245733AC0076826F /* ZMMessageTests+Removal.swift */,
 				F93A302E1D6F2633005CCB1D /* ZMMessageTests+Confirmation.swift */,
 				060D194D2462A9D000623376 /* ZMMessageTests+GenericMessage.swift */,
@@ -3345,6 +3348,7 @@
 				F9A7085C1CAEED1B00C2F5FE /* ZMBaseManagedObjectTest.m in Sources */,
 				1670D01E231825BE003A143B /* ZMUserTests+Permissions.swift in Sources */,
 				8767E8682163B9EE00390F75 /* ZMConversationTests+Mute.swift in Sources */,
+				163CE6AF25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift in Sources */,
 				F9A708351CAEEB7500C2F5FE /* ManagedObjectContextTests.m in Sources */,
 				874D9798211064D300B07674 /* ZMConversationLastMessagesTest.swift in Sources */,
 				87C125F91EF94F2E00D28DC1 /* ZMManagedObjectGroupingTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Introduce `isDecryptionErrorRecoverable` to expose decryption errors which can be resolved by resetting the session.