### PR TITLE
[Fix] Update predicate for valid conversations

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -172,7 +172,7 @@ extension ZMConversation {
                                                                                                        NSNumber(value: ZMConnectionStatus.cancelled.rawValue)]) //pending connections should be in other list, ignored and cancelled are not displayed
         let predicate1 = NSCompoundPredicate(orPredicateWithSubpredicates: [notAConnection, activeConnection]) // one-to-one conversations and not pending and not ignored connections
         let noConnection = NSPredicate(format: "\(ZMConversationConnectionKey) == nil") // group conversations
-        let notBlocked = NSPredicate(format: "\(ZMConversationConnectionKey).status != \(ZMConnectionStatus.blocked.rawValue)")
+        let notBlocked = NSPredicate(format: "\(ZMConversationConnectionKey).status != \(ZMConnectionStatus.blocked.rawValue) && \(ZMConversationConnectionKey).status != \(ZMConnectionStatus.blockedMissingLegalholdConsent.rawValue)")
         let predicate2 = NSCompoundPredicate(orPredicateWithSubpredicates: [noConnection, notBlocked]) //group conversations and not blocked connections
         
         return NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, predicate1, predicate2])


### PR DESCRIPTION
## What's new in this PR?

Since we have a new connection status `blockedMissingLegalholdConsent`, we should exclude these conversations from the valid conversation list.