### PR TITLE
Fix: downstream framework can not compile Xcode 13 framework

### DIFF
--- a/Source/Utilis/PINCache+ZMessaging.swift
+++ b/Source/Utilis/PINCache+ZMessaging.swift
@@ -16,30 +16,27 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import PINCache
 
-extension PINCache
-{
+extension PINCache {
     // configures
-    public func configureLimits(_ bytes: UInt) {
-        self.diskCache.byteLimit = bytes;
-        self.memoryCache.ageLimit  = 60 * 60; // if we didn't use it in 1 hour, it can go from memory
+    func configureLimits(_ bytes: UInt) {
+        diskCache.byteLimit = bytes
+        memoryCache.ageLimit  = 60 * 60; // if we didn't use it in 1 hour, it can go from memory
     }
-    
+
     // disable backup of URL
-    public func makeURLSecure() {
-        self.diskCache.makeURLSecure()
+    func makeURLSecure() {
+        diskCache.makeURLSecure()
     }
 }
 
-extension PINDiskCache
-{
+extension PINDiskCache {
     // disable backup of URL
-    public func makeURLSecure() {
-        
-        let secureBlock : (PINDiskCache) -> Void = { cache in
+    func makeURLSecure() {
+
+        let secureBlock: (PINDiskCache) -> Void = { cache in
             // exclude from backup
             do {
                 var url = cache.cacheURL
@@ -50,12 +47,11 @@ extension PINDiskCache
                 fatal("Could not exclude \(cache.cacheURL) from backup")
             }
         }
-        
+
         // every time the directory is recreated, make sure we set the property
-        self.didRemoveAllObjectsBlock = secureBlock
-        
+        didRemoveAllObjectsBlock = secureBlock
+
         // just do it once initially
-        self.synchronouslyLockFileAccessWhileExecuting(secureBlock)
+        synchronouslyLockFileAccessWhileExecuting(secureBlock)
     }
 }
-


### PR DESCRIPTION
## What's new in this PR?

### Issues

When this framework is built with downstream request strategy, compile fails

### Causes
```
 Compiling AppDelegate.swift
[21:29:59]: ▸ ❌  /Users/runner/work/1/s/DerivedData/Build/Products/Debug-iphonesimulator/WireDataModel.framework/Modules/WireDataModel.swiftmodule/x86_64-apple-ios-simulator.swiftinterface:2878:20: 'PINCache' is not a member type of class 'PINCache.PINCache'
[21:29:59]: ▸ extension PINCache.PINCache {
```

### Solutions

Seems it is a namespace issue of we also encountered when building other framework. Remove the public access since the helpers are only used in this framework.
