### PR TITLE
Add quoteMessage to ZMTextMessageData

### DIFF
--- a/Source/Model/Message/Composite/CompositeMessageItemContent.swift
+++ b/Source/Model/Message/Composite/CompositeMessageItemContent.swift
@@ -56,6 +56,10 @@ extension CompositeMessageItemContent: ZMTextMessageData {
         return nil
     }
     
+    var quoteMessage: ZMConversationMessage? {
+        return quote
+    }
+    
     var linkPreviewHasImage: Bool {
         return false
     }

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -22,6 +22,10 @@ extension ZMClientMessage: ZMTextMessageData {
     
     @NSManaged public var quote: ZMMessage?
     
+    public var quoteMessage: ZMConversationMessage? {
+        return quote
+    }
+    
     public override var textMessageData: ZMTextMessageData? {        
         guard underlyingMessage?.textData != nil else {
             return nil

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -98,9 +98,6 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, readonly, nullable) NSString *messageText;
 @property (nonatomic, readonly, nullable) LinkMetadata *linkPreview;
 @property (nonatomic, readonly, nonnull) NSArray<Mention *> *mentions;
-
-@property (nonatomic, readonly, nullable) ZMMessage *quote;
-/// Quote message with ZMConversationMessage protocol type, returns casted quote
 @property (nonatomic, readonly, nullable) id<ZMConversationMessage> quoteMessage;
 
 /// Returns true if the link preview will have an image

--- a/Source/Public/ZMMessage.h
+++ b/Source/Public/ZMMessage.h
@@ -33,6 +33,7 @@
 @protocol ZMFileMessageData;
 @protocol UserClientType;
 @protocol UserType;
+@protocol ZMConversationMessage;
 
 #pragma mark - ZMImageMessageData
 
@@ -97,7 +98,10 @@ typedef NS_ENUM(int16_t, ZMSystemMessageType) {
 @property (nonatomic, readonly, nullable) NSString *messageText;
 @property (nonatomic, readonly, nullable) LinkMetadata *linkPreview;
 @property (nonatomic, readonly, nonnull) NSArray<Mention *> *mentions;
+
 @property (nonatomic, readonly, nullable) ZMMessage *quote;
+/// Quote message with ZMConversationMessage protocol type, returns casted quote
+@property (nonatomic, readonly, nullable) id<ZMConversationMessage> quoteMessage;
 
 /// Returns true if the link preview will have an image
 @property (nonatomic, readonly) BOOL linkPreviewHasImage;

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -337,8 +337,8 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
         let textMessage = try? conversation.appendText(content: "Hello World", replyingTo: imageMessage)
         
         // then
-        XCTAssertNotNil(textMessage?.textMessageData?.quote)
-        XCTAssertEqual(textMessage?.textMessageData?.quote?.nonce, imageMessage?.nonce)
+        XCTAssertNotNil(textMessage?.textMessageData?.quoteMessage)
+        XCTAssertEqual(textMessage?.textMessageData?.quoteMessage?.nonce, imageMessage?.nonce)
         
     }
 

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
@@ -397,7 +397,7 @@ extension ZMClientMessageTests_Editing {
         XCTAssertEqual(message.textMessageData?.messageText, newText)
         XCTAssertTrue(message.textMessageData!.hasQuote)
         XCTAssertNotEqual(message.nonce, oldNonce)
-        XCTAssertEqual(message.textMessageData?.quote, quotedMessage)
+        XCTAssertEqual(message.textMessageData?.quoteMessage as! ZMMessage, quotedMessage)
     }
     
     func testThatReadExpectationIsKeptAfterEdit() {

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Replies.swift
@@ -26,7 +26,7 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         
         let message = try! conversation.appendText(content: "That's fine", mentions: [], replyingTo: quotedMessage, fetchLinkPreview: false, nonce: UUID()) as! ZMTextMessageData
         
-        XCTAssertEqual(message.quote, quotedMessage)
+        XCTAssertEqual(message.quoteMessage as! ZMMessage, quotedMessage)
     }
     
     func testQuoteRelationshipIsEstablishedWhenReceivingMessage() {


### PR DESCRIPTION
## What's new in this PR?

Add `quoteMessage` with type `ZMConversationMessage` to `ZMTextMessageData` to allow mocking `quota` with creating a `ZMMessage` managed object.