### PR TITLE
Add conformances to AnalyticsAttributeValue (Part 2)

### DIFF
--- a/Source/Model/Analytics/AnalyticsAttributeKey.swift
+++ b/Source/Model/Analytics/AnalyticsAttributeKey.swift
@@ -18,12 +18,18 @@
 
 import Foundation
 
-/// A type able to record analytic events.
+/// A key denoting a particular analytics attribute.
 
-public protocol AnalyticsLike {
+public struct AnalyticsAttributeKey: Hashable, RawRepresentable {
 
-    /// Record the given event.
+    /// The unique string describing the key.
 
-    func tagEvent(_ event: AnalyticsEvent)
+    public let rawValue: String
+
+    /// Create a key with the given raw value.
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
 
 }

--- a/Source/Model/Analytics/AnalyticsAttributeValue.swift
+++ b/Source/Model/Analytics/AnalyticsAttributeValue.swift
@@ -1,0 +1,68 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A type that can be used an attribute value.
+
+public protocol AnalyticsAttributeValue {
+
+    /// The string representation of the value.
+
+    var analyticsValue: String { get }
+
+}
+
+extension UUID: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return transportString()
+    }
+
+}
+
+extension Int: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return String(describing: self)
+    }
+
+}
+
+extension String: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return self
+    }
+
+}
+
+extension TeamRole: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        switch self {
+            case .member, .admin, .owner:
+                return "member"
+            case .partner:
+                return "external"
+            case .none:
+                return "wireless"
+        }
+    }
+
+}

--- a/Source/Model/Analytics/AnalyticsAttributes.swift
+++ b/Source/Model/Analytics/AnalyticsAttributes.swift
@@ -18,12 +18,4 @@
 
 import Foundation
 
-/// A type able to record analytic events.
-
-public protocol AnalyticsLike {
-
-    /// Record the given event.
-
-    func tagEvent(_ event: AnalyticsEvent)
-
-}
+public typealias AnalyticsAttributes = [AnalyticsAttributeKey: AnalyticsAttributeValue]

--- a/Source/Model/Analytics/AnalyticsEvent.swift
+++ b/Source/Model/Analytics/AnalyticsEvent.swift
@@ -18,12 +18,23 @@
 
 import Foundation
 
-/// A type able to record analytic events.
+/// An event to be recorded for analytical purposes.
 
-public protocol AnalyticsLike {
+public struct AnalyticsEvent {
 
-    /// Record the given event.
+    /// The unique name of the event.
 
-    func tagEvent(_ event: AnalyticsEvent)
+    public let name: String
+
+    /// Additional data associated with the event.
+
+    public var attributes: AnalyticsAttributes
+
+    /// Create an event with the given name and attributes.
+
+    public init(name: String, attributes: AnalyticsAttributes = [:]) {
+        self.name = name
+        self.attributes = attributes
+    }
 
 }

--- a/Source/Model/Analytics/AnalyticsLike.swift
+++ b/Source/Model/Analytics/AnalyticsLike.swift
@@ -51,17 +51,9 @@ public struct AnalyticsEvent {
 
 public typealias AnalyticsAttributes = [AnalyticsAttributeKey: AnalyticsAttributeValue]
 
-public extension AnalyticsAttributes {
-
-    var rawValue: [String: String] {
-        return mapKeys(\.rawValue).mapValues(\.rawValue)
-    }
-
-}
-
 /// A key denoting a particular analytics attribute.
 
-public struct AnalyticsAttributeKey: Hashable {
+public struct AnalyticsAttributeKey: Hashable, RawRepresentable {
 
     /// The unique string describing the key.
 
@@ -81,6 +73,55 @@ public protocol AnalyticsAttributeValue {
 
     /// The string representation of the value.
 
-    var rawValue: String { get }
+    var analyticsValue: String { get }
+
+}
+
+public extension Dictionary where Key: RawRepresentable, Key.RawValue == String, Value == AnalyticsAttributeValue {
+
+    /// A dictionary of raw values used to send to the analytics server.
+
+    var rawValue: [String: String] {
+        return mapKeys(\.rawValue).mapValues(\.analyticsValue)
+    }
+
+}
+
+extension UUID: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return transportString()
+    }
+
+}
+
+extension Int: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return String(describing: self)
+    }
+
+}
+
+extension String: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        return self
+    }
+
+}
+
+extension TeamRole: AnalyticsAttributeValue {
+
+    public var analyticsValue: String {
+        switch self {
+            case .member, .admin, .owner:
+                return "member"
+            case .partner:
+                return "external"
+            case .none:
+                return "wireless"
+        }
+    }
 
 }

--- a/Source/Model/Analytics/Dictionary+AnalyticsRawValue.swift
+++ b/Source/Model/Analytics/Dictionary+AnalyticsRawValue.swift
@@ -18,12 +18,12 @@
 
 import Foundation
 
-/// A type able to record analytic events.
+public extension Dictionary where Key: RawRepresentable, Key.RawValue == String, Value == AnalyticsAttributeValue {
 
-public protocol AnalyticsLike {
+    /// A dictionary of raw values used to send to the analytics server.
 
-    /// Record the given event.
-
-    func tagEvent(_ event: AnalyticsEvent)
+    var rawValue: [String: String] {
+        return mapKeys(\.rawValue).mapValues(\.analyticsValue)
+    }
 
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -395,6 +395,11 @@
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
 		EE3EFE9725305A84009499E5 /* ModifiedObjects+Mergeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */; };
 		EE3EFEA1253090E0009499E5 /* PotentialChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */; };
+		EE41468825C8B22500E750E8 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41468725C8B22500E750E8 /* AnalyticsEvent.swift */; };
+		EE41468A25C8B24300E750E8 /* AnalyticsAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41468925C8B24300E750E8 /* AnalyticsAttributes.swift */; };
+		EE41468C25C8B25700E750E8 /* AnalyticsAttributeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41468B25C8B25700E750E8 /* AnalyticsAttributeKey.swift */; };
+		EE41468E25C8B26D00E750E8 /* AnalyticsAttributeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41468D25C8B26D00E750E8 /* AnalyticsAttributeValue.swift */; };
+		EE41469025C8B29400E750E8 /* Dictionary+AnalyticsRawValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41468F25C8B29400E750E8 /* Dictionary+AnalyticsRawValue.swift */; };
 		EE42938A252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE429389252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift */; };
 		EE42938C252C443000E70670 /* ManagedObjectObserverToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42938B252C443000E70670 /* ManagedObjectObserverToken.swift */; };
 		EE42938E252C460000E70670 /* Changes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42938D252C460000E70670 /* Changes.swift */; };
@@ -1122,6 +1127,11 @@
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
 		EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModifiedObjects+Mergeable.swift"; sourceTree = "<group>"; };
 		EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetectorTests.swift; sourceTree = "<group>"; };
+		EE41468725C8B22500E750E8 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
+		EE41468925C8B24300E750E8 /* AnalyticsAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAttributes.swift; sourceTree = "<group>"; };
+		EE41468B25C8B25700E750E8 /* AnalyticsAttributeKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAttributeKey.swift; sourceTree = "<group>"; };
+		EE41468D25C8B26D00E750E8 /* AnalyticsAttributeValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAttributeValue.swift; sourceTree = "<group>"; };
+		EE41468F25C8B29400E750E8 /* Dictionary+AnalyticsRawValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+AnalyticsRawValue.swift"; sourceTree = "<group>"; };
 		EE429389252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+ManagedObjectObservation.swift"; sourceTree = "<group>"; };
 		EE42938B252C443000E70670 /* ManagedObjectObserverToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectObserverToken.swift; sourceTree = "<group>"; };
 		EE42938D252C460000E70670 /* Changes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Changes.swift; sourceTree = "<group>"; };
@@ -1678,6 +1688,11 @@
 			children = (
 				BF10B59E1E645A3A00E7036E /* Events */,
 				EE92C73725C608A700C4F13E /* AnalyticsLike.swift */,
+				EE41468725C8B22500E750E8 /* AnalyticsEvent.swift */,
+				EE41468925C8B24300E750E8 /* AnalyticsAttributes.swift */,
+				EE41468B25C8B25700E750E8 /* AnalyticsAttributeKey.swift */,
+				EE41468D25C8B26D00E750E8 /* AnalyticsAttributeValue.swift */,
+				EE41468F25C8B29400E750E8 /* Dictionary+AnalyticsRawValue.swift */,
 				BF10B5951E64591600E7036E /* AnalyticsType.swift */,
 				BF10B5961E64591600E7036E /* NSManagedObjectContext+Analytics.swift */,
 			);
@@ -3128,6 +3143,7 @@
 				165DC51F21491C0400090B7B /* Mention.swift in Sources */,
 				F9A706531CAEE01D00C2F5FE /* NSManagedObjectContext+zmessaging.m in Sources */,
 				F110503D2220439900F3EB62 /* ZMUser+RichProfile.swift in Sources */,
+				EE41468C25C8B25700E750E8 /* AnalyticsAttributeKey.swift in Sources */,
 				5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */,
 				F9A706571CAEE01D00C2F5FE /* NSNotification+ManagedObjectContextSave.m in Sources */,
 				BF491CE61F063EE50055EE44 /* AccountStore.swift in Sources */,
@@ -3242,12 +3258,14 @@
 				54E3EE411F616BA600A261E3 /* ZMAssetClientMessage.swift in Sources */,
 				EE429390252C466500E70670 /* ChangeInfoConsumer.swift in Sources */,
 				EE770DAF25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift in Sources */,
+				EE41468E25C8B26D00E750E8 /* AnalyticsAttributeValue.swift in Sources */,
 				16F6BB3A1EDEC2D6009EA803 /* ZMConversation+ObserverHelper.swift in Sources */,
 				16E0FBC923326B72000E3235 /* ConversationDirectory.swift in Sources */,
 				F99C5B8A1ED460E20049CCD7 /* TeamChangeInfo.swift in Sources */,
 				165124D221886EDB006A3C75 /* ZMOTRMessage+Quotes.swift in Sources */,
 				87D9CCE91F27606200AA4388 /* NSManagedObjectContext+TearDown.swift in Sources */,
 				F963E9711D9ADD5A00098AD3 /* ZMImageAssetEncryptionKeys.m in Sources */,
+				EE41468825C8B22500E750E8 /* AnalyticsEvent.swift in Sources */,
 				F11F3E891FA32463007B6D3D /* InvalidClientsRemoval.swift in Sources */,
 				F9FD75781E2F9A0600B4558B /* SearchUserObserverCenter.swift in Sources */,
 				54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */,
@@ -3273,6 +3291,7 @@
 				EEAAD75C252C6DAE00E6A44E /* ModifiedObjects.swift in Sources */,
 				F991CE1B1CB561B0004D8465 /* ZMAddressBookContact.m in Sources */,
 				87EFA3AC210F52C6004DFA53 /* ZMConversation+LastMessages.swift in Sources */,
+				EE41469025C8B29400E750E8 /* Dictionary+AnalyticsRawValue.swift in Sources */,
 				541D1B351F1FAE3C0078C1F2 /* ManagedObjectContextDirectory.swift in Sources */,
 				EEA9C5071F3C9F3500DC39EC /* PersistentStorageInitialization.swift in Sources */,
 				F9C877091E000C9D00792613 /* AssetCollection.swift in Sources */,
@@ -3288,6 +3307,7 @@
 				F9A706901CAEE01D00C2F5FE /* ZMUser.m in Sources */,
 				F14B7AFF2220302B00458624 /* ZMUser+Predicates.swift in Sources */,
 				066A96FF25A88E510083E317 /* BiometricsState.swift in Sources */,
+				EE41468A25C8B24300E750E8 /* AnalyticsAttributes.swift in Sources */,
 				EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */,
 				16DF3B5D2285B13100D09365 /* UserClientType.swift in Sources */,
 				54E3EE431F6194A400A261E3 /* ZMAssetClientMessage+GenericMessage.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

This is a part of an ongoing effort to refactor the analytics system to align it to the implementation spec and improving and cleaning up the code along the way.

### Changes

- Add conformances to `AnalyticsAttributeValue` for various types.
- Add a helper extension to produce a stringly typed dictionary. Useful to avoid repeatedly converting type safe attribute dictionaries.
- Move types to separate files for better readability.
