### PR TITLE
Fix: Don't crash when accessing draft message on a deleted conversation

### DIFF
--- a/Source/Public/DraftMessage.swift
+++ b/Source/Public/DraftMessage.swift
@@ -120,10 +120,13 @@ fileprivate struct StorableQuote: Codable {
     public var draftMessage: DraftMessage? {
         set {
             if let value = newValue {
-                guard let encodedData = try? JSONEncoder().encode(value.storable) else { return }
+                guard
+                    let encodedData = try? JSONEncoder().encode(value.storable),
+                    let context = managedObjectContext
+                else { return }
                 
                 do {
-                    let (data, nonce) = try encryptDataIfNeeded(data: encodedData, in: managedObjectContext!)
+                    let (data, nonce) = try encryptDataIfNeeded(data: encodedData, in: context)
                     
                     draftMessageData = data
                     draftMessageNonce = nonce


### PR DESCRIPTION
## What's new in this PR?

### Issues

App sometimes crashes when accessing `draftMessage`

### Causes

If conversation in question has just been deleted the `managedObjectContext` can be nil.

### Solutions

Unwrap the `managedObjectContext` before using it.