### PR TITLE
[Fix] App crashes after update

### DIFF
--- a/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/Source/ManagedObjectContext/CoreDataStack.swift
@@ -285,8 +285,6 @@ public class CoreDataStack: NSObject, ContextProvider {
         context.mergePolicy = NSMergePolicy(merge: .rollbackMergePolicyType)
         ZMUser.selfUser(in: context)
         Label.fetchOrCreateFavoriteLabel(in: context, create: true)
-        FeatureService(context: context).createDefaultConfigsIfNeeded()
-        context.saveOrRollback()
     }
 
     func configureContextReferences() {
@@ -308,6 +306,9 @@ public class CoreDataStack: NSObject, ContextProvider {
                                       applicationContainer: applicationContainer)
             context.undoManager = nil
             context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+
+            FeatureService(context: context).createDefaultConfigsIfNeeded()
+            context.saveOrRollback()
         }
 
         // this will be done async, not to block the UI thread, but

--- a/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/Source/ManagedObjectContext/CoreDataStack.swift
@@ -285,6 +285,8 @@ public class CoreDataStack: NSObject, ContextProvider {
         context.mergePolicy = NSMergePolicy(merge: .rollbackMergePolicyType)
         ZMUser.selfUser(in: context)
         Label.fetchOrCreateFavoriteLabel(in: context, create: true)
+        FeatureService(context: context).createDefaultConfigsIfNeeded()
+        context.saveOrRollback()
     }
 
     func configureContextReferences() {
@@ -306,8 +308,6 @@ public class CoreDataStack: NSObject, ContextProvider {
                                       applicationContainer: applicationContainer)
             context.undoManager = nil
             context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
-
-            FeatureService(context: context).createDefaultConfigsIfNeeded()
         }
 
         // this will be done async, not to block the UI thread, but


### PR DESCRIPTION
## What's new in this PR?

### Issues
There's a crash when we try to update the public version from TestFlight.

### Causes
We create default feature configs in a sync context, but fetch them in a view context. This could be the cause of the crash.

### Solutions
Create default feature configs in the view context and save the context.
