### PR TITLE
fix: use private class for fetching framework bundle SQSERVICES-1031

### DIFF
--- a/Patches/PersistedDataPatches.swift
+++ b/Patches/PersistedDataPatches.swift
@@ -39,7 +39,7 @@ public struct PersistedDataPatch {
     public static func applyAll(in moc: NSManagedObjectContext, fromVersion: String? = nil, patches: [PersistedDataPatch]? = nil) {
         zmLog.safePublic("Beginning patches...")
 
-        guard let currentVersion = Bundle(for: ZMUser.self).infoDictionary!["CFBundleShortVersionString"] as? String else {
+        guard let currentVersion = Bundle(for: BundleAnchor.self).infoDictionary!["CFBundleShortVersionString"] as? String else {
             return zmLog.safePublic("Can't retrieve CFBundleShortVersionString for data model, skipping patches..")
         }
 
@@ -70,6 +70,8 @@ public struct PersistedDataPatch {
         zmLog.safePublic("Previous version: \(previousPatchVersion.version)")
     }
 }
+
+private class BundleAnchor {}
 
 private extension NSManagedObjectContext {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1031" title="SQSERVICES-1031" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10803&avatarType=issuetype" />SQSERVICES-1031</a>  [iOS] Release build crashes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The database patches should only we run when the app has upgraded and uses a new data model version, but we are observing that they're running all the time, even on a fresh install.

### Causes

The current version of the framework is fetched from the framework bundle, which is used to determine whether the patches should be run. For some reason, when this code is run in the testflight app, the Bundle we retrieve is actually the main app bundle, and the version that we retrieve is actually the app's short version, which is currently 3.93. This means that effectively all patches are run, because we expect a much larger data model version.

### Solutions

The bundle is fetched by passing in _ZMUser.self_  in an initializer. This should work, but for some reason it's not, and I wonder if the bundle code gets confused with this type because it is so ubiquitous and has extensions in the main app bundle. To test this, I am passing in a private class `BundleAnchor`. If this still doesn't work, then it seems like a bug with the Bundle initializer. If that's the case, then I will try fetch the bundle explicitly using the bundle identifier.

### Testing

This can only be tested by running this code in the testflight app.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
