### PR TITLE
Fix: xcode13 warning - Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

### DIFF
--- a/Source/ConversationList/ConversationDirectory.swift
+++ b/Source/ConversationList/ConversationDirectory.swift
@@ -36,7 +36,7 @@ public struct ConversationDirectoryChangeInfo {
     
 }
 
-public protocol ConversationDirectoryObserver: class {
+public protocol ConversationDirectoryObserver: AnyObject {
     
     func conversationDirectoryDidChange(_ changeInfo: ConversationDirectoryChangeInfo)
 

--- a/Source/Model/AccountDeletedObserver.swift
+++ b/Source/Model/AccountDeletedObserver.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public protocol AccountDeletedObserver: class {
+public protocol AccountDeletedObserver: AnyObject {
     func accountDeleted(accountId : UUID)
 }
 

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -20,7 +20,7 @@ public extension NSNotification.Name {
     static let teamDidRequestAsset = Notification.Name("TeamDidRequestAsset")
 }
 
-public protocol TeamType: class {
+public protocol TeamType: AnyObject {
 
     var conversations: Set<ZMConversation> { get }
     var name: String? { get }

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -121,7 +121,7 @@ public struct TextSearchQueryFetchConfiguration {
 }
 
 
-public protocol TextSearchQueryDelegate: class {
+public protocol TextSearchQueryDelegate: AnyObject {
     func textSearchQueryDidReceive(result: TextQueryResult)
 }
 

--- a/Source/Model/User/ServiceUser.swift
+++ b/Source/Model/User/ServiceUser.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-@objc public protocol ServiceUser: class, UserType {
+@objc public protocol ServiceUser: AnyObject, UserType {
     var providerIdentifier: String? { get }
     var serviceIdentifier: String? { get }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Replace all protocol extends class with AnyObject


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
