### PR TITLE
Self-deleting message config (part 2)

### DIFF
--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -171,7 +171,7 @@ public class Feature: ZMManagedObject {
         case .conferenceCalling:
             needsToNotifyUser = hasStatusChanged && newStatus == .enabled
 
-        case .fileSharing:
+        case .fileSharing, .selfDeletingMessages:
             needsToNotifyUser = hasStatusChanged
 
         default:

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -150,7 +150,7 @@ public class Feature: ZMManagedObject {
         // on a single context to avoid race conditions.
         assert(context.zm_isSyncContext, "Modifications of `Feature` can only occur on the sync context")
 
-        context.performGroupedBlock{
+        context.performGroupedBlock {
             if let existing = fetch(name: name, context: context) {
                 changes(existing)
             } else {
@@ -159,6 +159,7 @@ public class Feature: ZMManagedObject {
                 changes(feature)
                 feature.hasInitialDefault = true
             }
+
             context.saveOrRollback()
         }
     }

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -150,7 +150,7 @@ public class Feature: ZMManagedObject {
         // on a single context to avoid race conditions.
         assert(context.zm_isSyncContext, "Modifications of `Feature` can only occur on the sync context")
 
-        context.performGroupedBlock {
+        context.performGroupedAndWait { context in
             if let existing = fetch(name: name, context: context) {
                 changes(existing)
             } else {
@@ -165,9 +165,14 @@ public class Feature: ZMManagedObject {
     }
 
     private func updateNeedsToNotifyUser(oldStatus: Status, newStatus: Status) {
+        let hasStatusChanged = oldStatus != newStatus
+
         switch name {
         case .conferenceCalling:
-            needsToNotifyUser = (oldStatus != newStatus) && newStatus == .enabled
+            needsToNotifyUser = hasStatusChanged && newStatus == .enabled
+
+        case .fileSharing:
+            needsToNotifyUser = hasStatusChanged
 
         default:
             break

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -18,10 +18,6 @@
 
 import Foundation
 
-extension Notification.Name {
-    public static let featureDidChangeNotification = Notification.Name("FeatureDidChangeNotification")
-}
-
 private let zmLog = ZMSLog(tag: "Feature")
 
 @objcMembers
@@ -95,10 +91,8 @@ public class Feature: ZMManagedObject {
             if hasBeenUpdatedFromBackend {
                 updateNeedsToNotifyUser(oldStatus: status, newStatus: newValue)
             }
+
             statusValue = newValue.rawValue
-            if needsToNotifyUser {
-                NotificationCenter.default.post(name: .featureDidChangeNotification, object: change(from: self))
-            }
             hasInitialDefault = false
         }
     }
@@ -215,22 +209,4 @@ public class Feature: ZMManagedObject {
             needsToNotifyUser = oldConfig.enforcedTimeoutSeconds != newConfig.enforcedTimeoutSeconds
         }
     }
-}
-
-extension Feature {
-
-    public enum FeatureChange {
-        case conferenceCallingIsAvailable
-    }
-
-    private func change(from feature: Feature) -> FeatureChange? {
-        switch feature.name {
-        case .conferenceCalling where feature.status == .enabled:
-            return .conferenceCallingIsAvailable
-
-        default:
-            return nil
-        }
-    }
-
 }

--- a/Source/Model/FeatureConfig/FeatureService.swift
+++ b/Source/Model/FeatureConfig/FeatureService.swift
@@ -110,10 +110,10 @@ public class FeatureService {
 
         switch fileSharing.status {
         case .disabled:
-            self.notifyChange(.fileSharingDisabled)
+            notifyChange(.fileSharingDisabled)
 
         case .enabled:
-            self.notifyChange(.fileSharingEnabled)
+            notifyChange(.fileSharingEnabled)
         }
     }
 

--- a/Source/Model/FeatureConfig/FeatureService.swift
+++ b/Source/Model/FeatureConfig/FeatureService.swift
@@ -178,7 +178,7 @@ public class FeatureService {
         }
     }
 
-    public func needsToNotifyUser(for featureName: Feature.Name) -> Bool {
+    func needsToNotifyUser(for featureName: Feature.Name) -> Bool {
         var result = false
 
         context.performGroupedAndWait {

--- a/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
+++ b/Tests/Source/Model/FeatureConfiguration/FeatureTests.swift
@@ -26,9 +26,12 @@ final class FeatureTests: ZMBaseManagedObjectTest {
     func testThatItUpdatesFeature() {
         // given
         syncMOC.performGroupedAndWait { context in
-            guard let defaultAppLock = Feature.fetch(name: .appLock, context: context) else { return XCTFail() }
+            guard let defaultAppLock = Feature.fetch(name: .appLock, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertEqual(defaultAppLock.status, .enabled)
-            return
         }
 
         // when
@@ -42,7 +45,6 @@ final class FeatureTests: ZMBaseManagedObjectTest {
         syncMOC.performGroupedAndWait { context in
             let updatedAppLock = Feature.fetch(name: .appLock, context: context)
             XCTAssertEqual(updatedAppLock?.status, .disabled)
-            return
         }
     }
     
@@ -66,9 +68,12 @@ final class FeatureTests: ZMBaseManagedObjectTest {
         }
 
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .appLock, context: context) else { return XCTFail() }
+            guard let feature = Feature.fetch(name: .appLock, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertFalse(feature.needsToNotifyUser)
-            return
         }
 
         // when
@@ -80,9 +85,12 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
         // then
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .appLock, context: context) else { return XCTFail() }
+            guard let feature = Feature.fetch(name: .appLock, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertTrue(feature.needsToNotifyUser)
-            return
         }
     }
     
@@ -97,9 +105,12 @@ final class FeatureTests: ZMBaseManagedObjectTest {
         }
 
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .appLock, context: context) else { return XCTFail() }
+            guard let feature = Feature.fetch(name: .appLock, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertFalse(feature.needsToNotifyUser)
-            return
         }
 
         // when
@@ -111,13 +122,16 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
         // then
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .appLock, context: context) else { return XCTFail() }
+            guard let feature = Feature.fetch(name: .appLock, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertTrue(feature.needsToNotifyUser)
-            return
         }
     }
 
-    func testThatItDoesSomething() {
+    func testThatItNeedsToNotifyUser_AfterAChange() {
         // Given
         syncMOC.performGroupedAndWait { context in
             let defaultConferenceCalling = Feature.fetch(name: .conferenceCalling, context: self.syncMOC)
@@ -135,12 +149,16 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
         // Then
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .conferenceCalling, context: context) else { XCTFail(); return }
+            guard let feature = Feature.fetch(name: .conferenceCalling, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertTrue(feature.needsToNotifyUser)
         }
     }
 
-    func testThatItDoesNotNotifyAboutFeatureChanges_IfThePreviousValueIsDefault() {
+    func testThatItDoesNotNeedToNotifyUser_IfThePreviousValueIsDefault() {
         // Given
         syncMOC.performGroupedAndWait { context in
             let defaultConferenceCalling = Feature.fetch(name: .conferenceCalling, context: self.syncMOC)
@@ -157,11 +175,14 @@ final class FeatureTests: ZMBaseManagedObjectTest {
 
         // Then
         syncMOC.performGroupedAndWait { context in
-            guard let feature = Feature.fetch(name: .conferenceCalling, context: context) else { XCTFail(); return }
+            guard let feature = Feature.fetch(name: .conferenceCalling, context: context) else {
+                XCTFail()
+                return
+            }
+
             XCTAssertFalse(feature.needsToNotifyUser)
         }
     }
-    ;
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## What's new in this PR?

**Jira:** https://wearezeta.atlassian.net/browse/SQSERVICES-541

In this PR we do some refactoring to support showing an alert to the user when the self-deleting message config changes:

- Move responsibility to post feature change notifications to the `FeatureService`.
- Extend the `FeatureChange` type to include changes for other feature configs.


I found that there are two ways that we notify the ui layer of config changes:
1. posting a notification when receiving an update event (in the request strategy project) 
2. posting a notification when setting properties on the `Feature` entity.
3. General clean up along the way



