### PR TITLE
chore: Fix SwiftLint warnings for multiple rules in Tests Part 2

### DIFF
--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Cleared.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Cleared.swift
@@ -20,19 +20,18 @@ import Foundation
 @testable import WireDataModel
 
 final class ClientMessageTests_Cleared: BaseZMClientMessageTests {
-    
-    
+
     func testThatItCreatesPayloadForZMClearedMessages() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             // given
             self.syncConversation.clearedTimeStamp = Date()
             self.syncConversation.remoteIdentifier = UUID()
             guard let message = try? ZMConversation.updateSelfConversation(withClearedOf: self.syncConversation) else { return XCTFail() }
-            
+
             // when
             guard let payloadAndStrategy = message.encryptForTransport() else { return XCTFail() }
-            
+
             // then
             switch payloadAndStrategy.strategy {
             case .doNotIgnoreAnyMissingClient:
@@ -42,7 +41,7 @@ final class ClientMessageTests_Cleared: BaseZMClientMessageTests {
             }
         }
     }
-    
+
     func testThatLastClearedUpdatesInSelfConversationDontExpire() {
 
         self.syncMOC.performGroupedBlockAndWait {

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Editing.swift
@@ -26,10 +26,10 @@ class ZMClientMessageTests_Editing: BaseZMClientMessageTests {
         let conversationID = UUID.create()
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = conversationID
-        
+
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.remoteIdentifier = UUID.create()
-        
+
         let nonce = UUID.create()
         let message = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
         message.sender = user
@@ -37,98 +37,98 @@ class ZMClientMessageTests_Editing: BaseZMClientMessageTests {
         try message.setUnderlyingMessage(GenericMessage(content: Text(content: "text")))
 
         conversation.append(message)
-        
+
         let edited = MessageEdit.with {
             $0.replacingMessageID = nonce.transportString()
             $0.text = Text(content: "editedText")
         }
-        
+
         let genericMessage = GenericMessage(content: edited)
-        
+
         let updateEvent = createUpdateEvent(nonce, conversationID: conversationID, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier)
-        
+
         // WHEN
         var editedMessage: ZMClientMessage?
         performPretendingUiMocIsSyncMoc {
             editedMessage = ZMClientMessage.editMessage(withEdit: edited, forConversation: conversation, updateEvent: updateEvent, inContext: self.uiMOC, prefetchResult: ZMFetchRequestBatchResult())
         }
-        
+
         // THEN
         XCTAssertEqual(editedMessage?.messageText, "editedText")
     }
 }
 
-class ZMClientMessageTests_TextMessageData : BaseZMClientMessageTests {
-    
-    func testThatItUpdatesTheMesssageText_WhenEditing(){
-        
+class ZMClientMessageTests_TextMessageData: BaseZMClientMessageTests {
+
+    func testThatItUpdatesTheMesssageText_WhenEditing() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let message = try! conversation.appendText(content: "hello") as! ZMClientMessage
         message.delivered = true
-        
+
         // when
         message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
-        
+
         // then
         XCTAssertEqual(message.textMessageData?.messageText, "good bye")
     }
-    
-    func testThatItClearReactions_WhenEditing(){
-        
+
+    func testThatItClearReactions_WhenEditing() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let message = try! conversation.appendText(content: "hello") as! ZMClientMessage
         message.delivered = true
         message.addReaction("🤠", forUser: selfUser)
         XCTAssertFalse(message.reactions.isEmpty)
-        
+
         // when
         message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
-        
+
         // then
         XCTAssertTrue(message.reactions.isEmpty)
     }
-    
-    func testThatItKeepsQuote_WhenEditing(){
-        
+
+    func testThatItKeepsQuote_WhenEditing() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let quotedMessage = try! conversation.appendText(content: "Let's grab some lunch") as! ZMClientMessage
         let message = try! conversation.appendText(content: "Yes!", replyingTo: quotedMessage) as! ZMClientMessage
         message.delivered = true
         XCTAssertTrue(message.hasQuote)
-        
+
         // when
         message.textMessageData?.editText("good bye", mentions: [], fetchLinkPreview: false)
-        
+
         // then
         XCTAssertTrue(message.hasQuote)
     }
-    
+
 }
 
 // MARK: - Payload creation
 extension ZMClientMessageTests_Editing {
-    
+
     private func checkThatItCanEditAMessageFrom(sameSender: Bool, shouldEdit: Bool) {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let sender = sameSender
             ? self.selfUser
-            : ZMUser.insertNewObject(in:self.uiMOC)
-        
+            : ZMUser.insertNewObject(in: self.uiMOC)
+
         if !sameSender {
             sender?.remoteIdentifier = UUID.create()
         }
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMClientMessage
@@ -136,18 +136,18 @@ extension ZMClientMessageTests_Editing {
         message.markAsSent()
         message.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
         let originalNonce = message.nonce
-        
+
         XCTAssertEqual(message.visibleInConversation, conversation)
         XCTAssertEqual(conversation.allMessages.count, 1)
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
-        
+
         // when
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: true)
-        
+
         // then
-        
+
         XCTAssertEqual(conversation.allMessages.count, 1)
-        
+
         if shouldEdit {
             XCTAssertEqual(message.textMessageData?.messageText, newText)
             XCTAssertEqual(message.normalizedText, newText.lowercased())
@@ -157,203 +157,186 @@ extension ZMClientMessageTests_Editing {
             XCTAssertEqual(message.textMessageData?.messageText, oldText)
         }
     }
-    
+
     func testThatItCanEditAMessage_SameSender() {
         checkThatItCanEditAMessageFrom(sameSender: true, shouldEdit: true)
     }
-    
+
     func testThatItCanNotEditAMessage_DifferentSender() {
         checkThatItCanEditAMessageFrom(sameSender: false, shouldEdit: false)
     }
-    
+
     func testThatExtremeCombiningCharactersAreRemovedFromTheMessage() {
         // GIVEN
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         // WHEN
         let message: ZMMessage = try! conversation.appendText(content: "ť̹̱͉̥̬̪̝ͭ͗͊̕e͇̺̳̦̫̣͕ͫͤ̅s͇͎̟͈̮͎̊̾̌͛ͭ́͜t̗̻̟̙͑ͮ͊ͫ̂") as! ZMMessage
-        
+
         // THEN
         XCTAssertEqual(message.textMessageData?.messageText, "test̻̟̙")
     }
-    
+
     func testThatItResetsTheLinkPreviewState() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMClientMessage
         message.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
         message.linkPreviewState = ZMLinkPreviewState.done
         message.markAsSent()
-        
+
         XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewState.done)
-        
+
         // when
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: true)
-        
+
         // then
         XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewState.waitingToBeProcessed)
     }
-    
+
     func testThatItDoesNotFetchLinkPreviewIfExplicitlyToldNotTo() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
-        
+
         let fetchLinkPreview = false
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText, mentions: [], fetchLinkPreview: fetchLinkPreview, nonce: UUID.create()) as! ZMClientMessage
         message.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
         message.markAsSent()
-        
+
         XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewState.done)
-        
+
         // when
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: fetchLinkPreview)
-        
+
         // then
         XCTAssertEqual(message.linkPreviewState, ZMLinkPreviewState.done)
     }
-    
+
     func testThatItDoesNotEditAMessageThatFailedToSend() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message: ZMMessage = try! conversation.appendText(content: oldText) as! ZMMessage
         message.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
         message.expire()
         XCTAssertEqual(message.deliveryState, ZMDeliveryState.failedToSend)
-        
+
         // when
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: true)
-        
+
         // then
         XCTAssertEqual(message.textMessageData?.messageText, oldText)
     }
-    
+
     func testThatItUpdatesTheUpdatedTimestampAfterSuccessfulUpdate() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let originalDate = Date.init(timeIntervalSinceNow: -50)
         let updateDate: Date = Date.init(timeIntervalSinceNow: -20)
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMMessage
         message.serverTimestamp = originalDate
         message.markAsSent()
-        
+
         conversation.lastModifiedDate = originalDate
         conversation.lastServerTimeStamp = originalDate
-        
+
         XCTAssertEqual(message.visibleInConversation, conversation)
         XCTAssertEqual(conversation.allMessages.count, 1)
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
-        
+
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: false)
-        
+
         // when
         message.update(withPostPayload: ["time": updateDate], updatedKeys: nil)
-        
+
         // then
         XCTAssertEqual(message.serverTimestamp, originalDate)
         XCTAssertEqual(message.updatedAt, updateDate)
         XCTAssertEqual(message.textMessageData?.messageText, newText)
     }
-    
+
     func testThatItDoesNotOverwritesEditedTextWhenMessageExpiresButReplacesNonce() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let originalDate = Date.init(timeIntervalSinceNow: -50)
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMMessage
         message.serverTimestamp = originalDate
         message.markAsSent()
-        
+
         conversation.lastModifiedDate = originalDate
         conversation.lastServerTimeStamp = originalDate
         let originalNonce = message.nonce
-        
+
         XCTAssertEqual(message.visibleInConversation, conversation)
         XCTAssertEqual(conversation.allMessages.count, 1)
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
-        
+
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: false)
-        
+
         // when
         message.expire()
-        
+
         // then
         XCTAssertEqual(message.nonce, originalNonce)
     }
-    
+
     func testThatWhenResendingAFailedEditItReappliesTheEdit() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let originalDate = Date.init(timeIntervalSinceNow: -50)
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message: ZMClientMessage = try! conversation.appendText(content: oldText) as! ZMClientMessage
         message.serverTimestamp = originalDate
         message.markAsSent()
-        
-        conversation.lastModifiedDate = originalDate;
-        conversation.lastServerTimeStamp = originalDate;
+
+        conversation.lastModifiedDate = originalDate
+        conversation.lastServerTimeStamp = originalDate
         let originalNonce = message.nonce
-        
+
         XCTAssertEqual(message.visibleInConversation, conversation)
         XCTAssertEqual(conversation.allMessages.count, 1)
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
-        
+
         message.textMessageData?.editText(newText, mentions: [], fetchLinkPreview: false)
         let editNonce1 = message.nonce
-        
+
         message.expire()
-        
+
         // when
         message.resend()
         let editNonce2 = message.nonce
-        
+
         // then
         XCTAssertFalse(message.isExpired)
         XCTAssertNotEqual(editNonce2, editNonce1)
         XCTAssertEqual(message.underlyingMessage?.edited.replacingMessageID, originalNonce?.transportString())
     }
-    
-    private func createMessageEditUpdateEvent(oldNonce: UUID, newNonce: UUID, conversationID: UUID, senderID: UUID,  newText: String) -> ZMUpdateEvent? {
+
+    private func createMessageEditUpdateEvent(oldNonce: UUID, newNonce: UUID, conversationID: UUID, senderID: UUID, newText: String) -> ZMUpdateEvent? {
         let genericMessage: GenericMessage = GenericMessage(content: MessageEdit(replacingMessageID: oldNonce, text: Text(content: newText, mentions: [], linkPreviews: [], replyingTo: nil)), nonce: newNonce)
-        
-        let data = try? genericMessage.serializedData().base64String()
-        let payload: NSMutableDictionary = [
-            "conversation": conversationID.transportString(),
-            "from": senderID.transportString(),
-            "time": Date().transportString(),
-            "data": [
-                "text": data ?? "",
-            ],
-            "type": "conversation.otr-message-add"
-        ]
-        
-        return ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: UUID.create())
-    }
-    
-    private func createTextAddedEvent(nonce: UUID, conversationID: UUID, senderID: UUID) -> ZMUpdateEvent? {
-        let genericMessage: GenericMessage = GenericMessage(content: Text(content: "Yeah!", mentions: [], linkPreviews: [], replyingTo: nil), nonce: nonce)
-        
+
         let data = try? genericMessage.serializedData().base64String()
         let payload: NSMutableDictionary = [
             "conversation": conversationID.transportString(),
@@ -364,16 +347,33 @@ extension ZMClientMessageTests_Editing {
             ],
             "type": "conversation.otr-message-add"
         ]
-        
+
         return ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: UUID.create())
     }
-    
+
+    private func createTextAddedEvent(nonce: UUID, conversationID: UUID, senderID: UUID) -> ZMUpdateEvent? {
+        let genericMessage: GenericMessage = GenericMessage(content: Text(content: "Yeah!", mentions: [], linkPreviews: [], replyingTo: nil), nonce: nonce)
+
+        let data = try? genericMessage.serializedData().base64String()
+        let payload: NSMutableDictionary = [
+            "conversation": conversationID.transportString(),
+            "from": senderID.transportString(),
+            "time": Date().transportString(),
+            "data": [
+                "text": data ?? ""
+            ],
+            "type": "conversation.otr-message-add"
+        ]
+
+        return ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: UUID.create())
+    }
+
     func testThatItEditsMessageWithQuote() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let senderID = self.selfUser.remoteIdentifier
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let quotedMessage = try! conversation.appendText(content: "Quote") as! ZMMessage
@@ -383,59 +383,59 @@ extension ZMClientMessageTests_Editing {
                                           fetchLinkPreview: false,
                                           nonce: UUID.create()) as! ZMMessage
         self.uiMOC.saveOrRollback()
-        
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!, newNonce: UUID.create(), conversationID: conversation.remoteIdentifier!, senderID: senderID!, newText: newText)
-        
+
         let oldNonce = message.nonce
-        
+
         // when
         self.performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertEqual(message.textMessageData?.messageText, newText)
         XCTAssertTrue(message.textMessageData!.hasQuote)
         XCTAssertNotEqual(message.nonce, oldNonce)
         XCTAssertEqual(message.textMessageData?.quoteMessage as! ZMMessage, quotedMessage)
     }
-    
+
     func testThatReadExpectationIsKeptAfterEdit() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let senderID = self.selfUser.remoteIdentifier
-        
+
         self.selfUser.readReceiptsEnabled = true
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.conversationType = ZMConversationType.oneOnOne
-        
+
         let message = try! conversation.appendText(content: oldText, mentions: [], fetchLinkPreview: false, nonce: UUID.create()) as! ZMClientMessage
         var genericMessage = message.underlyingMessage!
         genericMessage.setExpectsReadConfirmation(true)
-        
+
         do {
             try message.setUnderlyingMessage(genericMessage)
         } catch {
             XCTFail()
         }
-        
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!, newNonce: UUID.create(), conversationID: conversation.remoteIdentifier!, senderID: senderID!, newText: newText)
         let oldNonce = message.nonce
-        
+
         // when
         self.performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertEqual(message.textMessageData?.messageText, newText)
         XCTAssertNotEqual(message.nonce, oldNonce)
         XCTAssertTrue(message.needsReadConfirmation)
     }
-    
+
     func checkThatItEditsMessageFor(sameSender: Bool, shouldEdit: Bool) {
         // given
         let oldText = "Hallo"
@@ -443,22 +443,22 @@ extension ZMClientMessageTests_Editing {
         let senderID = sameSender
             ? self.selfUser.remoteIdentifier
             : UUID.create()
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMMessage
-        
+
         message.addReaction("👻", forUser: self.selfUser)
         self.uiMOC.saveOrRollback()
-        
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!, newNonce: UUID.create(), conversationID: conversation.remoteIdentifier!, senderID: senderID!, newText: newText)
         let oldNonce = message.nonce
-        
+
         // when
         self.performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         if shouldEdit {
             XCTAssertEqual(message.textMessageData?.messageText, newText)
@@ -473,38 +473,38 @@ extension ZMClientMessageTests_Editing {
             XCTAssertNil(message.hiddenInConversation)
         }
     }
-    
+
     func testThatEditsMessageWhenSameSender() {
         checkThatItEditsMessageFor(sameSender: true, shouldEdit: true)
     }
-    
+
     func testThatDoesntEditMessageWhenSenderIsDifferent() {
         checkThatItEditsMessageFor(sameSender: false, shouldEdit: false)
     }
-    
+
     func testThatItDoesNotInsertAMessageWithANonceBelongingToAHiddenMessage() {
         // given
         let oldText = "Hallo"
         let senderID = self.selfUser.remoteIdentifier
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMMessage
         message.visibleInConversation = nil
         message.hiddenInConversation = conversation
-        
+
         let updateEvent = createTextAddedEvent(nonce: message.nonce!, conversationID: conversation.remoteIdentifier!, senderID: senderID!)
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertNil(newMessage)
     }
-    
+
     func testThatItSetsTheTimestampsOfTheOriginalMessage() {
         // given
         let oldText = "Hallo"
@@ -512,63 +512,63 @@ extension ZMClientMessageTests_Editing {
         let oldDate = Date.init(timeIntervalSinceNow: -20)
         let sender = ZMUser.insertNewObject(in: self.uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message = try! conversation.appendText(content: oldText) as! ZMMessage
         message.sender = sender
         message.serverTimestamp = oldDate
-        
+
         conversation.lastModifiedDate = oldDate
         conversation.lastServerTimeStamp = oldDate
         conversation.lastReadServerTimeStamp = oldDate
         XCTAssertEqual(conversation.estimatedUnreadCount, 0)
-        
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!, newNonce: UUID.create(), conversationID: conversation.remoteIdentifier!, senderID: sender.remoteIdentifier, newText: newText)
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertEqual(conversation.lastModifiedDate, oldDate)
         XCTAssertEqual(conversation.lastServerTimeStamp, oldDate)
         XCTAssertEqual(newMessage?.serverTimestamp, oldDate)
         XCTAssertEqual(newMessage?.updatedAt, updateEvent!.timestamp)
-        
+
         XCTAssertEqual(conversation.estimatedUnreadCount, 0)
     }
-    
+
     func testThatItDoesNotReinsertAMessageThatHasBeenPreviouslyHiddenLocally() {
         // given
         let oldText = "Hallo"
         let newText = "Hello"
         let oldDate = Date.init(timeIntervalSinceNow: -20)
-        let sender = ZMUser.insertNewObject(in:self.uiMOC)
+        let sender = ZMUser.insertNewObject(in: self.uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         // insert message locally
         let message: ZMMessage = try! conversation.appendText(content: oldText) as! ZMMessage
         message.sender = sender
         message.serverTimestamp = oldDate
-        
+
         // hide message locally
         ZMMessage.hideMessage(message)
         XCTAssertTrue(message.isZombieObject)
-        
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!, newNonce: UUID.create(), conversationID: conversation.remoteIdentifier!, senderID: sender.remoteIdentifier, newText: newText)
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertNil(newMessage)
         XCTAssertNil(message.visibleInConversation)
@@ -577,108 +577,108 @@ extension ZMClientMessageTests_Editing {
         XCTAssertNil(message.textMessageData)
         XCTAssertNil(message.sender)
         XCTAssertNil(message.senderClientID)
-        
+
         let clientMessage = message as! ZMClientMessage
         XCTAssertNil(clientMessage.underlyingMessage)
         XCTAssertEqual(clientMessage.dataSet.count, 0)
     }
-    
+
     func testThatItClearsReactionsWhenAMessageIsEdited() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message: ZMMessage = try! conversation.appendText(content: "Hallo") as! ZMMessage
-        
-        let otherUser = ZMUser.insertNewObject(in:self.uiMOC)
+
+        let otherUser = ZMUser.insertNewObject(in: self.uiMOC)
         otherUser.remoteIdentifier = UUID.create()
-        
-        message.addReaction("😱", forUser:self.selfUser)
-        message.addReaction("🤗", forUser:otherUser)
-        
-        XCTAssertFalse(message.reactions.isEmpty);
-        
+
+        message.addReaction("😱", forUser: self.selfUser)
+        message.addReaction("🤗", forUser: otherUser)
+
+        XCTAssertFalse(message.reactions.isEmpty)
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
                                                        senderID: message.sender!.remoteIdentifier!,
                                                        newText: "Hello")
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertTrue(message.reactions.isEmpty)
         XCTAssertEqual(conversation.allMessages.count, 1)
-        
+
         let editedMessage = conversation.lastMessage as! ZMMessage
         XCTAssertTrue(editedMessage.reactions.isEmpty)
         XCTAssertEqual(editedMessage.textMessageData?.messageText, "Hello")
     }
-    
+
     func testThatItClearsReactionsWhenAMessageIsEditedRemotely() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message: ZMMessage = try! conversation.appendText(content: "Hallo") as! ZMMessage
-        
-        let otherUser = ZMUser.insertNewObject(in:self.uiMOC)
+
+        let otherUser = ZMUser.insertNewObject(in: self.uiMOC)
         otherUser.remoteIdentifier = UUID.create()
-        
-        message.addReaction("😱", forUser:self.selfUser)
-        message.addReaction("🤗", forUser:otherUser)
-        
-        XCTAssertFalse(message.reactions.isEmpty);
-        
+
+        message.addReaction("😱", forUser: self.selfUser)
+        message.addReaction("🤗", forUser: otherUser)
+
+        XCTAssertFalse(message.reactions.isEmpty)
+
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
                                                        senderID: message.sender!.remoteIdentifier,
                                                        newText: "Hello")
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertTrue(message.reactions.isEmpty)
         let editedMessage = conversation.lastMessage as! ZMMessage
         XCTAssertTrue(editedMessage.reactions.isEmpty)
         XCTAssertEqual(editedMessage.textMessageData?.messageText, "Hello")
     }
-    
+
     func testThatMessageNonPersistedIdentifierDoesNotChangeAfterEdit() {
         // given
         let oldText = "Mamma mia"
         let newText = "here we go again"
         let oldNonce = UUID.create()
-        
-        let sender = ZMUser.insertNewObject(in:self.uiMOC)
+
+        let sender = ZMUser.insertNewObject(in: self.uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
         let message: ZMMessage = try! conversation.appendText(content: oldText) as! ZMMessage
         message.sender = sender
         message.nonce = oldNonce
-        
+
         let oldIdentifier = message.nonpersistedObjectIdentifer
         let updateEvent = createMessageEditUpdateEvent(oldNonce: message.nonce!,
                                                        newNonce: UUID.create(),
                                                        conversationID: conversation.remoteIdentifier!,
                                                        senderID: message.sender!.remoteIdentifier!,
                                                        newText: newText)
-        
+
         // when
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertNotEqual(oldNonce, newMessage!.nonce)
         XCTAssertEqual(oldIdentifier, newMessage!.nonpersistedObjectIdentifer)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Location.swift
@@ -16,29 +16,28 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import CoreLocation
 @testable import WireDataModel
 
 class ClientMessageTests_Location: BaseZMMessageTests {
- 
+
     func testThatItReturnsLocationMessageDataWhenPresent() throws {
         // given
         let (latitude, longitude): (Float, Float) = (48.53775, 9.041169)
         let (name, zoom) = ("Tuebingen, Deutschland", Int32(3))
-        let location = Location.with() {
+        let location = Location.with {
             $0.latitude = latitude
             $0.longitude = longitude
             $0.name = name
             $0.zoom = zoom
         }
         let message = GenericMessage(content: location)
-        
+
         // when
         let clientMessage = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         try clientMessage.setUnderlyingMessage(message)
-        
+
         // then
         let locationMessageData = clientMessage.locationMessageData
         XCTAssertNotNil(locationMessageData)
@@ -47,13 +46,13 @@ class ClientMessageTests_Location: BaseZMMessageTests {
         XCTAssertEqual(locationMessageData?.name, name)
         XCTAssertEqual(locationMessageData?.zoomLevel, zoom)
     }
-    
+
     func testThatItDoesNotReturnLocationMessageDataWhenNotPresent() {
         // given
         let clientMessage = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
-        
+
         // then
         XCTAssertNil(clientMessage.locationMessageData)
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Mentions.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Mentions.swift
@@ -16,82 +16,81 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 @testable import WireDataModel
 
 class ZMClientMessageTests_Mentions: BaseZMClientMessageTests {
-    
+
     func createMessage(text: String, mentions: [ Mention]) -> ZMClientMessage {
         let text = Text(content: text, mentions: mentions, linkPreviews: [])
         let message = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
-        
+
         do {
             try message.setUnderlyingMessage(GenericMessage(content: text))
         } catch {
             XCTFail()
         }
-        
+
         return message
     }
-    
+
     func testMentionsAreReturned() {
         // given
         let text = "@john hello"
         let mention = Mention(range: NSRange(location: 0, length: 5), user: user1)
         let message = createMessage(text: text, mentions: [mention])
-        
+
         // when
         let mentions = message.mentions
-        
+
         // then
         XCTAssertEqual(mentions, [mention])
     }
-    
+
     func testMentionsWithMultiplePartCharactersAreReturned() {
         // given
         let text = "@🙅‍♂️"
         let mention = Mention(range: NSRange(location: 0, length: 6), user: user1)
-        
+
         let message = createMessage(text: text, mentions: [mention])
-        
+
         // when
         let mentions = message.mentions
-        
+
         // then
         XCTAssertEqual(mentions, [mention])
     }
-    
+
     func testMentionsWithOverlappingRangesAreDiscarded() {
         // given
         let text = "@john hello"
         let mention = Mention(range: NSRange(location: 0, length: 5), user: user1)
         let mentionOverlapping = Mention(range: NSRange(location: 4, length: 5), user: user2)
-        
+
         let message = createMessage(text: text, mentions: [mention, mentionOverlapping])
-        
+
         // when
         let mentions = message.mentions
-        
+
         // then
         XCTAssertEqual(mentions, [mention])
     }
-    
+
     func testMentionsWithRangesOutsideTextAreDiscarded() {
         // given
         let text = "@john hello"
         let mention = Mention(range: NSRange(location: 0, length: 5), user: user1)
         let mentionOutsideText = Mention(range: NSRange(location: 6, length: 10), user: user2)
-        
+
         let message = createMessage(text: text, mentions: [mention, mentionOutsideText])
-        
+
         // when
         let mentions = message.mentions
-        
+
         // then
         XCTAssertEqual(mentions, [mention])
     }
-    
+
     func testMentionsIsCapppedAt500() {
         // given
         let text = String(repeating: "@", count: 501)
@@ -99,14 +98,14 @@ class ZMClientMessageTests_Mentions: BaseZMClientMessageTests {
             return Mention(range: NSRange(location: index, length: 1), user: user1)
         })
         let message = createMessage(text: text, mentions: tooManyMentions)
-        
+
         // when
         let mentions = message.mentions
-        
+
         // then
         XCTAssertEqual(mentions.count, 500)
         XCTAssertEqual(mentions, mentions)
         XCTAssertEqual(mentions, Array(tooManyMentions.prefix(500)))
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireDataModel
 
@@ -27,32 +26,32 @@ extension ClientMessageTests_OTR {
 
     func testThatCreatesEncryptedDataAndAddsItToGenericMessageAsBlob() {
         self.syncMOC.performGroupedBlockAndWait {
-            let otherUser = ZMUser.insertNewObject(in:self.syncMOC)
+            let otherUser = ZMUser.insertNewObject(in: self.syncMOC)
             otherUser.remoteIdentifier = UUID.create()
             let firstClient = self.createClient(for: otherUser, createSessionWithSelfUser: true, onMOC: self.syncMOC)
             let secondClient = self.createClient(for: otherUser, createSessionWithSelfUser: true, onMOC: self.syncMOC)
             let selfClients = ZMUser.selfUser(in: self.syncMOC).clients
             let selfClient = ZMUser.selfUser(in: self.syncMOC).selfClient()
             let notSelfClients = selfClients.filter { $0 != selfClient }
-            
-            let nonce = UUID.create()            
+
+            let nonce = UUID.create()
             let textMessage = GenericMessage(content: Text(content: self.textMessageRequiringExternalMessage(2)), nonce: nonce)
-            
-            let conversation = ZMConversation.insertNewObject(in:self.syncMOC)
+
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.conversationType = .group
             conversation.remoteIdentifier = UUID.create()
             conversation.addParticipantAndUpdateConversationState(user: otherUser, role: nil)
             XCTAssertTrue(self.syncMOC.saveOrRollback())
-            
+
             // when
             guard let dataAndStrategy = textMessage.encryptForTransport(for: conversation)
             else { return XCTFail() }
-            
+
             // then
             let createdMessage = Proteus_NewOtrMessage.with {
                 try? $0.merge(serializedData: dataAndStrategy.data)
             }
-           
+
             XCTAssertEqual(createdMessage.hasBlob, true)
             let clientIds = createdMessage.recipients.flatMap { userEntry -> [Proteus_ClientId] in
                 return (userEntry.clients).map { clientEntry -> Proteus_ClientId in
@@ -63,78 +62,78 @@ extension ClientMessageTests_OTR {
             XCTAssertEqual(clientSet.count, 2 + notSelfClients.count)
             XCTAssertTrue(clientSet.contains(firstClient.clientId))
             XCTAssertTrue(clientSet.contains(secondClient.clientId))
-            notSelfClients.forEach{
+            notSelfClients.forEach {
                 XCTAssertTrue(clientSet.contains($0.clientId))
             }
-            
+
             XCTAssertEqual(createdMessage.reportMissing.count, createdMessage.recipients.count)
         }
     }
-    
+
     func testThatCorruptedClientsReceiveBogusPayload() {
         self.syncMOC.performGroupedBlockAndWait {
-            
-            //given
+
+            // given
             let message = try! self.syncConversation.appendText(content: self.name, fetchLinkPreview: true, nonce: UUID.create()) as! ZMClientMessage
             self.syncUser3Client1.failedToEstablishSession = true
-            
-            //when
+
+            // when
             guard let dataAndStrategy = message.encryptForTransport() else {
                 XCTFail()
                 return
             }
-            
+
             // then
             let createdMessage = Proteus_NewOtrMessage.with {
                 try? $0.merge(serializedData: dataAndStrategy.data)
             }
             guard let userEntry = createdMessage.recipients.first(where: { self.syncUser3.userId == $0.user }) else { return XCTFail() }
-            
+
             XCTAssertEqual(userEntry.clients.count, 1)
             XCTAssertEqual(userEntry.clients.first?.text, ZMFailedToCreateEncryptedMessagePayloadString.data(using: .utf8))
             XCTAssertFalse(self.syncUser3Client1.failedToEstablishSession)
             }
     }
-    
+
     func testThatCorruptedClientsReceiveBogusPayloadWhenSentAsExternal() {
         self.syncMOC.performGroupedBlockAndWait {
-            
-            //given
+
+            // given
             let messageRequiringExternal = self.textMessageRequiringExternalMessage(6)
             let message = try! self.syncConversation.appendText(content: messageRequiringExternal) as! ZMClientMessage
             self.syncUser3Client1.failedToEstablishSession = true
-            
-            //when
+
+            // when
             guard let dataAndStrategy = message.encryptForTransport() else {
                 XCTFail()
                 return
             }
-            
-            //then
+
+            // then
             let createdMessage = Proteus_NewOtrMessage.with {
                 try? $0.merge(serializedData: dataAndStrategy.data)
             }
             guard let userEntry = createdMessage.recipients.first(where: { self.syncUser3.userId == $0.user }) else { return XCTFail() }
-            
+
             XCTAssertEqual(userEntry.clients.count, 1)
             XCTAssertEqual(userEntry.clients.first?.text, ZMFailedToCreateEncryptedMessagePayloadString.data(using: .utf8))
             XCTAssertFalse(self.syncUser3Client1.failedToEstablishSession)
         }
     }
-    
+
     func testThatItCreatesPayloadDataForTextMessage() {
         self.syncMOC.performGroupedBlockAndWait {
-            
-            //given
+
+            // given
             let message = try! self.syncConversation.appendText(content: self.name, fetchLinkPreview: true, nonce: UUID.create()) as! ZMClientMessage
-            
-            //when
+
+            // when
             guard let payloadAndStrategy = message.encryptForTransport() else {
                 XCTFail()
                 return
             }
-            
-            //then
+
+            // then
             self.assertMessageMetadata(payloadAndStrategy.data)
             switch payloadAndStrategy.strategy {
             case .doNotIgnoreAnyMissingClient:
@@ -144,21 +143,21 @@ extension ClientMessageTests_OTR {
             }
         }
     }
-    
+
     func testThatItCreatesPayloadDataForEphemeralTextMessage_Group() {
         self.syncMOC.performGroupedBlockAndWait {
-            
-            //given
+
+            // given
             self.syncConversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .selfUser)
             let message = try! self.syncConversation.appendText(content: self.name, fetchLinkPreview: true, nonce: UUID.create()) as! ZMClientMessage
             XCTAssertTrue(message.isEphemeral)
-            
-            //when
+
+            // when
             guard let payloadAndStrategy = message.encryptForTransport() else { return XCTFail() }
-            
-            //then
+
+            // then
             switch payloadAndStrategy.strategy {
-            case .ignoreAllMissingClientsNotFromUsers(_):
+            case .ignoreAllMissingClientsNotFromUsers:
                 fallthrough
             case .ignoreAllMissingClients:
                 XCTFail()
@@ -167,19 +166,19 @@ extension ClientMessageTests_OTR {
             }
         }
     }
-    
+
     func testThatItCreatesPayloadDataForDeletionOfEphemeralTextMessage_Group() {
-        
+
         var syncMessage: ZMClientMessage!
         self.syncMOC.performGroupedBlockAndWait {
-            //given
+            // given
             self.syncConversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .selfUser)
             syncMessage = try! self.syncConversation.appendText(content: self.name, fetchLinkPreview: true, nonce: UUID.create()) as? ZMClientMessage
             syncMessage.sender = self.syncUser1
             XCTAssertTrue(syncMessage.isEphemeral)
             self.syncMOC.saveOrRollback()
         }
-        
+
         let uiMessage = self.uiMOC.object(with: syncMessage.objectID) as! ZMMessage
         uiMessage.startDestructionIfNeeded()
         XCTAssertNotNil(uiMessage.destructionDate)
@@ -194,8 +193,8 @@ extension ClientMessageTests_OTR {
 
             // when
             guard let payloadAndStrategy = sut?.encryptForTransport() else { return XCTFail() }
-            
-            //then
+
+            // then
             switch payloadAndStrategy.strategy {
             case .ignoreAllMissingClientsNotFromUsers(users: let users):
                 XCTAssertEqual(users, Set(arrayLiteral: self.syncSelfUser, self.syncUser1))
@@ -204,39 +203,39 @@ extension ClientMessageTests_OTR {
             }
         }
     }
-    
+
     func testThatItCreatesPayloadForDeletionOfEphemeralTextMessage_Group_SenderWasDeleted() {
         // This can happen due to a race condition where we receive a delete for an ephemeral after deleting the same message locally, but before creating the payload
         var syncMessage: ZMClientMessage!
         self.syncMOC.performGroupedBlockAndWait {
-            //given
+            // given
             self.syncConversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .selfUser)
             syncMessage = try! self.syncConversation.appendText(content: self.name, fetchLinkPreview: true, nonce: UUID.create()) as? ZMClientMessage
             syncMessage.sender = self.syncUser1
             XCTAssertTrue(syncMessage.isEphemeral)
             self.syncMOC.saveOrRollback()
         }
-        
+
         let uiMessage = self.uiMOC.object(with: syncMessage.objectID) as! ZMMessage
         uiMessage.startDestructionIfNeeded()
         XCTAssertNotNil(uiMessage.destructionDate)
         self.uiMOC.zm_teardownMessageDeletionTimer()
         self.uiMOC.saveOrRollback()
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             self.syncMOC.refresh(syncMessage, mergeChanges: true)
             XCTAssertNotNil(syncMessage.destructionDate)
-            
+
             let sut = syncMessage.deleteForEveryone()
-            
+
             // when
             syncMessage.sender = nil
             var payload : (data: Data, strategy: MissingClientsStrategy)?
             self.performIgnoringZMLogError {
                  payload = sut?.encryptForTransport()
             }
-            
-            //then
+
+            // then
             guard let payloadAndStrategy = payload else { return XCTFail() }
             switch payloadAndStrategy.strategy {
             case .ignoreAllMissingClientsNotFromUsers(users: let users):
@@ -246,20 +245,19 @@ extension ClientMessageTests_OTR {
             }
         }
     }
-    
-    
+
     func testThatItCreatesPayloadForZMLastReadMessages() {
         self.syncMOC.performGroupedBlockAndWait {
             // given
             self.syncConversation.lastReadServerTimeStamp = Date()
             self.syncConversation.remoteIdentifier = UUID()
             guard let message = try? ZMConversation.updateSelfConversation(withLastReadOf: self.syncConversation) else { return XCTFail() }
-            
+
             self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier!]]
-            
+
             // when
             guard let payloadAndStrategy = message.encryptForTransport() else { return XCTFail() }
-            
+
             // then
             self.assertMessageMetadata(payloadAndStrategy.data)
             switch payloadAndStrategy.strategy {
@@ -277,12 +275,12 @@ extension ClientMessageTests_OTR {
             self.syncConversation.clearedTimeStamp = Date()
             self.syncConversation.remoteIdentifier = UUID()
             guard let message = try? ZMConversation.updateSelfConversation(withClearedOf: self.syncConversation) else { return XCTFail() }
-            
+
             self.expectedRecipients = [self.syncSelfUser.remoteIdentifier!.transportString(): [self.syncSelfClient2.remoteIdentifier!]]
-            
+
             // when
             guard let payloadAndStrategy = message.encryptForTransport() else { return XCTFail() }
-            
+
             // then
             self.assertMessageMetadata(payloadAndStrategy.data)
             switch payloadAndStrategy.strategy {
@@ -297,37 +295,37 @@ extension ClientMessageTests_OTR {
 
 // MARK: - Delivery
 extension ClientMessageTests_OTR {
-    
+
     func testThatItCreatesPayloadDataForConfirmationMessage() {
         self.syncMOC.performGroupedBlockAndWait {
-            
-            //given
+
+            // given
             let senderID = self.syncUser1.clients.first!.remoteIdentifier
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.conversationType = .oneOnOne
             conversation.remoteIdentifier = UUID.create()
-            
+
             let connection = ZMConnection.insertNewObject(in: self.syncMOC)
             connection.to = self.syncUser1
             connection.status = .accepted
             conversation.connection = connection
             conversation.addParticipantAndUpdateConversationState(user: self.syncUser1, role: nil)
-            
+
             self.syncMOC.saveOrRollback()
-                        
+
             let textMessage = try! conversation.appendText(content: self.stringLargeEnoughToRequireExternal, fetchLinkPreview: true, nonce: UUID.create()) as! ZMClientMessage
-            
+
             textMessage.sender = self.syncUser1
             textMessage.senderClientID = senderID
 
             let genericMessage = GenericMessage(content: Confirmation(messageId: textMessage.nonce!, type: .delivered))
             let confirmationMessage = try? conversation.appendClientMessage(with: genericMessage, expires: false, hidden: true)
-            
-            //when
+
+            // when
             guard let payloadAndStrategy = confirmationMessage?.encryptForTransport()
             else { return XCTFail()}
-            
-            //then
+
+            // then
             switch payloadAndStrategy.strategy {
             case .ignoreAllMissingClientsNotFromUsers(let users):
                 XCTAssertEqual(users, Set(arrayLiteral: self.syncUser1))
@@ -337,40 +335,39 @@ extension ClientMessageTests_OTR {
             let messageMetadata = Proteus_NewOtrMessage.with {
                 try? $0.merge(serializedData: payloadAndStrategy.data)
             }
-            
+
             let payloadClients = messageMetadata.recipients.compactMap { user -> [String] in
                 return user.clients.map({ String(format: "%llx", $0.client.client) })
             }.flatMap { $0 }
             XCTAssertEqual(payloadClients.sorted(), self.syncUser1.clients.map { $0.remoteIdentifier! }.sorted())
         }
     }
-    
+
     func testThatItCreatesPayloadForConfimationMessageWhenOriginalHasSender() {
         syncMOC.performGroupedBlockAndWait {
-            //given
+            // given
             let senderID = self.syncUser1.clients.first!.remoteIdentifier
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.conversationType = .oneOnOne
             conversation.remoteIdentifier = UUID.create()
-            
+
             let connection = ZMConnection.insertNewObject(in: self.syncMOC)
             connection.to = self.syncUser1
             connection.status = .accepted
             conversation.connection = connection
             conversation.addParticipantAndUpdateConversationState(user: self.syncUser1, role: nil)
 
-            
             self.syncMOC.saveOrRollback()
-                                    
+
             let textMessage = try! conversation.appendText(content: self.stringLargeEnoughToRequireExternal, fetchLinkPreview: true, nonce: UUID.create()) as! ZMClientMessage
-            
+
             textMessage.sender = self.syncUser1
             textMessage.senderClientID = senderID
 
             let confirmation = GenericMessage(content: Confirmation(messageId: textMessage.nonce!, type: .delivered))
             let confirmationMessage = try? conversation.appendClientMessage(with: confirmation, expires: false, hidden: true)
-            
-            //when
+
+            // when
             guard let _ = confirmationMessage?.encryptForTransport()
                 else { return XCTFail()}
         }
@@ -378,16 +375,16 @@ extension ClientMessageTests_OTR {
 
     func testThatItCreatesPayloadForConfimationMessageWhenOriginalHasNoSenderButInferSenderWithConnection() {
         syncMOC.performGroupedBlockAndWait {
-            //given
+            // given
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.conversationType = .oneOnOne
             conversation.remoteIdentifier = UUID.create()
-            
+
             let connection = ZMConnection.insertNewObject(in: self.syncMOC)
             connection.to = self.syncUser1
             connection.status = .accepted
             conversation.connection = connection
-            
+
             let genericMessage = GenericMessage(content: Text(content: "yo"), nonce: UUID.create())
             let clientmessage = ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC)
             do {
@@ -396,13 +393,13 @@ extension ClientMessageTests_OTR {
                 XCTFail()
             }
             clientmessage.visibleInConversation = conversation
-            
+
             self.syncMOC.saveOrRollback()
 
             let confirmation = GenericMessage(content: Confirmation(messageId: clientmessage.nonce!, type: .delivered))
             let confirmationMessage = try? conversation.appendClientMessage(with: confirmation, expires: false, hidden: true)
 
-            //when
+            // when
             guard let _ = confirmationMessage?.encryptForTransport()
                 else { return XCTFail()}
         }
@@ -410,12 +407,12 @@ extension ClientMessageTests_OTR {
 
     func testThatItCreatesPayloadForConfimationMessageWhenOriginalHasNoSenderAndConnectionButInferSenderOtherActiveParticipants() {
         syncMOC.performGroupedBlockAndWait {
-            //given
+            // given
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.conversationType = .oneOnOne
             conversation.remoteIdentifier = UUID.create()
             conversation.addParticipantAndUpdateConversationState(user: self.syncUser1, role: nil)
-            
+
             let genericMessage = GenericMessage(content: Text(content: "yo"), nonce: UUID.create())
             let clientMessage = ZMClientMessage(nonce: UUID(), managedObjectContext: self.syncMOC)
             do {
@@ -424,13 +421,13 @@ extension ClientMessageTests_OTR {
                 XCTFail()
             }
             clientMessage.visibleInConversation = conversation
-            
+
             self.syncMOC.saveOrRollback()
 
             let confirmation = GenericMessage(content: Confirmation(messageId: clientMessage.nonce!, type: .delivered))
             let confirmationMessage = try? conversation.appendClientMessage(with: confirmation, expires: false, hidden: true)
 
-            //when
+            // when
             guard let _ = confirmationMessage?.encryptForTransport()
                 else { return XCTFail()}
         }
@@ -440,19 +437,19 @@ extension ClientMessageTests_OTR {
 
 // MARK: - Session identifier
 extension ClientMessageTests_OTR {
-    
+
     func testThatItUsesTheProperSessionIdentifier() {
-        
+
         // GIVEN
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         user.remoteIdentifier = UUID.create()
         let client = UserClient.insertNewObject(in: self.uiMOC)
         client.user = user
         client.remoteIdentifier = UUID.create().transportString()
-        
+
         // WHEN
         let identifier = client.sessionIdentifier
-        
+
         // THEN
         XCTAssertEqual(identifier, EncryptionSessionIdentifier(userId: user.remoteIdentifier.uuidString, clientId: client.remoteIdentifier!))
     }
@@ -460,26 +457,26 @@ extension ClientMessageTests_OTR {
 
 // MARK: - Helper
 extension ClientMessageTests_OTR {
-    
+
     /// Returns a string large enough to have to be encoded in an external message
     fileprivate var stringLargeEnoughToRequireExternal: String {
         var text = "Hello"
-        while (text.data(using: String.Encoding.utf8)!.count < Int(ZMClientMessage.byteSizeExternalThreshold)) {
+        while text.data(using: String.Encoding.utf8)!.count < Int(ZMClientMessage.byteSizeExternalThreshold) {
             text.append(text)
         }
         return text
     }
-    
+
     /// Asserts that the message metadata is as expected
     fileprivate func assertMessageMetadata(_ payload: Data!, file: StaticString = #file, line: UInt = #line) {
         let messageMetadata = Proteus_NewOtrMessage.with {
             try? $0.merge(serializedData: payload)
         }
-        
+
         XCTAssertEqual(messageMetadata.sender.client, self.selfClient1.clientId.client, file: file, line: line)
         assertRecipients(messageMetadata.recipients, file: file, line: line)
     }
-    
+
     /// Returns a string that is big enough to require external message payload
     fileprivate func textMessageRequiringExternalMessage(_ numberOfClients: UInt) -> String {
         var string = "Exponential growth!"
@@ -491,7 +488,7 @@ extension ClientMessageTests_OTR {
 }
 
 extension DatabaseBaseTest {
-    
+
     func createSelfUser(in moc: NSManagedObjectContext) -> (ZMUser, ZMConversation) {
         let selfUser = ZMUser.selfUser(in: moc)
         selfUser.remoteIdentifier = UUID()
@@ -501,21 +498,21 @@ extension DatabaseBaseTest {
         moc.saveOrRollback()
         return (selfUser, conversation)
     }
-    
+
     func createSelfClient(on moc: NSManagedObjectContext) -> UserClient {
         let selfUser = ZMUser.selfUser(in: moc)
-        
+
         let selfClient = UserClient.insertNewObject(in: moc)
         selfClient.remoteIdentifier = NSString.createAlphanumerical()
         selfClient.user = selfUser
-        
+
         moc.setPersistentStoreMetadata(selfClient.remoteIdentifier, key: ZMPersistedClientIdKey)
-        
+
         let payload = ["id": selfClient.remoteIdentifier!,
                        "type": "permanent",
                        "time": Date().transportString()] as [String: AnyObject]
-        let _ = UserClient.createOrUpdateSelfUserClient(payload, context:moc)
-        
+        _ = UserClient.createOrUpdateSelfUserClient(payload, context: moc)
+
         moc.saveOrRollback()
         return selfClient
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Prefetching.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Prefetching.swift
@@ -26,17 +26,17 @@ class ZMClientMessageTests_Prefetching: BaseZMClientMessageTests {
         let event = createUpdateEvent(UUID(),
                                       conversationID: UUID(),
                                       genericMessage: .init(content: Text(content: "Hello World")))
-        
+
         // when
         var message: ZMOTRMessage?
         performPretendingUiMocIsSyncMoc {
             message = ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: prefetchResults)
         }
-        
+
         // then
         XCTAssertNotNil(message)
     }
-    
+
     func testThatMessageIsUpdated_WhenIncludedInPrefetchResults() throws {
         // given
         let senderClientID = "sender123"
@@ -48,17 +48,17 @@ class ZMClientMessageTests_Prefetching: BaseZMClientMessageTests {
                                       conversationID: UUID(),
                                       genericMessage: .init(content: Text(content: "Hello World"), nonce: existingMessage.nonce!),
                                       senderClientID: senderClientID)
-        
+
         // when
         var message: ZMOTRMessage?
         performPretendingUiMocIsSyncMoc {
             message = ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: prefetchResults)
         }
-        
+
         // then
         XCTAssertTrue(existingMessage === message)
     }
-        
+
     func testThatMessageIsUpdated_WhenNotIncludedInPrefetchResults_ButWasProcessedInTheSameBatch() throws {
         // given
         let prefetchResults = ZMFetchRequestBatchResult()
@@ -68,12 +68,12 @@ class ZMClientMessageTests_Prefetching: BaseZMClientMessageTests {
                                       conversationID: UUID(),
                                       genericMessage: .init(content: Text(content: "Hello World"), nonce: nonce),
                                       senderClientID: senderClientID)
-        
+
         let event2 = createUpdateEvent(UUID(),
         conversationID: UUID(),
         genericMessage: .init(content: Text(content: "Hello World"), nonce: nonce),
         senderClientID: senderClientID)
-        
+
         // when
         var message1: ZMOTRMessage?
         var message2: ZMOTRMessage?
@@ -81,7 +81,7 @@ class ZMClientMessageTests_Prefetching: BaseZMClientMessageTests {
             message1 = ZMOTRMessage.createOrUpdate(from: event1, in: self.uiMOC, prefetchResult: prefetchResults)
             message2 = ZMOTRMessage.createOrUpdate(from: event2, in: self.uiMOC, prefetchResult: prefetchResults)
         }
-        
+
         // then
         XCTAssertTrue(message1 === message2)
     }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Replies.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Replies.swift
@@ -20,15 +20,15 @@ import XCTest
 @testable import WireDataModel
 
 class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
-    
+
     func testQuoteRelationshipIsEstablishedWhenSendingMessage() {
         let quotedMessage = try! conversation.appendText(content: "I have a proposal", mentions: [], replyingTo: nil, fetchLinkPreview: false, nonce: UUID()) as! ZMClientMessage
-        
+
         let message = try! conversation.appendText(content: "That's fine", mentions: [], replyingTo: quotedMessage, fetchLinkPreview: false, nonce: UUID()) as! ZMTextMessageData
-        
+
         XCTAssertEqual(message.quoteMessage as! ZMMessage, quotedMessage)
     }
-    
+
     func testQuoteRelationshipIsEstablishedWhenReceivingMessage() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC); conversation.remoteIdentifier = UUID.create()
@@ -37,18 +37,18 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         let data = ["sender": NSString.createAlphanumerical(), "text": try? replyMessage.serializedData().base64EncodedString()]
         let payload = payloadForMessage(in: conversation, type: EventConversationAddOTRMessage, data: data)
         let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
-        
+
         // when
         var sut: ZMClientMessage! = nil
         performPretendingUiMocIsSyncMoc {
             sut = ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
-        XCTAssertNotNil(sut);
+        XCTAssertNotNil(sut)
         XCTAssertEqual(sut.quote, quotedMessage)
     }
-    
+
     func testQuoteRelationshipIsEstablishedWhenReceivingEphemeralMessage() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC); conversation.remoteIdentifier = UUID.create()
@@ -57,15 +57,15 @@ class ZMClientMessagesTests_Replies: BaseZMClientMessageTests {
         let data = ["sender": NSString.createAlphanumerical(), "text": try? replyMessage.serializedData().base64EncodedString()]
         let payload = payloadForMessage(in: conversation, type: EventConversationAddOTRMessage, data: data)
         let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
-        
+
         // when
         var sut: ZMClientMessage! = nil
         performPretendingUiMocIsSyncMoc {
             sut = ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
-        XCTAssertNotNil(sut);
+        XCTAssertNotNil(sut)
         XCTAssertEqual(sut.quote, quotedMessage)
     }
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+ResetSession.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+ResetSession.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import WireDataModel
 
 class ZMClientMessagesTests_ResetSession: BaseZMClientMessageTests {
-        
+
     func testSessionResetSystemMessageIsInserted_WhenReceivingMessage() throws {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC); conversation.remoteIdentifier = UUID.create()

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -16,14 +16,13 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 import WireLinkPreview
 
 @testable import WireDataModel
 
 class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
-    
+
     override func tearDown() {
         super.tearDown()
         wipeCaches()
@@ -42,7 +41,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         )
         article.title = "title"
         article.summary = "summary"
-        
+
         var linkPreview = LinkPreview(articleMetadata: article)
         linkPreview.update(withOtrKey: Data(), sha256: Data(), original: nil)
         let text = Text.with {
@@ -56,13 +55,13 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         }
         // when
         let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
-        
+
         // then
         XCTAssertTrue(willHaveAnImage)
     }
-    
+
     func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage() {
-        
+
         // given
         let nonce = UUID()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
@@ -84,14 +83,14 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         } catch {
             XCTFail()
         }
-        
+
         // when
         let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
-        
+
         // then
         XCTAssertFalse(willHaveAnImage)
     }
-    
+
     func testThatItHasImageReturnsTrueWhenLinkPreviewWillContainAnImage_TwitterStatus() {
         // given
         let nonce = UUID.create()
@@ -103,7 +102,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
             resolvedURLString: "http://www.example.com/article/1",
             offset: 42
         )
-        
+
         preview.author = "Author"
         preview.message = name
 
@@ -120,16 +119,15 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         }
         // when
         let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
-        
+
         // then
         XCTAssertTrue(willHaveAnImage)
     }
-    
+
     func testThatItHasImageReturnsFalseWhenLinkPreviewDoesntContainAnImage_TwitterStatus() {
         // given
         let nonce = UUID.create()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
-        
 
         let preview = TwitterStatusMetadata(
             originalURLString: "example.com/article/original",
@@ -137,7 +135,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
             resolvedURLString: "http://www.example.com/article/1",
             offset: 42
         )
-        
+
         preview.author = "Author"
         preview.message = name
         let text = Text.with {
@@ -149,14 +147,14 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         } catch {
             XCTFail()
         }
-        
+
         // when
         let willHaveAnImage = clientMessage.textMessageData!.linkPreviewHasImage
-        
+
         // then
         XCTAssertFalse(willHaveAnImage)
     }
-    
+
     func testThatItSendsANotificationToDownloadTheImageWhenRequestImageDownloadIsCalledAndItHasAAssetID() {
         // given
         let preview = TwitterStatusMetadata(
@@ -165,14 +163,14 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
             resolvedURLString: "http://www.example.com/article/1",
             offset: 42
         )
-        
+
         preview.author = "Author"
         preview.message = name
-        
+
         // then
         assertThatItSendsANotificationToDownloadTheImageWhenRequestImageDownloadIsCalled(preview)
     }
-    
+
     func testThatItSendsANotificationToDownloadTheImageWhenRequestImageDownloadIsCalledAndItHasAAssetID_Article() {
         // given
         let preview = ArticleMetadata(
@@ -181,20 +179,20 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
             resolvedURLString: "http://www.example.com/article/1",
             offset: 42
         )
-        
+
         preview.title = "title"
         preview.summary = "summary"
-        
+
         // then
         assertThatItSendsANotificationToDownloadTheImageWhenRequestImageDownloadIsCalled(preview)
     }
-    
+
     func assertThatItSendsANotificationToDownloadTheImageWhenRequestImageDownloadIsCalled(_ preview: LinkMetadata, line: UInt = #line) {
-        
+
         // given
         let nonce = UUID.create()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
-        
+
         var updated = LinkPreview(preview)
         updated.update(withOtrKey: .randomEncryptionKey(), sha256: .zmRandomSHA256Key(), original: nil)
         updated.update(withAssetKey: "id", assetToken: nil)
@@ -209,23 +207,20 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         }
         try! uiMOC.obtainPermanentIDs(for: [clientMessage])
 
-        
         // when
         let expectation = self.expectation(description: "Notified")
         let token: Any? = NotificationInContext.addObserver(name: ZMClientMessage.linkPreviewImageDownloadNotification,
                                           context: self.uiMOC.notificationContext,
-                                          object: clientMessage.objectID)
-        { _ in
+                                          object: clientMessage.objectID) { _ in
             expectation.fulfill()
         }
-        
+
         clientMessage.textMessageData?.requestLinkPreviewImageDownload()
-        
+
         // then
-        withExtendedLifetime(token) { () -> () in
+        withExtendedLifetime(token) { () -> Void in
             XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.2), line: line)
         }
     }
-    
 
 }

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+Unarchiving.swift
@@ -19,15 +19,15 @@
 import WireTesting
 import WireDataModel
 
-class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
+class ZMClientMessageTests_Unarchiving: BaseZMClientMessageTests {
 
-    func testThatItUnarchivesAConversationWhenItWasNotCleared(){
-    
+    func testThatItUnarchivesAConversationWhenItWasNotCleared() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.isArchived = true
-        
+
         let genericMessage = GenericMessage(content: Text(content: "bar"))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
 
@@ -35,35 +35,35 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         performPretendingUiMocIsSyncMoc {
             XCTAssertNotNil(ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil))
         }
-        
+
         // then
         XCTAssertFalse(conversation.isArchived)
     }
-    
-    func testThatItDoesNotUnarchiveASilencedConversation(){
-        
+
+    func testThatItDoesNotUnarchiveASilencedConversation() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.isArchived = true
         conversation.mutedMessageTypes = .all
 
         let genericMessage = GenericMessage(content: Text(content: "bar"))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertTrue(conversation.isArchived)
     }
-    
-    func testThatItDoesNotUnarchiveAClearedConversation_TimestampForMessageIsOlder(){
-        
+
+    func testThatItDoesNotUnarchiveAClearedConversation_TimestampForMessageIsOlder() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.isArchived = true
         uiMOC.saveOrRollback()
@@ -72,26 +72,26 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
         lastMessage.serverTimestamp = Date().addingTimeInterval(10)
         conversation.lastServerTimeStamp = lastMessage.serverTimestamp!
         conversation.clearMessageHistory()
-        
+
         let genericMessage = GenericMessage(content: Text(content: "bar"))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
         XCTAssertNotNil(event)
-        
+
         XCTAssertGreaterThan(conversation.clearedTimeStamp!.timeIntervalSince1970, event.timestamp!.timeIntervalSince1970)
-        
+
         // when
-        performPretendingUiMocIsSyncMoc { 
+        performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertTrue(conversation.isArchived)
     }
-    
-    func testThatItUnarchivesAClearedConversation_TimestampForMessageIsNewer(){
-        
+
+    func testThatItUnarchivesAClearedConversation_TimestampForMessageIsNewer() {
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.isArchived = true
         uiMOC.saveOrRollback()
@@ -103,9 +103,9 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
 
         let genericMessage = GenericMessage(content: Text(content: "bar"))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage)
-        
+
         XCTAssertLessThan(conversation.clearedTimeStamp!.timeIntervalSince1970, event.timestamp!.timeIntervalSince1970)
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMOTRMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
@@ -115,5 +115,3 @@ class ZMClientMessageTests_Unarchiving : BaseZMClientMessageTests {
     }
 
 }
-
-

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+ZMImageOwner.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireLinkPreview
 
@@ -27,7 +26,7 @@ enum ContentType {
 }
 
 class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
-        
+
     func insertMessageWithLinkPreview(contentType: ContentType) -> ZMClientMessage {
         let nonce = UUID()
         let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: uiMOC)
@@ -40,10 +39,10 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         article.title = "title"
         article.summary = "tile"
         let mention = Mention(range: NSRange(location: 0, length: 4), user: user1)
-       
+
         let text = Text(content: "@joe example.com/article/original", mentions: [mention], linkPreviews: [article], replyingTo: nil)
-        var genericMessage : GenericMessage!
-        switch contentType{
+        var genericMessage: GenericMessage!
+        switch contentType {
         case .textMessage:
             genericMessage = GenericMessage(content: text, nonce: nonce)
         case .editMessage:
@@ -58,33 +57,33 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.sender = selfUser
         return clientMessage
     }
-    
+
     func testThatItKeepsMentionsWhenSettingImageData() {
         // given
         let clientMessage = insertMessageWithLinkPreview(contentType: .textMessage)
         let imageData = mediumJPEGData()
-        
+
         // when
         let properties = ZMIImageProperties(size: CGSize(width: 42, height: 12), length: UInt(imageData.count), mimeType: "image/jpeg")
         clientMessage.setImageData(imageData, for: .medium, properties: properties)
-        
+
         // then
         XCTAssertEqual(clientMessage.mentions.count, 1)
     }
-    
+
     func testThatItCachesAndEncryptsTheMediumImage_TextMessage() {
         // given
         let clientMessage = insertMessageWithLinkPreview(contentType: .textMessage)
         let imageData = mediumJPEGData()
-        
+
         // when
         let properties = ZMIImageProperties(size: CGSize(width: 42, height: 12), length: UInt(imageData.count), mimeType: "image/jpeg")
         clientMessage.setImageData(imageData, for: .medium, properties: properties)
-        
+
         // then
         XCTAssertNotNil(self.uiMOC.zm_fileAssetCache.assetData(clientMessage, format: .medium, encrypted: false))
         XCTAssertNotNil(self.uiMOC.zm_fileAssetCache.assetData(clientMessage, format: .medium, encrypted: true))
-        
+
         guard let linkPreview = clientMessage.underlyingMessage?.linkPreviews.first else { return XCTFail("did not contain linkpreview") }
         XCTAssertNotNil(linkPreview.image.uploaded.otrKey)
         XCTAssertNotNil(linkPreview.image.uploaded.sha256)
@@ -96,24 +95,24 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         XCTAssertEqual(original.image.height, 12)
         XCTAssertFalse(original.hasName)
     }
-    
+
     func testThatItCachesAndEncryptsTheMediumImage_EditMessage() {
         // given
         let clientMessage = insertMessageWithLinkPreview(contentType: .editMessage)
         let imageData = mediumJPEGData()
-        
+
         // when
         let properties = ZMIImageProperties(size: CGSize(width: 42, height: 12), length: UInt(imageData.count), mimeType: "image/jpeg")
         clientMessage.setImageData(imageData, for: .medium, properties: properties)
-        
+
         // then
         XCTAssertNotNil(self.uiMOC.zm_fileAssetCache.assetData(clientMessage, format: .medium, encrypted: false))
         XCTAssertNotNil(self.uiMOC.zm_fileAssetCache.assetData(clientMessage, format: .medium, encrypted: true))
-        
+
         guard let linkPreview = clientMessage.underlyingMessage?.linkPreviews.first else { return XCTFail("did not contain linkpreview") }
         XCTAssertNotNil(linkPreview.image.uploaded.otrKey)
         XCTAssertNotNil(linkPreview.image.uploaded.sha256)
-        
+
         let original = linkPreview.image.original
         XCTAssertEqual(Int(original.size), imageData.count)
         XCTAssertEqual(original.mimeType, "image/jpeg")
@@ -121,7 +120,7 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         XCTAssertEqual(original.image.height, 12)
         XCTAssertFalse(original.hasName)
     }
-    
+
     func testThatUpdatesLinkPreviewStateAndDeleteOriginalDataAfterProcessingFinishes() {
         // given
         let nonce = UUID()
@@ -129,15 +128,15 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.sender = selfUser
         clientMessage.visibleInConversation = conversation
         self.uiMOC.zm_fileAssetCache.storeAssetData(clientMessage, format: .original, encrypted: false, data: mediumJPEGData())
-        
+
         // when
         clientMessage.processingDidFinish()
-        
+
         // then
         XCTAssertEqual(clientMessage.linkPreviewState, ZMLinkPreviewState.processed)
         XCTAssertNil(self.uiMOC.zm_fileAssetCache.assetData(clientMessage, format: .original, encrypted: false))
     }
-    
+
     func testThatItReturnsCorrectOriginalImageSize() {
         // given
         let nonce = UUID()
@@ -145,13 +144,12 @@ class ClientMessageTests_ZMImageOwner: BaseZMClientMessageTests {
         clientMessage.sender = selfUser
         clientMessage.visibleInConversation = conversation
         self.uiMOC.zm_fileAssetCache.storeAssetData(clientMessage, format: .original, encrypted: false, data: mediumJPEGData())
-        
+
         // when
         let imageSize = clientMessage.originalImageSize()
-        
-        // then
-        XCTAssertEqual(imageSize, CGSize(width: 1352, height:1803))
-    }
-    
-}
 
+        // then
+        XCTAssertEqual(imageSize, CGSize(width: 1352, height: 1803))
+    }
+
+}

--- a/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessagesTests+Reaction.swift
@@ -19,41 +19,41 @@
 import WireTesting
 
 class ZMClientMessageTests_Reaction: BaseZMClientMessageTests {
-    
+
 }
 
 extension ZMClientMessageTests_Reaction {
-    
-    func insertMessage() ->  ZMMessage {
+
+    func insertMessage() -> ZMMessage {
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = .create()
-        
+
         let message = try! conversation.appendText(content: "JCVD, full split please") as! ZMMessage
         message.sender = sender
         uiMOC.saveOrRollback()
 
         return message
     }
-    
+
     func updateEventForAddingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
         let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "❤️", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
-    
+
     func updateEventForRemovingReaction(to message: ZMMessage, sender: ZMUser? = nil) -> ZMUpdateEvent {
         let sender = sender ?? message.sender!
         let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: sender.remoteIdentifier!)
         return event
     }
-    
+
     func testThatItAppendsAReactionWhenReceivingUpdateEventWithValidReaction() {
-        
+
         let message = insertMessage()
         let event = updateEventForAddingReaction(to: message)
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
@@ -61,67 +61,65 @@ extension ZMClientMessageTests_Reaction {
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        
         XCTAssertEqual(message.reactions.count, 1)
         XCTAssertEqual(message.usersReaction.count, 1)
     }
-    
-    func testThatItUpdatesTheCategoryWhenAddingAReaction(){
+
+    func testThatItUpdatesTheCategoryWhenAddingAReaction() {
         let message = insertMessage()
         XCTAssertTrue(message.cachedCategory.contains(.text))
         XCTAssertFalse(message.cachedCategory.contains(.liked))
-        
+
         let event = updateEventForAddingReaction(to: message, sender: ZMUser.selfUser(in: uiMOC))
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertTrue(message.cachedCategory.contains(.text))
         XCTAssertTrue(message.cachedCategory.contains(.liked))
     }
-    
+
     func testThatItDoesNOTAppendsAReactionWhenReceivingUpdateEventWithValidReaction() {
-        
+
         let message = insertMessage()
         let genericMessage = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "TROP BIEN", messageID: message.nonce!))
         let event = createUpdateEvent(UUID(), conversationID: conversation.remoteIdentifier!, genericMessage: genericMessage, senderID: message.sender!.remoteIdentifier!)
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
-        
+
         XCTAssertEqual(message.reactions.count, 0)
         XCTAssertEqual(message.usersReaction.count, 0)
     }
-    
+
     func testThatItRemovesAReactionWhenReceivingUpdateEventWithValidReaction() {
-        
+
         let message = insertMessage()
         message.addReaction("❤️", forUser: message.sender!)
         uiMOC.saveOrRollback()
-        
+
         let event = updateEventForRemovingReaction(to: message)
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(message.usersReaction.count, 0)
     }
 
-    func testThatItUpdatesTheCategoryWhenRemovingAReaction(){
+    func testThatItUpdatesTheCategoryWhenRemovingAReaction() {
 
         // given
         let message = insertMessage()
@@ -129,16 +127,16 @@ extension ZMClientMessageTests_Reaction {
         uiMOC.saveOrRollback()
         XCTAssertTrue(message.cachedCategory.contains(.text))
         XCTAssertTrue(message.cachedCategory.contains(.liked))
-        
+
         let event = updateEventForRemovingReaction(to: message, sender: ZMUser.selfUser(in: uiMOC))
-        
+
         // when
         performPretendingUiMocIsSyncMoc {
             ZMClientMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertTrue(message.cachedCategory.contains(.text))
         XCTAssertFalse(message.cachedCategory.contains(.liked))

--- a/Tests/Source/Model/Messages/ZMGenericMessageDataTests.swift
+++ b/Tests/Source/Model/Messages/ZMGenericMessageDataTests.swift
@@ -25,12 +25,12 @@ class ZMGenericMessageDataTests: ModelObjectsTests {
 
     override func setUp() {
         super.setUp()
-        
+
         createSelfClient(onMOC: uiMOC)
         uiMOC.encryptMessagesAtRest = false
         uiMOC.encryptionKeys = nil
     }
-    
+
     // MARK: - Positive Tests
 
     func test_ItDoesNotEncryptProtobufData_IfEncryptionAtRest_IsDisabled() throws {

--- a/Tests/Source/Model/Messages/ZMMessage+DataRetentionTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessage+DataRetentionTests.swift
@@ -26,21 +26,21 @@ class ZMMessage_DataRetentionTests: BaseZMMessageTests {
         let now = Date(timeIntervalSinceNow: 0)
         let past = Date(timeIntervalSinceNow: -100)
         let future = Date(timeIntervalSinceNow: 100)
-        
+
         let messages: [ZMMessage] = [now, past, future].map { timestamp in
             let message = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
             message.serverTimestamp = timestamp
             return message
         }
-        
+
         // when
         let matches = messages.filter({ ZMMessage.predicateForMessagesOlderThan(now).evaluate(with: $0) })
-        
+
         // then
         XCTAssertEqual(matches.count, 1)
         XCTAssertEqual(matches.first?.serverTimestamp, past)
     }
-    
+
     func testThatCachedAssetsAreDeleted_WhenMessagesAreDeleted() throws {
         // GIVEN
         let sut = createConversation(in: uiMOC)
@@ -49,10 +49,10 @@ class ZMMessage_DataRetentionTests: BaseZMMessageTests {
         let cacheKey = FileAssetCache.cacheKeyForAsset(message)!
         self.uiMOC.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: Data.secureRandomData(ofLength: 100))
         XCTAssertNotNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
-        
+
         // WHEN
         try ZMMessage.deleteMessagesOlderThan(Date(), context: uiMOC)
-        
+
         // THEN
         XCTAssertNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
     }

--- a/Tests/Source/Model/Messages/ZMMessage+Reaction.swift
+++ b/Tests/Source/Model/Messages/ZMMessage+Reaction.swift
@@ -20,23 +20,23 @@ import XCTest
 @testable import WireDataModel
 
 class ZMMessage_Reaction: BaseZMClientMessageTests {
-    
+
     func testThatAddingAReactionAddsAReactionGenericMessage_fromUI() {
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let message = try! conversation.appendText(content: self.name) as! ZMMessage
         message.markAsSent()
         self.uiMOC.saveOrRollback()
-        
+
         XCTAssertEqual(message.deliveryState, ZMDeliveryState.sent)
-        
+
         // when
         // this is the UI facing call to add reaction
         ZMMessage.addReaction(MessageReaction.like, toMessage: message)
         self.uiMOC.saveOrRollback()
-        
-        //then
+
+        // then
         XCTAssertEqual(conversation.hiddenMessages.count, 1)
         let reactionMessage = conversation.hiddenMessages.first as! ZMClientMessage
         XCTAssertNotNil(reactionMessage)

--- a/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageCategorizationTests.swift
@@ -22,7 +22,7 @@ import WireUtilities
 import WireLinkPreview
 
 extension ZMConversationMessage {
-    fileprivate var categorization : MessageCategory {
+    fileprivate var categorization: MessageCategory {
         guard let message = self as? ZMMessage else {
             return .none
         }
@@ -30,61 +30,61 @@ extension ZMConversationMessage {
     }
 }
 
-class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
-    
-    var conversation : ZMConversation!
-    
+class ZMMessageCategorizationTests: ZMBaseManagedObjectTest {
+
+    var conversation: ZMConversation!
+
     override func setUp() {
         super.setUp()
         self.conversation = ZMConversation.insertNewObject(in: uiMOC)
         self.conversation.conversationType = .group
         self.conversation.remoteIdentifier = UUID.create()
-        
+
         let selfUser = ZMUser.selfUser(in: uiMOC)
         selfUser.remoteIdentifier = UUID()
-        
+
         uiMOC.saveOrRollback()
     }
-    
+
     override func tearDown() {
         self.conversation = nil
         super.tearDown()
     }
-    
+
     func testThatItCategorizesATextMessage() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on!")
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.text)
     }
-    
+
     func testThatItCategorizeTimedMessages() {
-        
+
         // GIVEN
         let otherUser = ZMUser.insertNewObject(in: self.conversation.managedObjectContext!)
         otherUser.remoteIdentifier = UUID.create()
-        
+
         conversation.addParticipantAndUpdateConversationState(user: otherUser, role: nil)
         conversation.setMessageDestructionTimeoutValue(.fiveMinutes, for: .selfUser)
         let message = try! self.conversation.appendText(content: "ramble on!") as! ZMMessage
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.text)
     }
 
     func testThatItCategorizesATextMessageWithLink() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on https://en.wikipedia.org/wiki/Ramble_On here")
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.text, MessageCategory.link])
     }
-    
+
     func testThatItCategorizesALinkPreviewMessage() throws {
-        
+
         // GIVEN
         let article = ArticleMetadata(
             originalURLString: "www.example.com/article/original",
@@ -97,26 +97,26 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         let genericMessage = GenericMessage(content: Text(content: "foo", mentions: [], linkPreviews: [article], replyingTo: nil), nonce: UUID.create())
         let message = try self.conversation.appendClientMessage(with: genericMessage)
         message.linkPreviewState = .processed
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.text, MessageCategory.link, MessageCategory.linkPreview])
     }
-    
+
     func testThatItCategorizesAnImageMessage() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendImage(from: self.verySmallJPEGData())
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.image)
     }
 
     func testThatItCategorizesAnImageMessage_WithoutData() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendImage(from: self.verySmallJPEGData())
         uiMOC.zm_fileAssetCache.deleteAssetData(message, format: .original, encrypted: false)
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.image, MessageCategory.excludedFromCollection])
     }
@@ -132,119 +132,119 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
     }
 
     func testThatItCategorizesKnocks() throws {
-        
+
         // GIVEN
         let message = try self.conversation.appendKnock() as! ZMClientMessage
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.knock)
     }
-    
+
     func testThatItCategorizesFile() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt")))
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.file)
     }
-    
+
     func testThatItDoesCategorizeAFailedToUploadFile_ExcludedFromCollection() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt"))) as! ZMAssetClientMessage
         message.transferState = .uploadingFailed
         message.updateCategoryCache()
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.file, MessageCategory.excludedFromCollection])
     }
-    
+
     func testThatItDoesNotCategorizeACancelledToUploadFile_ExcludedFromCollection() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt"))) as! ZMAssetClientMessage
         message.transferState = .uploadingCancelled
         message.updateCategoryCache()
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.file, MessageCategory.excludedFromCollection])
     }
-    
+
     func testThatItCategorizesAudioFile() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMAudioMetadata(fileURL: self.fileURL(forResource: "audio", extension: "m4a"), duration: 12.2))
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.file, MessageCategory.audio])
     }
-    
+
     func testThatItCategorizesVideoFile() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData()))
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.file, MessageCategory.video])
     }
-    
+
     func testThatItCategorizesLocation() throws {
-        
+
         // GIVEN
         let message = try self.conversation.appendLocation(with: LocationData.locationData(withLatitude: 40.42, longitude: 50.2, name: "Fooland", zoomLevel: Int32(2)))
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.location)
     }
-    
+
     func testThatItCategorizesV3Images() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendImage(from: self.verySmallJPEGData())
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.image)
     }
-    
+
     func testThatItCategorizesSystemMessage() {
-        
+
         // GIVEN
         let message = ZMSystemMessage(nonce: UUID(), managedObjectContext: conversation.managedObjectContext!)
         message.systemMessageType = .conversationNameChanged
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.systemMessage)
     }
-    
+
     func testThatItCategorizesLikedTextMessageWhenLikedBySelfUser() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on!") as! ZMClientMessage
         message.delivered = true
         ZMMessage.addReaction(.like, toMessage: message)
         XCTAssertFalse(message.usersReaction.isEmpty)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.text, MessageCategory.liked])
     }
-    
+
     func testThatItCategorizesLikedFileMessageWhenLikedBySelfUser() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt"))) as! ZMAssetClientMessage
         message.delivered = true
         ZMMessage.addReaction(.like, toMessage: message)
         XCTAssertFalse(message.usersReaction.isEmpty)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // THEN
         XCTAssertEqual(message.categorization, [MessageCategory.file, MessageCategory.liked])
     }
-    
+
     func testThatItCategorizesLikedTextMessageWhenNotLikedBySelfUser() {
-        
+
         // GIVEN
         let otherUser = ZMUser.insertNewObject(in: self.conversation.managedObjectContext!)
         otherUser.remoteIdentifier = UUID.create()
@@ -253,7 +253,7 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
         message.addReaction("❤️", forUser: otherUser)
         XCTAssertFalse(message.usersReaction.isEmpty)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // THEN
         XCTAssertEqual(message.categorization, MessageCategory.text)
     }
@@ -261,63 +261,63 @@ class ZMMessageCategorizationTests : ZMBaseManagedObjectTest {
 
 // MARK: - Cache
 extension ZMMessageCategorizationTests {
-    
+
     func testThatItComputesTheCachedCategoryLazily() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on!") as! ZMMessage
         message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: 0))
-        
+
         // WHEN
         let category = message.cachedCategory
-        
+
         // THEN
         XCTAssertEqual(category, MessageCategory.text)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.text.rawValue))
     }
-    
+
     func testThatItUsedCachedCategoryValueIfPresent() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on!") as! ZMMessage
         message.willChangeValue(forKey: ZMMessageCachedCategoryKey)
         message.setPrimitiveValue(NSNumber(value: MessageCategory.audio.rawValue), forKey: ZMMessageCachedCategoryKey)
         message.didChangeValue(forKey: ZMMessageCachedCategoryKey)
-        
+
         // WHEN
         let category = message.cachedCategory
-        
+
         // THEN
         XCTAssertEqual(category, MessageCategory.audio)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.audio.rawValue))
 
     }
-    
+
     func testThatItComputestheCachedCategoryWhenAsked() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendText(content: "ramble on!") as! ZMMessage
         message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: 0))
-        
+
         // WHEN
         message.updateCategoryCache()
-        
+
         // THEN
         message.willAccessValue(forKey: ZMMessageCachedCategoryKey)
         let category = message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber
         message.didAccessValue(forKey: ZMMessageCachedCategoryKey)
-        
+
         XCTAssertEqual(category?.int32Value, MessageCategory.text.rawValue)
     }
 }
 
 // MARK: - Fetch request
 extension ZMMessageCategorizationTests {
-    
+
     func testThatItCreatesAFetchRequestToFetchText() {
-        
+
         // GIVEN
         let textMessage = try! self.conversation.appendText(content: "in the still of the night") as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
@@ -332,11 +332,11 @@ extension ZMMessageCategorizationTests {
         likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
         likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text))
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -347,9 +347,9 @@ extension ZMMessageCategorizationTests {
         XCTAssertTrue(messages.contains(linkTextMessage))
         XCTAssertTrue(messages.contains(likedTextMessage))
     }
-    
+
     func testThatItCreatesAFetchRequestToFetchTextOrKnock() {
-        
+
         // GIVEN
         let textMessage = try! self.conversation.appendText(content: "in the still of the night") as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
@@ -364,11 +364,11 @@ extension ZMMessageCategorizationTests {
         likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
         likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text, MessageCategory.knock))
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -379,9 +379,9 @@ extension ZMMessageCategorizationTests {
         XCTAssertTrue(messages.contains(linkTextMessage))
         XCTAssertTrue(messages.contains(likedTextMessage))
     }
-    
+
     func testThatItCreatesAFetchRequestToFetchLikedText() {
-        
+
         // GIVEN
         let textMessage = try! self.conversation.appendText(content: "в ночной тиши") as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
@@ -396,11 +396,11 @@ extension ZMMessageCategorizationTests {
         likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
         likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: [MessageCategory.text, MessageCategory.liked]))
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -411,9 +411,9 @@ extension ZMMessageCategorizationTests {
         XCTAssertFalse(messages.contains(linkTextMessage))
         XCTAssertTrue(messages.contains(likedTextMessage))
     }
-    
+
     func testThatItCreatesAFetchRequestToFetchLikedTextOrKnock() {
-        
+
         // GIVEN
         let textMessage = try! self.conversation.appendText(content: "in the still of the night") as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
@@ -428,11 +428,11 @@ extension ZMMessageCategorizationTests {
         likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
         likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: [MessageCategory.text, MessageCategory.liked], MessageCategory.knock))
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -443,9 +443,9 @@ extension ZMMessageCategorizationTests {
         XCTAssertFalse(messages.contains(linkTextMessage))
         XCTAssertTrue(messages.contains(likedTextMessage))
     }
-    
+
     func testThatItCreatesAFetchRequestToFetchTextExcludingLinksAndLiked() {
-        
+
         // GIVEN
         let textMessage = try! self.conversation.appendText(content: "in the still of the night") as! ZMMessage
         textMessage.cachedCategory = MessageCategory.text
@@ -460,11 +460,11 @@ extension ZMMessageCategorizationTests {
         likedTextMessage.cachedCategory = [MessageCategory.liked, MessageCategory.text]
         likedTextMessage.serverTimestamp = Date(timeIntervalSince1970: 5000)
         self.conversation.managedObjectContext?.saveOrRollback()
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text), excluding: [MessageCategory.link, MessageCategory.liked])
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -475,22 +475,22 @@ extension ZMMessageCategorizationTests {
         XCTAssertFalse(messages.contains(linkTextMessage))
         XCTAssertFalse(messages.contains(likedTextMessage))
     }
-    
+
     func testThatItFetchesFromAllConversations() {
-        
+
         // GIVEN
         let otherConversation = ZMConversation.insertNewObject(in: self.uiMOC)
         otherConversation.conversationType = .group
         otherConversation.remoteIdentifier = UUID.create()
-        
+
         let textMessage1 = try! self.conversation.appendText(content: "hey Jean!") as! ZMMessage
         textMessage1.cachedCategory = MessageCategory.text
         textMessage1.serverTimestamp = Date(timeIntervalSince1970: 100)
-        
+
         let textMessage2 = try! otherConversation.appendText(content: "hey Jean!") as! ZMMessage
         textMessage2.cachedCategory = MessageCategory.text
         textMessage2.serverTimestamp = Date(timeIntervalSince1970: 300)
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text))
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
@@ -503,26 +503,26 @@ extension ZMMessageCategorizationTests {
         XCTAssertTrue(messages.contains(textMessage1))
         XCTAssertTrue(messages.contains(textMessage2))
     }
-    
+
     func testThatItFetchesFromASpecificConversations() {
-        
+
         // GIVEN
         let otherConversation = ZMConversation.insertNewObject(in: self.uiMOC)
         otherConversation.conversationType = .group
         otherConversation.remoteIdentifier = UUID.create()
-        
+
         let textMessage1 = try! self.conversation.appendText(content: "hey Jean!") as! ZMMessage
         textMessage1.cachedCategory = MessageCategory.text
         textMessage1.serverTimestamp = Date(timeIntervalSince1970: 100)
-        
+
         let textMessage2 = try! otherConversation.appendText(content: "hey Jean!") as! ZMMessage
         textMessage2.cachedCategory = MessageCategory.text
         textMessage2.serverTimestamp = Date(timeIntervalSince1970: 300)
-        
+
         // WHEN
         let fetchRequest = ZMMessage.fetchRequestMatching(categories: Set(arrayLiteral: MessageCategory.text), conversation: otherConversation)
         let results = try? self.conversation.managedObjectContext!.fetch(fetchRequest)
-        
+
         // THEN
         guard let messages = results as? [ZMMessage] else {
             XCTFail("Result is \(String(describing: results))")
@@ -533,76 +533,72 @@ extension ZMMessageCategorizationTests {
     }
 }
 
-
-
-
 // MARK: Categorization on insert
 
 extension ZMMessageCategorizationTests {
 
-    func testThatItCategorizesAClientMessageOnInsert(){
-        
+    func testThatItCategorizesAClientMessageOnInsert() {
+
         // when
         let message = try! self.conversation.appendText(content: "hey Jean!") as! ZMMessage
-        
+
         // then
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.text.rawValue))
     }
-    
+
     func testThatItCategorizesALocationMessageOnInsert() throws {
-        
+
         // when
         let message = try self.conversation.appendLocation(with: LocationData.locationData(withLatitude: 40.42, longitude: 50.2, name: "Fooland", zoomLevel: Int32(2))) as! ZMMessage
-        
+
         // then
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.location.rawValue))
     }
-    
+
     func testThatItCategorizesAKnockMessageOnInsert() throws {
-        
+
         // when
         let message = try self.conversation.appendKnock() as! ZMMessage
         // then
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.knock.rawValue))
     }
 
-    func testThatItCategorizesAnImageMessageOnInsert(){
-        
+    func testThatItCategorizesAnImageMessageOnInsert() {
+
         // when
         let message = try! self.conversation.appendImage(from: verySmallJPEGData()) as! ZMMessage
-        
+
         // then
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.image.rawValue))
     }
-    
-    func testThatItCategorizesAVideoMessageOnInsert(){
-        
+
+    func testThatItCategorizesAVideoMessageOnInsert() {
+
         // when
         let message = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMMessage
-        
+
         // then
         let category = MessageCategory.file.union(MessageCategory.video)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: category.rawValue))
     }
-    
+
     func testThatItCategorizesAnAudioFile() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMAudioMetadata(fileURL: self.fileURL(forResource: "audio", extension: "m4a"), duration: 12.2)) as! ZMMessage
 
-        
         // THEN
         let category = MessageCategory.file.union(MessageCategory.audio)
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: category.rawValue))
     }
-    
+
     func testThatItCategorizesAFileOnInsert() {
-        
+
         // GIVEN
         let message = try! self.conversation.appendFile(with: ZMFileMetadata(fileURL: self.fileURL(forResource: "Lorem Ipsum", extension: "txt"))) as! ZMMessage
-        
+
         // THEN
         XCTAssertEqual(message.primitiveValue(forKey: ZMMessageCachedCategoryKey) as? NSNumber, NSNumber(value: MessageCategory.file.rawValue))
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -26,74 +26,74 @@ class ZMMessageTests_Confirmation: BaseZMClientMessageTests {
 // MARK: - Sending confirmation messages
 
 extension ZMMessageTests_Confirmation {
-    
+
     // MARK: Read receipts
-    
+
     func testThatMessageExpectsReadConfirmation_InAGroup_WhenConversationHasReadReceiptsEnabled() {
         // given
         let user = createUser(in: uiMOC)
         let conversation = createConversation(in: uiMOC)
         conversation.hasReadReceiptsEnabled = true
-        
+
         // when
         let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
-        
+
         // then
         XCTAssertTrue(message.expectsReadConfirmation)
         XCTAssertTrue(message.needsReadConfirmation)
     }
-    
+
     func testThatMessageDoesntExpectReadConfirmation_InAGroup_WhenConversationHasReadReceiptsDisabled() {
         // given
         let user = createUser(in: uiMOC)
         let conversation = createConversation(in: uiMOC)
         conversation.hasReadReceiptsEnabled = false
-        
+
         // when
         let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
-        
+
         // then
         XCTAssertFalse(message.expectsReadConfirmation)
         XCTAssertFalse(message.needsReadConfirmation)
     }
-    
+
     func testThatMessageDoesntExpectReadConfirmation_InAGroup_ForMessagesSentBySelfUser() {
         // given
         let conversation = createConversation(in: uiMOC)
         conversation.hasReadReceiptsEnabled = true
-        
+
         // when
         let message = insertMessage(conversation, fromSender: ZMUser.selfUser(in: uiMOC), timestamp: Date()) as! ZMClientMessage
-        
+
         // then
         XCTAssertFalse(message.expectsReadConfirmation)
         XCTAssertFalse(message.needsReadConfirmation)
     }
-    
+
     func testThatMessageDoesntExpectReadConfirmation_InAOneToOne__WhenConversationHasReadReceiptsEnabled() {
         // given
         let conversation = createConversation(in: uiMOC)
         conversation.hasReadReceiptsEnabled = true
         conversation.conversationType = .oneOnOne
-        
+
         // when
         let message = insertMessage(conversation, fromSender: ZMUser.selfUser(in: uiMOC), timestamp: Date()) as! ZMClientMessage
-        
+
         // then
         XCTAssertFalse(message.expectsReadConfirmation)
     }
-    
+
     func testThatMessageNeedsReadConfirmation_InAOneToOne_WhenSelfUserHasReadReceiptsEnabled() {
         // given
         let user = createUser(in: uiMOC)
         let conversation = createConversation(in: uiMOC)
         conversation.conversationType = .oneOnOne
-        
+
         // insert message which expects read confirmation
         let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
         var genericMessage = message.underlyingMessage!
         genericMessage.setExpectsReadConfirmation(true)
-        
+
         do {
             try message.setUnderlyingMessage(genericMessage)
         } catch {
@@ -102,47 +102,46 @@ extension ZMMessageTests_Confirmation {
 
         // when
         ZMUser.selfUser(in: uiMOC).readReceiptsEnabled = true
-        
+
         // then
         XCTAssertTrue(message.needsReadConfirmation)
     }
-    
+
     func testThatMessageDoesntNeedsReadConfirmation_InAOneToOne_WhenSelfUserHasReadReceiptsDisabled() {
         // given
         let user = createUser(in: uiMOC)
         let conversation = createConversation(in: uiMOC)
         conversation.conversationType = .oneOnOne
-        
-        
+
         // insert message which expects read confirmation
         let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
         var genericMessage = message.underlyingMessage!
         genericMessage.setExpectsReadConfirmation(true)
-        
+
         do {
             try message.setUnderlyingMessage(genericMessage)
         } catch {
             XCTFail()
         }
-        
+
         // when
         ZMUser.selfUser(in: uiMOC).readReceiptsEnabled = false
 
         // then
         XCTAssertFalse(message.needsReadConfirmation)
     }
-    
+
     func testThatMessageDoesntNeedsReadConfirmation_InAOneToOne_WhenSelfUserHasReadReceiptsEnabledButMessageDoesntExpectReadConfirmation() {
         // given
         let user = createUser(in: uiMOC)
         let conversation = createConversation(in: uiMOC)
         conversation.conversationType = .oneOnOne
-        
+
         ZMUser.selfUser(in: uiMOC).readReceiptsEnabled = true
-        
+
         // insert message which doesn't expect read confirmation
         let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
-        
+
         // then
         XCTAssertFalse(message.needsReadConfirmation)
     }
@@ -169,11 +168,11 @@ extension ZMMessageTests_Confirmation {
 
 // MARK: - Deletion
 extension ZMMessageTests_Confirmation {
-    
+
     func testThatItCanDeleteAMessageThatWasConfirmed() {
-        
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         let message = try! conversation.appendText(content: "foo") as! ZMClientMessage
         message.markAsSent()
@@ -183,12 +182,12 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertTrue(uiMOC.saveOrRollback())
-        
+
         guard let confirmation = message.confirmations.first else {
             XCTFail()
             return
         }
-        
+
         // when
         self.uiMOC.delete(message)
         self.uiMOC.saveOrRollback()
@@ -196,107 +195,107 @@ extension ZMMessageTests_Confirmation {
         // then
         XCTAssertNil(confirmation.managedObjectContext) // this will detect if it was deleted
     }
-    
+
     func testThatItDeletesConfirmationsPendingForDeletedMessages() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         conversation.conversationType = .oneOnOne
-        
+
         let lastModified = Date(timeIntervalSince1970: 1234567890)
         conversation.lastModifiedDate = lastModified
-        
+
         let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
         remoteUser.remoteIdentifier = .create()
-        
+
         // when
         let sut = insertMessage(conversation, fromSender: remoteUser)
         let confirmation = GenericMessage(content: Confirmation(messageId: sut.nonce!, type: .delivered))
         _ = try? conversation.appendClientMessage(with: confirmation, expires: false, hidden: true)
-        
+
         // then
         guard let hiddenMessage = conversation.hiddenMessages.first as? ZMClientMessage else {
             XCTFail("Did not insert confirmation message.")
             return
         }
-        
+
         XCTAssertTrue(hiddenMessage.underlyingMessage?.hasConfirmation == true)
         // when
-        
+
         sut.removePendingDeliveryReceipts()
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(conversation.hiddenMessages.count, 0)
     }
 
     func testThatItDeletesConfirmationsForDeletedMessage() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         conversation.conversationType = .group
         conversation.hasReadReceiptsEnabled = true
-        
+
         let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
         remoteUser.remoteIdentifier = .create()
-        
+
         let textMessage = insertMessage(conversation, fromSender: selfUser)
         let confirmation = ZMMessageConfirmation(type: .read, message: textMessage, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
         textMessage.mutableSetValue(forKey: "confirmations").add(confirmation)
-        
+
         XCTAssertEqual(textMessage.confirmations.count, 1)
         // when
         textMessage.hideForSelfUser()
         uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(textMessage.confirmations.count, 0)
         XCTAssertNil(confirmation.managedObjectContext)
     }
-    
+
     func testThatItDeletesConfirmationsForDeletedForEveryoneMessage() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         conversation.conversationType = .group
         conversation.hasReadReceiptsEnabled = true
-        
+
         let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
         remoteUser.remoteIdentifier = .create()
-        
+
         let textMessage = insertMessage(conversation, fromSender: selfUser)
         let confirmation = ZMMessageConfirmation(type: .read, message: textMessage, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
         textMessage.mutableSetValue(forKey: "confirmations").add(confirmation)
-        
+
         XCTAssertEqual(textMessage.confirmations.count, 1)
         // when
         textMessage.deleteForEveryone()
         uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(textMessage.confirmations.count, 0)
         XCTAssertNil(confirmation.managedObjectContext)
     }
-    
+
     func testThatItKeepsConfirmationsForObfuscatedMessage() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
         conversation.conversationType = .group
         conversation.hasReadReceiptsEnabled = true
-        
+
         let remoteUser = ZMUser.insertNewObject(in: self.uiMOC)
         remoteUser.remoteIdentifier = .create()
-        
+
         let textMessage = insertMessage(conversation, fromSender: selfUser)
         let confirmation = ZMMessageConfirmation(type: .read, message: textMessage, sender: remoteUser, serverTimestamp: Date(), managedObjectContext: uiMOC)
         textMessage.mutableSetValue(forKey: "confirmations").add(confirmation)
-        
+
         XCTAssertEqual(textMessage.confirmations.count, 1)
         // when
         textMessage.obfuscate()
         uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(textMessage.confirmations.count, 1)
         XCTAssertNotNil(confirmation.managedObjectContext)
@@ -306,21 +305,21 @@ extension ZMMessageTests_Confirmation {
 // MARK: - Receiving confirmation messages
 
 extension ZMMessageTests_Confirmation {
-    
+
     // MARK: Read receipts
-    
+
     func testThatItUpdatesTheDeliveryStatus_WhenItReceivesReadConfirmation() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let sut = try! conversation.appendText(content: "foo") as! ZMClientMessage
         sut.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.sent)
-        
+
         // when
         // other user sends confirmation
         let updateEvent = createMessageReadConfirmationUpdateEvent([sut.nonce!], conversationID: conversation.remoteIdentifier!)
@@ -329,23 +328,23 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.read)
     }
-    
-    func testThatItAddsDeliveryReceipt_WhenItReceivesReadConfirmation(){
+
+    func testThatItAddsDeliveryReceipt_WhenItReceivesReadConfirmation() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let sut = try! conversation.appendText(content: "foo") as! ZMClientMessage
         sut.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.sent)
-        
+
         // when
         // other user sends read confirmation
         let updateEvent = createMessageReadConfirmationUpdateEvent([sut.nonce!], conversationID: conversation.remoteIdentifier!)
@@ -354,27 +353,27 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(sut.readReceipts.count, 1)
         XCTAssertEqual(sut.readReceipts.first?.user.remoteIdentifier, updateEvent.senderUUID)
     }
-    
-    func testThatItAddsDeliveryReceipt_WhenItReceivesMultipleReadConfirmations(){
+
+    func testThatItAddsDeliveryReceipt_WhenItReceivesMultipleReadConfirmations() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let messsage1 = try! conversation.appendText(content: "foo") as! ZMClientMessage
         messsage1.markAsSent()
         let messsage2 = try! conversation.appendText(content: "foo") as! ZMClientMessage
         messsage2.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertEqual(messsage1.deliveryState, ZMDeliveryState.sent)
         XCTAssertEqual(messsage2.deliveryState, ZMDeliveryState.sent)
-        
+
         // when
         // other user sends read confirmation
         let updateEvent = createMessageReadConfirmationUpdateEvent([messsage1.nonce!, messsage2.nonce!], conversationID: conversation.remoteIdentifier!)
@@ -383,32 +382,32 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(messsage1.readReceipts.count, 1)
         XCTAssertEqual(messsage1.readReceipts.first?.user.remoteIdentifier, updateEvent.senderUUID)
         XCTAssertEqual(messsage2.readReceipts.count, 1)
         XCTAssertEqual(messsage2.readReceipts.first?.user.remoteIdentifier, updateEvent.senderUUID)
     }
-    
-    func testThatItDeliveryReceiptsAreOrdedByTimestamp_WhenItReceivesReadConfirmation(){
+
+    func testThatItDeliveryReceiptsAreOrdedByTimestamp_WhenItReceivesReadConfirmation() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let sut = try! conversation.appendText(content: "foo") as! ZMClientMessage
         sut.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.sent)
-        
+
         // when
         // other user sends read confirmation
         let timestamp1 = Date(timeIntervalSince1970: 0)
         let timestamp2 = Date(timeIntervalSince1970: 1)
         let timestamp3 = Date(timeIntervalSince1970: 2)
-        
+
         let updateEvent1 = createMessageReadConfirmationUpdateEvent([sut.nonce!], conversationID: conversation.remoteIdentifier!, timestamp: timestamp2)
         let updateEvent2 = createMessageReadConfirmationUpdateEvent([sut.nonce!], conversationID: conversation.remoteIdentifier!, timestamp: timestamp1)
         let updateEvent3 = createMessageReadConfirmationUpdateEvent([sut.nonce!], conversationID: conversation.remoteIdentifier!, timestamp: timestamp3)
@@ -419,24 +418,24 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(sut.readReceipts.count, 3)
-        XCTAssertEqual(sut.readReceipts.map(\.serverTimestamp) , [timestamp1, timestamp2, timestamp3])
+        XCTAssertEqual(sut.readReceipts.map(\.serverTimestamp), [timestamp1, timestamp2, timestamp3])
     }
-    
+
     // MARK: Delivery receipts
-    
+
     func testThatItUpdatesTheDeliveryStatus_WhenItReceivesDeliveryConfirmation() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let sut = try! conversation.appendText(content: "foo") as! ZMClientMessage
         sut.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.sent)
 
         // when
@@ -447,24 +446,24 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(sut.deliveryState, ZMDeliveryState.delivered)
     }
-    
+
 }
 
 // MARK: - Change notifications
 
 extension ZMMessageTests_Confirmation {
-    
+
     func testThatItDoesNotUpdateTheDeliveryStatus_WhenTheSenderIsNotTheSelfUser() {
         // given
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = .create()
-        
+
         let sut = insertMessage(conversation)
-        
+
         // when
         // other user sends confirmation
         let updateEvent = createMessageDeliveryConfirmationUpdateEvent(sut.nonce!, conversationID: conversation.remoteIdentifier!)
@@ -473,38 +472,38 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertNotEqual(sut.deliveryState, ZMDeliveryState.delivered)
     }
-    
-    func testThatItSendsOutNotificationsForTheDeliveryStatusChange(){
+
+    func testThatItSendsOutNotificationsForTheDeliveryStatusChange() {
         // given
         let dispatcher = NotificationDispatcher(managedObjectContext: uiMOC)
-        
+
         defer {
             dispatcher.tearDown()
         }
-        
-        let conversation = ZMConversation.insertNewObject(in:uiMOC)
+
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
         conversation.addParticipantAndUpdateConversationState(user: sender, role: nil)
         conversation.remoteIdentifier = .create()
         let lastModified = Date(timeIntervalSince1970: 1234567890)
         conversation.lastModifiedDate = lastModified
-        
+
         let sut = try! conversation.appendText(content: "foo") as! ZMClientMessage
         sut.markAsSent()
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         let convObserver = ConversationObserver(conversation: conversation)
-        var messageObserver : MessageObserver!
-        self.performIgnoringZMLogError{
+        var messageObserver: MessageObserver!
+        self.performIgnoringZMLogError {
             messageObserver = MessageObserver(message: sut)
         }
-        
+
         // when
         let updateEvent = createMessageDeliveryConfirmationUpdateEvent(
             sut.nonce!,
@@ -514,7 +513,7 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(self.uiMOC.saveOrRollback())
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         if convObserver.notifications.count > 0 {
             return XCTFail()
@@ -524,12 +523,12 @@ extension ZMMessageTests_Confirmation {
         }
         XCTAssertTrue(messageChangeInfo.deliveryStateChanged)
     }
-    
+
 }
 
 // MARK: - Helpers
 extension ZMMessageTests_Confirmation {
-    
+
     func insertMessage(_ conversation: ZMConversation,
                        content: MessageCapable = Text(content: "foo"),
                        fromSender: ZMUser? = nil,
@@ -547,7 +546,7 @@ extension ZMMessageTests_Confirmation {
             senderID: fromSender?.remoteIdentifier ?? UUID.create(),
             eventSource: eventSource
         )
-        
+
         var message: ZMMessage!
         let MOC = moc ?? uiMOC
 
@@ -564,15 +563,15 @@ extension ZMMessageTests_Confirmation {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         return message
     }
-    
+
     func createMessageDeliveryConfirmationUpdateEvent(_ nonce: UUID, conversationID: UUID, senderID: UUID = .create(), timestamp: Date = .init()) -> ZMUpdateEvent {
         let genericMessage = GenericMessage(content: Confirmation(messageId: nonce, type: .delivered))
-        return createUpdateEvent(UUID(), conversationID: conversationID, timestamp: timestamp,  genericMessage: genericMessage, senderID: senderID)
+        return createUpdateEvent(UUID(), conversationID: conversationID, timestamp: timestamp, genericMessage: genericMessage, senderID: senderID)
     }
-    
+
     func createMessageReadConfirmationUpdateEvent(_ nonces: [UUID], conversationID: UUID, senderID: UUID = .create(), timestamp: Date = .init()) -> ZMUpdateEvent {
         let genericMessage = GenericMessage(content: Confirmation(messageIds: nonces, type: .read)!)
         return createUpdateEvent(UUID(), conversationID: conversationID, timestamp: timestamp, genericMessage: genericMessage, senderID: senderID)
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMMessageTests+GenericMessage.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+GenericMessage.swift
@@ -21,7 +21,7 @@ import XCTest
 @testable import WireDataModel
 
 class ZMMessageTests_GenericMessage: BaseZMClientMessageTests {
-    
+
    func testThatItDoesNotSetTheServerTimestampFromEventDataEvenIfMessageAlreadyExists() {
         self.syncMOC.performGroupedAndWait {_ in
             // given
@@ -62,7 +62,7 @@ class ZMMessageTests_GenericMessage: BaseZMClientMessageTests {
 // MARK: - KnockMessage
 
 extension ZMMessageTests_GenericMessage {
-    
+
     func testThatItCreatesOtrKnockMessageFromAnUpdateEvent() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)

--- a/Tests/Source/Model/Messages/ZMMessageTests+Removal.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+Removal.swift
@@ -19,66 +19,65 @@
 import Foundation
 @testable import WireDataModel
 
-
 class ZMMessageTests_Removal: BaseZMClientMessageTests {
     func testThatAMessageIsRemovedWhenAskForDeletionWithMessageHide() {
         // GIVEN
-        
+
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let nonce = UUID.create()
         var textMessage: ZMTextMessage? = ZMTextMessage(nonce: nonce, managedObjectContext: uiMOC)
         textMessage?.visibleInConversation = conversation
-        
+
         let hidden = MessageHide.with {
             $0.conversationID = conversation.remoteIdentifier!.transportString()
             $0.messageID = nonce.transportString()
         }
-        
+
         // sanity check
         XCTAssertNotNil(textMessage)
         uiMOC.saveOrRollback()
-        
+
         // WHEN
         performPretendingUiMocIsSyncMoc {
             ZMMessage.remove(remotelyHiddenMessage: hidden, inContext: self.uiMOC)
         }
         uiMOC.saveOrRollback()
-        
+
         // THEN
         textMessage = ZMTextMessage.fetch(withNonce: nonce, for: conversation, in: uiMOC)
         XCTAssertNil(textMessage)
         XCTAssertEqual(conversation.allMessages.count, 0)
     }
-    
+
     func testThatItDeletesTheMessageWithDelete() {
         // GIVEN
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let nonce = UUID.create()
         var textMessage: ZMTextMessage? = ZMTextMessage(nonce: nonce, managedObjectContext: uiMOC)
         textMessage?.sender = sender
         textMessage?.visibleInConversation = conversation
-        
+
         let deleted = MessageDelete.with {
             $0.messageID = nonce.transportString()
         }
-        
+
         // sanity check
         XCTAssertNotNil(textMessage)
         uiMOC.saveOrRollback()
-        
+
         // WHEN
         performPretendingUiMocIsSyncMoc {
             ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: textMessage!.sender!.remoteIdentifier, inContext: self.uiMOC)
         }
         uiMOC.saveOrRollback()
-        
+
         // THEN
         textMessage = ZMTextMessage.fetch(withNonce: nonce, for: conversation, in: uiMOC)
         XCTAssertTrue(textMessage?.hasBeenDeleted ?? false)
@@ -88,57 +87,57 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         // GIVEN
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let nonce = UUID.create()
         var textMessage: ZMTextMessage? = ZMTextMessage(nonce: nonce, managedObjectContext: uiMOC)
         textMessage?.sender = sender
         textMessage?.visibleInConversation = conversation
-        
+
         let deleted = MessageDelete.with {
             $0.messageID = nonce.transportString()
         }
-        
+
         // sanity check
         XCTAssertNotNil(textMessage)
         uiMOC.saveOrRollback()
-        
+
         // WHEN
         performPretendingUiMocIsSyncMoc {
             ZMMessage.remove(remotelyDeletedMessage: deleted, inConversation: conversation, senderID: UUID.create(), inContext: self.uiMOC)
         }
         uiMOC.saveOrRollback()
-        
+
         // THEN
         textMessage = ZMTextMessage.fetch(withNonce: nonce, for: conversation, in: uiMOC)
         XCTAssertFalse(textMessage?.hasBeenDeleted ?? true)
     }
-    
+
     func testThatItDoesNotDeleteTheDeletedMessageWithDelete() {
         // GIVEN
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let sender = ZMUser.insertNewObject(in: uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         let nonce = UUID.create()
         var textMessage: ZMTextMessage? = ZMTextMessage(nonce: nonce, managedObjectContext: uiMOC)
         textMessage?.sender = sender
         textMessage?.hiddenInConversation = conversation
-        
+
         XCTAssertTrue(textMessage!.hasBeenDeleted)
-        
+
         let deleted = MessageDelete.with {
             $0.messageID = nonce.transportString()
         }
-        
+
         // sanity check
         XCTAssertNotNil(textMessage)
         uiMOC.saveOrRollback()
-        
+
         // WHEN
         performPretendingUiMocIsSyncMoc {
             self.performIgnoringZMLogError {
@@ -146,12 +145,12 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
             }
         }
         uiMOC.saveOrRollback()
-        
+
         // THEN
         textMessage = ZMTextMessage.fetch(withNonce: nonce, for: conversation, in: uiMOC)
         XCTAssertTrue(textMessage?.hasBeenDeleted ?? false)
     }
-    
+
     func testThatAClientMessageIsRemovedWhenAskForDeletion() {
         // when
         let removed = checkThatAMessageIsRemoved { () -> ZMMessage in
@@ -160,36 +159,36 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         // then
         XCTAssertTrue(removed)
     }
-    
+
     // Returns whether the message was deleted
     private func checkThatAMessageIsRemoved(messageCreationBlock: (() -> ZMMessage)) -> Bool {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.remoteIdentifier = UUID.create()
-        
+
         let testMessage = messageCreationBlock()
         testMessage.visibleInConversation = conversation
-        
-        //sanity check
+
+        // sanity check
         XCTAssertNotNil(conversation)
         XCTAssertNotNil(testMessage)
         self.uiMOC.saveOrRollback()
-        
-        //when
+
+        // when
         self.performPretendingUiMocIsSyncMoc {
             testMessage.removeClearingSender(true)
         }
         self.uiMOC.saveOrRollback()
-        
-        //then
+
+        // then
         let fetchedMessage = ZMMessage.fetch(withNonce: testMessage.nonce, for: conversation, in: self.uiMOC) as! ZMMessage
         var removed = fetchedMessage.visibleInConversation == nil && fetchedMessage.hiddenInConversation == conversation && fetchedMessage.sender == nil
-        
+
         if fetchedMessage.isKind(of: ZMClientMessage.self) {
             let clientMessage = fetchedMessage as! ZMClientMessage
             removed = clientMessage.dataSet.count == 0 && clientMessage.underlyingMessage == nil
         }
-        
+
         return removed
     }
 
@@ -207,7 +206,7 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         let removed = checkThatAMessageIsRemoved { () -> ZMMessage in
             return ZMAssetClientMessage(nonce: UUID.create(), managedObjectContext: uiMOC)
         }
-        
+
         // then
         XCTAssertTrue(removed)
     }
@@ -226,7 +225,7 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         let removed = checkThatAMessageIsRemoved { () -> ZMMessage in
             return ZMImageMessage(nonce: UUID.create(), managedObjectContext: uiMOC)
         }
-        
+
         // then
         XCTAssertTrue(removed)
     }
@@ -236,9 +235,9 @@ class ZMMessageTests_Removal: BaseZMClientMessageTests {
         let removed = checkThatAMessageIsRemoved { () -> ZMMessage in
             return ZMKnockMessage(nonce: UUID.create(), managedObjectContext: uiMOC)
         }
-        
+
         // then
         XCTAssertTrue(removed)
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+ShouldGenerateUnreadCount.swift
@@ -19,119 +19,119 @@
 import XCTest
 
 class ZMMessageTests_ShouldGenerateUnreadCount: BaseZMClientMessageTests {
-    
+
     // MARK: New Conversation
-    
+
     func testThatNewConversationSystemMessage_fromOtherGeneratesUnreadCount() {
         // given
         let conversation = createConversation(in: uiMOC)
         conversation.lastServerTimeStamp = Date()
-        
+
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .newConversation
         systemMessage.sender = user1
         systemMessage.visibleInConversation = conversation
-        
+
         // then
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     func testThatNewConversationSystemMessage_fromSelfDoesntGenerateUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .newConversation
         systemMessage.sender = selfUser
-        
+
         // then
         XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     // MARK: Add Participants
-    
+
     func testThatAddParticipantSystemMessage_fromSelfDoesntGenerateUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsAdded
         systemMessage.sender = selfUser
         systemMessage.users = Set(arrayLiteral: user1)
-        
+
         // then
         XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     func testThatAddParticipantSystemMessage_fromOtherInvolvingSomeoneElseDoesntGenerateUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsAdded
         systemMessage.sender = user1
         systemMessage.users = Set(arrayLiteral: user2)
-        
+
         // then
         XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     func testThatAddParticipantSystemMessage_fromOtherInvolvingSelfGeneratesUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsAdded
         systemMessage.sender = user1
         systemMessage.users = Set(arrayLiteral: selfUser)
-        
+
         // then
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     // MARK: Remove Participants
-    
+
     func testThatRemoveParticipantSystemMessage_fromSelfDoesntGenerateUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsRemoved
         systemMessage.sender = selfUser
         systemMessage.users = Set(arrayLiteral: user1)
-        
+
         // then
         XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     func testThatRemoveParticipantSystemMessage_fromOtherInvolvingSomeoneElseDoesntGenerateUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsRemoved
         systemMessage.sender = user1
         systemMessage.users = Set(arrayLiteral: user2)
-        
+
         // then
         XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     func testThatRemoveParticipantSystemMessage_fromOtherInvolvingSelfGeneratesUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .participantsRemoved
         systemMessage.sender = user1
         systemMessage.users = Set(arrayLiteral: selfUser)
-        
+
         // then
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     // MARK: Missed Call
-    
+
     func testThatMissedCallSystemMessage_generatesUnreadCount() {
         // given
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .missedCall
         systemMessage.sender = user1
-        
+
         // then
         XCTAssertTrue(systemMessage.shouldGenerateUnreadCount())
     }
-    
+
     // MARK: Non-unread count generating system messages
-    
+
     func testThatRemainingSystemMessages_doesntGenerateUnreadCount() {
-        
+
         let nonUnreadCountGeneratingSystemMessages: [ZMSystemMessageType] = [.connectionRequest,
                                                                              .connectionUpdate,
                                                                              .conversationIsSecure,
@@ -150,16 +150,16 @@ class ZMMessageTests_ShouldGenerateUnreadCount: BaseZMClientMessageTests {
                                                                              .readReceiptsOn,
                                                                              .teamMemberLeave,
                                                                              .usingNewDevice]
-        
+
         for systemMessageType in nonUnreadCountGeneratingSystemMessages {
             // given
             let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
             systemMessage.systemMessageType = systemMessageType
             systemMessage.sender = user1
-            
+
             // then
             XCTAssertFalse(systemMessage.shouldGenerateUnreadCount())
         }
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
@@ -41,20 +41,20 @@ class ZMMessageTests_SystemMessages: BaseZMMessageTests {
             CBOX_INIT_ERROR,
             CBOX_DEGENERATED_KEY
         ]
-        
+
         let recoverableEncryptionErrors = [
             CBOX_TOO_DISTANT_FUTURE,
             CBOX_DEGENERATED_KEY,
             CBOX_PREKEY_NOT_FOUND
         ]
-        
+
         for encryptionError in allEncryptionErrors {
             assertDecryptionErrorIsReportedAsRecoverable(
                 encryptionError,
                 recoverable: recoverableEncryptionErrors.contains(encryptionError))
         }
     }
-    
+
     private func assertDecryptionErrorIsReportedAsRecoverable(_ decryptionError: CBoxResult,
                                                               recoverable: Bool,
                                                               file: StaticString = #file,
@@ -63,7 +63,7 @@ class ZMMessageTests_SystemMessages: BaseZMMessageTests {
         let systemMessage = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage.systemMessageType = .decryptionFailed
         systemMessage.decryptionErrorCode = NSNumber(value: decryptionError.rawValue)
-        
+
         // then
         XCTAssertEqual(systemMessage.isDecryptionErrorRecoverable, recoverable, file: file, line: line)
     }
@@ -109,15 +109,15 @@ extension ZMMessageTests_SystemMessages {
     }
 
     private func createSystemMessageFrom(updateEventType: ZMUpdateEventType,
-                                         in conversation:ZMConversation,
-                                         with usersIDs:[UUID],
+                                         in conversation: ZMConversation,
+                                         with usersIDs: [UUID],
                                          senderID: UUID?,
                                          reason: ZMParticipantsRemovedReason?,
                                          domain: String? = nil) -> ZMSystemMessage? {
-        let updateEventTypeDict: [ZMUpdateEventType : String] = [
-            .conversationMemberJoin : "conversation.member-join",
-            .conversationMemberLeave : "conversation.member-leave",
-            .conversationRename : "conversation.rename"
+        let updateEventTypeDict: [ZMUpdateEventType: String] = [
+            .conversationMemberJoin: "conversation.member-join",
+            .conversationMemberLeave: "conversation.member-leave",
+            .conversationRename: "conversation.rename"
         ]
 
         var data: [String: Any]
@@ -127,14 +127,14 @@ extension ZMMessageTests_SystemMessages {
                     ["qualified_id":
                         ["id": $0.transportString(), "domain": domain]
                     ]
-                } ] as [String : Any]
+                } ] as [String: Any]
             } else {
                 data = ["qualified_user_ids": usersIDs.map {
                     ["id": $0.transportString(), "domain": domain]
-                } ] as [String : Any]
+                } ] as [String: Any]
             }
         } else {
-            data = ["user_ids": usersIDs.map { $0.transportString() }] as [String : Any]
+            data = ["user_ids": usersIDs.map { $0.transportString() }] as [String: Any]
         }
 
         if reason != nil {
@@ -147,14 +147,14 @@ extension ZMMessageTests_SystemMessages {
         )
         let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
         var result: ZMSystemMessage?
-        self.performPretendingUiMocIsSyncMoc() {
+        self.performPretendingUiMocIsSyncMoc {
             result = ZMSystemMessage.createOrUpdate(from: event, in: self.uiMOC, prefetchResult: nil)
         }
         return result
     }
 
     private func checkThatUpdateEventTypeGeneratesSystemMessage(updateEventType: ZMUpdateEventType,
-                                                                systemMessageType:ZMSystemMessageType,
+                                                                systemMessageType: ZMSystemMessageType,
                                                                 reason: ZMParticipantsRemovedReason?,
                                                                 selfUserDomain: String? = nil,
                                                                 otherUserDomain: String? = nil) {

--- a/Tests/Source/Model/Messages/ZMMessageTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTests.swift
@@ -26,15 +26,15 @@ extension ZMMessageTests {
                    data: [AnyHashable: Any]?) -> ZMUpdateEvent {
         let updateEvent = ZMUpdateEvent()
         updateEvent.type = type
-        
-        let serverTimeStamp : Date = conversation?.lastServerTimeStamp?.addingTimeInterval(5) ??
+
+        let serverTimeStamp: Date = conversation?.lastServerTimeStamp?.addingTimeInterval(5) ??
             Date()
-        
+
         let from = senderID ?? UUID()
-        
+
         if let remoteIdentifier = conversation?.remoteIdentifier?.transportString(),
            let data = data {
-            
+
             updateEvent.payload = [
                 "conversation": remoteIdentifier,
                 "time": serverTimeStamp.transportString(),
@@ -42,19 +42,19 @@ extension ZMMessageTests {
                 "data": data
             ]
         }
-        
+
         return updateEvent
     }
-    
+
     func testThatSpecialKeysAreNotPartOfTheLocallyModifiedKeysForClientMessages() {
         // when
         let message = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: uiMOC)
-        
+
         // then
         let keysThatShouldBeTracked = Set<AnyHashable>(["dataSet", "linkPreviewState"])
         XCTAssertEqual(message.keysTrackedForLocalModifications(), keysThatShouldBeTracked)
     }
-    
+
     func testThatFlagIsNotSetWhenSenderIsNotTheOnlyUser() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
@@ -72,10 +72,10 @@ extension ZMMessageTests {
         let userIDs: [ZMTransportEncoding] = [sender.remoteIdentifier as NSUUID,
                                               user.remoteIdentifier as NSUUID]
         var message: ZMSystemMessage?
-        performPretendingUiMocIsSyncMoc{ [weak self] in
+        performPretendingUiMocIsSyncMoc { [weak self] in
             message = self?.createSystemMessage(from: .conversationMemberJoin, in: conversation, withUsersIDs: userIDs, senderID: sender.remoteIdentifier)
         }
-        
+
         uiMOC.saveOrRollback()
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 

--- a/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
+++ b/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
@@ -21,45 +21,45 @@ import XCTest
 import WireTransport
 
 class ZMMessageTimerTests: BaseZMMessageTests {
-    
+
     var sut: ZMMessageTimer!
-    
+
     override func setUp() {
         super.setUp()
         sut = ZMMessageTimer(managedObjectContext: uiMOC)!
     }
-    
+
     override func tearDown() {
         sut.tearDown()
         sut = nil
         super.tearDown()
     }
-    
+
     func testThatItDoesNotCreateBackgroundActivityWhenTimerStarted() {
         // given
         XCTAssertFalse(BackgroundActivityFactory.shared.isActive)
         let message = createClientTextMessage(withText: "hello")
-        
+
         // when
         sut.start(forMessageIfNeeded: message, fire: Date(timeIntervalSinceNow: 1.0), userInfo: [:])
-        
+
         // then
         let timer = sut.timer(for: message)
         XCTAssertNotNil(timer)
-        
+
         XCTAssertFalse(BackgroundActivityFactory.shared.isActive)
     }
-    
+
     func testThatItRemovesTheInternalTimerAfterTimerFired() {
         // given
         let message = createClientTextMessage(withText: "hello")
         let expectation = self.expectation(description: "timer fired")
         sut.timerCompletionBlock = { _, _ in expectation.fulfill() }
-        
+
         // when
         sut.start(forMessageIfNeeded: message, fire: Date(), userInfo: [:])
         _ = waitForCustomExpectations(withTimeout: 0.5)
-        
+
         // then
         XCTAssertNil(sut.timer(for: message))
     }
@@ -68,10 +68,10 @@ class ZMMessageTimerTests: BaseZMMessageTests {
         // given
         let message = createClientTextMessage(withText: "hello")
         sut.start(forMessageIfNeeded: message, fire: Date(), userInfo: [:])
-        
+
         // when
         sut.stop(for: message)
-        
+
         // then
         XCTAssertNil(sut.timer(for: message))
     }

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SecurityDegradationTests.swift
@@ -21,41 +21,40 @@ import WireUtilities
 @testable import WireDataModel
 import WireLinkPreview
 
+class ZMOTRMessage_SecurityDegradationTests: BaseZMClientMessageTests {
 
-class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
-    
     func testThatAtCreationAMessageIsNotCausingDegradation_UIMoc() {
-        
+
         // GIVEN
         let convo = createConversation(moc: self.uiMOC)
-        
+
         // WHEN
         let message = try! convo.appendText(content: "Foo")
         self.uiMOC.saveOrRollback()
-        
+
         // THEN
         XCTAssertFalse(message.causedSecurityLevelDegradation)
         XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.isEmpty)
         XCTAssertFalse(self.uiMOC.zm_hasChanges)
     }
-    
+
     func testThatAtCreationAMessageIsNotCausingDegradation_SyncMoc() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
-            
+
             // WHEN
             let message = try! convo.appendText(content: "Foo")
-            
+
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.isEmpty)
         }
     }
-    
+
     func testThatItSetsMessageAsCausingDegradation() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
@@ -64,7 +63,7 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
 
             // WHEN
             message.causedSecurityLevelDegradation = true
-            
+
             // THEN
             XCTAssertTrue(message.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.contains(message))
@@ -72,9 +71,9 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
 
         }
     }
-    
+
     func testThatItDoesNotSetDeliveryReceiptAsCausingDegradation() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
@@ -90,7 +89,7 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
             let newClient = UserClient.insertNewObject(in: self.syncMOC)
             convo.decreaseSecurityLevelIfNeededAfterDiscovering(clients: [newClient], causedBy: confirmationMessage)
             self.syncMOC.saveOrRollback()
-            
+
             // THEN
             XCTAssertEqual(convo.securityLevel, .secureWithIgnored)
             XCTAssertFalse(message.causedSecurityLevelDegradation)
@@ -99,20 +98,19 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
             XCTAssertFalse(self.syncMOC.zm_hasChanges)
         }
     }
-    
+
     func testThatItResetsMessageAsCausingDegradation() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
             let message = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message.causedSecurityLevelDegradation = true
             self.syncMOC.saveOrRollback()
-            
+
             // WHEN
             message.causedSecurityLevelDegradation = false
 
-            
             // THEN
             XCTAssertFalse(message.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.isEmpty)
@@ -120,21 +118,21 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
 
         }
     }
-    
+
     func testThatItResetsDegradedConversationWhenRemovingAllMessages() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
-            
+
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
             let message1 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message1.causedSecurityLevelDegradation = true
             let message2 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message2.causedSecurityLevelDegradation = true
-            
+
             // WHEN
             message1.causedSecurityLevelDegradation = false
-            
+
             // THEN
             XCTAssertFalse(message1.causedSecurityLevelDegradation)
             XCTAssertFalse(convo.messagesThatCausedSecurityLevelDegradation.contains(message1))
@@ -143,26 +141,26 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
             // and WHEN
             self.syncMOC.saveOrRollback()
             message2.causedSecurityLevelDegradation = false
-            
+
             // THEN
             XCTAssertFalse(message2.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.isEmpty)
             XCTAssertTrue(self.syncMOC.zm_hasChanges)
-            
+
         }
     }
-    
+
     func testThatItResetsDegradedConversationWhenClearingDegradedMessagesOnConversation() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
-            
+
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
             let message1 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message1.causedSecurityLevelDegradation = true
             let message2 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message2.causedSecurityLevelDegradation = true
-            
+
             // WHEN
             convo.clearMessagesThatCausedSecurityLevelDegradation()
 
@@ -173,31 +171,31 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
             XCTAssertTrue(self.syncMOC.zm_hasUserInfoChanges)
         }
     }
-    
+
     func testThatItResetsOnlyDegradedConversationWhenClearingDegradedMessagesOnThatConversation() {
-        
+
         self.syncMOC.performGroupedBlockAndWait {
-            
+
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
             let message1 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message1.causedSecurityLevelDegradation = true
             let message2 = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message2.causedSecurityLevelDegradation = true
-            
+
             let otherConvo = self.createConversation(moc: self.syncMOC)
             let otherMessage = try! otherConvo.appendText(content: "Foo") as! ZMOTRMessage
             otherMessage.causedSecurityLevelDegradation = true
-            
+
             // WHEN
             convo.clearMessagesThatCausedSecurityLevelDegradation()
-            
+
             // THEN
             XCTAssertFalse(message1.causedSecurityLevelDegradation)
             XCTAssertFalse(message2.causedSecurityLevelDegradation)
             XCTAssertTrue(convo.messagesThatCausedSecurityLevelDegradation.isEmpty)
             XCTAssertTrue(self.syncMOC.zm_hasUserInfoChanges)
-            
+
             XCTAssertFalse(otherConvo.messagesThatCausedSecurityLevelDegradation.isEmpty)
             XCTAssertTrue(otherMessage.causedSecurityLevelDegradation)
         }
@@ -207,54 +205,54 @@ class ZMOTRMessage_SecurityDegradationTests : BaseZMClientMessageTests {
 
 // MARK: - Propagation across contexes
 extension ZMOTRMessage_SecurityDegradationTests {
-    
+
     func testThatMessageIsNotMarkedOnUIMOCBeforeMerge() {
         // GIVEN
         let convo = createConversation(moc: self.uiMOC)
         let message = try! convo.appendText(content: "Foo") as! ZMOTRMessage
         self.uiMOC.saveOrRollback()
-        
+
         // WHEN
-        self.syncMOC.performGroupedBlockAndWait { 
+        self.syncMOC.performGroupedBlockAndWait {
             let syncMessage = try! self.syncMOC.existingObject(with: message.objectID) as! ZMOTRMessage
             syncMessage.causedSecurityLevelDegradation = true
             self.syncMOC.saveOrRollback()
         }
-        
+
         // THEN
         XCTAssertFalse(message.causedSecurityLevelDegradation)
     }
-    
+
     func testThatMessageIsMarkedOnUIMOCAfterMerge() {
         // GIVEN
         let convo = createConversation(moc: self.uiMOC)
         let message = try! convo.appendText(content: "Foo") as! ZMOTRMessage
         self.uiMOC.saveOrRollback()
-        var userInfo : [String: Any] = [:]
+        var userInfo: [String: Any] = [:]
         self.syncMOC.performGroupedBlockAndWait {
             let syncMessage = try! self.syncMOC.existingObject(with: message.objectID) as! ZMOTRMessage
             syncMessage.causedSecurityLevelDegradation = true
             self.syncMOC.saveOrRollback()
             userInfo = self.syncMOC.userInfo.asDictionary() as! [String: Any]
         }
-        
+
         // WHEN
         self.uiMOC.mergeUserInfo(fromUserInfo: userInfo)
-        
+
         // THEN
         XCTAssertTrue(message.causedSecurityLevelDegradation)
     }
-    
+
     func testThatItPreservesMessagesMargedOnSyncMOCAfterMerge() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let convo = self.createConversation(moc: self.syncMOC)
             let message = try! convo.appendText(content: "Foo") as! ZMOTRMessage
             message.causedSecurityLevelDegradation = true
-            
+
             // WHEN
             self.syncMOC.mergeUserInfo(fromUserInfo: [:])
-            
+
             // THEN
             XCTAssertTrue(message.causedSecurityLevelDegradation)
         }
@@ -263,7 +261,7 @@ extension ZMOTRMessage_SecurityDegradationTests {
 
 // MARK: - Helper
 extension ZMOTRMessage_SecurityDegradationTests {
-    
+
     /// Creates a group conversation with two users
     func createConversation(moc: NSManagedObjectContext) -> ZMConversation {
         let user1 = ZMUser.insertNewObject(in: moc)
@@ -273,5 +271,5 @@ extension ZMOTRMessage_SecurityDegradationTests {
         let convo = ZMConversation.insertGroupConversation(moc: moc, participants: [user1, user2], team: nil, participantsRole: nil)!
         return convo
     }
-    
+
 }

--- a/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
+++ b/Tests/Source/Model/Messages/ZMOTRMessage+SelfConversationUpdateTests.swift
@@ -20,10 +20,9 @@ import XCTest
 @testable import WireDataModel
 
 class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
-    
-    
+
     func testThatWeIgnoreClearedEventNotSentFromSelfUser() {
-        
+
         syncMOC.performGroupedBlockAndWait {
             // given
             let nonce = UUID()
@@ -31,18 +30,18 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let selfConversation = ZMConversation.selfConversation(in: self.syncMOC)
             let message = GenericMessage(content: Cleared(timestamp: clearedDate, conversationID: self.syncConversation.remoteIdentifier!), nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
-            
+
             // when
             ZMOTRMessage.createOrUpdate(from: event, in: self.syncMOC, prefetchResult: nil)
-            
+
             // then
             XCTAssertNil(self.syncConversation.clearedTimeStamp)
         }
-        
+
     }
-    
+
     func testThatWeIgnoreLastReadEventNotSentFromSelfUser() {
-        
+
         syncMOC.performGroupedBlockAndWait {
             // given
             let nonce = UUID()
@@ -51,18 +50,18 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let message = GenericMessage(content: LastRead(conversationID: self.syncConversation.remoteIdentifier!, lastReadTimestamp: lastReadDate), nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
             self.syncConversation.lastReadServerTimeStamp = nil
-            
+
             // when
             ZMOTRMessage.createOrUpdate(from: event, in: self.syncMOC, prefetchResult: nil)
-            
+
             // then
             XCTAssertNil(self.syncConversation.lastReadServerTimeStamp)
         }
-        
+
     }
-    
+
     func testThatWeIgnoreHideMessageEventNotSentFromSelfUser() {
-        
+
         syncMOC.performGroupedBlockAndWait {
             // given
             let nonce = UUID()
@@ -71,14 +70,14 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             let hideMessage = MessageHide(conversationId: self.syncConversation.remoteIdentifier!, messageId: toBehiddenMessage.nonce!)
             let message = GenericMessage(content: hideMessage, nonce: nonce)
             let event = self.createUpdateEvent(nonce, conversationID: selfConversation.remoteIdentifier!, timestamp: Date(), genericMessage: message, senderID: UUID(), eventSource: ZMUpdateEventSource.download)
-            
+
             // when
             ZMOTRMessage.createOrUpdate(from: event, in: self.syncMOC, prefetchResult: nil)
-            
+
             // then
             XCTAssertFalse(toBehiddenMessage.hasBeenDeleted)
         }
-        
+
     }
 
     // MARK: - Analytics Data Transfer
@@ -164,5 +163,5 @@ class ZMOTRMessage_SelfConversationUpdateEventTests: BaseZMClientMessageTests {
             eventSource: ZMUpdateEventSource.download
         )
     }
-    
+
 }

--- a/Tests/Source/Model/ModelObjectsTests+Helpers.swift
+++ b/Tests/Source/Model/ModelObjectsTests+Helpers.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 extension ModelObjectsTests {
-    
+
     // MARK: Users & Teams Members
-    
+
     @discardableResult func createTeamAndMember(for user: ZMUser, with permissions: Permissions? = nil) -> (Team, Member) {
         let member = Member.insertNewObject(in: uiMOC)
         member.team = .insertNewObject(in: uiMOC)
@@ -32,7 +32,7 @@ extension ModelObjectsTests {
         }
         return (member.team!, member)
     }
-    
+
     @discardableResult func createUserAndAddMember(to team: Team, with domain: String? = nil) -> (ZMUser, Member) {
         let member = Member.insertNewObject(in: uiMOC)
         member.user = .insertNewObject(in: uiMOC)
@@ -61,35 +61,35 @@ extension ModelObjectsTests {
         })
         return user
     }
-    
+
     // MARK: Files
-    
+
     func createFileMetadata(filename: String? = nil) -> ZMFileMetadata {
         let fileURL: URL
-        
+
         if let fileName = filename {
             fileURL = testURLWithFilename(fileName)
         } else {
             fileURL = testURLWithFilename("file.dat")
         }
-        
+
         _ = createTestFile(at: fileURL)
-        
+
         return ZMFileMetadata(fileURL: fileURL)
     }
-    
+
     func testURLWithFilename(_ filename: String) -> URL {
         let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
         let documentsURL = URL(fileURLWithPath: documents)
         return documentsURL.appendingPathComponent(filename)
     }
-    
+
     func createTestFile(at url: URL) -> Data {
         let data: Data! = "Some other data".data(using: String.Encoding.utf8)
         try! data.write(to: url, options: [])
         return data
     }
-    
+
     func removeTestFile(at url: URL) {
         do {
             let fm = FileManager.default

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -19,37 +19,36 @@
 import XCTest
 @testable import WireDataModel
 
-class ChangedIndexesTests : ZMBaseManagedObjectTest {
-    
+class ChangedIndexesTests: ZMBaseManagedObjectTest {
+
     // MARK: CollectionView
 
-    func testThatItCalculatesInsertsAndDeletesBetweenSets(){
+    func testThatItCalculatesInsertsAndDeletesBetweenSets() {
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
-        let endState = WireDataModel.OrderedSetState(array:["A", "F", "E", "C", "D"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C", "D", "E"])
+        let endState = WireDataModel.OrderedSetState(array: ["A", "F", "E", "C", "D"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
-        
+
         // then
         XCTAssertEqual(sut.deletedIndexes, [1])
         XCTAssertEqual(sut.insertedIndexes, [1])
     }
-    
-    
-    func testThatItCalculatesMovesCorrectly(){
-        
+
+    func testThatItCalculatesMovesCorrectly() {
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
-        let endState = WireDataModel.OrderedSetState(array:["A", "F", "D", "C", "E"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C", "D", "E"])
+        let endState = WireDataModel.OrderedSetState(array: ["A", "F", "D", "C", "E"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
-        
+
         // then
         // [A,B,C,D,E] -> [A,F,C,D,E] delete & insert
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
+        sut.enumerateMovedIndexes { (from, to) in
             if callCount == 0 {
                 // D: [3->2]
                 XCTAssertEqual(from, 3)
@@ -58,10 +57,10 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 1)
-        
-        var result = ["A","B", "C", "D", "E"]
-        sut.deletedIndexes.forEach{result.remove(at: $0)}
-        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+
+        var result = ["A", "B", "C", "D", "E"]
+        sut.deletedIndexes.forEach {result.remove(at: $0)}
+        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
         sut.enumerateMovedIndexes { (from, to) in
             let item = startState.array[from]
             result.remove(at: result.firstIndex(of: item)!)
@@ -69,21 +68,20 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         }
         XCTAssertEqual(result, ["A", "F", "D", "C", "E"])
     }
-    
-    
-    func testThatItCalculatesMovesCorrectly_2(){
-        
+
+    func testThatItCalculatesMovesCorrectly_2() {
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
-        let endState = WireDataModel.OrderedSetState(array:["A", "D", "E", "F", "C"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C", "D", "E"])
+        let endState = WireDataModel.OrderedSetState(array: ["A", "D", "E", "F", "C"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
-        
+
         // then
         // [A,B,C,D,E] -> [A,C,D,F,E] delete & insert
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
+        sut.enumerateMovedIndexes { (from, to) in
             if callCount == 0 {
                 // ACDFE
                 // E: [3->1] -> ADCFE
@@ -105,10 +103,10 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 3)
-        
-        var result = ["A","B", "C", "D", "E"]
-        sut.deletedIndexes.forEach{result.remove(at: $0)}
-        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+
+        var result = ["A", "B", "C", "D", "E"]
+        sut.deletedIndexes.forEach {result.remove(at: $0)}
+        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
         sut.enumerateMovedIndexes { (from, to) in
             let item = startState.array[from]
             result.remove(at: result.firstIndex(of: item)!)
@@ -116,36 +114,36 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         }
         XCTAssertEqual(result, ["A", "D", "E", "F", "C"])
     }
-    
+
     func testThatItCalculatesMovedIndexesForSwappedIndexesCorrectly() {
         // If you move an item from 0->1 another item has to move to index 0
-        
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C"])
-        let endState = WireDataModel.OrderedSetState(array:["C", "B", "A"])
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C"])
+        let endState = WireDataModel.OrderedSetState(array: ["C", "B", "A"])
 
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set())
-        
+
         // then
         XCTAssertEqual(sut.deletedIndexes, IndexSet())
         XCTAssertEqual(sut.insertedIndexes, IndexSet())
 
         // then
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
-            if (callCount == 0) {
+        sut.enumerateMovedIndexes { (from, to) in
+            if callCount == 0 {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 0)
             }
-            if (callCount == 1) {
+            if callCount == 1 {
                 XCTAssertEqual(from, 1)
                 XCTAssertEqual(to, 1)
             }
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 2)
-        
+
         var result = ["A", "B", "C"]
         sut.enumerateMovedIndexes { (from, to) in
             let item = startState.array[from]
@@ -154,39 +152,36 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
         }
         XCTAssertEqual(result, ["C", "B", "A"])
     }
-    
-    func testThatItCalculatesUpdatesCorrectly(){
+
+    func testThatItCalculatesUpdatesCorrectly() {
         // Updated indexes refer to the indexes after the update
-        
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C"])
-        let endState = WireDataModel.OrderedSetState(array:["C", "D", "B", "A"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C"])
+        let endState = WireDataModel.OrderedSetState(array: ["C", "D", "B", "A"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(["B"]))
-        
+
         // then
         XCTAssertEqual(sut.updatedIndexes, IndexSet([2]))
     }
-    
-    
-    
-    
+
     // MARK: TableView
-    
-    func testThatItCalculatesMovesCorrectly_tableView(){
-        
+
+    func testThatItCalculatesMovesCorrectly_tableView() {
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
-        let endState = WireDataModel.OrderedSetState(array:["A", "F", "D", "C", "E"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C", "D", "E"])
+        let endState = WireDataModel.OrderedSetState(array: ["A", "F", "D", "C", "E"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
-        
+
         // then
         // [A,B,C,D,E] -> [A,F,C,D,E] delete & insert
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
+        sut.enumerateMovedIndexes { (from, to) in
             if callCount == 0 {
                 // D: [3->2]
                 XCTAssertEqual(from, 3)
@@ -195,31 +190,30 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 1)
-        
-        var result = ["A","B", "C", "D", "E"]
-        sut.deletedIndexes.forEach{result.remove(at: $0)}
-        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+
+        var result = ["A", "B", "C", "D", "E"]
+        sut.deletedIndexes.forEach {result.remove(at: $0)}
+        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
         sut.enumerateMovedIndexes { (from, to) in
             let item = result.remove(at: from)
             result.insert(item, at: to)
         }
         XCTAssertEqual(result, ["A", "F", "D", "C", "E"])
     }
-    
-    
-    func testThatItCalculatesMovesCorrectly_2_tableView(){
-        
+
+    func testThatItCalculatesMovesCorrectly_2_tableView() {
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C", "D", "E"])
-        let endState = WireDataModel.OrderedSetState(array:["A", "D", "E", "F", "C"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C", "D", "E"])
+        let endState = WireDataModel.OrderedSetState(array: ["A", "D", "E", "F", "C"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
-        
+
         // then
         // [A,B,C,D,E] -> [A,C,D,F,E] delete & insert
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
+        sut.enumerateMovedIndexes { (from, to) in
             if callCount == 0 {
                 // ACDFE
                 // E: [3->1] -> ADCFE
@@ -241,46 +235,46 @@ class ChangedIndexesTests : ZMBaseManagedObjectTest {
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 3)
-        
-        var result = ["A","B", "C", "D", "E"]
-        sut.deletedIndexes.forEach{result.remove(at: $0)}
-        sut.insertedIndexes.forEach{result.insert(endState.array[$0], at: $0)}
+
+        var result = ["A", "B", "C", "D", "E"]
+        sut.deletedIndexes.forEach {result.remove(at: $0)}
+        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
         sut.enumerateMovedIndexes { (from, to) in
             let item = result.remove(at: from)
             result.insert(item, at: to)
         }
         XCTAssertEqual(result, ["A", "D", "E", "F", "C"])
     }
-    
+
     func testThatItCalculatesMovedIndexesForSwappedIndexesCorrectly_tableView() {
         // If you move an item from 0->1 the item at index 1 moves implicitly to 0, its move do not need to be defined
-        
+
         // given
-        let startState = WireDataModel.OrderedSetState(array:["A","B", "C"])
-        let endState = WireDataModel.OrderedSetState(array:["C", "B", "A"])
-        
+        let startState = WireDataModel.OrderedSetState(array: ["A", "B", "C"])
+        let endState = WireDataModel.OrderedSetState(array: ["C", "B", "A"])
+
         // when
         let sut = WireDataModel.ChangedIndexes(start: startState, end: endState, updated: Set(), moveType: .uiTableView)
-        
+
         // then
         XCTAssertEqual(sut.deletedIndexes, IndexSet())
         XCTAssertEqual(sut.insertedIndexes, IndexSet())
-        
+
         // then
         var callCount = 0
-        sut.enumerateMovedIndexes{ (from, to) in
-            if (callCount == 0) {
+        sut.enumerateMovedIndexes { (from, to) in
+            if callCount == 0 {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 0)
             }
-            if (callCount == 1) {
+            if callCount == 1 {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 1)
             }
             callCount = callCount+1
         }
         XCTAssertEqual(callCount, 2)
-        
+
         var result = ["A", "B", "C"]
         sut.enumerateMovedIndexes { (from, to) in
             let item = result.remove(at: from)

--- a/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
+++ b/Tests/Source/Model/Observer/NewUnreadMessageObserverTests.swift
@@ -16,146 +16,144 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 @objc class UnreadMessageTestObserver: NSObject, ZMNewUnreadMessagesObserver, ZMNewUnreadKnocksObserver {
-    
-    var unreadMessageNotes : [NewUnreadMessagesChangeInfo] = []
-    var unreadKnockNotes : [NewUnreadKnockMessagesChangeInfo] = []
-    
+
+    var unreadMessageNotes: [NewUnreadMessagesChangeInfo] = []
+    var unreadKnockNotes: [NewUnreadKnockMessagesChangeInfo] = []
+
     override init() {
         super.init()
     }
-    
-    @objc func didReceiveNewUnreadKnockMessages(_ changeInfo: NewUnreadKnockMessagesChangeInfo){
+
+    @objc func didReceiveNewUnreadKnockMessages(_ changeInfo: NewUnreadKnockMessagesChangeInfo) {
         self.unreadKnockNotes.append(changeInfo)
     }
-    
+
     @objc func didReceiveNewUnreadMessages(_ changeInfo: NewUnreadMessagesChangeInfo) {
         self.unreadMessageNotes.append(changeInfo)
     }
-    
+
     func clearNotifications() {
         self.unreadKnockNotes = []
         self.unreadMessageNotes = []
     }
 }
 
-class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
-    
+class NewUnreadMessageObserverTests: NotificationDispatcherTestBase {
+
     func processPendingChangesAndClearNotifications() {
         self.uiMOC.saveOrRollback()
         self.testObserver?.clearNotifications()
     }
-    
+
     var testObserver: UnreadMessageTestObserver!
-    var newMessageToken : NSObjectProtocol!
-    var newKnocksToken :  NSObjectProtocol!
+    var newMessageToken: NSObjectProtocol!
+    var newKnocksToken: NSObjectProtocol!
 
     override func setUp() {
         super.setUp()
-        
+
         self.testObserver = UnreadMessageTestObserver()
         self.newMessageToken = NewUnreadMessagesChangeInfo.add(observer: self.testObserver, managedObjectContext: self.uiMOC)
         self.newKnocksToken = NewUnreadKnockMessagesChangeInfo.add(observer: self.testObserver, managedObjectContext: self.uiMOC)
-        
+
     }
-    
+
     override func tearDown() {
         self.newMessageToken = nil
         self.newKnocksToken = nil
         self.testObserver = nil
-    
+
         super.tearDown()
     }
-    
+
     func testThatItNotifiesObserversWhenAMessageMoreRecentThanTheLastReadIsInserted() {
-        
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.lastReadServerTimeStamp = Date()
         self.uiMOC.saveOrRollback()
-        
+
         // when
         let msg1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         msg1.serverTimestamp = Date()
         msg1.visibleInConversation = conversation
-        
+
         let msg2 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         msg2.serverTimestamp = Date()
         msg2.visibleInConversation = conversation
 
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(self.testObserver.unreadMessageNotes.count, 1)
         XCTAssertEqual(self.testObserver.unreadKnockNotes.count, 0)
-        
+
         if let note = self.testObserver.unreadMessageNotes.first {
             let expected = NSSet(objects: msg1, msg2)
             XCTAssertEqual(NSSet(array: note.messages), expected)
         }
     }
-    
+
     func testThatItDoesNotNotifyObserversWhenAMessageOlderThanTheLastReadIsInserted() {
-        
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.lastReadServerTimeStamp = Date().addingTimeInterval(30)
         self.processPendingChangesAndClearNotifications()
-        
+
         // when
         let msg1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         msg1.visibleInConversation = conversation
         msg1.serverTimestamp = Date()
-        
+
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 0)
     }
-    
-    
+
     func testThatItNotifiesObserversWhenTheConversationHasNoLastRead() {
-        
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         self.processPendingChangesAndClearNotifications()
-        
+
         // when
         let msg1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         msg1.visibleInConversation = conversation
         msg1.serverTimestamp = Date()
-        
+
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 1)
     }
-    
+
     func testThatItDoesNotNotifyObserversWhenItHasNoConversation() {
-        
+
         // when
         let msg1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         msg1.serverTimestamp = Date()
-        
+
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 0)
     }
-    
+
     func testThatItNotifiesObserversWhenANewOTRKnockMessageIsInserted() {
-        
+
         // given
-        let conversation = ZMConversation.insertNewObject(in:self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.lastReadServerTimeStamp = Date()
         self.processPendingChangesAndClearNotifications()
-        
+
         // when
         let genMsg = GenericMessage(content: Knock.with { $0.hotKnock = false })
-        
+
         let msg1 = ZMClientMessage(nonce: UUID(), managedObjectContext: uiMOC)
         do {
             try msg1.setUnderlyingMessage(genMsg)
@@ -165,7 +163,7 @@ class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
         msg1.visibleInConversation = conversation
         msg1.serverTimestamp = Date()
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(self.testObserver!.unreadKnockNotes.count, 1)
         XCTAssertEqual(self.testObserver!.unreadMessageNotes.count, 0)
@@ -175,6 +173,3 @@ class NewUnreadMessageObserverTests : NotificationDispatcherTestBase {
         }
     }
 }
-
-
-

--- a/Tests/Source/Model/Observer/ObjectObserverToken/AnyClassTupleTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/AnyClassTupleTests.swift
@@ -16,81 +16,80 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import XCTest
 
 class AnyClassTupleTests: ZMBaseManagedObjectTest {
 
     func testThatTwoTuplesAreEqual() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
-        
+
         // then
         XCTAssertEqual(tuple1, tuple2)
-        
+
     }
 
     func testThatTwoTuplesHaveTheSameHash() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
-        
+
         // then
         XCTAssertEqual(tuple1.hashValue, tuple2.hashValue)
-        
+
     }
 
     func testThatTwoTuplesAreNotEqualOnString() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Bar")
-        
+
         // then
         XCTAssertNotEqual(tuple1, tuple2)
-        
+
     }
-    
+
     func testThatTwoTuplesDoNotHaveTheSameHashOnString() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Bar")
-        
+
         // then
         XCTAssertNotEqual(tuple1.hashValue, tuple2.hashValue)
-        
+
     }
-    
+
     func testThatTwoTuplesAreNotEqualOnClass() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: NSArray.self, secondElement: "Foo")
-        
+
         // then
         XCTAssertNotEqual(tuple1, tuple2)
-        
+
     }
-    
+
     func testThatTwoTuplesDoNotHaveTheSameHashOnClass() {
-        
+
         // given
-        let classOfObject : AnyClass = AnyClassTupleTests.self
+        let classOfObject: AnyClass = AnyClassTupleTests.self
         let tuple1 = AnyClassTuple<String>(classOfObject: classOfObject, secondElement: "Foo")
         let tuple2 = AnyClassTuple<String>(classOfObject: NSArray.self, secondElement: "Foo")
-        
+
         // then
         XCTAssertNotEqual(tuple1.hashValue, tuple2.hashValue)
-        
+
     }
 }

--- a/Tests/Source/Model/Observer/ObjectObserverToken/ParticipantRoleObserverTests.swift
+++ b/Tests/Source/Model/Observer/ObjectObserverToken/ParticipantRoleObserverTests.swift
@@ -16,57 +16,56 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 @testable import WireDataModel
 
-final class TestParticipantRoleObserver : NSObject, ParticipantRoleObserver {
-    
+final class TestParticipantRoleObserver: NSObject, ParticipantRoleObserver {
+
     var notifications = [ParticipantRoleChangeInfo]()
-    
-    func clearNotifications(){
+
+    func clearNotifications() {
         notifications = []
     }
-    
+
     func participantRoleDidChange(_ changeInfo: ParticipantRoleChangeInfo) {
         notifications.append(changeInfo)
     }
 }
 
 final class ParticipantRoleObserverTests: NotificationDispatcherTestBase {
-    
-    var observer : TestParticipantRoleObserver!
-    
+
+    var observer: TestParticipantRoleObserver!
+
     override func setUp() {
         super.setUp()
         observer = TestParticipantRoleObserver()
     }
-    
+
     override func tearDown() {
         observer = nil
         super.tearDown()
     }
-    
-    var userInfoKeys : Set<String> {
+
+    var userInfoKeys: Set<String> {
         return [
             #keyPath(ParticipantRoleChangeInfo.roleChanged)
         ]
     }
-    
-    func checkThatItNotifiesTheObserverOfAChange(_ participantRole : ParticipantRole, modifier: (ParticipantRole) -> Void, expectedChangedFields: Set<String>, customAffectedKeys: AffectedKeys? = nil,
+
+    func checkThatItNotifiesTheObserverOfAChange(_ participantRole: ParticipantRole, modifier: (ParticipantRole) -> Void, expectedChangedFields: Set<String>, customAffectedKeys: AffectedKeys? = nil,
                                                  file: StaticString = #file,
                                                  line: UInt = #line) {
-        
+
         // given
         uiMOC.saveOrRollback()
-        
+
         self.token = ParticipantRoleChangeInfo.add(observer: observer, for: participantRole, managedObjectContext: self.uiMOC)
-        
+
         // when
         modifier(participantRole)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         self.uiMOC.saveOrRollback()
-        
+
         // then
         let changeCount = observer.notifications.count
         if !expectedChangedFields.isEmpty {
@@ -77,10 +76,10 @@ final class ParticipantRoleObserverTests: NotificationDispatcherTestBase {
 
         // and when
         self.uiMOC.saveOrRollback()
-        
+
         // then
         XCTAssertEqual(observer.notifications.count, changeCount, "Should not have changed further once")
-        
+
         guard let changes = observer.notifications.first else { return }
         changes.checkForExpectedChangeFields(userInfoKeys: userInfoKeys,
                                              expectedChangedFields: expectedChangedFields,
@@ -88,4 +87,3 @@ final class ParticipantRoleObserverTests: NotificationDispatcherTestBase {
                                              line: line)
     }
 }
-

--- a/Tests/Source/Model/Observer/PotentialChangeDetectorTests.swift
+++ b/Tests/Source/Model/Observer/PotentialChangeDetectorTests.swift
@@ -139,5 +139,4 @@ final class PotentialChangeDetectorTests: BaseZMMessageTests {
         XCTAssertTrue(changes[0].object === object)
     }
 
-
 }

--- a/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
+++ b/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
@@ -18,50 +18,50 @@
 
 @testable import WireDataModel
 
-class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
+class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
 
-    var token: Any? = nil
-    
+    var token: Any?
+
     override func tearDown() {
         self.token = nil
         super.tearDown()
     }
-    
-    func testThatItCreatesASnapshotOfAllValues_noUser(){
+
+    func testThatItCreatesASnapshotOfAllValues_noUser() {
         // given
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
 
         // when
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // then
-        XCTAssertEqual(searchUser.completeImageData,            sut.snapshotValues[ #keyPath(ZMSearchUser.completeImageData)] as? Data)
-        XCTAssertEqual(searchUser.previewImageData,             sut.snapshotValues[ #keyPath(ZMSearchUser.previewImageData)] as? Data)
-        XCTAssertEqual(searchUser.user,                         sut.snapshotValues[ #keyPath(ZMSearchUser.user)] as? ZMUser)
-        XCTAssertEqual(searchUser.isConnected,                  sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
+        XCTAssertEqual(searchUser.completeImageData, sut.snapshotValues[ #keyPath(ZMSearchUser.completeImageData)] as? Data)
+        XCTAssertEqual(searchUser.previewImageData, sut.snapshotValues[ #keyPath(ZMSearchUser.previewImageData)] as? Data)
+        XCTAssertEqual(searchUser.user, sut.snapshotValues[ #keyPath(ZMSearchUser.user)] as? ZMUser)
+        XCTAssertEqual(searchUser.isConnected, sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
         XCTAssertEqual(searchUser.isPendingApprovalByOtherUser, sut.snapshotValues[ #keyPath(ZMSearchUser.isPendingApprovalByOtherUser)] as? Bool)
     }
-    
-    func testThatItCreatesASnapshotOfAllValues_withUser(){
+
+    func testThatItCreatesASnapshotOfAllValues_withUser() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
         user.setImage(data: verySmallJPEGData(), size: .preview)
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: UUID(), user: user)
-        
+
         // when
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // then
-        XCTAssertEqual(searchUser.completeImageData,            sut.snapshotValues[ #keyPath(ZMSearchUser.completeImageData)] as? Data)
-        XCTAssertEqual(searchUser.previewImageData,             sut.snapshotValues[ #keyPath(ZMSearchUser.previewImageData)] as? Data)
-        XCTAssertEqual(searchUser.user,                         sut.snapshotValues[ #keyPath(ZMSearchUser.user)] as? ZMUser)
-        XCTAssertEqual(searchUser.isConnected,                  sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
+        XCTAssertEqual(searchUser.completeImageData, sut.snapshotValues[ #keyPath(ZMSearchUser.completeImageData)] as? Data)
+        XCTAssertEqual(searchUser.previewImageData, sut.snapshotValues[ #keyPath(ZMSearchUser.previewImageData)] as? Data)
+        XCTAssertEqual(searchUser.user, sut.snapshotValues[ #keyPath(ZMSearchUser.user)] as? ZMUser)
+        XCTAssertEqual(searchUser.isConnected, sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
         XCTAssertEqual(searchUser.isPendingApprovalByOtherUser, sut.snapshotValues[ #keyPath(ZMSearchUser.isPendingApprovalByOtherUser)] as? Bool)
     }
-    
-    func testThatItPostsANotificationWhenUserImageChanged(){
+
+    func testThatItPostsANotificationWhenUserImageChanged() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
@@ -69,7 +69,7 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
 
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: UUID(), user: user)
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         self.token = NotificationInContext.addObserver(
@@ -81,27 +81,27 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
             XCTAssertTrue(changeInfo.imageSmallProfileDataChanged)
             expectation.fulfill()
         }
-        
+
         // when
         user.previewProfileAssetIdentifier = "123"
         uiMOC.zm_userImageCache.setUserImage(user, imageData: verySmallJPEGData(), size: .preview)
 
         sut.updateAndNotify()
-        
+
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertEqual(searchUser.previewImageData, sut.snapshotValues[ #keyPath(ZMSearchUser.previewImageData)] as? Data)
     }
-    
-    func testThatItPostsANotificationWhenConnectionChanged(){
+
+    func testThatItPostsANotificationWhenConnectionChanged() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
-        
+
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: UUID(), user: user)
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         self.token = NotificationInContext.addObserver(
@@ -113,19 +113,19 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
             XCTAssertTrue(changeInfo.connectionStateChanged)
             expectation.fulfill()
         }
-        
+
         // when
         let connection = ZMConnection.insertNewObject(in: uiMOC)
         connection.to = user
         connection.status = .accepted
         sut.updateAndNotify()
-        
+
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertEqual(searchUser.isConnected, sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
     }
-    
-    func testThatItPostsANotificationWhenPendingApprovalChanged(){
+
+    func testThatItPostsANotificationWhenPendingApprovalChanged() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
@@ -133,10 +133,10 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
         let connection = ZMConnection.insertNewObject(in: uiMOC)
         connection.to = user
         connection.status = .pending
-        
+
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: UUID(), user: user)
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         self.token = NotificationInContext.addObserver(
@@ -148,40 +148,40 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
             XCTAssertTrue(changeInfo.connectionStateChanged)
             expectation.fulfill()
         }
-        
+
         // when
         connection.status = .accepted
         sut.updateAndNotify()
-        
+
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertEqual(searchUser.isConnected, sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
         XCTAssertEqual(searchUser.isPendingApprovalByOtherUser, sut.snapshotValues[ #keyPath(ZMSearchUser.isPendingApprovalByOtherUser)] as? Bool)
     }
-    
-    func testThatItPostsANotificationWhenTheUserIsAdded(){
+
+    func testThatItPostsANotificationWhenTheUserIsAdded() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
-        
+
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         self.token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
             object: searchUser
-        ) { note in
+        ) { _ in
             expectation.fulfill()
         }
 
         // when
         searchUser.setValue(user, forKey: "user") // this is done internally
         sut.updateAndNotify()
-        
+
         // then
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertEqual(searchUser.isConnected, sut.snapshotValues[ #keyPath(ZMSearchUser.isConnected)] as? Bool)
@@ -189,100 +189,100 @@ class SearchUserSnapshotTests : ZMBaseManagedObjectTest {
     }
 }
 
-class SearchUserObserverCenterTests : ModelObjectsTests {
-    
-    var sut : SearchUserObserverCenter!
-    
+class SearchUserObserverCenterTests: ModelObjectsTests {
+
+    var sut: SearchUserObserverCenter!
+
     override func setUp() {
         super.setUp()
         sut = SearchUserObserverCenter(managedObjectContext: self.uiMOC)
         uiMOC.userInfo[NSManagedObjectContext.SearchUserObserverCenterKey] = sut
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
 
-    func testThatItDeallocates(){
+    func testThatItDeallocates() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
-        
+
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: UUID(), user: user)
         sut.addSearchUser(searchUser)
-        
+
         // when
         weak var observerCenter = sut
         sut = nil
         uiMOC.userInfo.removeObject(forKey: NSManagedObjectContext.SearchUserObserverCenterKey)
-        
+
         // then
         XCTAssertNil(observerCenter)
     }
-    
-    func testThatItAddsASnapshot(){
+
+    func testThatItAddsASnapshot() {
         // given
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
         XCTAssertEqual(sut.snapshots.count, 0)
 
         // when
         sut.addSearchUser(searchUser)
-        
+
         // then
         XCTAssertEqual(sut.snapshots.count, 1)
     }
-    
-    func testThatItRemovesAllSnapshotsOnReset(){
+
+    func testThatItRemovesAllSnapshotsOnReset() {
         // given
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
         sut.addSearchUser(searchUser)
         XCTAssertEqual(sut.snapshots.count, 1)
-        
+
         // when
         sut.reset()
-        
+
         // then
         XCTAssertEqual(sut.snapshots.count, 0)
     }
-    
-    func testThatItForwardsUserChangeInfosToTheSnapshot(){
+
+    func testThatItForwardsUserChangeInfosToTheSnapshot() {
         // given
         let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
-        
+
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: "", accentColor: .undefined, remoteIdentifier: nil, user: user)
         sut.addSearchUser(searchUser)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         let token: Any? = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
             object: searchUser
-        ) { note in
+        ) { _ in
             expectation.fulfill()
         }
 
-        withExtendedLifetime(token) { () -> () in
+        withExtendedLifetime(token) { () -> Void in
             // when
             user.name = "Horst"
             let changeInfo = UserChangeInfo(object: user)
             changeInfo.changedKeys = Set(["name"])
             sut.objectsDidChange(changes: [ZMUser.classIdentifier: [changeInfo]])
-            
+
             // then
             XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         }
     }
-    
-    func testThatItForwardCallsForUserUpdatesToTheSnapshot(){
+
+    func testThatItForwardCallsForUserUpdatesToTheSnapshot() {
         // given
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
         sut.addSearchUser(searchUser)
-        
+
         // expect
         let expectation = self.expectation(description: "notified")
         let token = NotificationInContext.addObserver(
@@ -294,14 +294,13 @@ class SearchUserObserverCenterTests : ModelObjectsTests {
             XCTAssertTrue(changeInfo.imageMediumDataChanged)
             expectation.fulfill()
         }
-        
-        withExtendedLifetime(token) { () -> () in
+
+        withExtendedLifetime(token) { () -> Void in
             // when
             searchUser.updateImageData(for: .complete, imageData: verySmallJPEGData())
-            
+
             // then
             XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         }
     }
 }
-

--- a/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -19,90 +19,90 @@
 import Foundation
 @testable import WireDataModel
 
-class SearchUserObserverTests : NotificationDispatcherTestBase {
-    
-    class TestSearchUserObserver : NSObject, ZMUserObserver {
-        
-        var receivedChangeInfo : [UserChangeInfo] = []
-        
+class SearchUserObserverTests: NotificationDispatcherTestBase {
+
+    class TestSearchUserObserver: NSObject, ZMUserObserver {
+
+        var receivedChangeInfo: [UserChangeInfo] = []
+
         func userDidChange(_ changeInfo: UserChangeInfo) {
             receivedChangeInfo.append(changeInfo)
         }
     }
-        
-    var testObserver : TestSearchUserObserver!
-    
+
+    var testObserver: TestSearchUserObserver!
+
     override func setUp() {
         super.setUp()
         testObserver = TestSearchUserObserver()
     }
-    
+
     override func tearDown() {
         testObserver = nil
         uiMOC.searchUserObserverCenter.reset()
         super.tearDown()
     }
-    
+
     func testThatItNotifiesTheObserverOfASmallProfilePictureChange() {
-        
+
         // given
         let remoteID = UUID.create()
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
-        
+
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
-        
+
         // when
         searchUser.updateImageData(for: .preview, imageData: verySmallJPEGData())
-        
+
         // then
         XCTAssertEqual(testObserver.receivedChangeInfo.count, 1)
         if let note = testObserver.receivedChangeInfo.first {
             XCTAssertTrue(note.imageSmallProfileDataChanged)
         }
     }
-    
+
     func testThatItNotifiesTheObserverOfASmallProfilePictureChangeIfTheInternalUserUpdates() {
-        
+
         // given
-        let user = ZMUser.insertNewObject(in:self.uiMOC)
+        let user = ZMUser.insertNewObject(in: self.uiMOC)
         user.remoteIdentifier = UUID.create()
         self.uiMOC.saveOrRollback()
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: nil, accentColor: .brightYellow, remoteIdentifier: nil, user: user)
-        
+
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
-        self.token = UserChangeInfo.add(observer: testObserver, for:searchUser, in: self.uiMOC)
-        
+        self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
+
         // when
         user.previewProfileAssetIdentifier = UUID.create().transportString()
         user.setImage(data: verySmallJPEGData(), size: .preview)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5)) 
-        
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // then
         XCTAssertEqual(testObserver.receivedChangeInfo.count, 1)
         if let note = testObserver.receivedChangeInfo.first {
             XCTAssertTrue(note.imageSmallProfileDataChanged)
         }
     }
-    
+
     func testThatItStopsNotifyingAfterUnregisteringTheToken() {
-        
+
         // given
         let remoteID = UUID.create()
         let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
-        
+
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
-        
+
         // when
         self.token = nil
         searchUser.updateImageData(for: .preview, imageData: verySmallJPEGData())
-        
+
         // then
         XCTAssertEqual(testObserver.receivedChangeInfo.count, 0)
     }
 
-    func testThatItNotifiesObserversWhenConnectingToASearchUserThatHasNoLocalUser(){
+    func testThatItNotifiesObserversWhenConnectingToASearchUserThatHasNoLocalUser() {
 
         // given
         let remoteID = UUID.create()

--- a/Tests/Source/Model/Observer/SnapshotCenterTests.swift
+++ b/Tests/Source/Model/Observer/SnapshotCenterTests.swift
@@ -19,56 +19,56 @@
 import Foundation
 @testable import WireDataModel
 
-class SnapshotCenterTests : BaseZMMessageTests {
+class SnapshotCenterTests: BaseZMMessageTests {
 
     var sut: SnapshotCenter!
-    
+
     override func setUp() {
         super.setUp()
         sut = SnapshotCenter(managedObjectContext: uiMOC)
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
-    
-    func testThatItCreatesSnapshotsOfObjects(){
+
+    func testThatItCreatesSnapshotsOfObjects() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
-        
+
         // when
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // then
         XCTAssertNotNil(sut.snapshots[conv.objectID])
     }
-    
-    func testThatItSnapshotsNilValues(){
+
+    func testThatItSnapshotsNilValues() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // when
         guard let snapshot = sut.snapshots[conv.objectID] else { return XCTFail("did not create snapshot")}
-        
+
         // then
-        let expectedAttributes : [String : NSObject?] = ["userDefinedName": nil,
-                                                           "internalEstimatedUnreadCount": 0 as Optional<NSObject>,
-                                                           "hasUnreadUnsentMessage": 0 as Optional<NSObject>,
+        let expectedAttributes: [String: NSObject?] = ["userDefinedName": nil,
+                                                           "internalEstimatedUnreadCount": 0 as NSObject?,
+                                                           "hasUnreadUnsentMessage": 0 as NSObject?,
                                                            "archivedChangedTimestamp": nil,
-                                                           "isSelfAnActiveMember": 1 as Optional<NSObject>,
+                                                           "isSelfAnActiveMember": 1 as NSObject?,
                                                            "draftMessageText": nil,
                                                            "modifiedKeys": nil,
-                                                           "securityLevel": 0 as Optional<NSObject>,
+                                                           "securityLevel": 0 as NSObject?,
                                                            "lastServerTimeStamp": nil,
-                                                           "localMessageDestructionTimeout": 0 as Optional<NSObject>,
-                                                           "syncedMessageDestructionTimeout": 0 as Optional<NSObject>,
+                                                           "localMessageDestructionTimeout": 0 as NSObject?,
+                                                           "syncedMessageDestructionTimeout": 0 as NSObject?,
                                                            "clearedTimeStamp": nil,
-                                                           "needsToBeUpdatedFromBackend": 0 as Optional<NSObject>,
+                                                           "needsToBeUpdatedFromBackend": 0 as NSObject?,
                                                            "lastUnreadKnockDate": nil,
-                                                           "conversationType": 0 as Optional<NSObject>,
-                                                           "internalIsArchived": 0 as Optional<NSObject>,
+                                                           "conversationType": 0 as NSObject?,
+                                                           "internalIsArchived": 0 as NSObject?,
                                                            "lastModifiedDate": nil,
                                                            "silencedChangedTimestamp": nil,
                                                            "lastUnreadMissedCallDate": nil,
@@ -77,21 +77,21 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                                            "lastReadServerTimeStamp": nil,
                                                            "normalizedUserDefinedName": nil,
                                                            "remoteIdentifier": nil,
-                                                           "mutedStatus": 0 as Optional<NSObject>]
+                                                           "mutedStatus": 0 as NSObject?]
         let expectedToManyRelationships = ["hiddenMessages": 0,
                                            "participantRoles": 0,
                                            "allMessages": 0,
                                            "labels": 0,
                                            "nonTeamRoles": 0,
                                            "lastServerSyncedActiveParticipants": 0]
-        
+
         expectedAttributes.forEach {
             XCTAssertEqual(snapshot.attributes[$0] ?? nil, $1)
         }
         XCTAssertEqual(snapshot.toManyRelationships, expectedToManyRelationships)
     }
-    
-    func testThatItSnapshotsSetValues(){
+
+    func testThatItSnapshotsSetValues() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         conv.conversationType = .group
@@ -108,57 +108,57 @@ class SnapshotCenterTests : BaseZMMessageTests {
         try! conv.appendText(content: "foo")
         conv.resetLocallyModifiedKeys(conv.keysThatHaveLocalModifications)
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // when
         guard let snapshot = sut.snapshots[conv.objectID] else { return XCTFail("did not create snapshot")}
-        
+
         // then
-        let expectedAttributes : [String : NSObject?] = ["userDefinedName": conv.userDefinedName as Optional<NSObject>,
-                                                         "internalEstimatedUnreadCount": 0 as Optional<NSObject>,
-                                                         "hasUnreadUnsentMessage": 0 as Optional<NSObject>,
+        let expectedAttributes: [String: NSObject?] = ["userDefinedName": conv.userDefinedName as NSObject?,
+                                                         "internalEstimatedUnreadCount": 0 as NSObject?,
+                                                         "hasUnreadUnsentMessage": 0 as NSObject?,
                                                          "archivedChangedTimestamp": nil,
                                                          "draftMessageText": nil,
                                                          "modifiedKeys": nil,
-                                                         "securityLevel": 0 as Optional<NSObject>,
-                                                         "lastServerTimeStamp": conv.lastServerTimeStamp as Optional<NSObject>,
-                                                         "localMessageDestructionTimeout": 0 as Optional<NSObject>,
-                                                         "syncedMessageDestructionTimeout": 0 as Optional<NSObject>,
+                                                         "securityLevel": 0 as NSObject?,
+                                                         "lastServerTimeStamp": conv.lastServerTimeStamp as NSObject?,
+                                                         "localMessageDestructionTimeout": 0 as NSObject?,
+                                                         "syncedMessageDestructionTimeout": 0 as NSObject?,
                                                          "clearedTimeStamp": nil,
-                                                         "needsToBeUpdatedFromBackend": 0 as Optional<NSObject>,
-                                                         "lastUnreadKnockDate": conv.lastUnreadKnockDate as Optional<NSObject>,
-                                                         "conversationType": conv.conversationType.rawValue as Optional<NSObject>,
-                                                         "internalIsArchived": 0 as Optional<NSObject>,
-                                                         "lastModifiedDate": conv.lastModifiedDate as Optional<NSObject>,
-                                                         "silencedChangedTimestamp": conv.silencedChangedTimestamp as Optional<NSObject>,
-                                                         "lastUnreadMissedCallDate": conv.lastUnreadMissedCallDate as Optional<NSObject>,
+                                                         "needsToBeUpdatedFromBackend": 0 as NSObject?,
+                                                         "lastUnreadKnockDate": conv.lastUnreadKnockDate as NSObject?,
+                                                         "conversationType": conv.conversationType.rawValue as NSObject?,
+                                                         "internalIsArchived": 0 as NSObject?,
+                                                         "lastModifiedDate": conv.lastModifiedDate as NSObject?,
+                                                         "silencedChangedTimestamp": conv.silencedChangedTimestamp as NSObject?,
+                                                         "lastUnreadMissedCallDate": conv.lastUnreadMissedCallDate as NSObject?,
                                                          "voiceChannel": nil,
                                                          "remoteIdentifier_data": nil,
-                                                         "lastReadServerTimeStamp": conv.lastReadServerTimeStamp as Optional<NSObject>,
-                                                         "normalizedUserDefinedName": conv.normalizedUserDefinedName as Optional<NSObject>,
+                                                         "lastReadServerTimeStamp": conv.lastReadServerTimeStamp as NSObject?,
+                                                         "normalizedUserDefinedName": conv.normalizedUserDefinedName as NSObject?,
                                                          "remoteIdentifier": nil,
-                                                         "mutedStatus": (MutedMessageOptionValue.all.rawValue) as Optional<NSObject>]
+                                                         "mutedStatus": (MutedMessageOptionValue.all.rawValue) as NSObject?]
         let expectedToManyRelationships = ["hiddenMessages": 0,
                                            "participantRoles": 0,
                                            "allMessages": 1,
                                            "labels": 0,
                                            "nonTeamRoles": 0,
                                            "lastServerSyncedActiveParticipants": 0]
-        
+
         let expectedToOneRelationships: [String: NSManagedObjectID] =
             ["creator": conv.creator.objectID]
-        
-        expectedAttributes.forEach{
+
+        expectedAttributes.forEach {
             XCTAssertEqual((snapshot.attributes[$0] ?? nil), $1, "values for \($0) don't match")
         }
         XCTAssertEqual(snapshot.toManyRelationships, expectedToManyRelationships)
         XCTAssertEqual(snapshot.toOneRelationships, expectedToOneRelationships)
     }
-    
+
     func testThatReturnsChangedKeys() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // when
         conv.userDefinedName = "foo"
         let changedKeys = sut.extractChangedKeysFromSnapshot(for: conv)
@@ -167,24 +167,24 @@ class SnapshotCenterTests : BaseZMMessageTests {
         XCTAssertEqual(changedKeys.count, 2)
         XCTAssertEqual(changedKeys, Set(["normalizedUserDefinedName", "userDefinedName"]))
     }
-    
-    func testThatItUpatesTheSnapshot(){
+
+    func testThatItUpatesTheSnapshot() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // when
         conv.userDefinedName = "foo"
         _ = sut.extractChangedKeysFromSnapshot(for: conv)
-        
+
         // then
         guard let snapshot = sut.snapshots[conv.objectID] else { return XCTFail("did not create snapshot")}
-        
+
         // then
         XCTAssertEqual(snapshot.attributes["userDefinedName"] as? String, "foo")
     }
-    
-    func testThatItReturnsAllKeysChangedWhenSnapshotDoesNotExist(){
+
+    func testThatItReturnsAllKeysChangedWhenSnapshotDoesNotExist() {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
 
@@ -199,8 +199,8 @@ class SnapshotCenterTests : BaseZMMessageTests {
                                                                                   "nonTeamRoles",
                                                                                   "lastServerSyncedActiveParticipants"]))
     }
-    
-    func testThatItUpatesTheSnapshotForParticipantRole(){
+
+    func testThatItUpatesTheSnapshotForParticipantRole() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         let user = ZMUser.insertNewObject(in: uiMOC)
@@ -212,19 +212,18 @@ class SnapshotCenterTests : BaseZMMessageTests {
         pr.role = role1
         uiMOC.saveOrRollback()
         _ = sut.extractChangedKeysFromSnapshot(for: pr)
-        
+
         // when
         pr.role = role2
         uiMOC.saveOrRollback()
         let changedKeys = sut.extractChangedKeysFromSnapshot(for: pr)
-        
+
         // then
         guard let snapshot = sut.snapshots[pr.objectID] else { return XCTFail("did not create snapshot")}
-        
+
         // then
         XCTAssertEqual(snapshot.toOneRelationships["role"], role2.objectID)
         XCTAssertEqual(changedKeys, Set(["role"]))
     }
 
 }
-

--- a/Tests/Source/Model/Observer/StringKeyPathTests.swift
+++ b/Tests/Source/Model/Observer/StringKeyPathTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 class StringKeyPathTests: ZMBaseManagedObjectTest {
@@ -34,7 +33,7 @@ class StringKeyPathTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(sut.count, 2)
         XCTAssertTrue(sut.isPath)
     }
-    
+
     func testThatItDecomposesSimpleKeys() {
         let sut = StringKeyPath.keyPathForString("name")
         if let (a, b) = sut.decompose {
@@ -44,7 +43,7 @@ class StringKeyPathTests: ZMBaseManagedObjectTest {
             XCTFail("Did not decompose")
         }
     }
-    
+
     func testThatItDecomposesKeyPaths() {
         let sut = StringKeyPath.keyPathForString("foo.name")
         if let (a, b) = sut.decompose {

--- a/Tests/Source/Model/Observer/UserClientObserverTests.swift
+++ b/Tests/Source/Model/Observer/UserClientObserverTests.swift
@@ -16,90 +16,88 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 @testable import WireDataModel
 
+class TestUserClientObserver: NSObject, UserClientObserver {
 
-class TestUserClientObserver : NSObject, UserClientObserver {
-    
-    var receivedChangeInfo : [UserClientChangeInfo] = []
-    
+    var receivedChangeInfo: [UserClientChangeInfo] = []
+
     func userClientDidChange(_ changes: UserClientChangeInfo) {
         receivedChangeInfo.append(changes)
     }
 }
 
 class UserClientObserverTests: NotificationDispatcherTestBase {
-    
-    var clientObserver : TestUserClientObserver!
-    
+
+    var clientObserver: TestUserClientObserver!
+
     override func setUp() {
         super.setUp()
         clientObserver = TestUserClientObserver()
     }
-    
+
     override func tearDown() {
         clientObserver = nil
         super.tearDown()
     }
-    
+
     let userInfoKeys: Set<String> = [
         UserClientChangeInfoKey.TrustedByClientsChanged.rawValue,
         UserClientChangeInfoKey.IgnoredByClientsChanged.rawValue,
         UserClientChangeInfoKey.FingerprintChanged.rawValue
     ]
-    
-    func checkThatItNotifiesTheObserverOfAChange(_ userClient : UserClient, modifier: (UserClient) -> Void, expectedChangedFields: Set<String>, customAffectedKeys: AffectedKeys? = nil) {
-        
+
+    func checkThatItNotifiesTheObserverOfAChange(_ userClient: UserClient, modifier: (UserClient) -> Void, expectedChangedFields: Set<String>, customAffectedKeys: AffectedKeys? = nil) {
+
         // given
         self.uiMOC.saveOrRollback()
-        
+
         let token = UserClientChangeInfo.add(observer: clientObserver, for: userClient)
-        
+
         // when
         modifier(userClient)
         self.uiMOC.saveOrRollback()
-        
+
         // then
         let changeCount = clientObserver.receivedChangeInfo.count
         XCTAssertEqual(changeCount, 1)
-        
+
         // and when
         self.uiMOC.saveOrRollback()
-        
+
         // then
-        withExtendedLifetime(token) { () -> () in
+        withExtendedLifetime(token) { () -> Void in
             XCTAssertEqual(clientObserver.receivedChangeInfo.count, changeCount, "Should not have changed further once")
-            
+
             guard let changes = clientObserver.receivedChangeInfo.first else { return }
             changes.checkForExpectedChangeFields(userInfoKeys: userInfoKeys,
                                                  expectedChangedFields: expectedChangedFields)
         }
     }
-    
+
     func testThatItNotifiesTheObserverOfTrustedByClientsChange() {
         // given
         let client = UserClient.insertNewObject(in: self.uiMOC)
         let otherClient = UserClient.insertNewObject(in: self.uiMOC)
         self.uiMOC.saveOrRollback()
-        
+
         // when
         self.checkThatItNotifiesTheObserverOfAChange(client,
                                                      modifier: { otherClient.trustClient($0) },
                                                      expectedChangedFields: [UserClientChangeInfoKey.TrustedByClientsChanged.rawValue]
         )
-        
+
         XCTAssertTrue(client.trustedByClients.contains(otherClient))
     }
-    
+
     func testThatItNotifiesTheObserverOfIgnoredByClientsChange() {
         // given
         let client = UserClient.insertNewObject(in: self.uiMOC)
         let otherClient = UserClient.insertNewObject(in: self.uiMOC)
         otherClient.trustClient(client)
         self.uiMOC.saveOrRollback()
-        
+
         // when
         self.checkThatItNotifiesTheObserverOfAChange(client,
                                                      modifier: { otherClient.ignoreClient($0) },
@@ -108,42 +106,42 @@ class UserClientObserverTests: NotificationDispatcherTestBase {
                                                         UserClientChangeInfoKey.TrustedByClientsChanged.rawValue
             ]
         )
-        
+
         XCTAssertTrue(client.ignoredByClients.contains(otherClient))
     }
-    
+
     func testThatItNotifiesTheObserverOfFingerprintChange() {
         // given
         let client = UserClient.insertNewObject(in: self.uiMOC)
         client.fingerprint = NSString.createAlphanumerical().data(using: String.Encoding.utf8)
         self.uiMOC.saveOrRollback()
-        
+
         let newFingerprint = NSString.createAlphanumerical().data(using: String.Encoding.utf8)
-        
+
         // when
         self.checkThatItNotifiesTheObserverOfAChange(client,
                                                      modifier: { _ in client.fingerprint = newFingerprint },
                                                      expectedChangedFields: [UserClientChangeInfoKey.FingerprintChanged.rawValue]
         )
-        
+
         XCTAssertTrue(client.fingerprint == newFingerprint)
     }
-    
+
     func testThatItStopsNotifyingAfterUnregisteringTheToken() {
         // given
         let client = UserClient.insertNewObject(in: self.uiMOC)
         let otherClient = UserClient.insertNewObject(in: self.uiMOC)
         otherClient.trustClient(client)
         self.uiMOC.saveOrRollback()
-        
+
         let otherObserver = TestUserClientObserver()
         _ = UserClientChangeInfo.add(observer: otherObserver, for: client) // not storing the token
-        
+
         // when
         otherClient.ignoreClient(client)
         self.uiMOC.saveOrRollback()
-        
+
         XCTAssertEqual(otherObserver.receivedChangeInfo.count, 0)
     }
-    
+
 }

--- a/Tests/Source/Model/PermissionsTests.swift
+++ b/Tests/Source/Model/PermissionsTests.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import WireTesting
 @testable import WireDataModel
-
 
 class PermissionsTests: BaseZMClientMessageTests {
 
@@ -137,25 +135,25 @@ class PermissionsTests: BaseZMClientMessageTests {
         XCTAssertFalse(TeamRole.none.isA(role: .member))
         XCTAssertFalse(TeamRole.none.isA(role: .admin))
         XCTAssertFalse(TeamRole.none.isA(role: .owner))
-        
+
         XCTAssert(TeamRole.partner.isA(role: .none))
         XCTAssert(TeamRole.partner.isA(role: .partner))
         XCTAssertFalse(TeamRole.partner.isA(role: .member))
         XCTAssertFalse(TeamRole.partner.isA(role: .admin))
         XCTAssertFalse(TeamRole.partner.isA(role: .owner))
-        
+
         XCTAssert(TeamRole.member.isA(role: .none))
         XCTAssert(TeamRole.member.isA(role: .partner))
         XCTAssert(TeamRole.member.isA(role: .member))
         XCTAssertFalse(TeamRole.member.isA(role: .admin))
         XCTAssertFalse(TeamRole.member.isA(role: .owner))
-        
+
         XCTAssert(TeamRole.admin.isA(role: .none))
         XCTAssert(TeamRole.admin.isA(role: .partner))
         XCTAssert(TeamRole.admin.isA(role: .member))
         XCTAssert(TeamRole.admin.isA(role: .admin))
         XCTAssertFalse(TeamRole.admin.isA(role: .owner))
-        
+
         XCTAssert(TeamRole.owner.isA(role: .none))
         XCTAssert(TeamRole.owner.isA(role: .partner))
         XCTAssert(TeamRole.owner.isA(role: .member))

--- a/Tests/Source/Model/TeamDeletionRuleTests.swift
+++ b/Tests/Source/Model/TeamDeletionRuleTests.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import WireTesting
 @testable import WireDataModel
-
 
 class TeamDeletionRuleTests: BaseZMClientMessageTests {
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix warnings in Tests for the rules below: 

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- 
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
