### PR TITLE
convert testThatFlagIsNotSetWhenSenderIsNotTheOnlyUser to Swift

### DIFF
--- a/Tests/Source/Model/Messages/ZMMessageTests.h
+++ b/Tests/Source/Model/Messages/ZMMessageTests.h
@@ -37,4 +37,5 @@
 @end
 
 @interface ZMMessageTests : BaseZMMessageTests
+- (ZMSystemMessage *)createSystemMessageFromType:(ZMUpdateEventType)updateEventType inConversation:(ZMConversation *)conversation withUsersIDs:(NSArray *)userIDs senderID:(NSUUID *)senderID;
 @end

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -1102,33 +1102,6 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     XCTAssertTrue(message.userIsTheSender);
 }
 
-- (void)testThatFlagIsNotSetWhenSenderIsNotTheOnlyUser
-{
-    // given
-    ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
-    conversation.remoteIdentifier = [NSUUID createUUID];
-    conversation.conversationType = ZMConversationTypeGroup;
-    XCTAssertNotNil(conversation);
-
-    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    user.remoteIdentifier = [NSUUID createUUID];
-
-    ZMUser *sender = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    sender.remoteIdentifier = [NSUUID createUUID];
-
-    // add selfUser to the conversation
-    __block ZMSystemMessage *message;
-    [self performPretendingUiMocIsSyncMoc:^{
-        message = [self createSystemMessageFromType:ZMUpdateEventTypeConversationMemberJoin inConversation:conversation withUsersIDs:@[sender.remoteIdentifier, user.remoteIdentifier] senderID:sender.remoteIdentifier];
-    }];
-    [self.uiMOC saveOrRollback];
-    WaitForAllGroupsToBeEmpty(0.5);
-
-
-    // then
-    XCTAssertFalse(message.userIsTheSender);
-}
-
 @end
 
 


### PR DESCRIPTION
## What's new in this PR?

Convert `testThatFlagIsNotSetWhenSenderIsNotTheOnlyUser` to swift for preparing create a protocol for `ZMUpdateEvent`