### PR TITLE
[Fix] Not fetching local user if domain is omitted

### DIFF
--- a/Source/Model/ZMManagedObject+Fetching.swift
+++ b/Source/Model/ZMManagedObject+Fetching.swift
@@ -33,10 +33,10 @@ extension ZMManagedObject {
     /// If the domain is nil only objects belonging to your own domain will be returned. Similarily if the self user aren't associated with a domain the domain parameter will be ignored.
     @objc public static func fetch(with remoteIdentifier: UUID, domain: String?, in context: NSManagedObjectContext) -> Self? {
         let localDomain = ZMUser.selfUser(in: context).domain
-        let isSearchingLocalDomain = localDomain == nil || localDomain == domain
+        let isSearchingLocalDomain = domain == nil || localDomain == nil || localDomain == domain
 
         return internalFetch(withRemoteIdentifier: remoteIdentifier,
-                             domain: domain,
+                             domain: domain ?? localDomain,
                              searchingLocalDomain: isSearchingLocalDomain,
                              in: context)
     }

--- a/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
+++ b/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
@@ -158,6 +158,24 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
         XCTAssertEqual(user.objectID, fetched?.objectID)
     }
 
+    func testThatItFetchesEntityByDomain_WhenSelfUserDomainIsSetButSearchDomainIsNil() throws {
+        // given
+        let domain = "example.com"
+        let selfUser = ZMUser.selfUser(in: mocs.viewContext)
+        selfUser.domain = domain
+
+        let uuid = UUID()
+        let user = ZMUser.insertNewObject(in: mocs.viewContext)
+        user.remoteIdentifier = uuid
+        user.domain = domain
+
+        // when
+        let fetched = ZMUser.fetch(with: uuid, domain: nil, in: mocs.viewContext)
+
+        // then
+        XCTAssertEqual(user.objectID, fetched?.objectID)
+    }
+
     func testThatItDoesntFetchEntityByDomain_WhenEntityDomainDoesntMatchSearchDomain() throws {
         // given
         let domain = "example.com"


### PR DESCRIPTION
## What's new in this PR?

### Issues

If fetching a user without supplying a domain it would not find a local user.

### Solutions

- We should assume that we are searching for local users if the domain is omitted.
- We should default to the local domain if the domain is omitted.