### PR TITLE
Fix: creating duplicate conversations/users when domain is empty string

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -61,7 +61,7 @@ extension ZMConversation {
             created.pointee = true
             let conversation = ZMConversation.insertNewObject(in: context)
             conversation.remoteIdentifier = remoteIdentifier
-            conversation.domain = domain
+            conversation.domain = domain?.isEmpty == true ? nil : domain
             return conversation
         }
     }

--- a/Source/Model/User/ZMUser+Create.swift
+++ b/Source/Model/User/ZMUser+Create.swift
@@ -58,7 +58,7 @@ public extension ZMUser {
             created.pointee = true
             let user = ZMUser.insertNewObject(in: context)
             user.remoteIdentifier = remoteIdentifier
-            user.domain = domain
+            user.domain = domain?.isEmpty == true ? nil : domain
             return user
         }
     }

--- a/Source/Model/ZMManagedObject+Fetching.swift
+++ b/Source/Model/ZMManagedObject+Fetching.swift
@@ -32,6 +32,7 @@ extension ZMManagedObject {
     ///
     /// If the domain is nil only objects belonging to your own domain will be returned. Similarily if the self user aren't associated with a domain the domain parameter will be ignored.
     @objc public static func fetch(with remoteIdentifier: UUID, domain: String?, in context: NSManagedObjectContext) -> Self? {
+        let domain = domain?.isEmpty == true ? nil : domain
         let localDomain = ZMUser.selfUser(in: context).domain
         let isSearchingLocalDomain = domain == nil || localDomain == nil || localDomain == domain
 

--- a/Source/Model/ZMManagedObject.m
+++ b/Source/Model/ZMManagedObject.m
@@ -365,7 +365,7 @@ static NSString * const KeysForCachedValuesKey = @"ZMKeysForCachedValues";
     Require(entity != nil);
 
     NSString *key = [self remoteIdentifierDataKey];
-    NSString *domainKey = [self remoteIdentifierDataKey];
+    NSString *domainKey = [self domainKey];
     NSData *data = uuid.data;
     for (NSManagedObject *mo in moc.registeredObjects) {
         if (!mo.isFault && mo.entity == entity &&

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -358,7 +358,7 @@
     }];
 }
 
-- (void)testThatItCreatesAUserForNonExistingUUID
+- (void)testThatItCreatesAConversationForNonExistingUUID
 {
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
@@ -369,6 +369,21 @@
         
         // then
         XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+    }];
+}
+
+- (void)testThatItTreatsEmptyDomainAsNil
+{
+    [self.syncMOC performGroupedBlockAndWait:^{
+        // given
+        NSUUID *uuid = NSUUID.createUUID;
+
+        // when
+        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
+
+        // then
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(nil, found.domain);
     }];
 }
 

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -175,6 +175,21 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     }];
 }
 
+- (void)testThatItTreatsEmptyDomainAsNil
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+
+    [self.syncMOC performBlockAndWait:^{
+        // when
+        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
+
+        // then
+        XCTAssertNotNil(found);
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(nil, found.domain);
+    }];
+}
 
 - (void)testThatItReturnsAnExistingUserByPhone
 {

--- a/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
+++ b/Tests/Source/Model/ZMManagedObjectFetchingTests.swift
@@ -128,6 +128,25 @@ class ZMManagedObjectFetchingTests: DatabaseBaseTest {
         XCTAssertEqual(user.objectID, fetched?.objectID)
     }
 
+    func testThatEmptyDomainIsTreatedAsNilDomain() throws {
+        // given
+        let selfUser = ZMUser.selfUser(in: mocs.viewContext)
+        selfUser.domain = "example.com"
+
+        let uuid = UUID()
+        let user = ZMUser.insertNewObject(in: mocs.viewContext)
+        user.remoteIdentifier = uuid
+        user.domain = "example.com"
+        try mocs.viewContext.save()
+        mocs.viewContext.refresh(user, mergeChanges: false)
+
+        // when
+        let fetched = ZMUser.fetch(with: uuid, domain: "", in: mocs.viewContext)
+
+        // then
+        XCTAssertEqual(user.objectID, fetched?.objectID)
+    }
+
     func testEntityFetching_WhenSearchingForLocalEntity() {
         let localDomain = "example.com"
         let remoteDomain = "remote.com"


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's been observed that app starts to crash while processing events.

### Causes

The app crashes due to sanity check that we don't have multiple conversations with the same ID.

The code path which causes duplicate conversation to inserted:
```
    static func updateConversation(withLastReadFromSelfConversation lastRead: LastRead, inContext moc: NSManagedObjectContext) {
        let newTimeStamp = Double(integerLiteral: lastRead.lastReadTimestamp)
        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
        guard let conversationID = UUID(uuidString: lastRead.conversationID) else {
            return
        }
        let conversation = ZMConversation.fetchOrCreate(with: conversationID, domain: lastRead.qualifiedConversationID.domain, in: moc)
        conversation.updateLastRead(timestamp, synchronize: false)
    }
 ```

If the `lastRead` protobuf object doesn't contain a `qualifiedConversationID` it will default to an empty string. An empty domain is treated as different from the local domain and new conversation is therefore inserted. Later if fetch is being made without a domain parameter it will find both conversations.

### Solutions

Treat empty domain as a nil domain.

### Future improvements

- Make it impossible to to fetch conversations/users without specifying a domain.