### PR TITLE
add mutedMessageTypes to SwiftConversationLike

### DIFF
--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -45,6 +45,8 @@ public protocol SwiftConversationLike {
     var teamType: TeamType? { get }
 
     var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
+
+    var mutedMessageTypes: MutedMessageTypes { get }
 }
 
 extension ZMConversation: ConversationLike {


### PR DESCRIPTION
## What's new in this PR?

Add `mutedMessageTypes` to `SwiftConversationLike` protocol to allow mocking that property.