### PR TITLE
Fix: Crash in isGuest(in:)

### DIFF
--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -196,9 +196,13 @@ public extension ZMUser {
                 return conversation.teamRemoteIdentifier != nil
             }
         } else {
+            guard let context = managedObjectContext else {
+                return false
+            }
+
             return !isServiceUser // Bots are never guests
                 && !isFederated // Federated uesrs are never guests
-                && ZMUser.selfUser(in: managedObjectContext!).hasTeam // There can't be guests in a team that doesn't exist
+                && ZMUser.selfUser(in: context).hasTeam // There can't be guests in a team that doesn't exist
                 && conversation.localParticipantsContain(user: self)
                 && membership == nil
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Application would crash in `isGuest(in:)` when perform data model patches which delete objects

### Causes

`managedObjectContext` is force unwrapped on a user object where it is nil because the object has been deleted.

### Solutions

Guard unwrap the context.