### PR TITLE
Fix: App crashes in [ZMConversation refreshObjectsThatAreNotNeededInSyncContext:self]

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -85,7 +85,7 @@ extension ZMConversation {
     @objc
     public var isSelfAnActiveMember: Bool {
         return self.participantRoles.contains(where: { (role) -> Bool in
-            role.user.isSelfUser == true
+            role.user?.isSelfUser == true
         })
     }
     // MARK: - keyPathsForValuesAffecting
@@ -182,7 +182,7 @@ extension ZMConversation {
     /// even if that state is not yet synchronized with the backend
     @objc
     public var localParticipants: Set<ZMUser> {
-        return Set(localParticipantRoles.map { $0.user })
+        return Set(localParticipantRoles.compactMap { $0.user })
     }
     
     /// Participants that are in the conversation, according to the local state
@@ -256,7 +256,7 @@ extension ZMConversation {
             return (result == .created) ? pr : nil
         }
         
-        let addedSelfUser = doesExistsOnBackend && addedRoles.contains(where: {$0.user.isSelfUser})
+        let addedSelfUser = doesExistsOnBackend && addedRoles.contains(where: {$0.user?.isSelfUser == true})
         if addedSelfUser {
             self.markToDownloadRolesIfNeeded()
             self.needsToBeUpdatedFromBackend = true
@@ -264,7 +264,7 @@ extension ZMConversation {
         
         if !addedRoles.isEmpty {
             self.checkIfArchivedStatusChanged(addedSelfUser: addedSelfUser)
-            self.checkIfVerificationLevelChanged(addedUsers: Set(addedRoles.map { $0.user}),  addedSelfUser: addedSelfUser)
+            self.checkIfVerificationLevelChanged(addedUsers: Set(addedRoles.compactMap { $0.user }),  addedSelfUser: addedSelfUser)
         }
     }
 
@@ -331,7 +331,7 @@ extension ZMConversation {
         
         guard let moc = self.managedObjectContext else { return }
         let existingUsers = Set(self.participantRoles.map { $0.user })
-        
+
         let removedUsers = Set(users.compactMap { user -> ZMUser? in
             
             guard existingUsers.contains(user),

--- a/Source/Model/ConversationRole/ParticipantRole.swift
+++ b/Source/Model/ConversationRole/ParticipantRole.swift
@@ -24,7 +24,7 @@ let ZMParticipantRoleRoleValueKey           = #keyPath(ParticipantRole.role)
 final public class ParticipantRole: ZMManagedObject {
     
     @NSManaged public var conversation: ZMConversation?
-    @NSManaged public var user: ZMUser
+    @NSManaged public var user: ZMUser?
     @NSManaged public var role: Role?
 
     public override static func entityName() -> String {

--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -106,7 +106,7 @@ extension ZMUser {
 
         let teamMembersInConversationWithSelfUser = selfUser.conversations.lazy
             .flatMap { $0.participantRoles }
-            .map { $0.user }
+            .compactMap { $0.user }
             .filter { $0.isOnSameTeam(otherUser: selfUser) && !$0.isSelfUser }
 
         return Set(teamMembersInConversationWithSelfUser)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
@@ -1001,7 +1001,7 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
         
         // given
         let conversation = self.setupVerifiedConversation()
-        let participant = conversation.participantRoles.first!.user
+        let participant = conversation.participantRoles.first!.user!
         XCTAssertEqual(conversation.securityLevel, .secure)
         participant.connection?.status = .blocked
         

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
@@ -266,6 +266,6 @@ extension ZMConversation {
     }
     
     fileprivate func participantForUser(id: UUID) -> ParticipantRole? {
-        return self.participantRoles.first(where: { $0.user.remoteIdentifier == id })
+        return self.participantRoles.first(where: { $0.user?.remoteIdentifier == id })
     }
 }

--- a/Tests/Source/Utils/SelfUserParticipantMigrationTests.swift
+++ b/Tests/Source/Utils/SelfUserParticipantMigrationTests.swift
@@ -37,7 +37,7 @@ class SelfUserParticipantMigrationTests: DiskDatabaseTest {
         
         // Then
         let hasSelfUser = conversation.participantRoles.contains(where: { (role) -> Bool in
-            role.user.isSelfUser == true
+            role.user?.isSelfUser == true
         })
         XCTAssertTrue(hasSelfUser)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes in `[ZMConversation refreshObjectsThatAreNotNeededInSyncContext:self]`

### Causes

When fetching the `localParticipants` the app crashes if a `ParticipantRole` doesn't have user since it's declared as non-optional. However when deleting users there's no current rule to delete the corresponding `ParticipantRole` the user can actually be nil.

### Solutions

Declare `user` as optional.