### PR TITLE
[Refactor] Message sending

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -65,7 +65,7 @@ public enum MissingClientsStrategy: Equatable {
 
 }
 
-
+// FUTUREWORK: remove this code duplication (it's duplicated on ZMAssetClientMessage)
 extension ZMClientMessage: EncryptedPayloadGenerator {
 
     public func encryptForTransport() -> Payload? {
@@ -91,7 +91,6 @@ extension ZMClientMessage: EncryptedPayloadGenerator {
         updateUnderlayingMessageBeforeSending(in: context)
         return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
     }
-
 
     func updateUnderlayingMessageBeforeSending(in context: NSManagedObjectContext) {
         if conversation?.conversationType == .oneOnOne {
@@ -131,17 +130,56 @@ extension ZMClientMessage: EncryptedPayloadGenerator {
 
 }
 
-
 extension ZMAssetClientMessage: EncryptedPayloadGenerator {
 
     public func encryptForTransport() -> Payload? {
-        guard let conversation = conversation else { return nil }
+        guard
+            let conversation = conversation,
+            let context = managedObjectContext
+        else {
+            return nil
+        }
+
+        updateUnderlayingMessageBeforeSending(in: context)
         return underlyingMessage?.encryptForTransport(for: conversation)
     }
 
     public func encryptForTransportQualified() -> Payload? {
-        guard let conversation = conversation else { return nil }
+        guard
+            let conversation = conversation,
+            let context = managedObjectContext
+        else {
+            return nil
+        }
+
+        updateUnderlayingMessageBeforeSending(in: context)
         return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+    }
+
+    func updateUnderlayingMessageBeforeSending(in context: NSManagedObjectContext) {
+        if conversation?.conversationType == .oneOnOne {
+            // Update expectsReadReceipt flag to reflect the current user setting
+            if var updatedGenericMessage = underlyingMessage {
+                updatedGenericMessage.setExpectsReadConfirmation(ZMUser.selfUser(in: context).readReceiptsEnabled)
+                do {
+                    try setUnderlyingMessage(updatedGenericMessage)
+                } catch {
+                    Logging.messageProcessing.warn("Failed to update generic message. Reason: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        if let legalHoldStatus = conversation?.legalHoldStatus {
+            // Update the legalHoldStatus flag to reflect the current known legal hold status
+            if var updatedGenericMessage = underlyingMessage {
+                updatedGenericMessage.setLegalHoldStatus(legalHoldStatus.denotesEnabledComplianceDevice ? .enabled : .disabled)
+                do {
+                    try setUnderlyingMessage(updatedGenericMessage)
+                } catch {
+                    Logging.messageProcessing.warn("Failed to update generic message. Reason: \(error.localizedDescription)")
+                }
+            }
+        }
     }
 
     public var debugInfo: String {

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -69,13 +69,54 @@ public enum MissingClientsStrategy: Equatable {
 extension ZMClientMessage: EncryptedPayloadGenerator {
 
     public func encryptForTransport() -> Payload? {
-        guard let conversation = conversation else { return nil }
+        guard
+            let conversation = conversation,
+            let context = managedObjectContext
+        else {
+            return nil
+        }
+
+        updateUnderlayingMessageBeforeSending(in: context)
         return underlyingMessage?.encryptForTransport(for: conversation)
     }
 
     public func encryptForTransportQualified() -> Payload? {
-        guard let conversation = conversation else { return nil }
+        guard
+            let conversation = conversation,
+            let context = managedObjectContext
+        else {
+            return nil
+        }
+
+        updateUnderlayingMessageBeforeSending(in: context)
         return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+    }
+
+
+    func updateUnderlayingMessageBeforeSending(in context: NSManagedObjectContext) {
+        if conversation?.conversationType == .oneOnOne {
+            // Update expectsReadReceipt flag to reflect the current user setting
+            if var updatedGenericMessage = underlyingMessage {
+                updatedGenericMessage.setExpectsReadConfirmation(ZMUser.selfUser(in: context).readReceiptsEnabled)
+                do {
+                    try setUnderlyingMessage(updatedGenericMessage)
+                } catch {
+                    Logging.messageProcessing.warn("Failed to update generic message. Reason: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        if let legalHoldStatus = conversation?.legalHoldStatus {
+            // Update the legalHoldStatus flag to reflect the current known legal hold status
+            if var updatedGenericMessage = underlyingMessage {
+                updatedGenericMessage.setLegalHoldStatus(legalHoldStatus.denotesEnabledComplianceDevice ? .enabled : .disabled)
+                do {
+                    try setUnderlyingMessage(updatedGenericMessage)
+                } catch {
+                    Logging.messageProcessing.warn("Failed to update generic message. Reason: \(error.localizedDescription)")
+                }
+            }
+        }
     }
 
     public var debugInfo: String {

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -112,6 +112,18 @@ extension ZMAssetClientMessage: EncryptedPayloadGenerator {
 
 extension GenericMessage {
 
+
+    public func encryptForProteus(for recipients: [ZMUser: Set<UserClient>],
+                                  with missingClientsStrategy: MissingClientsStrategy,
+                                  externalData: Data? = nil,
+                                  in context: NSManagedObjectContext) {
+
+    }
+
+}
+
+extension GenericMessage {
+
     /// Attempts to generate an encrypted payload for recipients in the given conversation.
 
     public func encryptForTransport(for conversation: ZMConversation,

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -438,7 +438,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
 
 + (NSPredicate *)predicateForObjectsThatNeedToBeInsertedUpstream;
 {
-    return [NSPredicate predicateWithFormat:@"%K == NULL", RemoteIdentifierDataKey];
+    return [NSPredicate predicateWithFormat:@"%K == NULL", self.remoteIdentifierDataKey];
 }
 
 - (NSSet *)ignoredKeys;


### PR DESCRIPTION
## What's new in this PR?

Refactor the message sending so that all strategies rely on a single code path for sending messages. This reduces code * test duplication.

- `updateUnderlayingMessageBeforeSending()` has been moved to data model so that it can be shared among strategies.
- Don't hardcode the  `remoteIdentifierDataKey` 