### PR TITLE
[Fix] Existing system message changing type due to changed enum order

### DIFF
--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -69,12 +69,10 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
     ZMSystemMessageTypeConnectionUpdate,
     ZMSystemMessageTypeMissedCall,
     ZMSystemMessageTypeNewClient,
-    ZMSystemMessageTypeSessionReset,
     ZMSystemMessageTypeIgnoredClient,
     ZMSystemMessageTypeConversationIsSecure,
     ZMSystemMessageTypePotentialGap,
     ZMSystemMessageTypeDecryptionFailed,
-    ZMSystemMessageTypeDecryptionFailedResolved,
     ZMSystemMessageTypeDecryptionFailed_RemoteIdentityChanged,
     ZMSystemMessageTypeNewConversation,
     ZMSystemMessageTypeReactivatedDevice,
@@ -87,7 +85,9 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
     ZMSystemMessageTypeReadReceiptsDisabled,
     ZMSystemMessageTypeReadReceiptsOn,
     ZMSystemMessageTypeLegalHoldEnabled,
-    ZMSystemMessageTypeLegalHoldDisabled
+    ZMSystemMessageTypeLegalHoldDisabled,
+    ZMSystemMessageTypeSessionReset,
+    ZMSystemMessageTypeDecryptionFailedResolved,
 };
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Existing system message would change type after upgrading to the latest version of Wire

### Causes

New entries were added to the `ZMSystemMessageType` enum which is represented as integer in the database. Adding a new entry to the enum changes the integer associated for all cases after the new entry:

```
enum Foo {
case A = 0
case B = 1
}

enum Foo (edited) {
case A = 0
case C = 1
case B = 2
}
```

### Solutions

Add new entries at the end of the enum.