### PR TITLE
[Fix] Feature insertion race condition

### DIFF
--- a/Patches/InvalidFeatureRemoval.swift
+++ b/Patches/InvalidFeatureRemoval.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum InvalidFeatureRemoval {
+
+    /// We had an issue where we were creating more than one instance of
+    /// `Feature` for a given name (there should be at most one). This patch
+    /// is to delete all instances of `Feature` in order to have a clean start.
+    /// This isn't a problem because the client creates its own default instance
+    /// and quickly fetches updates from the backend.
+
+    static func removeInvalid(in moc: NSManagedObjectContext) {
+        let fetchRequest = NSFetchRequest<Feature>(entityName: Feature.entityName())
+        let allInstances = moc.fetchOrAssert(request: fetchRequest)
+        allInstances.forEach(moc.delete)
+    }
+
+}

--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -36,7 +36,8 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "220.0.4", block: InvalidConnectionRemoval.removeInvalid),
         PersistedDataPatch(version: "234.0.0", block: TransferApplockKeychain.migrateKeychainItems),
         PersistedDataPatch(version: "234.1.1", block: InvalidConnectionRemoval.removeInvalid),
-        PersistedDataPatch(version: "236.0.0", block: MigrateSenderClient.migrateSenderClientID)
+        PersistedDataPatch(version: "236.0.0", block: MigrateSenderClient.migrateSenderClientID),
+        PersistedDataPatch(version: "243.0.0", block: InvalidFeatureRemoval.removeInvalid),
     ]
 
 }

--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -33,13 +33,10 @@ extension Team {
     /// - Parameter name: The name of the feature to refresh.
     
     public func enqueueBackendRefresh(for name: Feature.Name) {
-        guard let syncContext = managedObjectContext?.zm_sync else { return }
-
-        syncContext.performGroupedAndWait {
-            let feature = Feature.fetchOrCreate(name: name, team: self, context: $0)
-            feature.needsToBeUpdatedFromBackend = true
-        }
-
+        guard let context = managedObjectContext else { return }
+        
+        let feature = Feature.fetchOrCreate(name: name, team: self, context: context)
+        feature.needsToBeUpdatedFromBackend = true
     }
 
 }

--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -70,10 +70,13 @@ extension Team {
     /// - Parameter name: The name of the feature to refresh.
     
     public func enqueueBackendRefresh(for name: Feature.Name) {
-        guard let context = managedObjectContext else { return }
-        
-        let feature = Feature.fetchOrCreate(name: name, team: self, context: context)
-        feature.needsToBeUpdatedFromBackend = true
+        guard let syncContext = managedObjectContext?.zm_sync else { return }
+
+        syncContext.performGroupedAndWait {
+            let feature = Feature.fetchOrCreate(name: name, team: self, context: $0)
+            feature.needsToBeUpdatedFromBackend = true
+        }
+
     }
 
 }

--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -34,9 +34,9 @@ extension Team {
     
     public func enqueueBackendRefresh(for name: Feature.Name) {
         guard let context = managedObjectContext else { return }
-        
-        let feature = Feature.fetchOrCreate(name: name, team: self, context: context)
-        feature.needsToBeUpdatedFromBackend = true
+
+        let feature = Feature.fetch(name: name, context: context)
+        feature?.needsToBeUpdatedFromBackend = true
     }
 
 }

--- a/Source/Model/Conversation/Team+Feature.swift
+++ b/Source/Model/Conversation/Team+Feature.swift
@@ -22,45 +22,8 @@ extension Team {
 
     @NSManaged private var features: Set<Feature>
 
-    /// Fetch a particular team feature.
-    ///
-    /// If no instance exists yet in the database, a default one will be created
-    /// using the parameterless initializer for `T`.
-    ///
-    /// - Parameters:
-    ///     - type: The type of the desired feature. The available features
-    ///             are typically found in the namespace `Feature`.
-    ///
-    /// - Returns:
-    ///     The feature object.
-
-    public func feature<T: FeatureLike>(for featureType: T.Type) -> T {
-        guard let feature = features.first(where: { $0.name == T.name }) else {
-            return createAndStoreDefault(for: featureType)
-        }
-
-        guard let result = T(feature: feature) else {
-            fatalError("Failed to create feature wrapper for name: \(T.name)")
-        }
-
-        return result
-    }
-    
     func feature(for name: Feature.Name) -> Feature? {
         return features.first(where: { $0.name == name })
-    }
-
-    private func createAndStoreDefault<T: FeatureLike>(for type: T.Type) -> T {
-        let defaultInstance = T()
-
-        guard
-            let context = managedObjectContext,
-            let _ = try? defaultInstance.store(for: self, in: context)
-        else {
-            fatalError("Failed to store default instance for feature: \(T.name)")
-        }
-
-        return defaultInstance
     }
 
     /// Enqueue a backend refresh for the feature with the given name.

--- a/Source/Model/FeatureConfig/AppLock/AppLockController.swift
+++ b/Source/Model/FeatureConfig/AppLock/AppLockController.swift
@@ -73,16 +73,18 @@ public final class AppLockController: AppLockType {
     private let baseConfig: Config
     
     public var config: Config {
-        guard let team = selfUser.team else {
+        guard
+            let team = selfUser.team,
+            let feature = team.feature(for: .appLock),
+            let appLock = Feature.AppLock(feature: feature)
+        else {
             return baseConfig
         }
-        
-        let feature = team.feature(for: Feature.AppLock.self)
-        
+
         var result = baseConfig
-        result.forceAppLock = baseConfig.forceAppLock || feature.config.enforceAppLock
-        result.appLockTimeout = feature.config.inactivityTimeoutSecs
-        result.isAvailable = (feature.status == .enabled)
+        result.forceAppLock = baseConfig.forceAppLock || appLock.config.enforceAppLock
+        result.appLockTimeout = appLock.config.inactivityTimeoutSecs
+        result.isAvailable = (appLock.status == .enabled)
         
         return result
     }

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -138,11 +138,11 @@ public class Feature: ZMManagedObject {
     }
     
     @discardableResult
-    public static func insert(name: Name,
-                              status: Status,
-                              config: Data?,
-                              team: Team,
-                              context: NSManagedObjectContext) -> Feature {
+    static func insert(name: Name,
+                       status: Status,
+                       config: Data?,
+                       team: Team,
+                       context: NSManagedObjectContext) -> Feature {
 
         // There should be at most one instance per feature, so only allow inserting
         // on a single context to avoid race conditions.

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -165,13 +165,12 @@ public class Feature: ZMManagedObject {
         }
     }
 
-    @discardableResult
-    static func insert(name: Name,
-                       status: Status,
-                       config: Data?,
-                       team: Team,
-                       context: NSManagedObjectContext) -> Feature {
-        
+    private static func insert(name: Name,
+                               status: Status,
+                               config: Data?,
+                               team: Team,
+                               context: NSManagedObjectContext) {
+
         // There should be at most one instance per feature, so only allow inserting
         // on a single context to avoid race conditions.
         assert(context.zm_isSyncContext, "Can only insert `Feature` instance on the sync context")
@@ -181,7 +180,6 @@ public class Feature: ZMManagedObject {
         feature.status = status
         feature.config = config
         feature.team = team
-        return feature
     }
 
     public func updateNeedsToNotifyUser(oldData: Data?, newData: Data?) {

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -166,6 +166,11 @@ public class Feature: ZMManagedObject {
                               config: Data?,
                               team: Team,
                               context: NSManagedObjectContext) -> Feature {
+
+        // There should be at most one instance per feature, so only allow inserting
+        // on a single context to avoid race conditions.
+        assert(context.zm_isSyncContext, "Can only insert `Feature` instance on the sync context")
+
         let feature = Feature.insertNewObject(in: context)
         feature.name = name
         feature.status = status

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -138,26 +138,9 @@ public class Feature: ZMManagedObject {
         return feature
     }
 
-    @discardableResult
-    public static func createOrUpdate(name: Name,
-                                      status: Status,
-                                      config: Data?,
-                                      team: Team,
-                                      context: NSManagedObjectContext) -> Feature {
-        if let existing = fetch(name: name, context: context) {
-            existing.status = status
-            existing.config = config
-            existing.team = team
-            existing.needsToBeUpdatedFromBackend = false
-            return existing
-        }
-        
-        let feature = insert(name: name,
-                             status: status,
-                             config: config,
-                             team: team,
-                             context: context)
-        return feature
+    public static func update(havingName name: Name, in context: NSManagedObjectContext, changes: (Feature) -> Void) {
+        guard let existing = fetch(name: name, context: context) else { return }
+        changes(existing)
     }
     
     @discardableResult

--- a/Source/Model/FeatureConfig/FeatureLike.swift
+++ b/Source/Model/FeatureConfig/FeatureLike.swift
@@ -55,15 +55,17 @@ public protocol FeatureLike: Codable {
 
 public extension FeatureLike {
 
-    /// Store the feature in the given context as an instance of `Feature`.
+    /// Store the feature in the given context as an instance of `Feature`,
+    /// if it exists in the database.
 
-    @discardableResult
-    func store(for team: Team, in context: NSManagedObjectContext) throws -> Feature {
-        return Feature.insert(name: Self.name,
-                              status: status,
-                              config: try JSONEncoder().encode(config),
-                              team: team,
-                              context: context)
+    func store(for team: Team, in context: NSManagedObjectContext) throws {
+        let configData = try JSONEncoder().encode(config)
+
+        Feature.update(havingName: Self.name, in: context) {
+            $0.status = status
+            $0.config = configData
+            $0.team = team
+        }
     }
 
 }

--- a/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
+++ b/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
@@ -112,7 +112,8 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
 
             let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
             let configData = try? JSONEncoder().encode(config)
-            _ = Feature.createOrUpdate(
+
+            _ = Feature.insert(
                 name: .appLock,
                 status: .disabled,
                 config: configData,
@@ -141,7 +142,8 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
 
             let config = Feature.AppLock.Config.init(enforceAppLock: false, inactivityTimeoutSecs: 30)
             let configData = try? JSONEncoder().encode(config)
-            _ = Feature.createOrUpdate(
+
+            _ = Feature.insert(
                 name: .appLock,
                 status: .disabled,
                 config: configData,
@@ -170,7 +172,8 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
 
             let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
             let configData = try? JSONEncoder().encode(config)
-            _ = Feature.createOrUpdate(
+
+            _ = Feature.insert(
                 name: .appLock,
                 status: .disabled,
                 config: configData,

--- a/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
+++ b/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTest.swift
@@ -23,27 +23,10 @@ import LocalAuthentication
 final class AppLockControllerTest: ZMBaseManagedObjectTest {
     
     let decoder = JSONDecoder()
-    var selfUser: ZMUser!
-    var sut: AppLockController!
-    
-    override func setUp() {
-        super.setUp()
-        
-        selfUser = ZMUser.selfUser(in: uiMOC)
-        sut = createAppLockController()
-    }
-    
-    override func tearDown() {
-        selfUser = nil
-        sut = nil
-        
-        super.tearDown()
-    }
 
     func testThatForcedAppLockDoesntAffectSettings() {
-        
         //given
-        sut = createAppLockController(forceAppLock: true)
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC), forceAppLock: true)
         XCTAssertTrue(sut.config.forceAppLock)
         
         //when
@@ -55,8 +38,8 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
     }
     
     func testThatAppLockAffectsSettings() {
-
         //given
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC))
         XCTAssertFalse(sut.config.forceAppLock)
         sut.isActive = true
 
@@ -71,6 +54,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
     
     func testThatBiometricsChangedIsTrueIfDomainStatesDiffer() {
         //given
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC))
         UserDefaults.standard.set(Data(), forKey: "DomainStateKey")
         
         let context = LAContext()
@@ -84,6 +68,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
     
     func testThatBiometricsChangedIsFalseIfDomainStatesDontDiffer() {
         //given
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC))
         let context = LAContext()
         var error: NSError?
         context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error)
@@ -96,6 +81,7 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
     
     func testThatBiometricsStatePersistsState() {
         //given
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC))
         let evaluatedPolicyDomainStateData = "test".data(using: .utf8)
         UserDefaults.standard.set(evaluatedPolicyDomainStateData, forKey: "DomainStateKey")
         
@@ -111,81 +97,92 @@ final class AppLockControllerTest: ZMBaseManagedObjectTest {
     }
 
     func testThatItHonorsTheTeamConfiguration_WhenSelfUserIsATeamUser() {
-        
-        //given
-        XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isAvailable)
-        XCTAssertEqual(sut.config.appLockTimeout, 900)
-        
-        //when
-        let team = createTeam(in: uiMOC)
-        _ = createMembership(in: uiMOC, user: selfUser, team: team)
-        
-        let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
-        let configData = try? JSONEncoder().encode(config)
-        _ = Feature.createOrUpdate(
-            name: .appLock,
-            status: .disabled,
-            config: configData,
-            team: team,
-            context: uiMOC
-        )
-        
-        //then
-        XCTAssertTrue(sut.config.forceAppLock)
-        XCTAssertFalse(sut.config.isAvailable)
-        XCTAssertEqual(sut.config.appLockTimeout, 30)
+        syncMOC.performGroupedAndWait { context in
+            //given
+            let selfUser = ZMUser.selfUser(in: context)
+            let sut = self.createAppLockController(selfUser: selfUser)
+
+            XCTAssertFalse(sut.config.forceAppLock)
+            XCTAssertTrue(sut.config.isAvailable)
+            XCTAssertEqual(sut.config.appLockTimeout, 900)
+
+            //when
+            let team = self.createTeam(in: context)
+            _ = self.createMembership(in: context, user: selfUser, team: team)
+
+            let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
+            let configData = try? JSONEncoder().encode(config)
+            _ = Feature.createOrUpdate(
+                name: .appLock,
+                status: .disabled,
+                config: configData,
+                team: team,
+                context: context
+            )
+
+            //then
+            XCTAssertTrue(sut.config.forceAppLock)
+            XCTAssertFalse(sut.config.isAvailable)
+            XCTAssertEqual(sut.config.appLockTimeout, 30)
+        }
     }
     
     func testThatItHonorsForcedAppLockFromTheBaseConfiguration() {
-        
-        //given
-        sut = createAppLockController(forceAppLock: true)
-        XCTAssertTrue(sut.config.forceAppLock)
-        
-        //when
-        let team = createTeam(in: uiMOC)
-        _ = createMembership(in: uiMOC, user: selfUser, team: team)
-        
-        let config = Feature.AppLock.Config.init(enforceAppLock: false, inactivityTimeoutSecs: 30)
-        let configData = try? JSONEncoder().encode(config)
-        _ = Feature.createOrUpdate(
-            name: .appLock,
-            status: .disabled,
-            config: configData,
-            team: team,
-            context: uiMOC
-        )
-        
-        //then
-        XCTAssertTrue(sut.config.forceAppLock)
+        syncMOC.performGroupedAndWait { context in
+            //given
+            let selfUser = ZMUser.selfUser(in: context)
+            let sut = self.createAppLockController(selfUser: selfUser, forceAppLock: true)
+
+            XCTAssertTrue(sut.config.forceAppLock)
+
+            //when
+            let team = self.createTeam(in: context)
+            _ = self.createMembership(in: context, user: selfUser, team: team)
+
+            let config = Feature.AppLock.Config.init(enforceAppLock: false, inactivityTimeoutSecs: 30)
+            let configData = try? JSONEncoder().encode(config)
+            _ = Feature.createOrUpdate(
+                name: .appLock,
+                status: .disabled,
+                config: configData,
+                team: team,
+                context: context
+            )
+
+            //then
+            XCTAssertTrue(sut.config.forceAppLock)
+        }
     }
     
     func testThatItDoesNotHonorTheTeamConfiguration_WhenSelfUserIsNotATeamUser() {
-        
-        //given
-        XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isAvailable)
-        XCTAssertEqual(sut.config.appLockTimeout, 900)
-        
-        //when
-        let team = createTeam(in: uiMOC)
-        XCTAssertNil(selfUser.team)
-        
-        let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
-        let configData = try? JSONEncoder().encode(config)
-        _ = Feature.createOrUpdate(
-            name: .appLock,
-            status: .disabled,
-            config: configData,
-            team: team,
-            context: uiMOC
-        )
-        
-        //then
-        XCTAssertFalse(sut.config.forceAppLock)
-        XCTAssertTrue(sut.config.isAvailable)
-        XCTAssertNotEqual(sut.config.appLockTimeout, 30)
+        syncMOC.performGroupedAndWait { context in
+            //given
+            let selfUser = ZMUser.selfUser(in: context)
+            let sut = self.createAppLockController(selfUser: selfUser)
+
+            XCTAssertFalse(sut.config.forceAppLock)
+            XCTAssertTrue(sut.config.isAvailable)
+            XCTAssertEqual(sut.config.appLockTimeout, 900)
+
+            //when
+            let team = self.createTeam(in: context)
+            XCTAssertNil(selfUser.team)
+
+            let config = Feature.AppLock.Config.init(enforceAppLock: true, inactivityTimeoutSecs: 30)
+            let configData = try? JSONEncoder().encode(config)
+            _ = Feature.createOrUpdate(
+                name: .appLock,
+                status: .disabled,
+                config: configData,
+                team: team,
+                context: context
+            )
+
+            //then
+            XCTAssertFalse(sut.config.forceAppLock)
+            XCTAssertTrue(sut.config.isAvailable)
+            XCTAssertNotEqual(sut.config.appLockTimeout, 30)
+        }
     }
 }
 
@@ -237,7 +234,7 @@ extension AppLockControllerTest {
     typealias Input = (scenario: AppLockController.AuthenticationScenario, canEvaluate: Bool, biometricsChanged: Bool)
     
     private func assert(input: Input, output: AppLockController.AuthenticationResult, file: StaticString = #file, line: UInt = #line) {
-        
+        let sut = createAppLockController(selfUser: .selfUser(in: uiMOC))
         let context = MockLAContext(canEvaluate: input.canEvaluate)
         sut.biometricsState = MockBiometricsState(didChange: input.biometricsChanged)
         
@@ -249,7 +246,7 @@ extension AppLockControllerTest {
         }
     }
     
-    private func createAppLockController(useBiometricsOrCustomPasscode: Bool = false, forceAppLock: Bool = false, timeOut: UInt = 900) -> AppLockController {
+    private func createAppLockController(selfUser: ZMUser, useBiometricsOrCustomPasscode: Bool = false, forceAppLock: Bool = false, timeOut: UInt = 900) -> AppLockController {
         let config = AppLockController.Config(useBiometricsOrCustomPasscode: useBiometricsOrCustomPasscode,
                                               forceAppLock: forceAppLock,
                                               timeOut: timeOut)

--- a/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
+++ b/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
@@ -185,6 +185,7 @@ extension FeatureTests {
 
 extension Feature {
 
+    @discardableResult
     static func insert(name: Name,
                        status: Status,
                        config: Data?,

--- a/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
+++ b/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
@@ -182,3 +182,21 @@ extension FeatureTests {
         }()
     }
 }
+
+extension Feature {
+
+    static func insert(name: Name,
+                       status: Status,
+                       config: Data?,
+                       team: Team,
+                       context: NSManagedObjectContext) -> Feature {
+
+        let feature = Feature.insertNewObject(in: context)
+        feature.name = name
+        feature.status = status
+        feature.config = config
+        feature.team = team
+        return feature
+    }
+
+}

--- a/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
+++ b/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
@@ -82,6 +82,21 @@ final class FeatureTests: ZMBaseManagedObjectTest {
             XCTAssertNotNil(fetchedFeature)
         }
     }
+
+    func testItCreatesADefaultInstance() {
+        syncMOC.performGroupedAndWait { context in
+            // Given
+            let team = self.createTeam(in: context)
+
+            XCTAssertNil(Feature.fetch(name: .appLock, context: context))
+
+            // When
+            Feature.createDefaultInstanceIfNeeded(name: .appLock, team: team, context: context)
+
+            // Then
+            XCTAssertNotNil(Feature.fetch(name: .appLock, context: context))
+        }
+    }
     
     func testThatItUpdatesNeedsToNotifyUserFlag_IfAppLockBecameForced() {
         syncMOC.performGroupedAndWait { context in

--- a/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
+++ b/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
@@ -29,11 +29,11 @@ final class FeatureTests: ZMBaseManagedObjectTest {
             let team = self.createTeam(in: context)
 
             // when
-            let feature = Feature.createOrUpdate(name: .appLock,
-                                                 status: .enabled,
-                                                 config: self.configData(enforced: false),
-                                                 team: team,
-                                                 context: context)
+            let feature = Feature.insert(name: .appLock,
+                                         status: .enabled,
+                                         config: self.configData(enforced: false),
+                                         team: team,
+                                         context: context)
             // then
             let fetchedFeature = Feature.fetch(name: .appLock, context: context)
             XCTAssertEqual(feature, fetchedFeature)
@@ -54,11 +54,9 @@ final class FeatureTests: ZMBaseManagedObjectTest {
             XCTAssertEqual(feature.status, .enabled)
 
             // when
-            let _ = Feature.createOrUpdate(name: .appLock,
-                                           status: .disabled,
-                                           config: self.configData(enforced: false),
-                                           team: team,
-                                           context: context)
+            Feature.update(havingName: .appLock, in: context) {
+                $0.status = .disabled
+            }
 
             // then
             XCTAssertEqual(feature.status, .disabled)
@@ -70,11 +68,11 @@ final class FeatureTests: ZMBaseManagedObjectTest {
             // given
             let team = self.createTeam(in: context)
 
-            let _ = Feature.createOrUpdate(name: .appLock,
-                                           status: .enabled,
-                                           config: self.configData(enforced: false),
-                                           team: team,
-                                           context: context)
+            let _ = Feature.insert(name: .appLock,
+                                   status: .enabled,
+                                   config: self.configData(enforced: false),
+                                   team: team,
+                                   context: context)
 
 
             // when
@@ -104,11 +102,10 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
             // when
             let newConfigData = self.configData(enforced: true)
-            let _ = Feature.createOrUpdate(name: .appLock,
-                                           status: .enabled,
-                                           config: newConfigData,
-                                           team: team,
-                                           context: context)
+
+            Feature.update(havingName: .appLock, in: context) {
+                $0.config = newConfigData
+            }
 
             let newConfig = try? decoder.decode(Feature.AppLock.Config.self, from: newConfigData)
             XCTAssertTrue(newConfig!.enforceAppLock)
@@ -139,11 +136,10 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
             // when
             let newConfigData = self.configData(enforced: false)
-            let _ = Feature.createOrUpdate(name: .appLock,
-                                           status: .enabled,
-                                           config: newConfigData,
-                                           team: team,
-                                           context: context)
+
+            Feature.update(havingName: .appLock, in: context) {
+                $0.config = newConfigData
+            }
 
             let newConfig = try? decoder.decode(Feature.AppLock.Config.self, from: newConfigData)
             XCTAssertFalse(newConfig!.enforceAppLock)

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -220,7 +220,7 @@ final class TeamTests: ZMConversationTestsBase {
             // Given
             let sut = self.createTeam(in: context)
 
-            let feature = Feature.createOrUpdate(
+            let feature = Feature.insert(
                 name: .appLock,
                 status: .enabled,
                 config: nil,

--- a/Tests/Source/Model/TeamTests.swift
+++ b/Tests/Source/Model/TeamTests.swift
@@ -215,62 +215,27 @@ final class TeamTests: ZMConversationTestsBase {
 
     // MARK: - Features
 
-    func testItCreatesDefaultsUponFirstAccess() {
-        let sut = createTeam(in: uiMOC)
-
-        for name in Feature.Name.allCases {
-            switch name {
-            case .appLock:
-                // Given
-                XCTAssertNil(Feature.fetch(name: .appLock, context: uiMOC))
-
-                // When
-                let appLock1 = sut.feature(for: Feature.AppLock.self)
-
-                // Then
-                XCTAssertEqual(appLock1.status, .enabled)
-                XCTAssertEqual(appLock1.config.enforceAppLock, false)
-                XCTAssertEqual(appLock1.config.inactivityTimeoutSecs, 60)
-            }
-        }
-    }
-
     func testItEnqueuesBackendRefreshForFeature_WhenFeatureExistsInCoreData() {
-        // Given
-        let sut = createTeam(in: uiMOC)
+        syncMOC.performGroupedAndWait { context in
+            // Given
+            let sut = self.createTeam(in: context)
 
-        let feature = Feature.createOrUpdate(
-            name: .appLock,
-            status: .enabled,
-            config: nil,
-            team: sut,
-            context: uiMOC
-        )
+            let feature = Feature.createOrUpdate(
+                name: .appLock,
+                status: .enabled,
+                config: nil,
+                team: sut,
+                context: context
+            )
 
-        XCTAssertFalse(feature.needsToBeUpdatedFromBackend)
+            XCTAssertFalse(feature.needsToBeUpdatedFromBackend)
 
-        // When
-        sut.enqueueBackendRefresh(for: .appLock)
+            // When
+            sut.enqueueBackendRefresh(for: .appLock)
 
-        // Then
-        XCTAssertTrue(feature.needsToBeUpdatedFromBackend)
-    }
-    
-    func testItEnqueuesBackendRefreshForFeature_WhenThereIsNoFeatureInCoreData() {
-        // Given
-        let sut = createTeam(in: uiMOC)
-        XCTAssertNil(Feature.fetch(name: .appLock, context: uiMOC))
-        
-        // When
-        sut.enqueueBackendRefresh(for: .appLock)
-
-        // Then
-        guard let feature = Feature.fetch(name: .appLock, context: uiMOC) else {
-            XCTFail()
-            return
+            // Then
+            XCTAssertTrue(feature.needsToBeUpdatedFromBackend)
         }
-        
-        XCTAssertTrue(feature.needsToBeUpdatedFromBackend)
     }
     
 }

--- a/Tests/Source/Utils/InvalidFeatureRemovalTests.swift
+++ b/Tests/Source/Utils/InvalidFeatureRemovalTests.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class InvalidFeatureRemovalTests: DiskDatabaseTest {
+
+    func testAllInstancesRemoved() throws {
+        contextDirectory.syncContext.performGroupedAndWait { context in
+            // Given
+            let team = Team.insertNewObject(in: context)
+            team.remoteIdentifier = UUID()
+
+            Feature.insert(name: .appLock, status: .enabled, config: nil, team: team, context: context)
+            Feature.insert(name: .appLock, status: .disabled, config: nil, team: team, context: context)
+
+            XCTAssertEqual(self.fetchInstances(in: context).count, 2)
+
+            // When
+            InvalidFeatureRemoval.removeInvalid(in: context)
+
+            // Then
+            XCTAssertEqual(self.fetchInstances(in: context).count, 0)
+        }
+    }
+
+    private func fetchInstances(in context: NSManagedObjectContext) -> [Feature] {
+        let fetchRequest = NSFetchRequest<Feature>(entityName: Feature.entityName())
+        return context.fetchOrAssert(request: fetchRequest)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -390,6 +390,8 @@
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
 		EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */; };
+		EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */; };
+		EE2BA00925CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */; };
 		EE30F4592592423F000FC69C /* AppLockController+Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30F4582592423F000FC69C /* AppLockController+Passcode.swift */; };
 		EE30F45B2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30F45A2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift */; };
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
@@ -1116,6 +1118,8 @@
 		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
 		EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagedObjectContextDirectory+EncryptionAtRest.swift"; sourceTree = "<group>"; };
+		EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidFeatureRemoval.swift; sourceTree = "<group>"; };
+		EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidFeatureRemovalTests.swift; sourceTree = "<group>"; };
 		EE30F4582592423F000FC69C /* AppLockController+Passcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppLockController+Passcode.swift"; sourceTree = "<group>"; };
 		EE30F45A2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockController.PasscodeKeychainItem.swift; sourceTree = "<group>"; };
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
@@ -1543,6 +1547,7 @@
 				1639A8122260916E00868AB9 /* AlertAvailabilityBehaviourChange.swift */,
 				0660FEBC2580E4A900F4C19F /* TransferApplockKeychain.swift */,
 				169315EE25AC4C8100709F15 /* MigrateSenderClient.swift */,
+				EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */,
 			);
 			path = Patches;
 			sourceTree = "<group>";
@@ -1612,6 +1617,7 @@
 				16E6F26524B8952F0015B249 /* EncryptionKeysTests.swift */,
 				0630E4BE257FA2BD00C75BFB /* TransferAppLockKeychainTests.swift */,
 				169315F025AC501300709F15 /* MigrateSenderClientTests.swift */,
+				EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -3181,6 +3187,7 @@
 				541D1B331F1F8D660078C1F2 /* StorageStack.swift in Sources */,
 				BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */,
 				16E6F26424B614DC0015B249 /* EncryptionKeys.swift in Sources */,
+				EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */,
 				1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */,
 				63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */,
 				BF3493F21EC3623200B0C314 /* ZMUser+Teams.swift in Sources */,
@@ -3494,6 +3501,7 @@
 				EE3EFEA1253090E0009499E5 /* PotentialChangeDetectorTests.swift in Sources */,
 				1684141722282A1A00FCB9BC /* TransferStateMigrationTests.swift in Sources */,
 				16DF3B5F2289510600D09365 /* ZMConversationTests+Legalhold.swift in Sources */,
+				EE2BA00925CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift in Sources */,
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				16C391E2214BD438003AB3AD /* MentionTests.swift in Sources */,
 				F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We assert that there can only be a maximum of one instance of `Feature` for any given feature name, however this assertion is failing sometimes.

### Causes

While we have checks to only insert a feature instance if none is present, it is possible that two instance can be created simultaneously from different contexts.

### Solutions

Previously we were trying to create default instances when trying to fetch an instance and finding that it wasn't created yet. This is a **lazy** approach.This over-complicates things and makes it difficult to reason about when we're inserting feature instances and in which context.

Instead I think we should take an **eager** approach and try to create the default instances (if needed) as early as possible so that it is available for use immediately. This simplifies things a lot since we can create a single method to create the default instances which will do all the checking internally. This will be the only way that an instance can be created. Furthermore, we restrict using this method on the sync context only to ensure that two instances can't be created simultaneously.
