### PR TITLE
[Feature] Avoid unintentionally fetching federated users

### DIFF
--- a/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/Source/ManagedObjectContext/CoreDataStack.swift
@@ -232,7 +232,8 @@ public class CoreDataStack: NSObject, ContextProvider {
             self.configureSyncContext(self.syncContext)
             self.configureSearchContext(self.searchContext)
 
-            #if DEBUG
+            // NOTE disabled since MemoryReferenceDebugger reports false postives for the NSManagedObjectContext
+            #if false // DEBUG
             MemoryReferenceDebugger.register(self.viewContext)
             MemoryReferenceDebugger.register(self.syncContext)
             MemoryReferenceDebugger.register(self.searchContext)

--- a/Source/Model/ZMManagedObject+Fetching.swift
+++ b/Source/Model/ZMManagedObject+Fetching.swift
@@ -35,11 +35,10 @@ extension ZMManagedObject {
         let localDomain = ZMUser.selfUser(in: context).domain
         let isSearchingLocalDomain = localDomain == nil || localDomain == domain
 
-        if let domain = domain, !isSearchingLocalDomain {
-            return internalFetch(withRemoteIdentifier: remoteIdentifier, domain: domain, in: context)
-        } else {
-            return internalFetch(withRemoteIdentifier: remoteIdentifier, in: context)
-        }
+        return internalFetch(withRemoteIdentifier: remoteIdentifier,
+                             domain: domain,
+                             searchingLocalDomain: isSearchingLocalDomain,
+                             in: context)
     }
 
 }

--- a/Source/Model/ZMManagedObject+Internal.h
+++ b/Source/Model/ZMManagedObject+Internal.h
@@ -69,7 +69,8 @@ extern NSString * _Nonnull const ZMManagedObjectLocallyModifiedKeysKey;
                                           inManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
 
 + (nullable instancetype)internalFetchObjectWithRemoteIdentifier:(nonnull NSUUID *)uuid
-                                                          domain:(nonnull NSString *)domain
+                                                          domain:(nullable NSString *)domain
+                                            searchingLocalDomain:(BOOL)searchingLocalDomain
                                           inManagedObjectContext:(nonnull NSManagedObjectContext *)moc;
 
 + (nullable NSSet *)fetchObjectsWithRemoteIdentifiers:(nonnull NSSet <NSUUID *> *)uuids

--- a/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
+++ b/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
@@ -128,7 +128,7 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
         XCTAssertEqual(user.objectID, fetched?.objectID)
     }
 
-    func testThatItFetchesEntityByDomain_WhenEntityDomainIsNilButDomainMatchesSelfUserDomain() throws {
+    func testThatItFetchesEntityByDomain_WhenEntityDomainIsNilAndSearchDomainMatchesSelfUserDomain() throws {
         // given
         let domain = "example.com"
         let selfUser = ZMUser.selfUser(in: mocs.viewContext)
@@ -145,7 +145,7 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
         XCTAssertEqual(user.objectID, fetched?.objectID)
     }
 
-    func testThatItFetchesEntityByDomain_WhenDomainDoesntMatchButSelfUserDomainIsNil() throws {
+    func testThatItFetchesEntityByDomain_WhenEntityDomainIsNilAndSelfUserDomainIsNil() throws {
         // given
         let uuid = UUID()
         let user = ZMUser.insertNewObject(in: mocs.viewContext)
@@ -158,7 +158,7 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
         XCTAssertEqual(user.objectID, fetched?.objectID)
     }
 
-    func testThatItDoesntFetchEntityByDomain_WhenDomainDoesntMatch() throws {
+    func testThatItDoesntFetchEntityByDomain_WhenEntityDomainDoesntMatchSearchDomain() throws {
         // given
         let domain = "example.com"
         let selfUser = ZMUser.selfUser(in: mocs.viewContext)
@@ -171,6 +171,42 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
 
         // when
         let fetched = ZMUser.fetch(with: uuid, domain: "different.com", in: mocs.viewContext)
+
+        // then
+        XCTAssertNil(fetched)
+    }
+
+    func testThatItDoesntFetchEntityByDomain_WhenEntityDomainIsNonNilAndSearchDomainIsNil() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: mocs.viewContext)
+        selfUser.domain = "different.com"
+
+        let domain = "example.com"
+        let uuid = UUID()
+        let user = ZMUser.insertNewObject(in: mocs.viewContext)
+        user.remoteIdentifier = uuid
+        user.domain = domain
+
+        // when
+        let fetched = ZMUser.fetch(with: uuid, domain: nil, in: mocs.viewContext)
+
+        // then
+        XCTAssertNil(fetched)
+    }
+
+    func testThatItDoesntFetchEntityByDomain_WhenEntityDomainIsNonNilAndSelfUserDomainIsNil() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: mocs.viewContext)
+        selfUser.domain = nil
+
+        let domain = "example.com"
+        let uuid = UUID()
+        let user = ZMUser.insertNewObject(in: mocs.viewContext)
+        user.remoteIdentifier = uuid
+        user.domain = domain
+
+        // when
+        let fetched = ZMUser.fetch(with: uuid, domain: nil, in: mocs.viewContext)
 
         // then
         XCTAssertNil(fetched)


### PR DESCRIPTION
## What's new in this PR?

### Issues

If a client for some reason ended up with federated user in their database it could in theory introduce a collision with a local user.

### Causes

If `fetch(with remoteIdentifier: UUID, domain: String?, in context: NSManagedObjectContext)` was called without a domain and the self doesn't have domain assigned it would end up with the following fetch request:

```
"remoteIdentifier == %@"
```

which doesn't match on the domain and therefore could return a federated user.

### Solutions

Ensure that domain is nil or equal to the self user domain when searching for local users.