### PR TITLE
Add ProtosReactionFactory to fix WireProtos.Reaction extension not generated correct in Swift interface

### DIFF
--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -410,6 +410,13 @@ extension WireProtos.Reaction {
     }
 }
 
+public enum ProtosReactionFactory {
+    public static func createReaction(emoji: String, messageID: UUID) -> WireProtos.Reaction {
+        return WireProtos.Reaction.createReaction(emoji: emoji,
+                                                  messageID: messageID)
+    }
+}
+
 // MARK: - LastRead
 
 extension LastRead {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When testing conversion to XCFramework, `WireProtos.Reaction.createReaction` can not be found. Similar PR: https://github.com/wireapp/wire-ios-data-model/pull/1170

### Causes

generated Swift interface can not find method `createReaction` under `WireProtos.Reaction`, seems it has ambiguity between `WireProtos.Reaction` & `WireDataModel.Reaction`.

### Solutions

Create a container enum `ProtosReactionFactory` wrapper to solve the namespace issue.