### PR TITLE
[Feature] Add actions for adding / removing participants

### DIFF
--- a/Source/Model/EntityAction.swift
+++ b/Source/Model/EntityAction.swift
@@ -1,0 +1,101 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// An EntityActionHandler is responsible for performing actions requested by an EntityAction.
+///
+public protocol EntityActionHandler {
+    associatedtype Action
+
+    /// Perform the action represented by Action
+    ///
+    /// When the action is complete or has failed the EntityActionHandler should
+    /// call `notifyResult()` on the action. The EntityActionHandler is expected to
+    /// retain the action until this method has been called.
+    ///
+    func performAction(_ action: Action)
+}
+
+/// Represents an action which an entity can request to be performed.
+///
+public protocol EntityAction {
+    associatedtype Result
+    associatedtype Failure: Error
+
+    var resultHandler: ResultHandler? { get set }
+}
+
+public extension EntityAction {
+
+    typealias ResultHandler = (Swift.Result<Result, Failure>) -> Void
+
+    static var notificationName: Notification.Name {
+        return Notification.Name(String(describing: Self.Type.self))
+    }
+
+    static var userInfoKey: String {
+        return "action"
+    }
+
+    /// Request the action to be performed
+    func send(in context: NotificationContext) {
+        NotificationInContext(name: Self.notificationName,
+                              context: context,
+                              object: nil,
+                              userInfo: [Self.userInfoKey: self]).post()
+    }
+
+    /// Called by an `EntityActionHandler` when the action has been performed.
+    mutating func notifyResult(_ result: Swift.Result<Result, Failure>) {
+        let resultHandler = self.resultHandler
+        self.resultHandler = nil
+
+        DispatchQueue.main.async {
+            resultHandler?(result)
+        }
+    }
+
+    /// Register a result handler which will be called when the action has been performed.
+    mutating func onResult(resultHandler: @escaping ResultHandler) {
+        self.resultHandler = resultHandler
+    }
+
+    /// Register an action handler
+    ///
+    /// - parameters:
+    ///   - handler: action handler
+    ///   - context: context in which to listen for actions
+    ///   - queue: queue on which the `performAction()` will be called
+    static func registerHandler<Handler: EntityActionHandler>(_ handler: Handler,
+                                                              context: NotificationContext,
+                                                              queue: OperationQueue? = nil) -> Any where Handler.Action == Self {
+        return NotificationInContext.addObserver(name: notificationName,
+                                          context: context,
+                                          object: nil,
+                                          queue: queue) { (note) in
+
+            guard let action = note.userInfo[userInfoKey] as? Handler.Action else {
+                return
+            }
+
+            handler.performAction(action)
+        }
+    }
+
+}

--- a/Source/Model/QualifiedID.swift
+++ b/Source/Model/QualifiedID.swift
@@ -1,0 +1,9 @@
+//
+//  QualifiedID.swift
+//  WireDataModel
+//
+//  Created by Jacob Persson on 21.09.21.
+//  Copyright © 2021 Wire Swiss GmbH. All rights reserved.
+//
+
+import Foundation

--- a/Source/Model/QualifiedID.swift
+++ b/Source/Model/QualifiedID.swift
@@ -1,9 +1,87 @@
 //
-//  QualifiedID.swift
-//  WireDataModel
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
 //
-//  Created by Jacob Persson on 21.09.21.
-//  Copyright © 2021 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation
+
+public struct QualifiedID: Codable, Hashable {
+
+    enum CodingKeys: String, CodingKey {
+        case uuid = "id"
+        case domain
+    }
+
+    public init(uuid: UUID, domain: String) {
+        self.uuid = uuid
+        self.domain = domain
+    }
+
+    public let uuid: UUID
+    public let domain: String
+}
+
+public extension ZMUser {
+
+    var qualifiedID: QualifiedID? {
+        guard
+            let context = managedObjectContext,
+            let uuid = remoteIdentifier,
+            let domain = domain ?? ZMUser.selfUser(in: context).domain
+        else {
+            return nil
+        }
+
+        return QualifiedID(uuid: uuid, domain: domain)
+    }
+
+}
+
+public extension ZMConversation {
+
+    var qualifiedID: QualifiedID? {
+        guard
+            let context = managedObjectContext,
+            let uuid = remoteIdentifier,
+            let domain = domain ?? ZMUser.selfUser(in: context).domain
+        else {
+            return nil
+        }
+
+        return QualifiedID(uuid: uuid, domain: domain)
+    }
+
+}
+
+public extension Collection where Element == ZMUser {
+
+    var qualifiedUserIDs: [QualifiedID]? {
+        let list = compactMap(\.qualifiedID)
+
+        return list.count == count ? list : nil
+    }
+
+}
+
+public extension Collection where Element == ZMConversation {
+
+    var qualifiedIDs: [QualifiedID]? {
+        let list = compactMap(\.qualifiedID)
+
+        return list.count == count ? list : nil
+    }
+
+}

--- a/Source/Model/ZMManagedObject+Fetching.swift
+++ b/Source/Model/ZMManagedObject+Fetching.swift
@@ -42,3 +42,19 @@ extension ZMManagedObject {
     }
 
 }
+
+public extension ZMManagedObject {
+
+    static func existingObject(for id: NSManagedObjectID, in context: NSManagedObjectContext) -> Self? {
+        return try? context.existingObject(with: id) as? Self
+    }
+
+}
+
+public extension Collection where Element == NSManagedObjectID {
+
+    func existingObjects<T: ZMManagedObject>(in context: NSManagedObjectContext) -> [T]? {
+        let objects = compactMap({ T.existingObject(for: $0, in: context) })
+        return objects.count == self.count ? objects : nil
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -137,6 +137,8 @@
 		1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1687ABAD20ECD51E0007C240 /* ZMSearchUser.swift */; };
 		1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1687C0E12150EE91003099DD /* ZMClientMessageTests+Mentions.swift */; };
 		1689FD462194A63E00A656E2 /* ZMClientMessageTests+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */; };
+		168D7BFD26F365ED00789960 /* EntityAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168D7BFC26F365ED00789960 /* EntityAction.swift */; };
+		168D7C9626F9ED1E00789960 /* QualifiedID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168D7C9526F9ED1E00789960 /* QualifiedID.swift */; };
 		168FF330258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168FF32F258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift */; };
 		16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */; };
 		1693155325A30D4E00709F15 /* UserClientTests+ResetSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1693155225A30D4E00709F15 /* UserClientTests+ResetSession.swift */; };
@@ -835,6 +837,8 @@
 		1687ABAD20ECD51E0007C240 /* ZMSearchUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMSearchUser.swift; sourceTree = "<group>"; };
 		1687C0E12150EE91003099DD /* ZMClientMessageTests+Mentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Mentions.swift"; sourceTree = "<group>"; };
 		1689FD452194A63E00A656E2 /* ZMClientMessageTests+Editing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Editing.swift"; sourceTree = "<group>"; };
+		168D7BFC26F365ED00789960 /* EntityAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityAction.swift; sourceTree = "<group>"; };
+		168D7C9526F9ED1E00789960 /* QualifiedID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualifiedID.swift; sourceTree = "<group>"; };
 		168E96C4220B445000FC92FA /* zmessaging2.61.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.61.0.xcdatamodel; sourceTree = "<group>"; };
 		168FF32F258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+ResetSession.swift"; sourceTree = "<group>"; };
 		16925336234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationListDirectoryTests+Labels.swift"; sourceTree = "<group>"; };
@@ -1926,6 +1930,8 @@
 				54CD46091DEDA55C00BA3429 /* AddressBookEntry.swift */,
 				87C125F61EF94EE800D28DC1 /* ZMManagedObject+Grouping.swift */,
 				16460A45206544B00096B616 /* PersistentMetadataKeys.swift */,
+				168D7BFC26F365ED00789960 /* EntityAction.swift */,
+				168D7C9526F9ED1E00789960 /* QualifiedID.swift */,
 			);
 			name = Model;
 			path = Source/Model;
@@ -3166,6 +3172,7 @@
 				F1FDF2FE21B1572500E037A1 /* ZMGenericMessageData.swift in Sources */,
 				54CD460A1DEDA55C00BA3429 /* AddressBookEntry.swift in Sources */,
 				BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */,
+				168D7BFD26F365ED00789960 /* EntityAction.swift in Sources */,
 				F1FDF30021B1580400E037A1 /* GenericMessage+Utils.swift in Sources */,
 				F12BD0B01E4DCEC40012ADBA /* ZMMessage+Insert.swift in Sources */,
 				16127CF3220058160020E65C /* InvalidConversationRemoval.swift in Sources */,
@@ -3305,6 +3312,7 @@
 				0604F7C8265184B70016A71E /* ZMSystemMessage+ParticipantsRemovedReason.swift in Sources */,
 				F11F3E891FA32463007B6D3D /* InvalidClientsRemoval.swift in Sources */,
 				F9FD75781E2F9A0600B4558B /* SearchUserObserverCenter.swift in Sources */,
+				168D7C9626F9ED1E00789960 /* QualifiedID.swift in Sources */,
 				54F6CEAB1CE2972200A1276D /* ZMAssetClientMessage+Download.swift in Sources */,
 				F9B71F221CB264EF001DB03F /* ZMConversation.m in Sources */,
 				EEAAD760252C713E00E6A44E /* ClassIdentifier.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Introduce `EntityAction` and `EntityActionHandler` as new pattern for adding actions to entities which returns a result or failure.

This new pattern is used to re-implement support for adding / removing participants.

## Notes

 - `QualifiedID` was moved here from the wire-ios-request-strategy.
 - This PR needs to be rebased once https://github.com/wireapp/wire-ios-data-model/pull/1236 is merged