### PR TITLE
fix: update merge spell action to bump version.xcconfig SQPIT-773

### DIFF
--- a/.github/workflows/mergePR.yml
+++ b/.github/workflows/mergePR.yml
@@ -1,6 +1,6 @@
-name: Merge PR v0.1.5
+name: Merge PR v0.1.6
 
-on: 
+on:
   issue_comment:
     types: [created]
 
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ADMINS: ('billypchan' 'marcoconti83' 'typfel' 'johnxnguyen' 'David-Henner' 'KaterinaWire')
+      ADMINS: ('billypchan' 'marcoconti83' 'typfel' 'johnxnguyen' 'David-Henner' 'KaterinaWire' 'sb88k' 'agisilaos')
     steps:
       - name: get release type
         id: releaseType
@@ -31,7 +31,7 @@ jobs:
               adminFound=1
             fi
           done
-          
+
           if [ $adminFound = 0 ]; then
             echo ${{ github.actor }} is not allowed for releasing
             exit 1
@@ -41,7 +41,44 @@ jobs:
           github_token: ${{ secrets.github_token }}
           body: |
             Hello, @${{ github.actor }}! Merging PR for command **${{ github.event.comment.body}}** for PR #**${{ github.event.issue.number }}**. Will create a **${{ steps.releaseType.outputs.TYPE }}** release after merged
-      - name: Merge Pull Request 
+      - name: Get the next version tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: ''
+          release_branches: 'develop'
+          default_bump: ${{ steps.releaseType.outputs.TYPE }}
+          dry_run: 'true'
+      - uses: actions-ecosystem/action-create-comment@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          body: |
+            Next version is ${{ steps.tag_version.outputs.new_tag }}
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Checkout Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hub pr checkout ${{ github.event.issue.number }}
+      - name: update version.xcconfig
+        run: |
+          echo "new tag: '${{steps.dry_run.outputs.new_tag}}'"
+          echo "tag: '${{steps.dry_run.outputs.tag}}'"
+          # process version.xcconfig
+          curl --silent https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master/Scripts/updateVersionXcconfig.swift --output updateVersionXcconfig.swift
+          chmod +x updateVersionXcconfig.swift
+          swift updateVersionXcconfig.swift ./Resources/Configurations/version.xcconfig ${{ steps.tag_version.outputs.new_tag }}
+          rm updateVersionXcconfig.swift
+
+          git config --global user.email "iosx@wire.com"
+          git config --global user.name "zenkins"
+          git add .
+          git commit -m"update version.xcconfig for '${{ steps.tag_version.outputs.new_tag }}'" || true
+          git push
+
+      - name: Merge Pull Request
         id: mergePullRequest
         run: |
           if gh pr merge ${{ github.event.issue.html_url }} -s --admin; then
@@ -61,20 +98,6 @@ jobs:
         run: |
           echo exit for merger fail
           exit 1
-      - name: Get the next version tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v5.6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_prefix: ''
-          release_branches: 'develop'
-          default_bump: ${{ steps.releaseType.outputs.TYPE }}
-          dry_run: 'true'
-      - uses: actions-ecosystem/action-create-comment@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          body: |
-            Next version is ${{ steps.tag_version.outputs.new_tag }}
       - name: get the latest develop SHA
         id: developSha
         run: |

--- a/.github/workflows/mergePR.yml
+++ b/.github/workflows/mergePR.yml
@@ -81,7 +81,7 @@ jobs:
           git config --global user.email "iosx@wire.com"
           git config --global user.name "zenkins"
           git add .
-          git commit -m"update version.xcconfig for '${{ steps.tag_version.outputs.new_tag }}'" || true
+          git commit -m"chore: Update version.xcconfig for '${{ steps.tag_version.outputs.new_tag }}'" || true
           git push
 
       - name: Merge Pull Request

--- a/.github/workflows/mergePR.yml
+++ b/.github/workflows/mergePR.yml
@@ -17,9 +17,11 @@ jobs:
           TYPE=`echo ${{ github.event.comment.body }} | cut -d " " -f 2`
           echo $TYPE
           echo "::set-output name=TYPE::$TYPE"
+          
       - name: guard for magic spell
         if: ${{ github.event.comment.body != 'release major' && github.event.comment.body != 'release minor' && github.event.comment.body != 'release patch'}}
         run: exit 1
+        
       - name: guard for admins
         run: |
           admins=${{ env.ADMINS }}
@@ -41,6 +43,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           body: |
             Hello, @${{ github.actor }}! Merging PR for command **${{ github.event.comment.body}}** for PR #**${{ github.event.issue.number }}**. Will create a **${{ steps.releaseType.outputs.TYPE }}** release after merged
+            
       - name: Get the next version tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.6
@@ -55,13 +58,16 @@ jobs:
           github_token: ${{ secrets.github_token }}
           body: |
             Next version is ${{ steps.tag_version.outputs.new_tag }}
+            
       - name: checkout
         uses: actions/checkout@v2
+        
       - name: Checkout Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           hub pr checkout ${{ github.event.issue.number }}
+          
       - name: update version.xcconfig
         run: |
           echo "new tag: '${{steps.dry_run.outputs.new_tag}}'"
@@ -93,20 +99,24 @@ jobs:
           github_token: ${{ secrets.github_token }}
           body: |
             Merging Failed. Please check the action log.
+            
       - name: Merge Pull Request exit
         if: ${{ steps.mergePullRequest.outputs.mergeResult == 0 }}
         run: |
           echo exit for merger fail
           exit 1
+          
       - name: get the latest develop SHA
         id: developSha
         run: |
           SHA=`git ls-remote ${{ github.event.repository.html_url}} develop | cut -f 1`
           echo "::set-output name=SHA::$SHA"
+          
       - name: checkout
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.developSha.outputs.SHA }}
+          
       - name: tagging new release version
         run: |
           git status


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-773" title="SQPIT-773" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />SQPIT-773</a>  update Github action merge PR to update version.xcconfig
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Recent framework release does not update `version.xcconfig`

### Causes (Optional)

It was done by Jenkins script, after we use `mergePR` action this feature is not included

### Solutions

Add this feature to mergePR action.
This action is tested in https://github.com/wireapp/wire-ios-canvas/pull/33
Add @agisilaos and @sb88k to admin list so that they can use this spell