### PR TITLE
Fix: UTType init returns nil on M1 Mac

### DIFF
--- a/Source/Model/Message/RasterImages+Protobuf.swift
+++ b/Source/Model/Message/RasterImages+Protobuf.swift
@@ -22,6 +22,7 @@ public extension WireProtos.Asset.Original {
             return false
         }
         
+        // FUTUREWORK remove once arm64 simulator support have been added JIRA ticket: SQPIT-583
         #if targetEnvironment(simulator)
         if let utType = UTType(mimeType: mimeType) {
             return utType.isSVG == false

--- a/Source/Model/Message/RasterImages+Protobuf.swift
+++ b/Source/Model/Message/RasterImages+Protobuf.swift
@@ -18,8 +18,21 @@
 
 public extension WireProtos.Asset.Original {
     var hasRasterImage: Bool {
-        guard case .image? = self.metaData,
-            UTType(mimeType: mimeType)?.isSVG == false else { return false }
+        guard case .image? = self.metaData else {
+            return false
+        }
+        
+        #if targetEnvironment(simulator)
+        if let utType = UTType(mimeType: mimeType) {
+            return utType.isSVG == false
+        } else if mimeType == "image/svg+xml" {
+            return false
+        }
+        #else
+        guard UTType(mimeType: mimeType)?.isSVG == false else {
+            return false
+        }
+        #endif
         return true
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running test on M1 Mac iOS simulator, `UTType(mimeType: )` always return nil and cause `hasRasterImage` always false

### Causes

Unknown

### Solutions

As a workaround, check `mimeType` is SVG to return it is a raster image or not.

related PR:
https://github.com/wireapp/wire-ios-images/pull/43
