### PR TITLE
[Feature] Add isRestricted property to ZMConversationMessage protocol

### DIFF
--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -154,6 +154,9 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     var needsLinkAttachmentsUpdate: Bool { get set }
     
     var isSilenced: Bool { get }
+
+    /// Whether the message can not be received or shared.
+    var isRestricted: Bool { get }
 }
 
 public protocol ConversationCompositeMessage {
@@ -270,6 +273,18 @@ extension ZMMessage : ZMConversationMessage {
     
     public var isSilenced: Bool {
         return conversation?.isMessageSilenced(nil, senderID: sender?.remoteIdentifier) ?? true
+    }
+
+    public var isRestricted: Bool {
+        guard (self.isFile || self.isImage),
+            let managedObjectContext = self.managedObjectContext else {
+            return false
+        }
+
+        let featureService = FeatureService(context: managedObjectContext)
+        let fileSharingFeature = featureService.fetchFileSharing()
+
+        return fileSharingFeature.status == .disabled
     }
 }
 

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -155,7 +155,7 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     
     var isSilenced: Bool { get }
 
-    /// Whether the message can not be received or shared.
+    /// Whether the asset message can not be received or shared.
     var isRestricted: Bool { get }
 }
 

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -276,10 +276,10 @@ extension ZMMessage : ZMConversationMessage {
     }
 
     public var isRestricted: Bool {
-        guard (self.isFile || self.isImage),
-            let managedObjectContext = self.managedObjectContext else {
-            return false
-        }
+        guard 
+            (self.isFile || self.isImage),
+            let managedObjectContext = self.managedObjectContext 
+        else { return false }
 
         let featureService = FeatureService(context: managedObjectContext)
         let fileSharingFeature = featureService.fetchFileSharing()
@@ -363,4 +363,3 @@ extension ZMMessage {
         return -1
     }
 }
-


### PR DESCRIPTION
## What's new in this PR?

Add `isRestricted` property to `ZMConversationMessage` which we can use and mock in the UI project.