### PR TITLE
[Fix] Setup hasInitialDefault property

### DIFF
--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -56,11 +56,10 @@ public class Feature: ZMManagedObject {
         }
 
         set {
-            if hasBeenUpdatedFromBackend {
+            if configHasBeenUpdatedFromBackend {
                 updateNeedsToNotifyUser(oldData: configData, newData: newValue)
             }
             configData = newValue
-            hasInitialDefault = false
         }
     }
     
@@ -88,18 +87,21 @@ public class Feature: ZMManagedObject {
         }
 
         set {
-            if hasBeenUpdatedFromBackend {
+            if statusHasBeenUpdatedFromBackend {
                 updateNeedsToNotifyUser(oldStatus: status, newStatus: newValue)
             }
-
             statusValue = newValue.rawValue
-            hasInitialDefault = false
         }
     }
 
-    /// Whether the feature has been updated from backend
-    private var hasBeenUpdatedFromBackend: Bool {
+    /// Whether the feature status has been updated from backend
+    private var statusHasBeenUpdatedFromBackend: Bool {
         return !statusValue.isEmpty && !hasInitialDefault
+    }
+
+    /// Whether the feature config has been updated from backend
+    private var configHasBeenUpdatedFromBackend: Bool {
+        return configData != nil && !hasInitialDefault
     }
 
     // MARK: - Methods
@@ -153,6 +155,7 @@ public class Feature: ZMManagedObject {
         context.performGroupedAndWait { context in
             if let existing = fetch(name: name, context: context) {
                 changes(existing)
+                existing.hasInitialDefault = false
             } else {
                 let feature = Feature.insertNewObject(in: context)
                 feature.name = name

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -56,7 +56,7 @@ public class Feature: ZMManagedObject {
         }
 
         set {
-            if configHasBeenUpdatedFromBackend {
+            if hasBeenUpdatedFromBackend {
                 updateNeedsToNotifyUser(oldData: configData, newData: newValue)
             }
             configData = newValue
@@ -87,21 +87,16 @@ public class Feature: ZMManagedObject {
         }
 
         set {
-            if statusHasBeenUpdatedFromBackend {
+            if hasBeenUpdatedFromBackend {
                 updateNeedsToNotifyUser(oldStatus: status, newStatus: newValue)
             }
             statusValue = newValue.rawValue
         }
     }
 
-    /// Whether the feature status has been updated from backend
-    private var statusHasBeenUpdatedFromBackend: Bool {
+    /// Whether the feature has been updated from backend
+    private var hasBeenUpdatedFromBackend: Bool {
         return !statusValue.isEmpty && !hasInitialDefault
-    }
-
-    /// Whether the feature config has been updated from backend
-    private var configHasBeenUpdatedFromBackend: Bool {
-        return configData != nil && !hasInitialDefault
     }
 
     // MARK: - Methods

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -107,13 +107,6 @@ public extension ZMUser {
     
     @objc(canModifyEphemeralSettingsInConversation:)
     func canModifyEphemeralSettings(in conversation: ConversationLike) -> Bool {
-        guard
-            let featureService = managedObjectContext.map(FeatureService.init),
-            featureService.fetchSelfDeletingMesssages().status == .enabled
-        else {
-            return false
-        }
-
         if conversation.conversationType == .group {
             return hasRoleWithAction(actionName: ConversationAction.modifyConversationMessageTimer.name, conversation: conversation)
         } else {


### PR DESCRIPTION
## What's new in this PR?

1. Remove the `selfDeletingMesssages` status check from `canModifyEphemeralSettings()` method, and with these changes, we allow ephemeralSettings for conversations to be changed despite the feature flag status. More context you can find [here](https://wearezeta.atlassian.net/browse/SQSERVICES-955).

2. Set `hasInitialDefault` to **false** after updating the status and config data.