### PR TITLE
Fix: returning the wrong connection causing data corruption and crashes SQCORE-1161

### DIFF
--- a/Source/Model/Connection/ZMConnection+Fetch.swift
+++ b/Source/Model/Connection/ZMConnection+Fetch.swift
@@ -66,7 +66,7 @@ extension ZMConnection {
         let predicate: NSPredicate
         if searchingLocalDomain {
             if let domain = domain {
-                predicate = NSPredicate(format: "to.remoteIdentifier_data == %@ AND to.domain == %@ || to.domain == NULL", userID.uuidData as NSData, domain)
+                predicate = NSPredicate(format: "to.remoteIdentifier_data == %@ AND (to.domain == %@ || to.domain == NULL)", userID.uuidData as NSData, domain)
             } else {
                 predicate = NSPredicate(format: "to.remoteIdentifier_data == %@", userID.uuidData as NSData)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash on login due to hitting an assertion about corrupted connection data

### Causes

When fetching connections from core data during the slow sync we would start fetching the wrong connection if we had a connection without the `to` field populated. 

This would happen because the fetch predicate ends with `|| to.domain == NULL`, which is always true if the `to` field is not populated.

this was surfaced after https://github.com/wireapp/wire-ios-data-model/pull/1254 was merged since now we don't assign the domain if federation is not enabled.

### Solutions

Add the missing `(` `)` to get the expected priority for the statements.