### PR TITLE
[Chore] Revert "Release 251.0.2"

### DIFF
--- a/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
+++ b/Source/ManagedObjectContext/ManagedObjectContextDirectory.swift
@@ -26,7 +26,6 @@ public class ManagedObjectContextDirectory: NSObject {
          accountDirectory: URL,
          applicationContainer: URL,
          dispatchGroup: ZMSDispatchGroup? = nil) {
-        self.storeCoordinator = persistentStoreCoordinator
         self.uiContext = ManagedObjectContextDirectory.createUIManagedObjectContext(persistentStoreCoordinator: persistentStoreCoordinator, dispatchGroup: dispatchGroup)
         self.syncContext = ManagedObjectContextDirectory.createSyncManagedObjectContext(persistentStoreCoordinator: persistentStoreCoordinator,
                                                                                         accountDirectory: accountDirectory,
@@ -51,8 +50,6 @@ public class ManagedObjectContextDirectory: NSObject {
     /// sync context.
     fileprivate(set) public var searchContext: NSManagedObjectContext!
 
-    fileprivate var storeCoordinator: NSPersistentStoreCoordinator!
-
     deinit {
         self.tearDown()
     }
@@ -72,16 +69,6 @@ extension ManagedObjectContextDirectory {
 }
 
 extension ManagedObjectContextDirectory {
-
-    func closeStores() {
-        do {
-        try storeCoordinator.persistentStores.forEach({
-            try self.storeCoordinator.remove($0)
-        })
-        } catch let error {
-            Logging.localStorage.error("Error while closing persistent store: \(error)")
-        }
-    }
     
     func tearDown() {
         // this will set all contextes to nil
@@ -95,7 +82,6 @@ extension ManagedObjectContextDirectory {
         self.uiContext = nil
         self.syncContext = nil
         self.searchContext = nil
-        self.closeStores()
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Revert https://github.com/wireapp/wire-ios-data-model/pull/1149 since it breaks the SE tests. This change will come with https://github.com/wireapp/wire-ios-data-model/pull/1151 instead.