### PR TITLE
Fix: Designated initializer cannot be declared in an extension of 'Mention'

### DIFF
--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -35,7 +35,7 @@ extension ZMMessage {
         guard message.isSent else { return nil }
         
         let emoji = unicodeValue ?? ""
-        let reaction = WireProtos.Reaction(emoji: emoji, messageID: messageID)
+        let reaction = WireProtos.Reaction.createReaction(emoji: emoji, messageID: messageID)
         let genericMessage = GenericMessage(content: reaction)
 
         guard let conversation = message.conversation else { return nil }

--- a/Source/Model/Message/ZMClientMessage+LinkPreview.swift
+++ b/Source/Model/Message/ZMClientMessage+LinkPreview.swift
@@ -175,7 +175,7 @@ extension ZMClientMessage: ZMImageOwner {
             
             let text = Text.with {
                 $0.content = textMessageData.messageText ?? ""
-                $0.mentions = textMessageData.mentions.compactMap { WireProtos.Mention($0) }
+                $0.mentions = textMessageData.mentions.compactMap { WireProtos.Mention.createMention($0) }
                 $0.linkPreview = [linkPreview]
             }
             

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -358,7 +358,7 @@ extension Text {
     public init(content: String, mentions: [Mention] = [], linkPreviews: [LinkMetadata] = [], replyingTo: ZMOTRMessage? = nil) {
         self = Text.with {
             $0.content = content
-            $0.mentions = mentions.compactMap { WireProtos.Mention($0) }
+            $0.mentions = mentions.compactMap { WireProtos.Mention.createMention($0) }
             $0.linkPreview = linkPreviews.map { WireProtos.LinkPreview($0) }
             
             if let quotedMessage = replyingTo,
@@ -402,8 +402,8 @@ extension Text {
 // MARK: - Reaction
 
 extension WireProtos.Reaction {
-    public init(emoji: String, messageID: UUID) {
-        self = WireProtos.Reaction.with({
+    public static func createReaction(emoji: String, messageID: UUID) -> WireProtos.Reaction {
+        return WireProtos.Reaction.with({
             $0.emoji = emoji
             $0.messageID = messageID.transportString()
         })
@@ -515,10 +515,10 @@ extension External {
 // MARK: - Mention
 
 public extension WireProtos.Mention {
-    init?(_ mention: WireDataModel.Mention) {
+    static func createMention(_ mention: WireDataModel.Mention) -> WireProtos.Mention? {
         guard let userID = (mention.user as? ZMUser)?.remoteIdentifier.transportString() else { return nil }
         
-        self = WireProtos.Mention.with {
+        return WireProtos.Mention.with {
             $0.start = Int32(mention.range.location)
             $0.length = Int32(mention.range.length)
             $0.userID = userID

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -513,6 +513,7 @@ extension External {
 }
 
 // MARK: - Mention
+///When other frameworks links to data modal XCFramework, the generated swift interface file omit the namespace and gives linker error. Added this typealias solves the issue.
 public typealias WireProtosMention = WireProtos.Mention
 public extension WireProtosMention {
     static func createMention(_ mention: WireDataModel.Mention) -> WireProtos.Mention? {

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -513,8 +513,8 @@ extension External {
 }
 
 // MARK: - Mention
-
-public extension WireProtos.Mention {
+public typealias WireProtosMention = WireProtos.Mention
+public extension WireProtosMention {
     static func createMention(_ mention: WireDataModel.Mention) -> WireProtos.Mention? {
         guard let userID = (mention.user as? ZMUser)?.remoteIdentifier.transportString() else { return nil }
         

--- a/Tests/Source/Model/Messages/GenericMessageTests+LegalHoldStatus.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests+LegalHoldStatus.swift
@@ -38,7 +38,7 @@ class GenericMessageTests_LegalHoldStatus: BaseZMClientMessageTests {
     func testThatItUpdatesLegalHoldStatusFlagForReaction() {
         
         // given
-        var genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "🤠", messageID: UUID.create()))
+        var genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "🤠", messageID: UUID.create()))
         
         // when
         XCTAssertEqual(genericMessage.reaction.legalHoldStatus, .unknown)

--- a/Tests/Source/Model/Messages/GenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests.swift
@@ -37,7 +37,7 @@ class GenericMessageTests: XCTestCase {
             { return GenericMessage(content: MessageHide(conversationId: UUID.create(), messageId: UUID.create())) },
             { return GenericMessage(content: Location(latitude: 1, longitude: 2)) },
             { return GenericMessage(content: MessageDelete(messageId: UUID.create())) },
-            { return GenericMessage(content: WireProtos.Reaction(emoji: "test", messageID: UUID.create())) },
+            { return GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "test", messageID: UUID.create())) },
             { return GenericMessage(content: WireProtos.Availability(.away)) }
         ]
         

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
@@ -37,14 +37,14 @@ extension ZMClientMessageTests_Reaction {
     
     func updateEventForAddingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
-        let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "❤️", messageID: message.nonce!))
+        let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "❤️", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
     
     func updateEventForRemovingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
-        let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "", messageID: message.nonce!))
+        let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
@@ -87,7 +87,7 @@ extension ZMClientMessageTests_Reaction {
     func testThatItDoesNOTAppendsAReactionWhenReceivingUpdateEventWithValidReaction() {
         
         let message = insertMessage()
-        let genericMessage = GenericMessage(content: WireProtos.Reaction(emoji: "TROP BIEN", messageID: message.nonce!))
+        let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "TROP BIEN", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier!)
         
         // when

--- a/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -483,7 +483,7 @@ class ModelValidationTests: XCTestCase {
 
     func testThatItCreatesReactionWithValidFields() {
         
-        let reaction = WireProtos.Reaction(emoji: "🤩", messageID: UUID(uuidString: "8B496992-E74D-41D2-A2C4-C92EEE777DCE")!)
+        let reaction = WireProtos.Reaction.createReaction(emoji: "🤩", messageID: UUID(uuidString: "8B496992-E74D-41D2-A2C4-C92EEE777DCE")!)
         let message = GenericMessage(content: reaction).validatingFields()
         XCTAssertNotNil(message)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When data model is build as a XCFramework and link with other frameworks, compile error occurs.

### Causes

`Designated initializer cannot be declared in an extension of 'Mention'` and similar error for `Reaction`

### Solutions

User static method instead of `init` in extensions. 

Add `typealias WireProtosMention = WireProtos.Mention` to prevent linker ambiguity issue when linking this framework.
