### PR TITLE
add verifyLegalHoldSubjects and sortedActiveParticipantsUserTypes to ConversationLike

### DIFF
--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -35,6 +35,8 @@ public protocol ConversationLike: NSObjectProtocol {
 
     var isUnderLegalHold: Bool { get }
     var securityLevel: ZMConversationSecurityLevel { get }
+    
+    func verifyLegalHoldSubjects()
 }
 
 // Since ConversationLike must have @objc signature(@objc UserType has a ConversationLike property), create another protocol to abstract Swift only properties
@@ -47,6 +49,8 @@ public protocol SwiftConversationLike {
     var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
 
     var mutedMessageTypes: MutedMessageTypes { get }
+
+    var sortedActiveParticipantsUserTypes: [UserType] { get }
 }
 
 extension ZMConversation: ConversationLike {

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -37,6 +37,8 @@ public protocol ConversationLike: NSObjectProtocol {
     var securityLevel: ZMConversationSecurityLevel { get }
     
     func verifyLegalHoldSubjects()
+
+    var sortedActiveParticipantsUserTypes: [UserType] { get }
 }
 
 // Since ConversationLike must have @objc signature(@objc UserType has a ConversationLike property), create another protocol to abstract Swift only properties
@@ -49,8 +51,6 @@ public protocol SwiftConversationLike {
     var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout? { get }
 
     var mutedMessageTypes: MutedMessageTypes { get }
-
-    var sortedActiveParticipantsUserTypes: [UserType] { get }
 }
 
 extension ZMConversation: ConversationLike {

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -92,6 +92,10 @@ extension ZMConversation: SwiftConversationLike {
     @NSManaged @objc dynamic internal var accessModeStrings: [String]?
     @NSManaged @objc dynamic internal var accessRoleString: String?
     
+    public var sortedActiveParticipantsUserTypes: [UserType] {
+        return sortedActiveParticipants
+    }
+
     public var teamType: TeamType? {
         return team
     }


### PR DESCRIPTION
## What's new in this PR?

Add `verifyLegalHoldSubjects` and `sortedActiveParticipantsUserTypes` to `ConversationLike` protocol to allow legal hold tests in UI project to mock these properties.