### PR TITLE
[Fix] Restore logic for only migrating when model version changed

### DIFF
--- a/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
+++ b/Source/ManagedObjectContext/NSPersistentStoreCoordinator+Wire.swift
@@ -104,6 +104,10 @@ extension NSPersistentStoreCoordinator {
             return false // if we have no version, we better wipe
         }
         
+        // this is used to avoid migrating internal builds when we update the DB internally between releases
+        let isSameAsCurrent = model.firstVersionIdentifier == oldModelVersion
+        guard !isSameAsCurrent else { return false }
+        
         // Between non-E2EE and E2EE we should not migrate the DB for privacy reasons.
         // We know that the old mom is a version supporting E2EE when it
         // contains the 'ClientMessage' entity or is at least of version 1.25


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios-data-model/pull/1144 we now show the DB migration screen on every app launch.

### Causes

We removed a rule for only migrating the database when the model version has changed since that path killing the app on any error.

### Solutions

The path for killing the app no longer exists after some further refactoring so we can restore the old behaviour of only attempting a migration when the model version changed.