### PR TITLE
Define RoundedInt (Part 3)

### DIFF
--- a/Source/Model/Analytics/AnalyticsAttributeValue.swift
+++ b/Source/Model/Analytics/AnalyticsAttributeValue.swift
@@ -54,6 +54,14 @@ public struct RoundedInt: AnalyticsAttributeValue {
 
 }
 
+public extension Int {
+
+    func rounded(byFactor factor: Int) -> RoundedInt {
+        return RoundedInt(self, factor: factor)
+    }
+
+}
+
 extension UUID: AnalyticsAttributeValue {
 
     public var analyticsValue: String {

--- a/Source/Model/Analytics/AnalyticsAttributeValue.swift
+++ b/Source/Model/Analytics/AnalyticsAttributeValue.swift
@@ -28,18 +28,36 @@ public protocol AnalyticsAttributeValue {
 
 }
 
-extension UUID: AnalyticsAttributeValue {
+/// An numeric container used to protect the privacy of integer values.
+///
+/// This is achieved by rounding an exact value by a certain factor. The
+/// rounding is logarithmic, meaning that small numbers are only slighly
+/// rounded whereas larger numbers will be rounded more. This kind of
+/// rounding is roughly equivalent to having buckets of increasing size.
 
-    public var analyticsValue: String {
-        return transportString()
+public struct RoundedInt: AnalyticsAttributeValue {
+
+    public let analyticsValue: String
+
+    /// Create a rounded integer by a certain factor.
+    ///
+    /// - Parameters:
+    ///     - exactValue: The integer value to round.
+    ///     - factor: Determines how much the value is rounded.
+
+    public init(_ exactValue: Int, factor: Int) {
+        let exactValue = Double(exactValue)
+        let factor = Double(factor)
+        let roundedValue = Int(ceil(pow(2, (floor(factor * log2(exactValue)) / factor))))
+        analyticsValue = String(describing: roundedValue)
     }
 
 }
 
-extension Int: AnalyticsAttributeValue {
+extension UUID: AnalyticsAttributeValue {
 
     public var analyticsValue: String {
-        return String(describing: self)
+        return transportString()
     }
 
 }

--- a/Tests/Source/Utils/AnalyticsAttributeValueTests.swift
+++ b/Tests/Source/Utils/AnalyticsAttributeValueTests.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class AnalyticsAttributeValueTests: XCTestCase {
+
+    func testRoundedInt() {
+        // Given
+        let factor = 2
+        var countByBucket = [String: Int]()
+
+        // When 500 numbers are rounded.
+        for exactValue in 0..<500 {
+            let roundedValue = RoundedInt(exactValue, factor: factor).analyticsValue
+            let existingCount = countByBucket[roundedValue] ?? 0
+            countByBucket[roundedValue] = existingCount + 1
+        }
+
+        // Then there are 18 buckets with exact frequencies.
+        XCTAssertEqual(countByBucket.keys.count, 18)
+        XCTAssertEqual(countByBucket["0"], 1)
+        XCTAssertEqual(countByBucket["1"], 1)
+        XCTAssertEqual(countByBucket["2"], 1)
+        XCTAssertEqual(countByBucket["3"], 1)
+        XCTAssertEqual(countByBucket["4"], 2)
+        XCTAssertEqual(countByBucket["6"], 2)
+        XCTAssertEqual(countByBucket["8"], 4)
+        XCTAssertEqual(countByBucket["12"], 4)
+        XCTAssertEqual(countByBucket["16"], 7)
+        XCTAssertEqual(countByBucket["23"], 9)
+        XCTAssertEqual(countByBucket["32"], 14)
+        XCTAssertEqual(countByBucket["46"], 18)
+        XCTAssertEqual(countByBucket["64"], 27)
+        XCTAssertEqual(countByBucket["91"], 37)
+        XCTAssertEqual(countByBucket["128"], 54)
+        XCTAssertEqual(countByBucket["182"], 74)
+        XCTAssertEqual(countByBucket["256"], 107)
+        XCTAssertEqual(countByBucket["363"], 137)
+    }
+
+}

--- a/Tests/Source/Utils/AnalyticsAttributeValueTests.swift
+++ b/Tests/Source/Utils/AnalyticsAttributeValueTests.swift
@@ -28,7 +28,7 @@ class AnalyticsAttributeValueTests: XCTestCase {
 
         // When 500 numbers are rounded.
         for exactValue in 0..<500 {
-            let roundedValue = RoundedInt(exactValue, factor: factor).analyticsValue
+            let roundedValue = exactValue.rounded(byFactor: factor).analyticsValue
             let existingCount = countByBucket[roundedValue] ?? 0
             countByBucket[roundedValue] = existingCount + 1
         }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -388,12 +388,12 @@
 		D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CA2063ECD400716618 /* BackupMetadataTests.swift */; };
 		D5FA30CF2063F8EC00716618 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30CE2063F8EC00716618 /* Version.swift */; };
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
+		EE05CD1925DD5E2D00777A25 /* AnalyticsAttributeValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE05CD1825DD5E2D00777A25 /* AnalyticsAttributeValueTests.swift */; };
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
 		EE2B874624D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */; };
 		EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */; };
 		EE2BA00925CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */; };
-		EE30F4592592423F000FC69C /* AppLockController+Passcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30F4582592423F000FC69C /* AppLockController+Passcode.swift */; };
 		EE30F45B2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30F45A2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift */; };
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
 		EE3EFE9725305A84009499E5 /* ModifiedObjects+Mergeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */; };
@@ -1134,12 +1134,12 @@
 		D5FA30CE2063F8EC00716618 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		D5FA30D02063FD3A00716618 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 		D5FD9FD32073B94500F6F4FC /* zmessaging2.45.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.45.0.xcdatamodel; sourceTree = "<group>"; };
+		EE05CD1825DD5E2D00777A25 /* AnalyticsAttributeValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAttributeValueTests.swift; sourceTree = "<group>"; };
 		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
 		EE2B874524D9A11A00936A4E /* ManagedObjectContextDirectory+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagedObjectContextDirectory+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidFeatureRemoval.swift; sourceTree = "<group>"; };
 		EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidFeatureRemovalTests.swift; sourceTree = "<group>"; };
-		EE30F4582592423F000FC69C /* AppLockController+Passcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppLockController+Passcode.swift"; sourceTree = "<group>"; };
 		EE30F45A2592A357000FC69C /* AppLockController.PasscodeKeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockController.PasscodeKeychainItem.swift; sourceTree = "<group>"; };
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
 		EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModifiedObjects+Mergeable.swift"; sourceTree = "<group>"; };
@@ -1664,6 +1664,7 @@
 				0630E4BE257FA2BD00C75BFB /* TransferAppLockKeychainTests.swift */,
 				169315F025AC501300709F15 /* MigrateSenderClientTests.swift */,
 				EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */,
+				EE05CD1825DD5E2D00777A25 /* AnalyticsAttributeValueTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -3409,6 +3410,7 @@
 				BF3494001EC46D3D00B0C314 /* ZMConversationTests+Teams.swift in Sources */,
 				63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */,
 				A96524BA23CDE07700303C60 /* String+WordTests.swift in Sources */,
+				EE05CD1925DD5E2D00777A25 /* AnalyticsAttributeValueTests.swift in Sources */,
 				16F7341424F9573C00AB93B1 /* XCTestCase+EncryptionKeys.swift in Sources */,
 				06F98D64243B2474007E914A /* SignatureStatusTests.swift in Sources */,
 				F9B71F941CB2BF08001DB03F /* UserImageLocalCacheTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

In order to protect the privacy of BI data, numeric attribute values should be rounded. Previously this was done on the UI side by adding an extension to `Int` to round the value. This is error prone because you need to remember to round the int value.

A more type safe solution is to remove the `Int` conformance of `AnalyticsAttributeValue` and instead define a `RoundedInt` container. 

