### PR TITLE
Move Conversation properties to ConversationLike

### DIFF
--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -19,6 +19,8 @@
 
 import Foundation
 
+typealias Conversation = ConversationLike & SwiftConversationLike
+
 @objc
 public protocol ConversationLike: NSObjectProtocol {
     var conversationType: ZMConversationType { get }
@@ -32,6 +34,8 @@ public protocol ConversationLike: NSObjectProtocol {
     var allowGuests: Bool { get }
     var team: Team? { get }
 
+    var isUnderLegalHold: Bool { get }
+    var securityLevel: ZMConversationSecurityLevel { get }
 }
 
 // Since ConversationLike must have @objc signature(@objc UserType has a ConversationLike property), create another protocol to abstract Swift only properties

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -26,11 +26,28 @@ public protocol ConversationLike: NSObjectProtocol {
     var teamRemoteIdentifier: UUID? { get }
     
     func localParticipantsContain(user: UserType) -> Bool
+
+    var displayName: String { get }
+    var connectedUserType: UserType? { get }
+    var allowGuests: Bool { get }
+    var team: Team? { get }
+
+}
+
+public protocol SwiftConversationLike {
+        var accessMode: ConversationAccessMode? { get }
+        var accessRole: ConversationAccessRole? { get }
+    
+        var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
 }
 
 extension ZMConversation: ConversationLike {
     public func localParticipantsContain(user: UserType) -> Bool {
         guard let user = user as? ZMUser else { return false }
         return localParticipants.contains(user)
+    }
+    
+    public var connectedUserType: UserType? {
+        return connectedUser
     }
 }

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -34,6 +34,7 @@ public protocol ConversationLike: NSObjectProtocol {
 
 }
 
+// Since ConversationLike must have @objc signature(@objc UserType has a ConversationLike property), create another protocol to abstract Swift only properties
 public protocol SwiftConversationLike {
         var accessMode: ConversationAccessMode? { get }
         var accessRole: ConversationAccessRole? { get }

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-typealias Conversation = ConversationLike & SwiftConversationLike
+public typealias Conversation = ConversationLike & SwiftConversationLike
 
 @objc
 public protocol ConversationLike: NSObjectProtocol {

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -32,7 +32,6 @@ public protocol ConversationLike: NSObjectProtocol {
     var displayName: String { get }
     var connectedUserType: UserType? { get }
     var allowGuests: Bool { get }
-    var team: Team? { get }
 
     var isUnderLegalHold: Bool { get }
     var securityLevel: ZMConversationSecurityLevel { get }
@@ -40,10 +39,12 @@ public protocol ConversationLike: NSObjectProtocol {
 
 // Since ConversationLike must have @objc signature(@objc UserType has a ConversationLike property), create another protocol to abstract Swift only properties
 public protocol SwiftConversationLike {
-        var accessMode: ConversationAccessMode? { get }
-        var accessRole: ConversationAccessRole? { get }
-    
-        var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
+    var accessMode: ConversationAccessMode? { get }
+    var accessRole: ConversationAccessRole? { get }
+
+    var teamType: TeamType? { get }
+
+    var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
 }
 
 extension ZMConversation: ConversationLike {

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -88,14 +88,14 @@ public extension ConversationAccessRole {
     }
 }
 
-public extension ZMConversation {
+extension ZMConversation: SwiftConversationLike {
     @NSManaged @objc dynamic internal var accessModeStrings: [String]?
     @NSManaged @objc dynamic internal var accessRoleString: String?
     
     /// If set to false, only team member can join the conversation.
     /// True means that a regular guest OR wireless guests could join
     /// Controls the values of `accessMode` and `accessRole`.
-    @objc var allowGuests: Bool {
+    @objc public var allowGuests: Bool {
         get {
             return accessMode != .teamOnly && accessRole != .team
         }
@@ -108,7 +108,7 @@ public extension ZMConversation {
     // The conversation access mode is stored as an array of string in CoreData, cf. `acccessModeStrings`.
     
     /// Defines how users can join a conversation.
-    var accessMode: ConversationAccessMode? {
+    public var accessMode: ConversationAccessMode? {
         get {
             guard let strings = self.accessModeStrings else {
                 return nil
@@ -126,7 +126,7 @@ public extension ZMConversation {
     }
     
     /// Defines who can join the conversation.
-    var accessRole: ConversationAccessRole? {
+    public var accessRole: ConversationAccessRole? {
         get {
             guard let strings = self.accessRoleString else {
                 return nil

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -92,6 +92,10 @@ extension ZMConversation: SwiftConversationLike {
     @NSManaged @objc dynamic internal var accessModeStrings: [String]?
     @NSManaged @objc dynamic internal var accessRoleString: String?
     
+    public var teamType: TeamType? {
+        return team
+    }
+
     /// If set to false, only team member can join the conversation.
     /// True means that a regular guest OR wireless guests could join
     /// Controls the values of `accessMode` and `accessRole`.

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -56,9 +56,9 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     /// The timestamp as received by the server
     var serverTimestamp: Date? { get }
     
-    /// For internal use only. The conversation this message belongs to
+    @available(*, deprecated, message: "Use `conversationLike` instead")
     var conversation: ZMConversation? { get }
-
+    
     /// The conversation this message belongs to
     var conversationLike: ConversationLike? { get }
 

--- a/Tests/Source/Model/CoreDataRelationshipsTests.m
+++ b/Tests/Source/Model/CoreDataRelationshipsTests.m
@@ -78,9 +78,9 @@
     // Check that the inverse have been set:
     [self.uiMOC processPendingChanges];
     
-    XCTAssertEqual(message1.conversation, conversation1);
-    XCTAssertEqual(message2.conversation, conversation1);
-    XCTAssertEqual(message3.conversation, conversation2);
+    XCTAssertEqual(message1.conversationLike, conversation1);
+    XCTAssertEqual(message2.conversationLike, conversation1);
+    XCTAssertEqual(message3.conversationLike, conversation2);
     
     XCTAssertEqual(conversation1.connection, connection1);
     XCTAssertEqual(connection2.conversation, conversation2);
@@ -125,9 +125,9 @@
         XCTAssertEqualObjects(c2Message2.objectID, message2.objectID);
         XCTAssertEqualObjects(c2Message3.objectID, message3.objectID);
         
-        XCTAssertEqual(c2Message1.conversation, c2Conversation1);
-        XCTAssertEqual(c2Message2.conversation, c2Conversation1);
-        XCTAssertEqual(c2Message3.conversation, c2Conversation2);
+        XCTAssertEqual(c2Message1.conversationLike, c2Conversation1);
+        XCTAssertEqual(c2Message2.conversationLike, c2Conversation1);
+        XCTAssertEqual(c2Message3.conversationLike, c2Conversation2);
         
         ZMUser *c2User1 = c2Conversation1.creator;
         XCTAssertEqualObjects(c2User1.objectID, user1.objectID);


### PR DESCRIPTION
## What's new in this PR?

Move Conversation form UI project protocol to `ConversationLike`. Put the Swift only property in extension to protocol `SwiftConversationLike` and create a new alias `Conversation` to combine them.