### PR TITLE
[Fix] Add additional verification to message sending

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -24,7 +24,7 @@ extension ZMConversation {
 
     /// An error describing why a message couldn't be appended to the conversation.
 
-    public enum AppendMessageError: LocalizedError {
+    public enum AppendMessageError: LocalizedError, Equatable {
 
         case missingManagedObjectContext
         case malformedNonce
@@ -33,6 +33,7 @@ extension ZMConversation {
         case failedToRemoveImageMetadata
         case invalidImageUrl
         case invalidFileUrl
+        case fileSharingIsRestricted
 
         public var errorDescription: String? {
             switch self {
@@ -50,6 +51,8 @@ extension ZMConversation {
                 return "Invalid image url."
             case .invalidFileUrl:
                 return "Invalid file url."
+            case .fileSharingIsRestricted:
+                return "File sharing is restricted."
             }
         }
 
@@ -277,6 +280,10 @@ extension ZMConversation {
                                                expiresAfter: messageDestructionTimeoutValue)
         } catch {
             throw AppendMessageError.failedToProcessMessageData(reason: error.localizedDescription)
+        }
+
+        guard !message.isRestricted else {
+            throw AppendMessageError.fileSharingIsRestricted
         }
 
         message.sender = ZMUser.selfUser(in: moc)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -326,6 +326,30 @@ class ZMConversationMessagesTests: ZMConversationTestsBase {
         XCTAssertFalse(fileMessage.fileMessageData!.isVideo)
         XCTAssertFalse(fileMessage.fileMessageData!.isAudio)
     }
+
+    func testThatWeCanNotInsertAFileMessage_WhenFileSharingIsDisabled()
+    {
+        // given
+        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent("secret_file.txt")
+        let data = Data.randomEncryptionKey()
+        try! data.write(to: fileURL)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.remoteIdentifier = UUID()
+
+
+        // when
+        let fileSharingFeature = Feature.fetch(name: .fileSharing, context: uiMOC)
+        fileSharingFeature?.status = .disabled
+        let fileMetaData = ZMFileMetadata(fileURL: fileURL)
+
+        do {
+            let _ = try conversation.appendFile(with: fileMetaData) as! ZMAssetClientMessage
+        } catch let error as NSError {
+            // then
+            XCTAssertEqual(error as! ZMConversation.AppendMessageError, .fileSharingIsRestricted)
+        }
+     }
     
     func testThatWeCanInsertATextMessageWithImageQuote() {
         // given


### PR DESCRIPTION
## What's new in this PR?

This fix is an extra layer of checking that the user cannot send a file (files or images) message if file sharing feature status is disable. With this fix, we can ensure that if the user finds a way to add a file from the UI, we won't send this message.