### PR TITLE
Fix: Handle conflicting domains FS-119

### DIFF
--- a/Patches/InvalidDomainRemoval.swift
+++ b/Patches/InvalidDomainRemoval.swift
@@ -1,0 +1,54 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+enum InvalidDomainRemoval {
+
+    /// We had a situation where we were creating duplicate users and conversations where the UUID would
+    /// be duplicated but the domain would be different.
+    ///
+    /// We need to delete all duplicated users and converations which doesn't have a domain equal to the
+    /// self user domain.
+    static func removeDuplicatedEntitiesWithInvalidDomain(in moc: NSManagedObjectContext) {
+        guard let selfDomain = ZMUser.selfUser(in: moc).domain else {
+            return
+        }
+
+        let duplicatedUsers: [Data: [ZMUser]] = moc.findDuplicated(by: ZMManagedObject.remoteIdentifierDataKey()!)
+
+        let duplicatedConversations: [Data: [ZMConversation]] = moc.findDuplicated(by: ZMManagedObject.remoteIdentifierDataKey()!)
+
+        duplicatedUsers.forEach { (_, users) in
+            for user in users {
+                if user.domain != selfDomain {
+                    moc.delete(user)
+                }
+            }
+        }
+
+        duplicatedConversations.forEach { (_, conversations) in
+            for conversation in conversations {
+                if conversation.domain != selfDomain {
+                    moc.delete(conversation)
+                }
+            }
+        }
+    }
+}

--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -38,6 +38,7 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "234.1.1", block: InvalidConnectionRemoval.removeInvalid),
         PersistedDataPatch(version: "236.0.0", block: MigrateSenderClient.migrateSenderClientID),
         PersistedDataPatch(version: "243.0.0", block: InvalidFeatureRemoval.removeInvalid),
+        PersistedDataPatch(version: "273.2.0", block: InvalidDomainRemoval.removeDuplicatedEntitiesWithInvalidDomain),
     ]
 
 }

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
@@ -29,6 +29,7 @@ extern NSString * _Nonnull const IsUserInterfaceContextKey;
 extern NSString * _Nonnull const IsSyncContextKey;
 extern NSString * _Nonnull const IsSearchContextKey;
 extern NSString * _Nonnull const IsEventContextKey;
+extern NSString * _Nonnull const IsFederationEnabledKey;
 
 @interface NSManagedObjectContext (zmessaging)
 
@@ -50,6 +51,9 @@ extern NSString * _Nonnull const IsEventContextKey;
 
 /// Returns @c YES if the context is still valid, false if it has been torn down
 @property (readonly) BOOL zm_isValidContext;
+
+/// Returns @c YES if federation is enabled
+@property (nonatomic) BOOL zm_isFederationEnabled;
 
 /// Returns @c self in case this is a sync context, or attached sync context, if present
 @property (nonatomic, null_unspecified) NSManagedObjectContext* zm_syncContext;

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -35,6 +35,7 @@ NSString * const IsSyncContextKey = @"ZMIsSyncContext";
 NSString * const IsSearchContextKey = @"ZMIsSearchContext";
 NSString * const IsUserInterfaceContextKey = @"ZMIsUserInterfaceContext";
 NSString * const IsEventContextKey = @"ZMIsEventDecoderContext";
+NSString * const IsFederationEnabledKey = @"ZMIsFederationEnabledKey";
 
 static NSString * const SyncContextKey = @"ZMSyncContext";
 static NSString * const UserInterfaceContextKey = @"ZMUserInterfaceContext";
@@ -144,6 +145,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"NSManagedObjectContext";
     }
     
     return nil;
+}
+
+- (BOOL)zm_isFederationEnabled {
+    return [[self validUserInfoValueOfClass:[NSNumber class] forKey:IsFederationEnabledKey] boolValue];
+}
+
+- (void)setZm_isFederationEnabled:(BOOL)enabled {
+    [self.userInfo setValue:[NSNumber numberWithBool:enabled] forKey:IsFederationEnabledKey];
 }
 
 - (void)setZm_syncContext:(NSManagedObjectContext *)zm_syncContext

--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -55,6 +55,8 @@ extension ZMConversation {
         // having two duplicates of that user, and we'd have a really hard time recovering from that.
         require(context.zm_isSyncContext, "Users are only allowed to be created on sync context")
 
+        let domain: String? = context.zm_isFederationEnabled ? domain : nil
+
         if let conversation = fetch(with: remoteIdentifier, domain: domain, in: context) {
             return conversation
         } else {

--- a/Source/Model/Conversation/ZMConversation+Deletion.swift
+++ b/Source/Model/Conversation/ZMConversation+Deletion.swift
@@ -23,7 +23,7 @@ extension ZMConversation {
     open override func prepareForDeletion() {
         super.prepareForDeletion()
         
-        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache.deleteAssetData($0)} )
+        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache?.deleteAssetData($0)} )
     }
     
 }

--- a/Source/Model/Message/FileAssetCache.swift
+++ b/Source/Model/Message/FileAssetCache.swift
@@ -25,9 +25,9 @@ private var zmLog = ZMSLog(tag: "assets")
 
 extension NSManagedObjectContext
 {
-    @objc public var zm_fileAssetCache : FileAssetCache {
+    @objc public var zm_fileAssetCache : FileAssetCache! {
         get {
-            return self.userInfo[NSManagedObjectContextFileAssetCacheKey] as! FileAssetCache
+            return self.userInfo[NSManagedObjectContextFileAssetCacheKey] as? FileAssetCache
         }
         
         set {

--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -34,7 +34,7 @@ public class V2Asset: NSObject, ZMImageMessageData {
         let originalKey = FileAssetCache.cacheKeyForAsset(assetClientMessage, format: .original)
         
         queue.async {
-            completionHandler([mediumKey, originalKey].lazy.compactMap({ $0 }).compactMap({ cache.assetData($0) }).first)
+            completionHandler([mediumKey, originalKey].lazy.compactMap({ $0 }).compactMap({ cache?.assetData($0) }).first)
         }
     }
     

--- a/Source/Model/Message/V3Asset.swift
+++ b/Source/Model/Message/V3Asset.swift
@@ -58,7 +58,7 @@ private let zmLog = ZMSLog(tag: "AssetV3")
         let originalKey = FileAssetCache.cacheKeyForAsset(assetClientMessage, format: .original)
         
         queue.async {
-            completionHandler([mediumKey, originalKey].lazy.compactMap({ $0 }).compactMap({ cache.assetData($0) }).first)
+            completionHandler([mediumKey, originalKey].lazy.compactMap({ $0 }).compactMap({ cache?.assetData($0) }).first)
         }
     }
         

--- a/Source/Model/User/ZMUser+Create.swift
+++ b/Source/Model/User/ZMUser+Create.swift
@@ -52,6 +52,8 @@ public extension ZMUser {
         // having two duplicates of that user, and we'd have a really hard time recovering from that.
         require(context.zm_isSyncContext, "Users are only allowed to be created on sync context")
 
+        let domain: String? = context.zm_isFederationEnabled ? domain : nil
+
         if let user = fetch(with: remoteIdentifier, domain: domain, in: context) {
             return user
         } else {

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -365,10 +365,10 @@
         NSUUID *uuid = NSUUID.createUUID;
         
         // when
-        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:nil in:self.syncMOC];
+        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:nil in:self.syncMOC];
         
         // then
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
     }];
 }
 
@@ -379,11 +379,11 @@
         NSUUID *uuid = NSUUID.createUUID;
 
         // when
-        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
+        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
 
         // then
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(nil, found.domain);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(nil, created.domain);
     }];
 }
 
@@ -395,12 +395,12 @@
     [self.syncMOC performBlockAndWait:^{
         // when
         self.syncMOC.zm_isFederationEnabled = NO;
-        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
+        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
 
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(nil, found.domain);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(nil, created.domain);
     }];
 }
 
@@ -413,12 +413,12 @@
     [self.syncMOC performBlockAndWait:^{
         // when
         self.syncMOC.zm_isFederationEnabled = YES;
-        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
+        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
 
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(domain, found.domain);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(domain, created.domain);
     }];
 }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -387,6 +387,40 @@
     }];
 }
 
+- (void)testThatItIgnoresDomainWhenFederationIsDisabled
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+
+    [self.syncMOC performBlockAndWait:^{
+        // when
+        self.syncMOC.zm_isFederationEnabled = NO;
+        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
+
+        // then
+        XCTAssertNotNil(found);
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(nil, found.domain);
+    }];
+}
+
+- (void)testThatItAssignsDomainWhenFederationIsEnabled
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSString *domain = @"a.com";
+
+    [self.syncMOC performBlockAndWait:^{
+        // when
+        self.syncMOC.zm_isFederationEnabled = YES;
+        ZMConversation *found = [ZMConversation fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
+
+        // then
+        XCTAssertNotNil(found);
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(domain, found.domain);
+    }];
+}
 
 - (void)testThatConversationsDoNotGetInsertedUpstreamUnlessTheyAreGroupConversations;
 {

--- a/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -847,7 +847,7 @@ extension ZMAssetClientMessageTests {
     }
 
     func createV2AssetClientMessageWithSampleImageAndEncryptionKeys(_ storeOriginal: Bool, storeEncrypted: Bool, storeProcessed: Bool, imageData: Data? = nil) -> ZMAssetClientMessage {
-        let directory = self.uiMOC.zm_fileAssetCache
+        let directory = self.uiMOC.zm_fileAssetCache!
         let nonce = UUID.create()
         let imageData = imageData ?? sampleImageData()
         var genericMessage : [ZMImageFormat : GenericMessage] = [:]

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -67,7 +67,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         let conversation = ZMConversation.insertNewObject(in:uiMOC)
         let sut = try! conversation.appendImage(from: mediumJPEGData(), nonce: .create()) as! ZMAssetClientMessage
         
-        let cache = uiMOC.zm_fileAssetCache
+        let cache = uiMOC.zm_fileAssetCache!
         cache.storeAssetData(sut, format: .preview, encrypted: false, data: verySmallJPEGData())
         cache.storeAssetData(sut, format: .medium, encrypted: false, data: mediumJPEGData())
         cache.storeAssetData(sut, format: .original, encrypted: false, data: mediumJPEGData())
@@ -111,7 +111,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         let fileMetaData = ZMFileMetadata(fileURL: url, thumbnail: verySmallJPEGData())
         let sut = try! conversation.appendFile(with: fileMetaData, nonce: .create())  as! ZMAssetClientMessage
 
-        let cache = uiMOC.zm_fileAssetCache
+        let cache = uiMOC.zm_fileAssetCache!
         
         cache.storeAssetData(sut, format: .original, encrypted: true, data: verySmallJPEGData())
         cache.storeAssetData(sut, encrypted: true, data: mediumJPEGData())
@@ -215,7 +215,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
         sut.visibleInConversation = conversation
         sut.sender = selfUser
         
-        let cache = uiMOC.zm_fileAssetCache
+        let cache = uiMOC.zm_fileAssetCache!
         cache.storeAssetData(sut, format: .preview, encrypted: false, data: verySmallJPEGData())
         cache.storeAssetData(sut, format: .medium, encrypted: false, data: mediumJPEGData())
         cache.storeAssetData(sut, format: .original, encrypted: false, data: mediumJPEGData())
@@ -584,7 +584,7 @@ extension ZMClientMessageTests_Deletion {
             XCTAssertNil(assetMessage.underlyingMessage, line: line)
             XCTAssertEqual(assetMessage.size, 0, line: line)
 
-            let cache = uiMOC.zm_fileAssetCache
+            let cache = uiMOC.zm_fileAssetCache!
             XCTAssertNil(cache.assetData(message, format: .original, encrypted: false))
             XCTAssertNil(cache.assetData(message, format: .medium, encrypted: false))
             XCTAssertNil(cache.assetData(message, format: .preview, encrypted: false))

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -167,11 +167,11 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
 
     [self.syncMOC performBlockAndWait:^{
         // when
-        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:nil in:self.syncMOC];
+        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:nil in:self.syncMOC];
         
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
     }];
 }
 
@@ -182,12 +182,12 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
 
     [self.syncMOC performBlockAndWait:^{
         // when
-        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
+        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
 
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(nil, found.domain);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(nil, created.domain);
     }];
 }
 
@@ -199,12 +199,12 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     [self.syncMOC performBlockAndWait:^{
         // when
         self.syncMOC.zm_isFederationEnabled = NO;
-        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
+        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
 
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(nil, found.domain);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(nil, created.domain);
     }];
 }
 
@@ -217,12 +217,12 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     [self.syncMOC performBlockAndWait:^{
         // when
         self.syncMOC.zm_isFederationEnabled = YES;
-        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
+        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
 
         // then
-        XCTAssertNotNil(found);
-        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
-        XCTAssertEqualObjects(domain, found.domain);
+        XCTAssertNotNil(created);
+        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
+        XCTAssertEqualObjects(domain, created.domain);
     }];
 }
 

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -191,6 +191,41 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     }];
 }
 
+- (void)testThatItIgnoresDomainWhenFederationIsDisabled
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+
+    [self.syncMOC performBlockAndWait:^{
+        // when
+        self.syncMOC.zm_isFederationEnabled = NO;
+        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
+
+        // then
+        XCTAssertNotNil(found);
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(nil, found.domain);
+    }];
+}
+
+- (void)testThatItAssignsDomainWhenFederationIsEnabled
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSString *domain = @"a.com";
+
+    [self.syncMOC performBlockAndWait:^{
+        // when
+        self.syncMOC.zm_isFederationEnabled = YES;
+        ZMUser *found = [ZMUser fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
+
+        // then
+        XCTAssertNotNil(found);
+        XCTAssertEqualObjects(uuid, found.remoteIdentifier);
+        XCTAssertEqualObjects(domain, found.domain);
+    }];
+}
+
 - (void)testThatItReturnsAnExistingUserByPhone
 {
     // given

--- a/Tests/Source/Utils/InvalidDomainRemovalTests.swift
+++ b/Tests/Source/Utils/InvalidDomainRemovalTests.swift
@@ -1,0 +1,76 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+class InvalidDomainRemovalTests: DiskDatabaseTest {
+
+    func testAllUsersWithInvalidDomainIsRemoved() throws {
+        coreDataStack.syncContext.performGroupedAndWait { context in
+            // GIVEN
+            let selfDomain = "example.com"
+            let otherDomain = "other.com"
+            let userUUID = UUID()
+
+            ZMUser.selfUser(in: context).domain = selfDomain
+            
+            let user1 = ZMUser.insertNewObject(in: context)
+            user1.remoteIdentifier = userUUID
+            user1.domain = selfDomain
+            let user2 = ZMUser.insertNewObject(in: context)
+            user2.remoteIdentifier = userUUID
+            user2.domain = otherDomain
+            context.saveOrRollback()
+
+            // WHEN
+            InvalidDomainRemoval.removeDuplicatedEntitiesWithInvalidDomain(in: context)
+
+            // THEN
+            XCTAssertFalse(user1.isDeleted)
+            XCTAssertTrue(user2.isDeleted)
+        }
+    }
+
+    func testAllConversationsWithInvalidDomainIsRemoved() throws {
+        coreDataStack.syncContext.performGroupedAndWait { context in
+            // GIVEN
+            let selfDomain = "example.com"
+            let otherDomain = "other.com"
+            let userUUID = UUID()
+
+            ZMUser.selfUser(in: context).domain = selfDomain
+
+            let conversation1 = ZMConversation.insertNewObject(in: context)
+            conversation1.remoteIdentifier = userUUID
+            conversation1.domain = selfDomain
+            let conversation2 = ZMConversation.insertNewObject(in: context)
+            conversation2.remoteIdentifier = userUUID
+            conversation2.domain = otherDomain
+            context.saveOrRollback()
+
+            // WHEN
+            InvalidDomainRemoval.removeDuplicatedEntitiesWithInvalidDomain(in: context)
+
+            // THEN
+            XCTAssertFalse(conversation1.isDeleted)
+            XCTAssertTrue(conversation2.isDeleted)
+        }
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		167BCC86260CFC7B00E9D7E3 /* UserTypeTests+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167BCC85260CFC7B00E9D7E3 /* UserTypeTests+Federation.swift */; };
 		167BCC92260DB5FA00E9D7E3 /* CoreDataStackTests+ClearStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167BCC91260DB5FA00E9D7E3 /* CoreDataStackTests+ClearStorage.swift */; };
 		167BCC96260DC3F100E9D7E3 /* CoreDataStack+ClearStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167BCC95260DC3F100E9D7E3 /* CoreDataStack+ClearStorage.swift */; };
+		16827AEA2732A3C20079405D /* InvalidDomainRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16827AE92732A3C20079405D /* InvalidDomainRemoval.swift */; };
+		16827AF22732AB2E0079405D /* InvalidDomainRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16827AF12732AB2E0079405D /* InvalidDomainRemovalTests.swift */; };
 		168413EB222594ED00FCB9BC /* store2-65-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 168413E9222594E600FCB9BC /* store2-65-0.wiredatabase */; };
 		168413ED2225965500FCB9BC /* TransferStateMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168413EC2225965500FCB9BC /* TransferStateMigration.swift */; };
 		1684141722282A1A00FCB9BC /* TransferStateMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1684141622282A1A00FCB9BC /* TransferStateMigrationTests.swift */; };
@@ -836,6 +838,8 @@
 		167BCC85260CFC7B00E9D7E3 /* UserTypeTests+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserTypeTests+Federation.swift"; sourceTree = "<group>"; };
 		167BCC91260DB5FA00E9D7E3 /* CoreDataStackTests+ClearStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataStackTests+ClearStorage.swift"; sourceTree = "<group>"; };
 		167BCC95260DC3F100E9D7E3 /* CoreDataStack+ClearStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+ClearStorage.swift"; sourceTree = "<group>"; };
+		16827AE92732A3C20079405D /* InvalidDomainRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidDomainRemoval.swift; sourceTree = "<group>"; };
+		16827AF12732AB2E0079405D /* InvalidDomainRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidDomainRemovalTests.swift; sourceTree = "<group>"; };
 		168413E82225902200FCB9BC /* zmessaging2.65.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.65.0.xcdatamodel; sourceTree = "<group>"; };
 		168413E9222594E600FCB9BC /* store2-65-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-65-0.wiredatabase"; sourceTree = "<group>"; };
 		168413EC2225965500FCB9BC /* TransferStateMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferStateMigration.swift; sourceTree = "<group>"; };
@@ -1607,6 +1611,7 @@
 				54FB03A01E41E273000E13DC /* PersistedDataPatches.swift */,
 				54FB03A81E41F1B6000E13DC /* PersistedDataPatches+Directory.swift */,
 				54F84CFC1F9950B300ABD7D5 /* DuplicatedEntityRemoval.swift */,
+				16827AE92732A3C20079405D /* InvalidDomainRemoval.swift */,
 				F11F3E881FA32463007B6D3D /* InvalidClientsRemoval.swift */,
 				16127CF2220058160020E65C /* InvalidConversationRemoval.swift */,
 				87C1C25E207F7DA80083BF6B /* InvalidGenericMessageDataRemoval.swift */,
@@ -1688,6 +1693,7 @@
 				0630E4BE257FA2BD00C75BFB /* TransferAppLockKeychainTests.swift */,
 				169315F025AC501300709F15 /* MigrateSenderClientTests.swift */,
 				EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */,
+				16827AF12732AB2E0079405D /* InvalidDomainRemovalTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -3214,6 +3220,7 @@
 				16BA4305233CDEA30018E883 /* ZMConversation+Labels.swift in Sources */,
 				5451DE371F604CD500C82E75 /* ZMMoveIndex.swift in Sources */,
 				63D41E5324531BAD0076826F /* ZMMessage+Reaction.swift in Sources */,
+				16827AEA2732A3C20079405D /* InvalidDomainRemoval.swift in Sources */,
 				54E3EE451F61A53C00A261E3 /* ZMAssetClientMessage+Ephemeral.swift in Sources */,
 				5EDDC7A62088CE3B00B24850 /* ZMConversation+Invalid.swift in Sources */,
 				F9A706B01CAEE01D00C2F5FE /* MessageChangeInfo.swift in Sources */,
@@ -3552,6 +3559,7 @@
 				F963E9741D9BF9ED00098AD3 /* ProtosTests.swift in Sources */,
 				16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */,
 				873B88FE2040470900FBE254 /* ConversationCreationOptionsTests.swift in Sources */,
+				16827AF22732AB2E0079405D /* InvalidDomainRemovalTests.swift in Sources */,
 				5E771F3B2080C42300575629 /* PBMessageValidationTests.swift in Sources */,
 				F9FD757B1E2FB60E00B4558B /* SearchUserObserverTests.swift in Sources */,
 				F9B71F9A1CB2BF0E001DB03F /* ZMUserTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are instances of Wire servers which share the same database but run on different domains. This causes the iOS client to stop receiving  and sending messages in some cases.

### Causes

In this multi domain setup it's possible to login to account A1 on server S1 (domain: s1.com) and on server S2 (domain s2.com) since they both share the same database. When this user sends a message from S1 the qualified ID of the sender will be (uuid: 123, domain: s1.com) and when it's sent from S2 the qualified ID will be (uuid: 123, domain: s2.com).

The iOS client will treat these qualified IDs as coming from different user since the domain is different and thus insert a user object for each one of them. This causes problems since they are actually referring to the same user on the backend.

### Solutions

- Ignore the domain when creating users and conversations if federation is not enabled.
- Delete previously created duplicate users and conversations with a domain not equal to self user domain.