### PR TITLE
Add UserType getter to ReadReceipt

### DIFF
--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -41,6 +41,10 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
     @NSManaged open var message: ZMMessage
     @NSManaged open var user: ZMUser
 
+    public var userType: UserType {
+        return user
+    }
+
     override open class func entityName() -> String {
         return "MessageConfirmation"
     }

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -36,6 +36,7 @@ public enum ZMDeliveryState : UInt {
 public protocol ReadReceipt {
     
     var user: ZMUser { get }
+    var userType: UserType { get }
     var serverTimestamp: Date? { get }
     
 }

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -35,8 +35,10 @@ public enum ZMDeliveryState : UInt {
 @objc
 public protocol ReadReceipt {
     
+    @available(*, deprecated, message: "Use `userType` instead")
     var user: ZMUser { get }
     var userType: UserType { get }
+
     var serverTimestamp: Date? { get }
     
 }


### PR DESCRIPTION
## What's new in this PR?

Add `UserType` property `userType` to `ReadReceipt` protocol to allow mocking `NSManaged` `user` property