### PR TITLE
fix: SwiftLint warnings in Tests for multiple rules Part 4

### DIFF
--- a/Tests/Source/Helper/BaseTestSwiftHelpers.swift
+++ b/Tests/Source/Helper/BaseTestSwiftHelpers.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireTesting
-
 
 func AssertKeyPathDictionaryHasOptionalValue<T: NSObject>( _ dictionary: @autoclosure () -> [WireDataModel.StringKeyPath: T?], key: @autoclosure () -> WireDataModel.StringKeyPath, expected: @autoclosure () -> T, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
     if let v = dictionary()[key()] {
@@ -29,10 +27,9 @@ func AssertKeyPathDictionaryHasOptionalValue<T: NSObject>( _ dictionary: @autocl
     }
 }
 
-
 func AssertKeyPathDictionaryHasOptionalNilValue<T: NSObject>( _ dictionary: @autoclosure () -> [WireDataModel.StringKeyPath: T?], key: @autoclosure () -> WireDataModel.StringKeyPath, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
     if let v = dictionary()[key()] {
-        AssertOptionalNil(v, message , file: file, line: line)
+        AssertOptionalNil(v, message, file: file, line: line)
     } else {
         XCTFail("No value for \(key()). \(message)", file: file, line: line)
     }

--- a/Tests/Source/Helper/NotificationObservers.swift
+++ b/Tests/Source/Helper/NotificationObservers.swift
@@ -18,9 +18,9 @@
 
 import Foundation
 
-protocol ObserverType : NSObjectProtocol {
-    associatedtype ChangeInfo : ObjectChangeInfo
-    var notifications : [ChangeInfo] {get set}
+protocol ObserverType: NSObjectProtocol {
+    associatedtype ChangeInfo: ObjectChangeInfo
+    var notifications: [ChangeInfo] {get set}
 }
 
 extension ObserverType {
@@ -29,94 +29,93 @@ extension ObserverType {
     }
 }
 
-class UserObserver : NSObject, ZMUserObserver {
-    
+class UserObserver: NSObject, ZMUserObserver {
+
     var notifications = [UserChangeInfo]()
-    
-    func clearNotifications(){
+
+    func clearNotifications() {
         notifications = []
     }
-    
+
     func userDidChange(_ changeInfo: UserChangeInfo) {
         notifications.append(changeInfo)
     }
 }
 
-class MessageObserver : NSObject, ZMMessageObserver {
-    
-    var token : NSObjectProtocol?
-    
+class MessageObserver: NSObject, ZMMessageObserver {
+
+    var token: NSObjectProtocol?
+
     override init() {}
-    
-    init(message : ZMMessage) {
+
+    init(message: ZMMessage) {
         super.init()
         token = MessageChangeInfo.add(
             observer: self,
             for: message,
             managedObjectContext: message.managedObjectContext!)
     }
-    
-    var notifications : [MessageChangeInfo] = []
-    
+
+    var notifications: [MessageChangeInfo] = []
+
     func messageDidChange(_ changeInfo: MessageChangeInfo) {
         notifications.append(changeInfo)
     }
 }
 
 class NewUnreadMessageObserver: NSObject, ZMNewUnreadMessagesObserver {
-    
+
     var token: NSObjectProtocol?
-    var notifications : [NewUnreadMessagesChangeInfo] = []
-    
+    var notifications: [NewUnreadMessagesChangeInfo] = []
+
     override init() {}
-    
+
     init(context: NSManagedObjectContext) {
         super.init()
         token = NewUnreadMessagesChangeInfo.add(observer: self, managedObjectContext: context)
     }
-    
+
     func didReceiveNewUnreadMessages(_ changeInfo: NewUnreadMessagesChangeInfo) {
         notifications.append(changeInfo)
     }
-    
+
 }
 
-
 final class ConversationObserver: NSObject, ZMConversationObserver {
-    
-    var token : NSObjectProtocol?
-    
-    func clearNotifications(){
+
+    var token: NSObjectProtocol?
+
+    func clearNotifications() {
         notifications = []
     }
-    
+
     override init() {}
-    
-    init(conversation : ZMConversation) {
+
+    init(conversation: ZMConversation) {
         super.init()
         token = ConversationChangeInfo.add(observer: self, for: conversation)
     }
-    
+
     var notifications = [ConversationChangeInfo]()
-    
+
     func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
         notifications.append(changeInfo)
     }
 }
 
-@objcMembers class ConversationListChangeObserver : NSObject, ZMConversationListObserver {
-    
+@objcMembers class ConversationListChangeObserver: NSObject, ZMConversationListObserver {
+
     public var notifications = [ConversationListChangeInfo]()
-    public var observerCallback : ((ConversationListChangeInfo) -> Void)?
+    public var observerCallback: ((ConversationListChangeInfo) -> Void)?
     unowned var conversationList: ZMConversationList
-    var token : NSObjectProtocol?
-    
+    var token: NSObjectProtocol?
+
     init(conversationList: ZMConversationList, managedObjectContext: NSManagedObjectContext) {
         self.conversationList = conversationList
         super.init()
         self.token = ConversationListChangeInfo.addListObserver(self, for: conversationList, managedObjectContext: managedObjectContext)
     }
-    
+
     func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
         notifications.append(changeInfo)
         if let callBack = observerCallback {

--- a/Tests/Source/Helper/XCTestCase+EncryptionKeys.swift
+++ b/Tests/Source/Helper/XCTestCase+EncryptionKeys.swift
@@ -20,30 +20,30 @@ import Foundation
 @testable import WireDataModel
 
 extension XCTestCase {
-    
+
     private func generatePublicPrivateKey() -> (SecKey, SecKey) {
         var publicKeySec, privateKeySec: SecKey?
         let keyattribute = [
             kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecAttrKeySizeInBits as String : 256
+            kSecAttrKeySizeInBits as String: 256
             ] as CFDictionary
         SecKeyGeneratePair(keyattribute, &publicKeySec, &privateKeySec)
-        
+
         return (publicKeySec!, privateKeySec!)
     }
-    
+
     var validEncryptionKeys: EncryptionKeys {
         let (publicKeySec, privateKeySec) = generatePublicPrivateKey()
         let databaseKey = Data.zmRandomSHA256Key()
-        
+
         return EncryptionKeys(publicKey: publicKeySec, privateKey: privateKeySec, databaseKey: databaseKey)
     }
-    
+
     var malformedEncryptionKeys: EncryptionKeys {
         let (publicKeySec, privateKeySec) = generatePublicPrivateKey()
         let databaseKey = Data.zmRandomSHA256Key()
-        
+
         return EncryptionKeys(publicKey: publicKeySec, privateKey: privateKeySec, databaseKey: databaseKey.dropFirst())
     }
-    
+
 }

--- a/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
+++ b/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
@@ -56,7 +56,7 @@ extension ZMBaseManagedObjectTest {
 
     @discardableResult func createTeamMember(in moc: NSManagedObjectContext, for team: Team) -> ZMUser {
         let user = createUser(in: moc)
-        createMembership(in:moc, user: user, team: team)
+        createMembership(in: moc, user: user, team: team)
         return user
     }
 
@@ -70,7 +70,7 @@ extension ZMBaseManagedObjectTest {
 
     func createExternal(in moc: NSManagedObjectContext) -> ZMUser {
         let externalUser = createUser(in: moc)
-        createMembership(in:moc, user: externalUser, team: nil, with: .partner)
+        createMembership(in: moc, user: externalUser, team: nil, with: .partner)
         return externalUser
     }
 }

--- a/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
+++ b/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
@@ -19,21 +19,21 @@
 import XCTest
 
 class BackupMetadataTests: XCTestCase {
-    
+
     var url: URL!
-    
+
     override func setUp() {
         super.setUp()
         let documentsURL = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
         url = URL(fileURLWithPath: documentsURL).appendingPathComponent(name)
     }
-    
+
     override func tearDown() {
         try? FileManager.default.removeItem(at: url)
         url = nil
         super.tearDown()
     }
-    
+
     func testThatItWritesMetadataToURL() throws {
         // Given
         let date = Date()
@@ -46,12 +46,12 @@ class BackupMetadataTests: XCTestCase {
             userIdentifier: userIdentifier,
             clientIdentifier: clientIdentifier
         )
-        
+
         // When & Then
         try sut.write(to: url)
         XCTAssert(FileManager.default.fileExists(atPath: url.path))
     }
-    
+
     func testThatItReadsMetadataFromURL() throws {
         // Given
         let date = Date()
@@ -64,78 +64,78 @@ class BackupMetadataTests: XCTestCase {
             userIdentifier: userIdentifier,
             clientIdentifier: clientIdentifier
         )
-        
+
         try sut.write(to: url)
-        
+
         // When
         let decoded = try BackupMetadata(url: url)
-        
+
         // Then
         XCTAssert(decoded == sut)
     }
-    
+
     func testThatItVerifiesValidMetadata() {
         // Given
         let userIdentifier = UUID.create()
-        
+
         let sut = BackupMetadata(
             appVersion: "3",
             modelVersion: "3.212",
             userIdentifier: userIdentifier,
             clientIdentifier: UUID.create().transportString()
         )
-        
+
         // When & Then
         let provider = MockProvider(version: "4.1.23")
         XCTAssertNil(sut.verify(using: userIdentifier, modelVersionProvider: provider))
     }
-    
+
     func testThatItReturnsAnErrorForNewerAppVersionBackupVerification() {
         // Given
         let userIdentifier = UUID.create()
-        
+
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
             userIdentifier: userIdentifier,
             clientIdentifier: UUID.create().transportString()
         )
-        
+
         // When
         let provider = MockProvider(version: "2.9.12")
         let error = sut.verify(using: userIdentifier, modelVersionProvider: provider)
-        
+
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.backupFromNewerAppVersion)
     }
-    
+
     func testThatItReturnsAnErrorForWrongUser() {
         // Given
         let userIdentifier = UUID.create()
-        
+
         let sut = BackupMetadata(
             appVersion: "3.1",
             modelVersion: "24.2.8",
             userIdentifier: userIdentifier,
             clientIdentifier: UUID.create().transportString()
         )
-        
+
         // When
         let provider = MockProvider(version: "3.1.0")
         let error = sut.verify(using: .create(), modelVersionProvider: provider)
-        
+
         // Then
         XCTAssertEqual(error, BackupMetadata.VerificationError.userMismatch)
     }
-    
+
 }
 
 // MARK: - Helper
 
-fileprivate class MockProvider: VersionProvider {
-    
+private class MockProvider: VersionProvider {
+
     var version: String
-    
+
     init(version: String) {
         self.version = version
     }

--- a/Tests/Source/ManagedObjectContext/CoreDataStackTests+EncryptionAtRest.swift
+++ b/Tests/Source/ManagedObjectContext/CoreDataStackTests+EncryptionAtRest.swift
@@ -64,10 +64,9 @@ class CoreDataStackTests_EncryptionAtRest: DatabaseBaseTest {
         sut.searchContext.performGroupedBlockAndWait {
             XCTAssertNil(sut.searchContext.encryptionKeys)
         }
-        
+
         // Clean up
         try! EncryptionKeys.deleteKeys(for: account)
     }
 
 }
-

--- a/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -21,9 +21,9 @@ import WireTesting
 @testable import WireDataModel
 
 @objcMembers public class DatabaseBaseTest: ZMTBaseTest {
-    
-    var accountID : UUID = UUID.create()
-    
+
+    var accountID: UUID = UUID.create()
+
     public var applicationContainer: URL {
         return FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
@@ -36,7 +36,7 @@ import WireTesting
         self.clearStorageFolder()
         try! FileManager.default.createDirectory(at: self.applicationContainer, withIntermediateDirectories: true)
     }
-    
+
     override public func tearDown() {
         self.clearStorageFolder()
         super.tearDown()
@@ -56,7 +56,7 @@ import WireTesting
 
         return stack
     }
-    
+
     /// Create a session in the keystore directory for the given account
     public func createSessionInKeyStore(accountDirectory: URL, applicationContainer: URL, sessionId: EncryptionSessionIdentifier) {
         let preKey = "pQABAQICoQBYICHHDV4Zh6yJzJSPhQmtxah8N4kVE+XSCmTVfIsvgm5UA6EAoQBYIJeiWi5TfAWBrYSOtM5nKk5isfRYX5pFqRk13jVenPz6BPY="
@@ -65,26 +65,26 @@ import WireTesting
             try! sessionsDirectory.createClientSession(sessionId, base64PreKeyString: preKey)
         }
     }
-    
+
     /// Returns true if the given session exists in the keystore for the given account
     public func doesSessionExistInKeyStore(accountDirectory: URL, applicationContainer: URL, sessionId: EncryptionSessionIdentifier) -> Bool {
-        
+
         var hasSession = false
-        
+
         let keyStore = UserClientKeysStore(accountDirectory: accountDirectory, applicationContainer: applicationContainer)
         keyStore.encryptionContext.perform { sessionsDirectory in
             hasSession = sessionsDirectory.hasSession(for: sessionId)
         }
-        
+
         return hasSession
     }
-    
+
     /// Clears the current storage folder and the legacy locations
     public func clearStorageFolder() {
         let url = self.applicationContainer
         try? FileManager.default.removeItem(at: url)
     }
-    
+
     /// Creates some dummy Core Data store support file
     func createDummyExternalSupportFileForDatabase(storeFile: URL) {
         let storeName = storeFile.deletingPathExtension().lastPathComponent
@@ -92,5 +92,5 @@ import WireTesting
         try! FileManager.default.createDirectory(at: supportPath, withIntermediateDirectories: true)
         try! self.mediumJPEGData().write(to: supportPath.appendingPathComponent("image.dat"))
     }
-    
+
 }

--- a/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
+++ b/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
@@ -23,26 +23,26 @@ import XCTest
 final class DatabaseMigrationTests: DatabaseBaseTest {
 
     func testThatItDoesNotMigrateFromANonE2EEVersionAndWipesTheDB() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "1-24")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion()
-        
+
         // THEN
         let users = try! directory.viewContext.fetch(ZMUser.sortedFetchRequest())
         XCTAssertEqual(users.count, 1) // only self user
     }
-    
+
     func testThatItPerformsMigrationFrom_1_25_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "1-25")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMTextMessage.sortedFetchRequest())
@@ -56,158 +56,158 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         XCTAssertEqual(conversationCount, 13)
         XCTAssertEqual(messageCount, 1681)
         XCTAssertEqual(systemMessageCount, 53)
         XCTAssertEqual(connectionCount, 5)
         XCTAssertEqual(userClientCount, 7)
         XCTAssertEqual(helloWorldMessageCount, 1515)
-    
+
         XCTAssertNotNil(message)
         XCTAssertEqual(messageServerTimestampTransportString, "2015-12-18T16:57:06.836Z")
-    
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 7)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture1_25 as NSArray)
     }
 
     func testThatItPerformsMigrationFrom_1_27_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "1-27")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
         let systemMessageCount = try! directory.viewContext.count(for: ZMSystemMessage.sortedFetchRequest())
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(conversationCount, 18)
         XCTAssertEqual(messageCount, 27)
         XCTAssertEqual(systemMessageCount, 18)
         XCTAssertEqual(connectionCount, 9)
         XCTAssertEqual(userClientCount, 25)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 7)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture1_27 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_1_28_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "1-28")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
         let systemMessageCount = try! directory.viewContext.count(for: ZMSystemMessage.sortedFetchRequest())
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(conversationCount, 3)
         XCTAssertEqual(messageCount, 17)
         XCTAssertEqual(systemMessageCount, 1)
         XCTAssertEqual(connectionCount, 2)
         XCTAssertEqual(userClientCount, 3)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 3)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture1_28 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_2_3_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "2-3")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
         let systemMessageCount = try! directory.viewContext.count(for: ZMSystemMessage.sortedFetchRequest())
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(conversationCount, 2)
         XCTAssertEqual(messageCount, 5)
         XCTAssertEqual(systemMessageCount, 0)
         XCTAssertEqual(connectionCount, 2)
         XCTAssertEqual(userClientCount, 8)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 3)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture2_3 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_2_4_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "2-4")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
         let systemMessageCount = try! directory.viewContext.count(for: ZMSystemMessage.sortedFetchRequest())
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(conversationCount, 2)
         XCTAssertEqual(messageCount, 15)
         XCTAssertEqual(systemMessageCount, 4)
         XCTAssertEqual(connectionCount, 2)
         XCTAssertEqual(userClientCount, 9)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 3)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture_2_45 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_2_5_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "2-5")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
@@ -215,12 +215,12 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
         let assetClientMessagesCount = try! directory.viewContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(assetClientMessagesCount, 5)
         XCTAssertEqual(conversationCount, 2)
@@ -228,20 +228,20 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         XCTAssertEqual(systemMessageCount, 1)
         XCTAssertEqual(connectionCount, 2)
         XCTAssertEqual(userClientCount, 10)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 3)
         XCTAssertEqual(userDictionaries as NSArray, DatabaseMigrationTests.userDictionaryFixture_2_45 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_2_6_ToCurrentModelVersion() {
-        
+
         // GIVEN
         self.createDatabaseWithOlderModelVersion(versionName: "2-6")
-        
+
         // WHEN
         let directory = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-        
+
         // THEN
         let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
         let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
@@ -249,12 +249,12 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
         let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
         let assetClientMessagesCount = try! directory.viewContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
-        
+
         let userFetchRequest = ZMUser.sortedFetchRequest()
         userFetchRequest.resultType = .dictionaryResultType
         userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
         let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-        
+
         // THEN
         XCTAssertEqual(assetClientMessagesCount, 0)
         XCTAssertEqual(conversationCount, 20)
@@ -262,21 +262,21 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
         XCTAssertEqual(systemMessageCount, 21)
         XCTAssertEqual(connectionCount, 16)
         XCTAssertEqual(userClientCount, 12)
-        
+
         XCTAssertNotNil(userDictionaries)
         XCTAssertEqual(userDictionaries.count, 22)
         XCTAssertEqual(Array(userDictionaries[0..<3]) as NSArray, DatabaseMigrationTests.userDictionaryFixture2_6 as NSArray)
     }
-    
+
     func testThatItPerformsMigrationFrom_Between_2_7_and_2_21_4_ToCurrentModelVersion() {
-        
+
         ["2-7", "2-8", "2-21-1", "2-21-2"].forEach { storeFile in
             // GIVEN
             self.createDatabaseWithOlderModelVersion(versionName: storeFile)
-            
+
             // WHEN
             var directory: CoreDataStack! = self.createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
-            
+
             // THEN
             let conversationCount = try! directory.viewContext.count(for: ZMConversation.sortedFetchRequest())
             let messageCount = try! directory.viewContext.count(for: ZMClientMessage.sortedFetchRequest())
@@ -284,12 +284,12 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             let connectionCount = try! directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
             let userClientCount = try! directory.viewContext.count(for: UserClient.sortedFetchRequest())
             let assetClientMessagesCount = try! directory.viewContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
-            
+
             let userFetchRequest = ZMUser.sortedFetchRequest()
             userFetchRequest.resultType = .dictionaryResultType
             userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
             let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
-            
+
             // THEN
             XCTAssertEqual(assetClientMessagesCount, 0)
             XCTAssertEqual(conversationCount, 20)
@@ -297,34 +297,33 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             XCTAssertEqual(systemMessageCount, 21)
             XCTAssertEqual(connectionCount, 16)
             XCTAssertEqual(userClientCount, 12)
-            
+
             XCTAssertNotNil(userDictionaries)
             XCTAssertEqual(userDictionaries.count, 22)
             XCTAssertEqual(Array(userDictionaries[0..<3]) as NSArray, DatabaseMigrationTests.userDictionaryFixture2_7 as NSArray)
-            
+
             directory = nil // need to release
             self.clearStorageFolder()
         }
     }
-    
+
     func testThatItPerformsMigrationFrom_Between_2_24_1_and_PreLast_ToCurrentModelVersion() {
         // NOTICE: When a new version of data model is created, please increase the last number of the array.
         let allVersions = ["2-24-1"] +
             [(25...31),
              (39...57),
              (59...97)].joined().map { "2-\($0)-0" }
-        
+
         let modelVersion = CoreDataStack.loadMessagingModel().version
         let fixtureVersion = String(databaseFixtureFileName(for: modelVersion).dropFirst("store".count))
 
-        
         // Check that we have current version fixture file
         guard let _ = databaseFixtureURL(version: modelVersion) else {
             let versionsWithoutCurrent = allVersions.filter { $0 != fixtureVersion }
             createDatabaseWithOlderModelVersion(versionName: versionsWithoutCurrent.last!)
             let directory = createStorageStackAndWaitForCompletion(userID: DatabaseMigrationTests.testUUID)
             let currentDatabaseURL = directory.syncContext.persistentStoreCoordinator!.persistentStores.last!.url!
-            
+
             XCTFail("\nMissing current version database file: `store\(fixtureVersion).wiredatabase`. \n\n" +
                     "**HOW TO FIX THIS** \n" +
                     "- Run the test, until you hit the assertion\n" +
@@ -335,13 +334,12 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
                     "- Copy it to test bundle if this project in `WireDataModel/Test/Resources` with the other stores\n\n")
             assert(false)
         }
-        
+
         guard allVersions.contains(fixtureVersion) else {
             return XCTFail("Current model version '\(fixtureVersion)' is not added to allVersions array. \n" +
                 "Please add it to the array above, so that we are sure it's there when we bump to the next version\n" +
                 "and we don't forget to test the migration from that version")
         }
-        
 
         allVersions.forEach { storeFile in
             // GIVEN
@@ -360,7 +358,6 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             let messages = directory.viewContext.executeFetchRequestOrAssert(ZMMessage.sortedFetchRequest()) as! [ZMMessage]
             let users = directory.viewContext.fetchOrAssert(request: NSFetchRequest<ZMUser>(entityName: ZMUser.entityName()))
 
-
             let userFetchRequest = ZMUser.sortedFetchRequest()
             userFetchRequest.resultType = .dictionaryResultType
             userFetchRequest.propertiesToFetch = self.userPropertiesToFetch
@@ -374,7 +371,7 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             XCTAssertEqual(connectionCount, 16)
             XCTAssertEqual(userClientCount, 12)
 
-            //TODO: check still needed after XCode 11
+            // TODO: check still needed after XCode 11
             /*
             if storeFile == "2-53-0" {
                 let silencedConversations = ((directory.uiContext.executeFetchRequestOrAssert(ZMConversation.sortedFetchRequest()!)) as! [ZMConversation]).filter { conversation in
@@ -400,36 +397,36 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             self.clearStorageFolder()
         }
     }
-    
+
     func testThatTheVersionIdentifiersMatchModelNameAndDoNotDuplicate() throws {
         // given
         guard let source = Bundle(for: ZMMessage.self).url(forResource: "zmessaging", withExtension: "momd") else {
             fatalError("missing resource")
         }
         let fm = FileManager.default
-    
+
         let excludedModels = Set(["zmessaging.mom", "zmessaging2.9.mom", "zmessaging2.10.mom", "zmessaging2.11.mom"])
-        
+
         let regex = try NSRegularExpression(pattern: "[0-9\\.]+[0-9]+")
-        
+
         var processedVersions = Set<String>()
-        
+
         try fm.contentsOfDirectory(atPath: source.path).filter { URL(fileURLWithPath: $0).pathExtension == "mom" } .forEach { modelFileName in
-            
+
             let nameMatches = regex.matches(in: modelFileName, range: NSRange(modelFileName.startIndex..., in: modelFileName)).map {
                 String(modelFileName[Range($0.range, in: modelFileName)!])
             }
-            
+
             if excludedModels.contains(modelFileName) { // first version
                 return
             }
-            
+
             guard let version = nameMatches.first else {
                 fatal("Wrong name format: \(modelFileName)")
             }
-            
+
             XCTAssertFalse(processedVersions.contains(version))
-            
+
             let store = NSManagedObjectModel(contentsOf: source.appendingPathComponent(modelFileName))!
             // then
             XCTAssertTrue(store.versionIdentifiers.contains(version))
@@ -440,7 +437,7 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
 
 // MARK: - Helpers
 extension DatabaseMigrationTests {
-    
+
     static let testUUID: UUID = UUID()
 
     var userPropertiesToFetch: [String] {
@@ -454,25 +451,25 @@ extension DatabaseMigrationTests {
                  "handle"
         ]
     }
-    
+
     func createDatabaseWithOlderModelVersion(versionName: String, file: StaticString = #file, line: UInt = #line) {
         let storeFile = CoreDataStack.accountDataFolder(accountIdentifier: DatabaseMigrationTests.testUUID, applicationContainer: self.applicationContainer).appendingPersistentStoreLocation()
         try! FileManager.default.createDirectory(at: storeFile.deletingLastPathComponent(), withIntermediateDirectories: true)
-        
+
         // copy old version database into the expected location
         guard let source = databaseFixtureURL(version: versionName, file: file, line: line) else {
             return
         }
         try! FileManager.default.copyItem(at: source, to: storeFile)
     }
-    
+
     // The naming scheme is slightly different for fixture files
     func databaseFixtureFileName(for version: String) -> String {
         let fixedVersion = version.replacingOccurrences(of: ".", with: "-")
         let name = "store" + fixedVersion
         return name
     }
-    
+
     func databaseFixtureURL(version: String, file: StaticString = #file, line: UInt = #line) -> URL? {
         let name = databaseFixtureFileName(for: version)
         guard let source = Bundle(for: type(of: self)).url(forResource: name, withExtension: "wiredatabase") else {
@@ -485,14 +482,14 @@ extension DatabaseMigrationTests {
 
 // MARK: - Fixtures
 extension DatabaseMigrationTests {
-    
+
     static let userDictionaryFixture1_25 = [
         [
             "accentColorValue": 1,
             "emailAddress": "hello@example.com",
             "name": "awesome test user",
             "normalizedEmailAddress": "hello@example.com",
-            "normalizedName": "awesome test user",
+            "normalizedName": "awesome test user"
             ],
         [
             "accentColorValue": 1,
@@ -521,9 +518,9 @@ extension DatabaseMigrationTests {
         [
             "accentColorValue": 3,
             "emailAddress": "welcome+23@example.com",
-            "name" : "Otto the Bot",
+            "name": "Otto the Bot",
             "normalizedEmailAddress": "welcome+23@example.com",
-            "normalizedName": "otto the bot",
+            "normalizedName": "otto the bot"
             ],
         [
             "accentColorValue": 6,
@@ -531,57 +528,57 @@ extension DatabaseMigrationTests {
             "normalizedName": "pierrejoris"
         ]
     ]
-    
+
     static let userDictionaryFixture1_27 = [
         [
-            "accentColorValue" : (1),
-            "emailAddress" : "email@example.com",
-            "name" : "Bruno",
-            "normalizedEmailAddress" : "email@example.com",
-            "normalizedName" : "bruno",
+            "accentColorValue": (1),
+            "emailAddress": "email@example.com",
+            "name": "Bruno",
+            "normalizedEmailAddress": "email@example.com",
+            "normalizedName": "bruno"
             ],
         [
-            "accentColorValue" : (6),
-            "emailAddress" : "secret@example.com",
-            "name" : "Florian",
-            "normalizedEmailAddress" : "secret@example.com",
-            "normalizedName" : "florian",
+            "accentColorValue": (6),
+            "emailAddress": "secret@example.com",
+            "name": "Florian",
+            "normalizedEmailAddress": "secret@example.com",
+            "normalizedName": "florian"
             ],
         [
-            "accentColorValue" : (4),
-            "emailAddress" : "hidden@example.com",
-            "name" : "Heinzelmann",
-            "normalizedEmailAddress" : "hidden@example.com",
-            "normalizedName" : "heinzelmann",
+            "accentColorValue": (4),
+            "emailAddress": "hidden@example.com",
+            "name": "Heinzelmann",
+            "normalizedEmailAddress": "hidden@example.com",
+            "normalizedName": "heinzelmann"
             ],
         [
-            "accentColorValue" : (1),
-            "emailAddress" : "censored@example.com",
-            "name" : "It is me",
-            "normalizedEmailAddress" : "censored@example.com",
-            "normalizedName" : "it is me",
+            "accentColorValue": (1),
+            "emailAddress": "censored@example.com",
+            "name": "It is me",
+            "normalizedEmailAddress": "censored@example.com",
+            "normalizedName": "it is me"
             ],
         [
-            "accentColorValue" : (3),
-            "emailAddress" : "welcome+23@example.com",
-            "name" : "Otto the Bot",
-            "normalizedEmailAddress" : "welcome+23@example.com",
-            "normalizedName" : "otto the bot",
+            "accentColorValue": (3),
+            "emailAddress": "welcome+23@example.com",
+            "name": "Otto the Bot",
+            "normalizedEmailAddress": "welcome+23@example.com",
+            "normalizedName": "otto the bot"
             ],
         [
-            "accentColorValue" : (3),
-            "name" : "Pierre-Joris",
-            "normalizedName" : "pierrejoris",
+            "accentColorValue": (3),
+            "name": "Pierre-Joris",
+            "normalizedName": "pierrejoris"
             ],
         [
-            "accentColorValue" : (3),
-            "emailAddress" : "secret2@example.com",
-            "name" : "Test User",
-            "normalizedEmailAddress" : "secret2@example.com",
-            "normalizedName" : "test user",
+            "accentColorValue": (3),
+            "emailAddress": "secret2@example.com",
+            "name": "Test User",
+            "normalizedEmailAddress": "secret2@example.com",
+            "normalizedName": "test user"
             ]
     ]
-    
+
     static let userDictionaryFixture1_28 = [
         [
             "accentColorValue": 1,
@@ -602,10 +599,10 @@ extension DatabaseMigrationTests {
             "emailAddress": "user3@example.com",
             "name": "user3",
             "normalizedEmailAddress": "user3@example.com",
-            "normalizedName": "user3",
-            ],
+            "normalizedName": "user3"
+            ]
         ]
-    
+
     static let userDictionaryFixture2_3 = [
         [
             "accentColorValue": 1,
@@ -624,10 +621,10 @@ extension DatabaseMigrationTests {
             "emailAddress": "user3@example.com",
             "name": "Example User 3",
             "normalizedEmailAddress": "user3@example.com",
-            "normalizedName": "example user 3",
+            "normalizedName": "example user 3"
             ]
     ]
-    
+
     static let userDictionaryFixture_2_45 = [
         [
             "accentColorValue": 4,
@@ -646,10 +643,10 @@ extension DatabaseMigrationTests {
             "emailAddress": "user3@example.com",
             "name": "User 3",
             "normalizedEmailAddress": "user3@example.com",
-            "normalizedName": "user 3",
-            ],
+            "normalizedName": "user 3"
+            ]
         ]
-    
+
     static let userDictionaryFixture2_6 = [
         [
             "accentColorValue": 3,
@@ -668,10 +665,10 @@ extension DatabaseMigrationTests {
             "emailAddress": "183@example.com",
             "name": "Daniel",
             "normalizedEmailAddress": "183@example.com",
-            "normalizedName": "Daniel",
-            ],
+            "normalizedName": "Daniel"
+            ]
         ]
-    
+
     static let userDictionaryFixture2_7 = [
         [
             "accentColorValue": 3,
@@ -690,10 +687,10 @@ extension DatabaseMigrationTests {
             "emailAddress": "183@example.com",
             "name": "Daniel",
             "normalizedEmailAddress": "183@example.com",
-            "normalizedName": "Daniel",
-            ],
+            "normalizedName": "Daniel"
+            ]
         ]
-    
+
     static let userDictionaryFixture2_25_1 = [
         [
             "accentColorValue": 3,
@@ -707,15 +704,15 @@ extension DatabaseMigrationTests {
             "name": "Chad",
             "normalizedEmailAddress": "574@example.com",
             "normalizedName": "Chad",
-            "handle":"titus"
+            "handle": "titus"
         ],
         [
             "accentColorValue": 5,
             "emailAddress": "183@example.com",
             "name": "Daniel",
             "normalizedEmailAddress": "183@example.com",
-            "normalizedName": "Daniel",
-            ],
+            "normalizedName": "Daniel"
+            ]
         ]
 
 }

--- a/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -16,12 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-
-class ManagedObjectContextChangeObserverTests : ZMBaseManagedObjectTest {
-
+class ManagedObjectContextChangeObserverTests: ZMBaseManagedObjectTest {
 
     func testThatItCallsTheCallbackWhenObjectsAreInserted() {
         // given

--- a/Tests/Source/ManagedObjectContext/Migrations/PersistentStoreRelocatorTests.swift
+++ b/Tests/Source/ManagedObjectContext/Migrations/PersistentStoreRelocatorTests.swift
@@ -20,82 +20,82 @@ import XCTest
 @testable import WireDataModel
 
 class PersistentStoreRelocatorTests: DatabaseBaseTest {
-    
+
     override func setUp() {
         super.setUp()
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testThatItFindsPreviousStoreInCachesDirectory() {
-        
+
         // given
         self.createLegacyStore(path: .cachesDirectory)
-        
+
         // new store is located in documents directory
-        let sut = PersistentStoreRelocator (sharedContainerURL: self.sharedContainerDirectoryURL,
+        let sut = PersistentStoreRelocator(sharedContainerURL: self.sharedContainerDirectoryURL,
                                            newStoreURL: StorageStack.accountFolder(accountIdentifier: UUID(), applicationContainer: self.sharedContainerDirectoryURL))
-        
+
         // then
         XCTAssertEqual(sut.previousStoreLocation, FileManager.storeURL(in: .cachesDirectory))
     }
-    
+
     func testThatItFindsPreviousStoreInApplicationSupportDirectory() {
-        
+
         // given
         self.createLegacyStore(path: .applicationSupportDirectory)
-        
+
         // new store is located in documents directory
         let sut = PersistentStoreRelocator(sharedContainerURL: self.sharedContainerDirectoryURL,
                                            newStoreURL: FileManager.currentStoreURLForAccount(
                                             with: UUID(), in: self.sharedContainerDirectoryURL))
-        
+
         // then
         XCTAssertEqual(sut.previousStoreLocation, FileManager.storeURL(in: .applicationSupportDirectory))
-        
+
     }
-    
+
     func testThatIsNecessaryToRelocateStoreIfItsLocatedInAPreviousLocation_and_newStoreAlreadyExists() {
         // given
         let cachesStoreURL = FileManager.storeURL(in: .cachesDirectory)
         self.createLegacyStore(path: .documentDirectory)
         self.createDirectoryForStore(at: cachesStoreURL)
         self.createExternalSupportFileForDatabase(at: cachesStoreURL)
-        
+
         // new store is located in documents directory
         let sut = PersistentStoreRelocator(sharedContainerURL: self.sharedContainerDirectoryURL,
                                            newStoreURL: FileManager.currentStoreURLForAccount(
                                             with: UUID(), in: self.sharedContainerDirectoryURL))
-        
+
         // then
         XCTAssertNotNil(sut.previousStoreLocation)
     }
-    
+
     func testThatIsNotNecessaryToRelocateStoreIfNotPreviousStoreExists() {
         // given new store is located in documents directory
         let sut = PersistentStoreRelocator(sharedContainerURL: self.sharedContainerDirectoryURL,
                                            newStoreURL: FileManager.currentStoreURLForAccount(
                                             with: UUID(), in: self.sharedContainerDirectoryURL))
-        
+
         // then
         XCTAssertNil(sut.previousStoreLocation)
     }
-    
+
     func testThatIsNotNecessaryToRelocateStoreIfItsLocatedInAPreviousLocation_and_newStoreIsTheSame() {
         // given
         let accountId = UUID()
         createDatabase(in: .documentDirectory, accountIdentifier: accountId)
-        
+
         // new store is also located in caches directory
         let sut = PersistentStoreRelocator(sharedContainerURL: self.sharedContainerDirectoryURL,
                                            newStoreURL: FileManager.currentStoreURLForAccount(
                                             with: accountId,
                                             in: self.sharedContainerDirectoryURL))
-        
+
         // then
         XCTAssertNil(sut.previousStoreLocation)
     }
-    
+
 }

--- a/Tests/Source/ManagedObjectContext/MockBackgroundActivityManager.swift
+++ b/Tests/Source/ManagedObjectContext/MockBackgroundActivityManager.swift
@@ -22,17 +22,17 @@ import WireTransport
 @objc class MockBackgroundActivityManager: NSObject, BackgroundActivityManager {
 
     var backgroundTimeRemaining: TimeInterval = 10
-    
+
     var applicationState: UIApplication.State = .active
-    
+
     // MARK: - BackgroundActivityManager
-    
+
     @objc public var startedTasks = [String]()
     func beginBackgroundTask(withName name: String?, expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
         startedTasks.append(name ?? "NO-NAME")
         return UIBackgroundTaskIdentifier(rawValue: startedTasks.count)
     }
-    
+
     @objc public var endedTasks = [Int]()
     func endBackgroundTask(_ task: UIBackgroundTaskIdentifier) {
         endedTasks.append(task.rawValue)

--- a/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
+++ b/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
@@ -16,15 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-
-
-class NSManagedObjectContextDebuggingTests : ZMBaseManagedObjectTest {
+class NSManagedObjectContextDebuggingTests: ZMBaseManagedObjectTest {
 
     func testThatItInvokesCallbackWhenFailedToSave() {
-        
+
         // GIVEN
         self.makeChangeThatWillCauseRollback()
         let expectation = self.expectation(description: "callback invoked")
@@ -33,12 +30,12 @@ class NSManagedObjectContextDebuggingTests : ZMBaseManagedObjectTest {
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
-        
+
         // WHEN
         self.performIgnoringZMLogError {
             self.uiMOC.saveOrRollback()
         }
-        
+
         // THEN
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
     }
@@ -46,12 +43,12 @@ class NSManagedObjectContextDebuggingTests : ZMBaseManagedObjectTest {
 
 // MARK: - Helper
 
-private let longString = (0..<50).reduce("") { (prev, next) -> String in
+private let longString = (0..<50).reduce("") { (prev, _) -> String in
     return prev + "AaAaAaAaAa"
 }
 
 extension NSManagedObjectContextDebuggingTests {
-    
+
     func makeChangeThatWillCauseRollback() {
         let user = ZMUser.selfUser(in: self.uiMOC)
         // this user name is too long and will fail validation

--- a/Tests/Source/ManagedObjectContext/NSManagedObjectContextTests+EncryptionAtRest.swift
+++ b/Tests/Source/ManagedObjectContext/NSManagedObjectContextTests+EncryptionAtRest.swift
@@ -20,7 +20,6 @@ import Foundation
 import XCTest
 @testable import WireDataModel
 
-
 class NSManagedObjectContextTests_EncryptionAtRest: ZMBaseManagedObjectTest {
 
     private typealias MigrationError = NSManagedObjectContext.MigrationError
@@ -30,7 +29,7 @@ class NSManagedObjectContextTests_EncryptionAtRest: ZMBaseManagedObjectTest {
         createSelfClient(onMOC: uiMOC)
     }
 
-    private func fetchObjects<T: ZMManagedObject>() throws -> [T]{
+    private func fetchObjects<T: ZMManagedObject>() throws -> [T] {
         let request = NSFetchRequest<T>(entityName: T.entityName())
         request.returnsObjectsAsFaults = false
         return try request.execute()
@@ -73,7 +72,6 @@ class NSManagedObjectContextTests_EncryptionAtRest: ZMBaseManagedObjectTest {
         // Given
         let validEncryptionKeys = self.validEncryptionKeys
         try uiMOC.enableEncryptionAtRest(encryptionKeys: validEncryptionKeys, skipMigration: true)
-        
 
         let conversation = createConversation(in: uiMOC)
         try conversation.appendText(content: "Beep bloop")

--- a/Tests/Source/ManagedObjectContext/NSPersistentStoreMetadataTests.swift
+++ b/Tests/Source/ManagedObjectContext/NSPersistentStoreMetadataTests.swift
@@ -16,23 +16,22 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import XCTest
 
-class NSPersistentStoreMetadataTests : ZMBaseManagedObjectTest {
-    
-    override var shouldUseInMemoryStore : Bool {
+class NSPersistentStoreMetadataTests: ZMBaseManagedObjectTest {
+
+    override var shouldUseInMemoryStore: Bool {
         return false
     }
-    
+
     override func setUp() {
         super.setUp()
     }
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func forceSave() {
         // I need to insert or modify an entity, or core data will not save
         self.uiMOC.forceSaveOrRollback()
@@ -40,125 +39,125 @@ class NSPersistentStoreMetadataTests : ZMBaseManagedObjectTest {
 }
 
 extension NSPersistentStoreMetadataTests {
-    
+
     func testThatItStoresMetadataInMemory() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
-        
+
         // WHEN
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // THEN
         XCTAssertEqual(data, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatItDeletesMetadataFromMemory() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // WHEN
         self.uiMOC.setPersistentStoreMetadata(nil as String?, key: key)
-        
+
         // THEN
         XCTAssertEqual(nil, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatMetadataAreNotPersisted() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // WHEN
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         XCTAssertEqual(nil, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatItPersistsMetadataWhenSaving() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // WHEN
         self.forceSave()
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         XCTAssertEqual(data, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatItDiscardsMetadataWhenRollingBack() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // WHEN
         self.uiMOC.enableForceRollback()
         self.forceSave()
-        
+
         // THEN
         XCTAssertEqual(nil, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
-        
+
         // AFTER
         self.uiMOC.disableForceRollback()
     }
-    
+
     func testThatItDeletesAlreadySetMetadataInMemory() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
         self.forceSave()
-        
+
         // WHEN
         self.uiMOC.setPersistentStoreMetadata(nil as String?, key: key)
-        
+
         // THEN
         XCTAssertEqual(nil, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatItDiscardsDeletesAlreadySetMetadataInMemory() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
         self.forceSave()
         self.uiMOC.setPersistentStoreMetadata(nil as String?, key: key)
-        
+
         // WHEN
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         XCTAssertEqual(data, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
-    
+
     func testThatItDeletesAlreadySetMetadataFromStore() {
-        
+
         // GIVEN
         let data = "foo"
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
         self.forceSave()
         self.uiMOC.setPersistentStoreMetadata(nil as String?, key: key)
-        
+
         // WHEN
         self.forceSave()
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         XCTAssertEqual(nil, self.uiMOC.persistentStoreMetadata(forKey: key) as? String)
     }
@@ -166,43 +165,43 @@ extension NSPersistentStoreMetadataTests {
 
 // MARK: - What can be saved
 extension NSPersistentStoreMetadataTests {
-    
+
     func checkThatItCanSave<T: Equatable & SwiftPersistableInMetadata>(data: T, file: StaticString = #file, line: UInt = #line) {
-        
+
         // GIVEN
         let key = "boo"
         self.uiMOC.setPersistentStoreMetadata(data, key: key)
-        
+
         // WHEN
         self.forceSave()
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         XCTAssertEqual(data, self.uiMOC.persistentStoreMetadata(forKey: key) as? T, file: file, line: line)
     }
-    
+
     func testThatItCanStoreStrings() {
         self.checkThatItCanSave(data: "Foo")
     }
-    
+
     func testThatItCanStoreDates() {
         self.checkThatItCanSave(data: Date())
     }
-    
+
     func testThatItCanStoreData() {
-        self.checkThatItCanSave(data: Data([21,3]))
+        self.checkThatItCanSave(data: Data([21, 3]))
     }
-        
+
     func testThatItCanStoreArrayOfString() {
         // GIVEN
         let key = "boo"
         let data = ["a", "z"]
         self.uiMOC.setPersistentStoreMetadata(array: data, key: key)
-        
+
         // WHEN
         self.forceSave()
         self.resetUIandSyncContextsAndResetPersistentStore(false)
-        
+
         // THEN
         for i in 0..<data.count {
             XCTAssertEqual(data[i], (self.uiMOC.persistentStoreMetadata(forKey: key) as? [String])?[i])

--- a/Tests/Source/ManagedObjectContext/VersionTests.swift
+++ b/Tests/Source/ManagedObjectContext/VersionTests.swift
@@ -17,40 +17,40 @@
 //
 
 final class VersionTests: XCTestCase {
-  
+
     func testThatItComparesCorrectly() {
         let version1 = Version(string: "0.1")
         let version2 = Version(string: "1.0")
         let version3 = Version(string: "1.0")
         let version4 = Version(string: "1.0.1")
         let version5 = Version(string: "1.1")
-        
+
         XCTAssertLessThan(version1, version2)
         XCTAssertLessThan(version1, version3)
         XCTAssertLessThan(version1, version4)
         XCTAssertLessThan(version1, version5)
-        
+
         XCTAssertGreaterThan(version2, version1)
         XCTAssertEqual(version2, version3)
         XCTAssertEqual(version2.compare(with: version3), .orderedSame)
         XCTAssertLessThan(version2, version4)
         XCTAssertLessThan(version2, version5)
-        
+
         XCTAssertGreaterThan(version3, version1)
         XCTAssertEqual(version3, version2)
         XCTAssertEqual(version3.compare(with: version2), .orderedSame)
         XCTAssertLessThan(version3, version4)
         XCTAssertLessThan(version3, version5)
-        
+
         XCTAssertGreaterThan(version4, version1)
         XCTAssertGreaterThan(version4, version2)
         XCTAssertGreaterThan(version4, version3)
         XCTAssertLessThan(version4, version5)
-        
+
         XCTAssertGreaterThan(version5, version1)
         XCTAssertGreaterThan(version5, version2)
         XCTAssertGreaterThan(version5, version3)
         XCTAssertGreaterThan(version5, version4)
     }
-    
+
 }

--- a/Tests/Source/Model/AccountManagerTests.swift
+++ b/Tests/Source/Model/AccountManagerTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 final class AccountManagerTests: ZMConversationTestsBase {
 
@@ -142,7 +140,7 @@ final class AccountManagerTests: ZMConversationTestsBase {
             XCTAssertEqual(manager.accounts, [])
         }
     }
-    
+
     func testThatItRemovesTheSelectedAccountWhenItIsRemoved() {
         // given
         let manager = AccountManager(sharedDirectory: url)
@@ -163,18 +161,18 @@ final class AccountManagerTests: ZMConversationTestsBase {
         XCTAssertNil(manager.selectedAccount)
         XCTAssertEqual(manager.accounts, [])
     }
-    
+
     func testThatItUpdatesExisitingAccountPropertiesFromStore() {
         // given
         let manager = AccountManager(sharedDirectory: url)
         let accountID = UUID.create()
         manager.addAndSelect(Account(userName: "Jacob", userIdentifier: accountID))
         let account = manager.selectedAccount!
-        
+
         // when
         let updatedAccount = Account(userName: "Vytis", userIdentifier: accountID, teamName: "Wire")
         manager.addAndSelect(updatedAccount)
-        
+
         // then
         XCTAssertTrue(manager.selectedAccount === account)
         XCTAssertEqual(account.userIdentifier, accountID)

--- a/Tests/Source/Model/AccountStoreTests.swift
+++ b/Tests/Source/Model/AccountStoreTests.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 @testable import WireDataModel
-
 
 final class AccountStoreTests: ZMConversationTestsBase {
 
@@ -179,25 +177,25 @@ final class AccountStoreTests: ZMConversationTestsBase {
         XCTAssertNil(account.imageData)
         XCTAssertNil(account.teamImageData)
     }
-    
+
     func testThatItUpdatesAnExistingAccount_WithImages() {
         // given
         let store = AccountStore(root: url)
         let uuid = UUID.create()
-        
+
         do {
             let account = Account(userName: "Silvan", userIdentifier: uuid)
             XCTAssert(store.add(account))
             XCTAssertEqual(store.load(), [account])
         }
-        
+
         // when
         let name = "Marco", team = "Wire", image = verySmallJPEGData()
         do {
             let account = Account(userName: name, userIdentifier: uuid, teamName: team, imageData: image, teamImageData: image)
             XCTAssert(store.add(account))
         }
-        
+
         // then
         guard let account = store.load(uuid) else { return XCTFail("Unable to load account") }
         XCTAssertEqual(account.userName, name)

--- a/Tests/Source/Model/AccountTests.swift
+++ b/Tests/Source/Model/AccountTests.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 @testable import WireDataModel
-
 
 final class AccountTests: ZMConversationTestsBase {
 
@@ -107,7 +105,6 @@ final class AccountTests: ZMConversationTestsBase {
         XCTAssertEqual(account.unreadConversationCount, count)
         XCTAssertEqual(account.loginCredentials, credentials)
     }
-
 
     func testThatAccountsAreEqualWhenNotImportantPropertiesAreDifferent() {
         // given

--- a/Tests/Source/Model/AddressBookEntryTests.swift
+++ b/Tests/Source/Model/AddressBookEntryTests.swift
@@ -16,28 +16,27 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 import WireUtilities
 import Contacts
 
-class AddressBookEntryTests : ZMBaseManagedObjectTest {
+class AddressBookEntryTests: ZMBaseManagedObjectTest {
 
     func testThatItReturnsTrackedKeys() {
-        
+
         // GIVEN
         let entry = AddressBookEntry.insertNewObject(in: self.uiMOC)
-        
+
         // WHEN
         let keys = entry.keysTrackedForLocalModifications()
-        
+
         // THEN
         XCTAssertTrue(keys.isEmpty)
     }
-    
+
     @available(iOS 9.0, *)
     func testThatItCreatesEntryFromContact() {
-        
+
         // GIVEN
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         let contact = CNMutableContact()
@@ -45,14 +44,14 @@ class AddressBookEntryTests : ZMBaseManagedObjectTest {
         contact.givenName = "MyName"
         contact.emailAddresses.append(CNLabeledValue(label: "home", value: "foo@example.com"))
         contact.phoneNumbers.append(CNLabeledValue(label: "home", value: CNPhoneNumber(stringValue: "+15557654321")))
-        
+
         // WHEN
         let sut = AddressBookEntry.create(from: contact, managedObjectContext: self.uiMOC, user: user)
-        
+
         // THEN
         XCTAssertEqual(sut.localIdentifier, contact.identifier)
         XCTAssertEqual(sut.cachedName, "MyName TheFamily")
         XCTAssertEqual(sut.user, user)
-        
+
     }
 }

--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -18,13 +18,12 @@
 
 @testable import WireDataModel
 
+class AssetColletionBatchedTests: ModelObjectsTests {
 
-class AssetColletionBatchedTests : ModelObjectsTests {
-    
-    var sut : AssetCollectionBatched!
-    var delegate : MockAssetCollectionDelegate!
-    var conversation : ZMConversation!
-    
+    var sut: AssetCollectionBatched!
+    var delegate: MockAssetCollectionDelegate!
+    var conversation: ZMConversation!
+
     override func setUp() {
         super.setUp()
         delegate = MockAssetCollectionDelegate()
@@ -32,7 +31,7 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         conversation.remoteIdentifier = UUID()
         uiMOC.saveOrRollback()
     }
-    
+
     override func tearDown() {
         delegate = nil
         sut?.tearDown()
@@ -42,16 +41,15 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         conversation = nil
         super.tearDown()
     }
-    
-    var defaultMatchPair : CategoryMatch {
+
+    var defaultMatchPair: CategoryMatch {
         return CategoryMatch(including: .image, excluding: .none)
     }
-    
-    
+
     @discardableResult func insertAssetMessages(count: Int) -> [ZMMessage] {
-        var offset : TimeInterval = 0
+        var offset: TimeInterval = 0
         var messages = [ZMMessage]()
-        (0..<count).forEach{ _ in
+        (0..<count).forEach { _ in
             let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMMessage
             offset = offset + 5
             message.setValue(Date().addingTimeInterval(offset), forKey: "serverTimestamp")
@@ -61,105 +59,105 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         uiMOC.saveOrRollback()
         return messages
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountSmallerThanInitialFetchCount() {
         // given
         let totalMessageCount = AssetCollectionBatched.defaultFetchCount - 10
         XCTAssertGreaterThan(totalMessageCount, 0)
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 1)
         XCTAssertTrue(sut.fetchingDone)
-        
+
         let receivedMessageCount = delegate.messagesByFilter.first?[defaultMatchPair]?.count
         XCTAssertEqual(receivedMessageCount, totalMessageCount)
-        
+
         guard let lastMessage =  delegate.messagesByFilter.last?[defaultMatchPair]?.last,
             let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItGetsMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertTrue(receivedMessages.first!.compare(receivedMessages.last!) == .orderedDescending)
         XCTAssertEqual(messages.first, receivedMessages.last)
         XCTAssertEqual(messages.last, receivedMessages.first)
     }
-    
-    func testThatItReturnsUIObjects(){
+
+    func testThatItReturnsUIObjects() {
         // given
         insertAssetMessages(count: 1)
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // when
         let messages = sut.assets(for: defaultMatchPair)
-        
+
         // then
         XCTAssertEqual(messages.count, 1)
-        guard let message = messages.first as? ZMMessage , let moc = message.managedObjectContext else {return XCTFail()}
+        guard let message = messages.first as? ZMMessage, let moc = message.managedObjectContext else {return XCTFail()}
         XCTAssertTrue(moc.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountEqualDefaultFetchCount() {
         // given
         let totalMessageCount = AssetCollectionBatched.defaultFetchCount
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 1)
         XCTAssertTrue(sut.fetchingDone)
-        
+
         let receivedMessageCount = delegate.messagesByFilter.first?[defaultMatchPair]?.count
         XCTAssertEqual(receivedMessageCount, totalMessageCount)
-        
+
         guard let lastMessage =  delegate.messagesByFilter.last?[defaultMatchPair]?.last,
             let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountGreaterThanInitialFetchCount() {
         // given
         let totalMessageCount = 2 * AssetCollectionBatched.defaultFetchCount
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         // messages were filtered in three batches
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 2)
         XCTAssertTrue(sut.fetchingDone)
-        
+
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertEqual(receivedMessages.count, totalMessageCount)
-        
+
         guard let lastMessage =  receivedMessages.last,
             let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCallsTheDelegateWhenTheMessageCountIsZero() {
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
@@ -170,23 +168,23 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertTrue(sut.fetchingDone)
     }
-    
+
     func testThatItCanCancelFetchingMessages() {
         // given
         let totalMessageCount = 5 * AssetCollectionBatched.defaultFetchCount
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         sut.tearDown()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         // messages would filtered in three batches if the fetching was not cancelled
         XCTAssertNotEqual(delegate.messagesByFilter.count, 5)
         XCTAssertTrue(sut.fetchingDone)
     }
-    
+
     func testPerformanceOfMessageFetching() {
         // Before caching:
         // 1 category, 100 paging, messages: average: 0.270, relative standard deviation: 8.876%, values: [0.341864, 0.262725, 0.264362, 0.266097, 0.260730, 0.264372, 0.257983, 0.262659, 0.260060, 0.261362],
@@ -196,35 +194,35 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         // 1 category, 1000 paging, messages: average: 0.286, relative standard deviation: 9.671%, values: [0.368397, 0.275279, 0.274547, 0.276134, 0.275657, 0.275912, 0.274775, 0.274407, 0.278609, 0.288635]
         // 2 categories, 200 paging - average: 0.512, relative standard deviation: 4.773%, values: [0.584575, 0.500881, 0.510514, 0.499623, 0.502749, 0.502768, 0.505693, 0.502528, 0.505087, 0.503482]
         // 10.000 messages, 1 category, 200 paging, average: 2.960, relative standard deviation: 5.543%, values: [3.370468, 2.725436, 2.806839, 2.851691, 3.032464, 2.910135, 3.004918, 2.986125, 2.953004, 2.957812]
-        
+
         // given
         insertAssetMessages(count: 1000)
-        uiMOC.registeredObjects.forEach{uiMOC.refresh($0, mergeChanges: false)}
-        
+        uiMOC.registeredObjects.forEach {uiMOC.refresh($0, mergeChanges: false)}
+
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            
+
             // when
             self.startMeasuring()
             self.sut = AssetCollectionBatched(conversation: self.conversation, matchingCategories: [self.defaultMatchPair], delegate: self.delegate)
             XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-            
+
             self.stopMeasuring()
-            
+
             // then
             self.sut.tearDown()
             self.sut = nil
-            self.uiMOC.registeredObjects.forEach{self.uiMOC.refresh($0, mergeChanges: false)}
+            self.uiMOC.registeredObjects.forEach {self.uiMOC.refresh($0, mergeChanges: false)}
         }
     }
-    
-    func testThatItReturnsPreCategorizedItems(){
+
+    func testThatItReturnsPreCategorizedItems() {
         // given
         insertAssetMessages(count: 10)
-        
+
         // when
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -232,136 +230,136 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertEqual(receivedMessages.count, 10)
     }
-    
+
     func testThatItGetsPreCategorizedMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
 
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertTrue(receivedMessages.first!.compare(receivedMessages.last!) == .orderedDescending)
         XCTAssertEqual(messages.first, receivedMessages.last)
         XCTAssertEqual(messages.last, receivedMessages.first)
     }
-    
-    func testThatItExcludesDefinedCategories_PreCategorized(){
+
+    func testThatItExcludesDefinedCategories_PreCategorized() {
         // given
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
         uiMOC.saveOrRollback()
-        
+
         // when
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [excludingGif], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.messagesByFilter.first?[excludingGif]?.count
         XCTAssertNil(receivedMessages)
-        
+
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .noAssetsToFetch)
     }
-    
-    func testThatItExcludesDefinedCategories_NotPreCategorized(){
+
+    func testThatItExcludesDefinedCategories_NotPreCategorized() {
         // given
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
         uiMOC.saveOrRollback()
-        
+
         // when
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [excludingGif], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: excludingGif)
         XCTAssertEqual(receivedMessages.count, 0)
-        
+
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .noAssetsToFetch)
     }
-    
-    func testThatItFetchesImagesAndTextMessages(){
+
+    func testThatItFetchesImagesAndTextMessages() {
         // given
         insertAssetMessages(count: 10)
         try! conversation.appendText(content: "foo")
         uiMOC.saveOrRollback()
-        
+
         // when
         let textMatchPair = CategoryMatch(including: .text, excluding: .none)
 
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair, textMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedAssets = delegate.allMessages(for: defaultMatchPair)
         XCTAssertEqual(receivedAssets.count, 10)
-        
+
         let receivedTexts = delegate.allMessages(for: textMatchPair)
         XCTAssertEqual(receivedTexts.count, 1)
-        
+
         XCTAssertEqual(delegate.result, .success)
         XCTAssertTrue(delegate.finished.contains(defaultMatchPair))
         XCTAssertTrue(delegate.finished.contains(textMatchPair))
     }
-    
-    func testThatItSortsExcludingCategories(){
+
+    func testThatItSortsExcludingCategories() {
         // given
         insertAssetMessages(count: 1)
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
         uiMOC.saveOrRollback()
-        
+
         // when
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         let onlyGif = CategoryMatch(including: .GIF, excluding: .none)
         let allImages = CategoryMatch(including: .image, excluding: .none)
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [excludingGif, onlyGif, allImages], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedNonGifs = delegate.allMessages(for: excludingGif)
         let receivedGifs = delegate.allMessages(for: onlyGif)
         let receivedImages = delegate.allMessages(for: allImages)
-        
+
         XCTAssertEqual(receivedNonGifs.count, 1)
         XCTAssertEqual(receivedGifs.count, 1)
         XCTAssertEqual(receivedImages.count, 2)
-        
+
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .success)
     }
-    
-    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects(){
+
+    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects() {
         // given
         let messages = insertAssetMessages(count: 20)
-        messages[0..<10].forEach{_ = $0.cachedCategory}
+        messages[0..<10].forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true){ result, element in
+        XCTAssertTrue(allMessages.reduce(true) { result, element in
             guard let message = element as? ZMMessage else { return false }
             return result && message.managedObjectContext!.zm_isUserInterfaceContext
         })
     }
-    
-    func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized(){
+
+    func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized() {
         // given
         let includedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
         let excludedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
@@ -369,9 +367,9 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         excludedMessage.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         includedMessage.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         uiMOC.saveOrRollback()
-        
-        let match = CategoryMatch(including:.file, excluding:.none)
-        
+
+        let match = CategoryMatch(including: .file, excluding: .none)
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [match], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -381,7 +379,7 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         XCTAssertEqual(receivedMessages.count, 1)
         XCTAssertEqual(receivedMessages.first, includedMessage)
     }
-    
+
     func testThatItDoesNotReturnFailedToUploadAssets_PreCategorized() {
         // given
         let includedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
@@ -389,13 +387,13 @@ class AssetColletionBatchedTests : ModelObjectsTests {
         excludedMessage.transferState = .uploadingFailed
         excludedMessage.updateCategoryCache()
         uiMOC.saveOrRollback()
-        
-        let match = CategoryMatch(including:.file, excluding:.none)
-        
+
+        let match = CategoryMatch(including: .file, excluding: .none)
+
         // when
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [match], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: match)
         XCTAssertEqual(receivedMessages.count, 1)

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -18,44 +18,43 @@
 
 @testable import WireDataModel
 
-class MockAssetCollectionDelegate : NSObject, AssetCollectionDelegate {
-    
+class MockAssetCollectionDelegate: NSObject, AssetCollectionDelegate {
+
     var messagesByFilter = [[CategoryMatch: [ZMMessage]]]()
     var didCallDelegate = false
-    var result : AssetFetchResult?
+    var result: AssetFetchResult?
     var finished: [CategoryMatch] = []
-    
+
     public func assetCollectionDidFinishFetching(collection: ZMCollection, result: AssetFetchResult) {
         self.result = result
         didCallDelegate = true
     }
-    
-    public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMConversationMessage]], hasMore: Bool) {
+
+    public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch: [ZMConversationMessage]], hasMore: Bool) {
         // For testing purposes it's easier to work with ZMMessage directly
         var toAppend = [CategoryMatch: [ZMMessage]]()
         for (key, value) in messages {
             toAppend[key] = value.map { $0 as! ZMMessage }
         }
         messagesByFilter.append(toAppend)
-        
+
         didCallDelegate = true
         if !hasMore {
             finished = finished + messages.keys
         }
     }
-    
+
     func allMessages(for categoryMatch: CategoryMatch) -> [ZMMessage] {
-        return messagesByFilter.reduce([ZMMessage]()){$0 + ($1[categoryMatch] ?? [])}
+        return messagesByFilter.reduce([ZMMessage]()) {$0 + ($1[categoryMatch] ?? [])}
     }
 }
 
+class AssetColletionTests: ModelObjectsTests {
 
-class AssetColletionTests : ModelObjectsTests {
+    var sut: AssetCollection!
+    var delegate: MockAssetCollectionDelegate!
+    var conversation: ZMConversation!
 
-    var sut : AssetCollection!
-    var delegate : MockAssetCollectionDelegate!
-    var conversation : ZMConversation!
-    
     override func setUp() {
         super.setUp()
         delegate = MockAssetCollectionDelegate()
@@ -63,7 +62,7 @@ class AssetColletionTests : ModelObjectsTests {
         conversation.remoteIdentifier = UUID()
         uiMOC.saveOrRollback()
     }
-    
+
     override func tearDown() {
         delegate = nil
         sut?.tearDown()
@@ -73,15 +72,15 @@ class AssetColletionTests : ModelObjectsTests {
         conversation = nil
         super.tearDown()
     }
-    
-    var defaultMatchPair : CategoryMatch {
+
+    var defaultMatchPair: CategoryMatch {
         return CategoryMatch(including: .image, excluding: .none)
     }
-    
+
     @discardableResult func insertAssetMessages(count: Int) -> [ZMMessage] {
-        var offset : TimeInterval = 0
+        var offset: TimeInterval = 0
         var messages = [ZMMessage]()
-        (0..<count).forEach{ _ in
+        (0..<count).forEach { _ in
             let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMMessage
             offset = offset + 5
             message.setValue(Date().addingTimeInterval(offset), forKey: "serverTimestamp")
@@ -91,48 +90,47 @@ class AssetColletionTests : ModelObjectsTests {
         uiMOC.saveOrRollback()
         return messages
     }
-    
-    
+
     func testThatItGetsMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertTrue(receivedMessages.first!.compare(receivedMessages.last!) == .orderedDescending)
         XCTAssertEqual(messages.first, receivedMessages.last)
         XCTAssertEqual(messages.last, receivedMessages.first)
     }
-    
-    func testThatItReturnsUIObjects(){
+
+    func testThatItReturnsUIObjects() {
         // given
         insertAssetMessages(count: 1)
         sut = AssetCollection(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // when
         let messages = sut.assets(for: defaultMatchPair)
-        
+
         // then
         XCTAssertEqual(messages.count, 1)
-        guard let message = messages.first as? ZMMessage , let moc = message.managedObjectContext else {return XCTFail()}
+        guard let message = messages.first as? ZMMessage, let moc = message.managedObjectContext else {return XCTFail()}
         XCTAssertTrue(moc.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountSmallerThanInitialFetchCount() {
         // given
         let totalMessageCount = AssetCollection.initialFetchCount - 10
         XCTAssertGreaterThan(totalMessageCount, 0)
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 1)
@@ -140,201 +138,200 @@ class AssetColletionTests : ModelObjectsTests {
 
         let receivedMessageCount = delegate.messagesByFilter.first?[self.defaultMatchPair]?.count
         XCTAssertEqual(receivedMessageCount, 90)
-        
+
         guard let lastMessage =  delegate.messagesByFilter.last?[self.defaultMatchPair]?.last,
               let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountEqualInitialFetchCount() {
         // given
         let totalMessageCount = AssetCollection.initialFetchCount
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 1)
         XCTAssertTrue(sut.fetchingDone)
-        
+
         let receivedMessageCount = delegate.messagesByFilter.first?[self.defaultMatchPair]?.count
         XCTAssertEqual(receivedMessageCount, 100)
-        
+
         guard let lastMessage =  delegate.messagesByFilter.last?[self.defaultMatchPair]?.last,
             let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCanGetMessages_TotalMessageCountGreaterThanInitialFetchCount() {
         // given
         let totalMessageCount = 2 * AssetCollection.defaultFetchCount
         XCTAssertGreaterThan(totalMessageCount, AssetCollection.initialFetchCount)
 
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         // messages were filtered in three batches
         XCTAssertEqual(delegate.result, .success)
         XCTAssertEqual(delegate.messagesByFilter.count, 3)
         XCTAssertTrue(sut.fetchingDone)
-        
+
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertEqual(receivedMessages.count, 1000)
-        
+
         guard let lastMessage =  receivedMessages.last,
             let context = lastMessage.managedObjectContext else { return XCTFail() }
         XCTAssertTrue(context.zm_isUserInterfaceContext)
     }
-    
+
     func testThatItCallsTheDelegateWhenTheMessageCountIsZero() {
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.result, .noAssetsToFetch)
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertTrue(sut.fetchingDone)
     }
-    
+
     func testThatItCanCancelFetchingMessages() {
         // given
         let totalMessageCount = 2 * AssetCollection.defaultFetchCount
         insertAssetMessages(count: totalMessageCount)
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         sut.tearDown()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         // messages would filtered in three batches if the fetching was not cancelled
         XCTAssertNotEqual(delegate.messagesByFilter.count, 3)
         XCTAssertTrue(sut.fetchingDone)
     }
-    
+
     func testPerformanceOfMessageFetching() {
         // Before caching:
         // 1000 messages, 1 category, 500 defaultpaging, average: 0.275, relative standard deviation: 8.967%, values: [0.348496, 0.263188, 0.266409, 0.268903, 0.265612, 0.265829, 0.271573, 0.265206, 0.268697, 0.264837]
         // 1000 messages, 1 category, 200 defaultpaging, average: 0.304, relative standard deviation: 9.818%, values: [0.390736, 0.285759, 0.293118, 0.290341, 0.293730, 0.281093, 0.292787, 0.305865, 0.306954, 0.302983]
         // 1000 messages, 2 categories, 500 defaultpaging, average: 0.570, relative standard deviation: 5.990%, values: [0.656057, 0.526296, 0.530267, 0.572129, 0.557102, 0.586183, 0.574734, 0.580168, 0.563595, 0.556718]
         // 10000 messages, average: 3.495, relative standard deviation: 7.352%, values: [4.259749, 3.372894, 3.389057, 3.404054, 3.363652, 3.400085, 3.416911, 3.417086, 3.442652, 3.488077],
-        
+
         // given
         insertAssetMessages(count: 1000)
-        uiMOC.registeredObjects.forEach{uiMOC.refresh($0, mergeChanges: false)}
-        
+        uiMOC.registeredObjects.forEach {uiMOC.refresh($0, mergeChanges: false)}
+
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
-            
+
             // when
             self.startMeasuring()
             self.sut = AssetCollection(conversation: self.conversation, matchingCategories: [self.defaultMatchPair], delegate: self.delegate)
             XCTAssert(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-            
+
             self.stopMeasuring()
-            
+
             // then
             self.sut.tearDown()
             self.sut = nil
-            self.uiMOC.registeredObjects.forEach{self.uiMOC.refresh($0, mergeChanges: false)}
+            self.uiMOC.registeredObjects.forEach {self.uiMOC.refresh($0, mergeChanges: false)}
         }
     }
-    
-    func testThatItReturnsPreCategorizedItems(){
+
+    func testThatItReturnsPreCategorizedItems() {
         // given
         insertAssetMessages(count: 10)
-        
+
         // when
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessageCount = delegate.messagesByFilter.first?[self.defaultMatchPair]?.count
         XCTAssertEqual(receivedMessageCount, 10)
     }
-    
-    
+
     func testThatItGetsPreCategorizedMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: defaultMatchPair)
         XCTAssertTrue(receivedMessages.first!.compare(receivedMessages.last!) == .orderedDescending)
         XCTAssertEqual(messages.first, receivedMessages.last)
         XCTAssertEqual(messages.last, receivedMessages.first)
     }
-    
-    func testThatItExcludesDefinedCategories_PreCategorized(){
+
+    func testThatItExcludesDefinedCategories_PreCategorized() {
         // given
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
-        
+
         // when
-        conversation.allMessages.forEach{_ = $0.cachedCategory}
+        conversation.allMessages.forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         sut = AssetCollection(conversation: conversation, matchingCategories: [excludingGif], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         XCTAssertEqual(delegate.messagesByFilter.count, 0)
-        
+
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .noAssetsToFetch)
     }
-    
-    func testThatItExcludesDefinedCategories_NotPreCategorized(){
+
+    func testThatItExcludesDefinedCategories_NotPreCategorized() {
         // given
         insertAssetMessages(count: 1)
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
         uiMOC.saveOrRollback()
-        
+
         // when
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         sut = AssetCollection(conversation: conversation, matchingCategories: [excludingGif], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.messagesByFilter.first?[excludingGif]?.count
         XCTAssertEqual(receivedMessages, 1)
-        
+
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .success)
     }
-    
-    func testThatItSortsExcludingCategories(){
+
+    func testThatItSortsExcludingCategories() {
         // given
         insertAssetMessages(count: 1)
-        
+
         let data = self.data(forResource: "animated", extension: "gif")!
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
         uiMOC.saveOrRollback()
-        
+
         // when
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         let onlyGif = CategoryMatch(including: .GIF, excluding: .none)
         let allImages = defaultMatchPair
         sut = AssetCollection(conversation: conversation, matchingCategories: [excludingGif, onlyGif, allImages], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedNonGifs = delegate.allMessages(for: excludingGif)
         let receivedGifs = delegate.allMessages(for: onlyGif)
@@ -347,49 +344,49 @@ class AssetColletionTests : ModelObjectsTests {
         XCTAssertTrue(delegate.didCallDelegate)
         XCTAssertEqual(delegate.result, .success)
     }
-    
-    func testThatItFetchesImagesAndTextMessages(){
+
+    func testThatItFetchesImagesAndTextMessages() {
         // given
         insertAssetMessages(count: 10)
         try! conversation.appendText(content: "foo")
         uiMOC.saveOrRollback()
-        
+
         // when
         let textMatchPair = CategoryMatch(including: .text, excluding: .none)
 
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair, textMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedAssets = delegate.allMessages(for: defaultMatchPair)
         XCTAssertEqual(receivedAssets.count, 10)
-        
+
         let receivedTexts = delegate.allMessages(for: textMatchPair)
         XCTAssertEqual(receivedTexts.count, 1)
-        
+
         XCTAssertEqual(delegate.result, .success)
     }
-    
-    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects(){
+
+    func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects() {
         // given
         let messages = insertAssetMessages(count: 20)
-        messages[0..<10].forEach{_ = $0.cachedCategory}
+        messages[0..<10].forEach {_ = $0.cachedCategory}
         uiMOC.saveOrRollback()
-        
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true){ result, element in
+        XCTAssertTrue(allMessages.reduce(true) { result, element in
             guard let message = element as? ZMMessage else { return false }
             return result && message.managedObjectContext!.zm_isUserInterfaceContext
         })
     }
-    
-    func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized(){
+
+    func testThatItDoesNotReturnFailedToUploadAssets_Uncategorized() {
         // given
         let includedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
         let excludedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
@@ -397,38 +394,36 @@ class AssetColletionTests : ModelObjectsTests {
         excludedMessage.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         includedMessage.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)
         uiMOC.saveOrRollback()
-        
-        let match = CategoryMatch(including:.file, excluding:.none)
-        
+
+        let match = CategoryMatch(including: .file, excluding: .none)
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [match], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: match)
         XCTAssertEqual(receivedMessages.count, 1)
         XCTAssertEqual(receivedMessages.first, includedMessage)
     }
-    
-    func testThatItDoesNotReturnFailedToUploadAssets_PreCategorized(){
+
+    func testThatItDoesNotReturnFailedToUploadAssets_PreCategorized() {
         // given
         let includedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
         let excludedMessage = try! self.conversation.appendFile(with: ZMVideoMetadata(fileURL: self.fileURL(forResource: "video", extension: "mp4"), thumbnail: self.verySmallJPEGData())) as! ZMAssetClientMessage
         excludedMessage.transferState = .uploadingFailed
         excludedMessage.updateCategoryCache()
         uiMOC.saveOrRollback()
-        
-        let match = CategoryMatch(including:.file, excluding:.none)
-        
+
+        let match = CategoryMatch(including: .file, excluding: .none)
+
         // when
         sut = AssetCollection(conversation: conversation, matchingCategories: [match], delegate: delegate)
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // then
         let receivedMessages = delegate.allMessages(for: match)
         XCTAssertEqual(receivedMessages.count, 1)
         XCTAssertEqual(receivedMessages.first, includedMessage)
     }
 }
-
-

--- a/Tests/Source/Model/Conversation/ConversationObserverTests+ActiveParticipants.swift
+++ b/Tests/Source/Model/Conversation/ConversationObserverTests+ActiveParticipants.swift
@@ -18,27 +18,26 @@
 
 @testable import WireDataModel
 
-
 // MARK: - Participants
 extension ConversationObserverTests {
-    
+
     func testThatItRecalculatesActiveParticipantsWhenIsSelfActiveUserKeyChanges() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
         conversation.add(user: ZMUser.selfUser(in: uiMOC), isFromLocal: true)
-        
+
         let user1 = ZMUser.insertNewObject(in: uiMOC)
         let user2 = ZMUser.insertNewObject(in: uiMOC)
-        
+
         conversation.internalAddParticipants([user1, user2])
-        
+
         XCTAssert(conversation.isSelfAnActiveMember)
         XCTAssertEqual(conversation.participantRoles.count, 3)
         XCTAssertEqual(conversation.activeParticipants.count, 3)
-        
+
         // when
-        
+
         checkThatItNotifiesTheObserverOfAChange(conversation,
                                                 modifier: { conversation, _ in
                                                     conversation.minus(user: ZMUser.selfUser(in: uiMOC), isFromLocal: true)},
@@ -48,7 +47,6 @@ extension ConversationObserverTests {
                                                 expectedChangedKeys: ["localParticipantRoles", "displayName", "activeParticipants"]
         )
 
-        
         // then
         XCTAssertFalse(conversation.isSelfAnActiveMember)
         XCTAssertEqual(conversation.participantRoles.count, 2)
@@ -60,17 +58,17 @@ extension ConversationObserverTests {
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
         conversation.add(user: ZMUser.selfUser(in: uiMOC), isFromLocal: true)
-        
+
         let user1 = ZMUser.insertNewObject(in: uiMOC)
         let user2 = ZMUser.insertNewObject(in: uiMOC)
         conversation.internalAddParticipants([user1, user2])
-        
+
         XCTAssert(conversation.isSelfAnActiveMember)
         XCTAssertEqual(conversation.participantRoles.count, 3)
         XCTAssertEqual(conversation.activeParticipants.count, 3)
-        
+
         // when
-        
+
         checkThatItNotifiesTheObserverOfAChange(conversation,
                                                 modifier: { conversation, _ in
                                                     conversation.internalRemoveParticipants([user2],

--- a/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
@@ -20,14 +20,14 @@ import Foundation
 @testable import WireDataModel
 
 final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
-    
+
     func testThatItInsertsANewConversation() {
         // given
         let user1 = createUser()
         let user2 = createUser()
         let user3 = createUser()
         let selfUser = ZMUser.selfUser(in: uiMOC)
-        
+
         // when
         let conversation = ZMConversation.insertGroupConversation(moc: uiMOC,
                                                                   participants: [user1, user2, user3],
@@ -36,46 +36,45 @@ final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
                                                                   allowGuests: true,
                                                                   readReceipts: false,
                                                                   participantsRole: nil)
-        
+
         // then
         let conversations = ZMConversation.conversationsIncludingArchived(in: uiMOC)
-        
+
         XCTAssertEqual(conversations.count, 1)
         let fetchedConversation = conversations[0] as? ZMConversation
         XCTAssertEqual(fetchedConversation?.conversationType, .group)
         XCTAssertEqual(conversation?.objectID, fetchedConversation?.objectID)
-        
+
         let expectedParticipants = Set<AnyHashable>([user1, user2, user3, selfUser])
         XCTAssertEqual(expectedParticipants, conversation?.localParticipants)
     }
 
     func testThatItInsertsANewConversationInUIContext() {
         // given
-        
+
         let user1 = ZMUser.insertNewObject(in: uiMOC)
         let user2 = ZMUser.insertNewObject(in: uiMOC)
         let user3 = ZMUser.insertNewObject(in: uiMOC)
         let selfUser = ZMUser.selfUser(in: uiMOC)
-        
+
         // when
         let conversation = ZMConversation.insertGroupConversation(moc: uiMOC, participants: [user1, user2, user3], name: nil, team: nil, allowGuests: true, readReceipts: false, participantsRole: nil)
-        
+
         try! uiMOC.save()
 
-        
         // then
         XCTAssertNotNil(conversation)
-        
+
         let fetchRequest = ZMConversation.sortedFetchRequest()
         let conversations = uiMOC.executeFetchRequestOrAssert(fetchRequest)
-        
+
         XCTAssertEqual(conversations.count, 1)
         let fetchedConversation = conversations[0] as? ZMConversation
         XCTAssertEqual(conversation?.objectID, fetchedConversation?.objectID)
-        
+
         let expectedParticipants = Set<AnyHashable>([user1, user2, user3, selfUser])
         XCTAssertEqual(expectedParticipants, conversation?.localParticipants)
-        
+
     }
 
 }

--- a/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 final class ConversationTests: ZMConversationTestsBase {
-    
+
     @discardableResult
     private func insertMockGroupConversation(userDefinedName: String) -> ZMConversation {
         let selfUser = ZMUser.selfUser(in: uiMOC)
@@ -28,20 +28,20 @@ final class ConversationTests: ZMConversationTestsBase {
         conversation.conversationType = .group
         conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
         uiMOC.saveOrRollback()
-        let _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
-        
+        _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
+
         return conversation
     }
 
     func testThatItFindsConversationByUserDefinedNameDiacriticsWithSymbol() {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
-        
+
         // when
-        
+
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "@Sømebôdy", selfUser: selfUser))
         let result = uiMOC.executeFetchRequestOrAssert(request)
-        
+
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
@@ -50,12 +50,12 @@ final class ConversationTests: ZMConversationTestsBase {
     func testThatItFindsConversationByUserDefinedNameDiacritics() {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
-        
+
         // when
-        
+
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy", selfUser: selfUser))
         let result = uiMOC.executeFetchRequestOrAssert(request)
-        
+
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
@@ -80,25 +80,24 @@ final class ConversationTests: ZMConversationTestsBase {
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
 
         // when
-        
+
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy ", selfUser: selfUser))
         let result = uiMOC.executeFetchRequestOrAssert(request)
-        
+
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
     }
-
 
     func testThatItFindsConversationWithQueryStringWithWords() {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ to")
 
         // when
-        
+
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy to", selfUser: selfUser))
         let result = uiMOC.executeFetchRequestOrAssert(request)
-        
+
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
@@ -114,12 +113,12 @@ extension ConversationTests {
         conversation.remoteIdentifier = UUID.create()
         let sender = ZMUser.insertNewObject(in: self.uiMOC)
         sender.remoteIdentifier = UUID.create()
-        
+
         // when
         let message = try! conversation.appendText(content: "Test Message") as! ZMMessage
         message.sender = sender
         message.markAsSent()
-        
+
         let genericMessage = GenericMessage(content: MessageEdit(replacingMessageID: message.nonce!, text: Text(content: "Edited Test Message", mentions: [], linkPreviews: [], replyingTo: nil)), nonce: UUID.create())
         let genericMessageData = try? genericMessage.serializedData()
         let payload: NSDictionary = [
@@ -132,12 +131,12 @@ extension ConversationTests {
             "type": "conversation.otr-message-add"
         ]
         let updateEvent = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: UUID.create())
-        
+
         var newMessage: ZMClientMessage?
         self.performPretendingUiMocIsSyncMoc {
             newMessage = ZMClientMessage.createOrUpdate(from: updateEvent!, in: self.uiMOC, prefetchResult: nil)
         }
-        
+
         // then
         XCTAssertNil(conversation.lastEditableMessage)
         XCTAssertNotNil(newMessage)
@@ -152,28 +151,28 @@ extension ConversationTests {
         var updatedConversation: ZMConversation?
         let oldLastRead = Date()
         let newLastRead = oldLastRead.addingTimeInterval(100)
-        
+
         self.syncMOC.performGroupedAndWait {_ in
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             XCTAssertNotNil(selfUserID)
-            
+
             updatedConversation = ZMConversation.insertNewObject(in: self.syncMOC)
             updatedConversation?.remoteIdentifier = UUID.create()
             updatedConversation?.lastReadServerTimeStamp = oldLastRead
-            
-            let message = GenericMessage(content: LastRead(conversationID: updatedConversation!.remoteIdentifier!, lastReadTimestamp: newLastRead) , nonce: UUID.create())
+
+            let message = GenericMessage(content: LastRead(conversationID: updatedConversation!.remoteIdentifier!, lastReadTimestamp: newLastRead), nonce: UUID.create())
             let contentData = try? message.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : newLastRead.transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": newLastRead.transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
         }
@@ -182,85 +181,85 @@ extension ConversationTests {
             XCTAssertEqual(updatedConversation!.lastReadServerTimeStamp!.timeIntervalSince1970, newLastRead.timeIntervalSince1970, accuracy: 1.5)
         }
     }
-    
+
     func testThatItRemovesTheMessageWhenItReceivesAHidingMessage() {
         // given
         self.syncMOC.performGroupedAndWait {_ in
-            
+
             // given
             let messageID = UUID.create()
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             XCTAssertNotNil(selfUserID)
-            
+
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
             try! conversation.appendText(content: "Le fromage c'est delicieux", mentions: [], fetchLinkPreview: true, nonce: messageID)
-            
+
             let message = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: messageID), nonce: UUID.create())
             let contentData = try? message.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
-            
+
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
             self.syncMOC.saveOrRollback()
-            
+
             // then
             let fetchedMessage = ZMMessage.fetch(withNonce: messageID, for: conversation, in: self.syncMOC)
             XCTAssertNil(fetchedMessage)
         }
     }
-    
+
     func testThatItRemovesImageAssetsWhenItReceivesADeletionMessage() {
         // given
         self.syncMOC.performGroupedAndWait {_ in
-            
+
             // given
             let messageID = UUID.create()
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             let imageData = Data.secureRandomData(length: 100)
             XCTAssertNotNil(selfUserID)
-            
+
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
-            let message = try! conversation.appendImage(from: self.verySmallJPEGData(), nonce: messageID) 
-            
+            let message = try! conversation.appendImage(from: self.verySmallJPEGData(), nonce: messageID)
+
             // store asset data
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.original, encrypted: false, data: imageData)
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.preview, encrypted: false, data: imageData)
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.medium, encrypted: false, data: imageData)
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.preview, encrypted: true, data: imageData)
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, format: ZMImageFormat.medium, encrypted: true, data: imageData)
-            
+
             // delete
             let deleteMessage = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: messageID), nonce: UUID.create())
             let contentData = try? deleteMessage.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
             self.syncMOC.saveOrRollback()
-            
+
             // then
-            
+
             XCTAssertNil(self.syncMOC.zm_fileAssetCache.assetData(message, format: ZMImageFormat.original, encrypted: false))
             XCTAssertNil(self.syncMOC.zm_fileAssetCache.assetData(message, format: ZMImageFormat.preview, encrypted: false))
             XCTAssertNil(self.syncMOC.zm_fileAssetCache.assetData(message, format: ZMImageFormat.medium, encrypted: false))
@@ -268,17 +267,17 @@ extension ConversationTests {
             XCTAssertNil(self.syncMOC.zm_fileAssetCache.assetData(message, format: ZMImageFormat.medium, encrypted: true))
         }
     }
-    
+
     func testThatItRemovesFileAssetsWhenItReceivesADeletionMessage() {
         // given
         self.syncMOC.performGroupedAndWait {_ in
-            
+
             // given
             let messageID = UUID.create()
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             let fileData = Data.secureRandomData(length: 100)
             let fileName = "foo.bar"
-                        
+
             let documentsURL = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
             let fileURL = URL(fileURLWithPath: documentsURL).appendingPathComponent(fileName)
             do {
@@ -286,79 +285,79 @@ extension ConversationTests {
             } catch {
                 XCTFail()
             }
-            
+
             XCTAssertNotNil(selfUserID)
-            
+
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
-            
+
             let fileMetadata = ZMFileMetadata.init(fileURL: fileURL, thumbnail: nil)
             let message = try! conversation.appendFile(with: fileMetadata, nonce: messageID)
-            
+
             // store asset data
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: fileData)
             self.syncMOC.zm_fileAssetCache.storeAssetData(message, encrypted: true, data: fileData)
-            
+
             // delete
             let deleteMessage = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: messageID), nonce: UUID.create())
             let contentData = try? deleteMessage.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
-            
+
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
             self.syncMOC.saveOrRollback()
-            
+
             // re-create message with same nonce to access the cache
             let lookupMessage = try! conversation.appendText(content: "123")
-            
+
             // then
-            
+
             XCTAssertNil(self.syncMOC.zm_fileAssetCache .assetData(lookupMessage, encrypted: false))
             XCTAssertNil(self.syncMOC.zm_fileAssetCache .assetData(lookupMessage, encrypted: true))
         }
     }
-    
+
     func testThatItDoesNotRemovesANonExistingMessageWhenItReceivesADeletionMessage() {
         self.syncMOC.performGroupedAndWait {_ in
-            
+
             // given
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             XCTAssertNotNil(selfUserID)
-            
+
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
-                        
+
             try! conversation.appendText(content: "Le fromage c'est delicieux", mentions: [], fetchLinkPreview: true, nonce: UUID.create())
             let previusMessagesCount = conversation.allMessages.count
 
             let message = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: UUID.create()), nonce: UUID.create())
             let contentData = try? message.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
-            
+
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
             self.syncMOC.saveOrRollback()
-            
+
             // then
             XCTAssertEqual(previusMessagesCount, conversation.allMessages.count)
         }
@@ -367,74 +366,74 @@ extension ConversationTests {
     func testThatItDoesNotRemovesAMessageWhenItReceivesADeletionMessageNotFromSelfUser() {
         // given
         self.syncMOC.performGroupedAndWait {_ in
-            
-            // given
-            let messageID = UUID.create()
-            let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
-            XCTAssertNotNil(selfUserID);
-            
-            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
-            conversation.remoteIdentifier = UUID.create()
 
-            try! conversation.appendText(content: "Le fromage c'est delicieux", mentions: [], fetchLinkPreview: true, nonce: messageID)
-            let previusMessagesCount = conversation.allMessages.count
-                        
-            let message = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: UUID.create()), nonce: UUID.create())
-            let contentData = try? message.serializedData()
-            let data = contentData?.base64EncodedString()
-            
-            let payload: NSDictionary = [
-                "conversation" : selfUserID?.transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
-                "type": "conversation.client-message-add"
-            ]
-            
-            let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
-            // when
-            ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
-            self.syncMOC.saveOrRollback()
-            
-            // then
-            XCTAssertEqual(previusMessagesCount, conversation.allMessages.count)
-        }
-    }
-    
-    func testThatItDoesNotRemovesAMessageWhenItReceivesADeletionMessageNotInTheSelfConversation() {
-        // given
-        self.syncMOC.performGroupedAndWait {_ in
-            
             // given
             let messageID = UUID.create()
             let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
             XCTAssertNotNil(selfUserID)
-            
+
             let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             conversation.remoteIdentifier = UUID.create()
 
             try! conversation.appendText(content: "Le fromage c'est delicieux", mentions: [], fetchLinkPreview: true, nonce: messageID)
             let previusMessagesCount = conversation.allMessages.count
-                        
+
             let message = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: UUID.create()), nonce: UUID.create())
             let contentData = try? message.serializedData()
             let data = contentData?.base64EncodedString()
-            
+
             let payload: NSDictionary = [
-                "conversation" : UUID.create().transportString(),
-                "time" : Date().transportString(),
-                "data" : data,
-                "from" : selfUserID?.transportString(),
+                "conversation": selfUserID?.transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
                 "type": "conversation.client-message-add"
             ]
-            
+
             let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
-            
+
             // when
             ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
             self.syncMOC.saveOrRollback()
-            
+
+            // then
+            XCTAssertEqual(previusMessagesCount, conversation.allMessages.count)
+        }
+    }
+
+    func testThatItDoesNotRemovesAMessageWhenItReceivesADeletionMessageNotInTheSelfConversation() {
+        // given
+        self.syncMOC.performGroupedAndWait {_ in
+
+            // given
+            let messageID = UUID.create()
+            let selfUserID = ZMUser.selfUser(in: self.syncMOC).remoteIdentifier
+            XCTAssertNotNil(selfUserID)
+
+            let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
+            conversation.remoteIdentifier = UUID.create()
+
+            try! conversation.appendText(content: "Le fromage c'est delicieux", mentions: [], fetchLinkPreview: true, nonce: messageID)
+            let previusMessagesCount = conversation.allMessages.count
+
+            let message = GenericMessage(content: MessageHide(conversationId: conversation.remoteIdentifier!, messageId: UUID.create()), nonce: UUID.create())
+            let contentData = try? message.serializedData()
+            let data = contentData?.base64EncodedString()
+
+            let payload: NSDictionary = [
+                "conversation": UUID.create().transportString(),
+                "time": Date().transportString(),
+                "data": data,
+                "from": selfUserID?.transportString(),
+                "type": "conversation.client-message-add"
+            ]
+
+            let event = ZMUpdateEvent.eventFromEventStreamPayload(payload, uuid: nil)
+
+            // when
+            ZMClientMessage.createOrUpdate(from: event!, in: self.syncMOC, prefetchResult: nil)
+            self.syncMOC.saveOrRollback()
+
             // then
             XCTAssertEqual(previusMessagesCount, conversation.allMessages.count)
         }

--- a/Tests/Source/Model/Conversation/ParticipantRoleTests.swift
+++ b/Tests/Source/Model/Conversation/ParticipantRoleTests.swift
@@ -21,18 +21,18 @@ import Foundation
 @testable import WireDataModel
 
 class ParticipantRoleTests: ZMBaseManagedObjectTest {
-    
+
     var user: ZMUser!
     var conversation: ZMConversation!
     var role: Role!
-    
+
     override func setUp() {
         super.setUp()
         self.user = ZMUser.insertNewObject(in: self.uiMOC)
         self.conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         self.role = Role.insertNewObject(in: self.uiMOC)
     }
-    
+
     private func createParticipantRole() -> ParticipantRole {
         let pr = ParticipantRole.insertNewObject(in: self.uiMOC)
         pr.user = user
@@ -40,25 +40,25 @@ class ParticipantRoleTests: ZMBaseManagedObjectTest {
         pr.role = role
         return pr
     }
-    
+
     func testThatServicesBelongToOneToOneConversations() {
-        
+
         // GIVEN
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
         let service = createService(in: uiMOC, named: "Bob the Robot")
-        
+
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.remoteIdentifier = UUID()
         conversation.conversationType = .group
-        
+
         let team = Team.insertNewObject(in: self.uiMOC)
         team.remoteIdentifier = UUID.create()
         conversation.team = team
-        
+
         // WHEN
         conversation.addParticipantAndUpdateConversationState(user: service as! ZMUser, role: nil)
         conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
-        
+
         // THEN
         XCTAssertTrue(ZMConversation.predicateForOneToOneConversations().evaluate(with: conversation))
     }

--- a/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
+++ b/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 @testable import WireDataModel
-
 
 fileprivate extension Notification {
 
@@ -31,7 +29,6 @@ fileprivate extension Notification {
     }
 
 }
-
 
 class ContextDidSaveNotificationPersistenceTests: BaseZMMessageTests {
 
@@ -125,7 +122,6 @@ class ContextDidSaveNotificationPersistenceTests: BaseZMMessageTests {
 
 }
 
-
 class ShareExtensionAnalyticsPersistenceTests: BaseZMMessageTests {
 
     var sut: ShareExtensionAnalyticsPersistence!
@@ -176,38 +172,38 @@ class ShareExtensionAnalyticsPersistenceTests: BaseZMMessageTests {
 
 class ShareObjectStoreTests: ZMTBaseTest {
     var sut: SharedObjectStore<WireDataModel.SharedObjectTestClass>!
-    
+
     override func setUp() {
         super.setUp()
         sut = createStore()
     }
-    
+
     override func tearDown() {
         sut.clear()
         sut = nil
         super.tearDown()
     }
-    
+
     func createStore() -> SharedObjectStore<WireDataModel.SharedObjectTestClass> {
         let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return SharedObjectStore(accountContainer: url, fileName: "store")
     }
-    
+
     func testThatItCanDecodeClassSavedBeforeProjectRename() {
         // Given
-        
+
         // Module prefix before project rename
         NSKeyedArchiver.setClassName("ZMCDataModel.SharedObjectTestClass", for: WireDataModel.SharedObjectTestClass.self)
         let item = WireDataModel.SharedObjectTestClass()
         item.flag = true
-        
+
         // When
         sut.store(item)
         sut = createStore()
-        
+
         // Then
         let items = sut.load()
         XCTAssertEqual(items.first?.flag, item.flag)
     }
-    
+
 }

--- a/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import XCTest
 import WireTesting
@@ -30,29 +29,29 @@ public class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         conversation.conversationType = .group
         return conversation
     }
-    
+
     func testThatItFetchesLastMessage() throws {
         // GIVEN
         let conversation = createConversation()
-        
+
         // WHEN
         (0...40).forEach { i in
             try! conversation.appendText(content: "\(i)")
         }
-        
+
         // THEN
         XCTAssertEqual(conversation.lastMessage?.textMessageData?.messageText, "40")
     }
-    
+
     func testThatItFetchesLastMessagesWithLimit() throws {
         // GIVEN
         let conversation = createConversation()
-        
+
         // WHEN
         (0...40).forEach { i in
             try! conversation.appendText(content: "\(i)")
         }
-        
+
         // THEN
         let lastMessages = conversation.lastMessages(limit: 10)
         XCTAssertEqual(lastMessages.count, 10)
@@ -99,17 +98,17 @@ public class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         XCTAssertEqual(otherLastMessages.last?.textMessageData?.messageText, "Other 1")
 
     }
-    
+
     func testThatItReturnsMessageIfLastMessageIsEditedTextAndSentBySelfUser() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
-        
+
         // when
         let message = try! conversation.appendText(content: "Test Message") as! ZMMessage
         message.sender = ZMUser.selfUser(in: self.uiMOC)
         message.markAsSent()
         message.textMessageData?.editText("Edited Test Message", mentions: [], fetchLinkPreview: true)
-        
+
         // then
         XCTAssertEqual(conversation.lastEditableMessage, message)
     }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
@@ -24,22 +24,22 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
     func conversation() -> ZMConversation {
         return ZMConversation.insertNewObject(in: self.uiMOC)
     }
-    
+
     var sut: ZMConversation!
     var team: Team!
-    
+
     override func setUp() {
         super.setUp()
         team = Team.insertNewObject(in: self.uiMOC)
         sut = conversation()
     }
-    
+
     override func tearDown() {
         team = nil
         sut = nil
         super.tearDown()
     }
-    
+
     func testThatItCanSetTheMode() {
         sut.accessMode = .teamOnly
         XCTAssertEqual(sut.accessMode, .teamOnly)
@@ -48,12 +48,12 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         // then
         XCTAssertEqual(sut.accessMode, .allowGuests)
     }
-    
+
     func testDefaultMode() {
         // when & then
         XCTAssertEqual(sut.accessMode, nil)
     }
-    
+
     func testThatItCanReadTheMode() {
         // when
         sut.accessMode = []
@@ -69,7 +69,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         // then
         XCTAssertFalse(sut.keysThatHaveLocalModifications.contains("accessModeStrings"))
     }
-    
+
     let testSetAccessMode: [(ConversationAccessMode?, [String]?)] = [(nil, nil),
                                                                      (ConversationAccessMode.teamOnly, []),
                                                                      (ConversationAccessMode.code, ["code"]),
@@ -77,7 +77,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
                                                                      (ConversationAccessMode.invite, ["invite"]),
                                                                      (ConversationAccessMode.legacy, ["invite"]),
                                                                      (ConversationAccessMode.allowGuests, ["code", "invite"])]
-    
+
     func testThatModeSetWithOptionSetReflectedInStrings() {
         testSetAccessMode.forEach {
             // when
@@ -91,7 +91,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             }
         }
     }
-    
+
     func testThatModeSetWithStringsIsReflectedInOptionSet() {
         testSetAccessMode.forEach {
             // when
@@ -105,7 +105,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             }
         }
     }
-    
+
     func testThatChangingAllowGuestsSetsAccessModeStrings() {
         [(true, ["code", "invite"], ConversationAccessRole.nonActivated.rawValue),
          (false, [], ConversationAccessRole.team.rawValue)].forEach {
@@ -116,7 +116,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             XCTAssertEqual(Set(sut.accessRoleString!), Set($0.2))
         }
     }
-    
+
     func testThatAccessModeStringsChangingAllowGuestsSets() {
         let values = [
             (true, ["code", "invite"], ConversationAccessRole.nonActivated.rawValue),
@@ -133,7 +133,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             XCTAssertEqual(sut.allowGuests, allowGuests)
         }
     }
-    
+
     func testThatTheConversationIsInsertedWithCorrectAccessModeAccessRole_Default_WithTeam() {
         // when
         let conversation = ZMConversation.insertGroupConversation(moc: self.uiMOC,
@@ -144,7 +144,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         XCTAssertEqual(Set(conversation.accessModeStrings!), ["code", "invite"])
         XCTAssertEqual(conversation.accessRoleString!, ConversationAccessRole.nonActivated.rawValue)
     }
-    
+
     func testThatTheConversationIsInsertedWithCorrectAccessModeAccessRole_Default_NoTeam() {
         // when
         let conversation = ZMConversation.insertGroupConversation(moc: self.uiMOC,
@@ -155,7 +155,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         XCTAssertTrue(conversation.accessModeStrings == nil)
         XCTAssertEqual(conversation.accessRoleString, nil)
     }
-    
+
     func testThatTheConversationIsInsertedWithCorrectAccessModeAccessRole() {
         [(true, ["code", "invite"], ConversationAccessRole.nonActivated.rawValue),
          (false, [], ConversationAccessRole.team.rawValue)].forEach {
@@ -170,12 +170,12 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             XCTAssertEqual(Set(conversation.accessRoleString!), Set($0.2))
         }
     }
-    
+
     let testSetAccessRole: [(ConversationAccessRole?, String?)] = [(ConversationAccessRole.activated, "activated"),
                                                                    (ConversationAccessRole.nonActivated, "non_activated"),
                                                                    (ConversationAccessRole.team, "team"),
                                                                    (nil, nil)]
-    
+
     func testThatAccessRoleSetAccessRoleString() {
         testSetAccessRole.forEach {
             // when
@@ -184,7 +184,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
             XCTAssertEqual(sut.accessRoleString, $0.1)
         }
     }
-    
+
     func testThatAccessRoleStringSetAccesseRole() {
         testSetAccessRole.forEach {
             // when
@@ -194,4 +194,3 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         }
     }
 }
-

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CallSystemMessages.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 @testable import WireDataModel
-
 
 class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
 
@@ -75,7 +73,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
             XCTAssertNil(second.visibleInConversation)
             XCTAssertEqual(second.hiddenInConversation, conversation)
         }
-        
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
     }
 
@@ -129,7 +127,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
             // then
             let lastMessages = conversation.lastMessages()
             XCTAssertEqual(lastMessages.count, 3)
-            XCTAssertEqual(lastMessages[2] as? ZMSystemMessage , first)
+            XCTAssertEqual(lastMessages[2] as? ZMSystemMessage, first)
             XCTAssertEqual(lastMessages[1], intermediate)
             XCTAssertEqual(lastMessages[0] as? ZMSystemMessage, second)
         }
@@ -151,7 +149,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
             // then
             let lastMessages = conversation.lastMessages()
             XCTAssertEqual(lastMessages.count, 2)
-            XCTAssertEqual(lastMessages[1] as? ZMSystemMessage , first)
+            XCTAssertEqual(lastMessages[1] as? ZMSystemMessage, first)
             XCTAssertEqual(lastMessages[0] as? ZMSystemMessage, second)
         }
 
@@ -219,7 +217,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
         // then
         let lastMessages = conversation.lastMessages()
         XCTAssertEqual(lastMessages.count, 3)
-        XCTAssertEqual(lastMessages[2] as? ZMSystemMessage , first)
+        XCTAssertEqual(lastMessages[2] as? ZMSystemMessage, first)
         XCTAssertEqual(lastMessages[1], intermediate)
         XCTAssertEqual(lastMessages[0] as? ZMSystemMessage, second)
     }
@@ -236,7 +234,7 @@ class ZMConversationCallSystemMessageTests: ZMConversationTestsBase {
         // then
         let lastMessages = conversation.lastMessages()
         XCTAssertEqual(lastMessages.count, 2)
-        XCTAssertEqual(lastMessages[1] as? ZMSystemMessage , first)
+        XCTAssertEqual(lastMessages[1] as? ZMSystemMessage, first)
         XCTAssertEqual(lastMessages[0] as? ZMSystemMessage, second)
     }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
@@ -22,69 +22,68 @@ import XCTest
 
 class ZMConversationTests_Confirmations: ZMConversationTestsBase {
 
-
     func testThatConfirmUnreadMessagesAsRead_DoesntConfirmAlreadyReadMessages() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
-        
+
         let user1 = createUser()
         let user2 = createUser()
-        
+
         let message1 = try! conversation.appendText(content: "text1") as! ZMClientMessage
         let message2 = try! conversation.appendText(content: "text2") as! ZMClientMessage
         let message3 = try! conversation.appendText(content: "text3") as! ZMClientMessage
         let message4 = try! conversation.appendText(content: "text4") as! ZMClientMessage
-        
+
         [message1, message2, message3, message4].forEach({ $0.expectsReadConfirmation = true })
-        
+
         message1.sender = user2
         message2.sender = user1
         message3.sender = user2
         message4.sender = user1
-        
+
         conversation.conversationType = .group
         conversation.lastReadServerTimeStamp = message1.serverTimestamp
-        
+
         // when
         var confirmMessages = conversation.confirmUnreadMessagesAsRead(in: conversation.lastReadServerTimeStamp!...(.distantFuture))
-        
+
         // then
         XCTAssertEqual(confirmMessages.count, 2)
-        
-        if (confirmMessages[0].underlyingMessage?.confirmation.firstMessageID != message2.nonce?.transportString()) {
+
+        if confirmMessages[0].underlyingMessage?.confirmation.firstMessageID != message2.nonce?.transportString() {
             // Confirm messages order is not stable so we need swap if they are not in the expected order
             confirmMessages.swapAt(0, 1)
         }
-        
+
         XCTAssertEqual(confirmMessages[0].underlyingMessage?.confirmation.firstMessageID, message2.nonce?.transportString())
         XCTAssertEqual(confirmMessages[0].underlyingMessage?.confirmation.moreMessageIds, [message4.nonce!.transportString()])
         XCTAssertEqual(confirmMessages[1].underlyingMessage?.confirmation.firstMessageID, message3.nonce?.transportString())
         XCTAssertEqual(confirmMessages[1].underlyingMessage?.confirmation.moreMessageIds, [])
     }
-    
+
     func testThatConfirmUnreadMessagesAsRead_DoesntConfirmMessageAfterTheTimestamp() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
-        
+
         let user1 = createUser()
         let user2 = createUser()
-        
+
         let message1 = try! conversation.appendText(content: "text1") as! ZMClientMessage
         let message2 = try! conversation.appendText(content: "text2") as! ZMClientMessage
         let message3 = try! conversation.appendText(content: "text3") as! ZMClientMessage
-        
+
         [message1, message2, message3].forEach({ $0.expectsReadConfirmation = true })
-        
+
         message1.sender = user1
         message2.sender = user1
         message3.sender = user2
-        
+
         conversation.conversationType = .group
         conversation.lastReadServerTimeStamp = .distantPast
-        
+
         // when
         let confirmMessages = conversation.confirmUnreadMessagesAsRead(in: conversation.lastReadServerTimeStamp!...message2.serverTimestamp!)
-        
+
         // then
         XCTAssertEqual(confirmMessages.count, 1)
         XCTAssertEqual(confirmMessages[0].underlyingMessage?.confirmation.firstMessageID, message1.nonce?.transportString())
@@ -125,5 +124,5 @@ class ZMConversationTests_Confirmations: ZMConversationTestsBase {
         let moreMessageIds = [message3, message4].map { $0.nonce!.transportString() }
         XCTAssertEqual(confirmMessages[0].underlyingMessage?.confirmation.moreMessageIds, moreMessageIds)
     }
-    
+
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Creation.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Creation.swift
@@ -19,10 +19,10 @@
 import Foundation
 @testable import WireDataModel
 
-final class ZMConversationTests_Creation : ZMConversationTestsBase {
+final class ZMConversationTests_Creation: ZMConversationTestsBase {
 
     func testThatItCreatesParticipantsWithTheGivenRoleForAllParticipants() {
-        
+
         // given
         let team = Team.insertNewObject(in: self.uiMOC)
         let role1 = Role.create(managedObjectContext: uiMOC, name: "role1", team: team)
@@ -30,7 +30,7 @@ final class ZMConversationTests_Creation : ZMConversationTestsBase {
         user1.name = "user1"
         let user2 = ZMUser.insertNewObject(in: self.uiMOC)
         user2.name = "user2"
-        
+
         // when
         let conversation = ZMConversation.insertGroupConversation(
             moc: self.uiMOC,
@@ -39,13 +39,13 @@ final class ZMConversationTests_Creation : ZMConversationTestsBase {
             team: team,
             participantsRole: role1
         )!
-        
+
         // then
         XCTAssertEqual(conversation.participantRoles.compactMap { $0.role}, [role1, role1, role1])
     }
-    
+
     func testThatItCreatesConversationAndIncludesSelfUser() {
-        
+
         // given
         let team = Team.insertNewObject(in: self.uiMOC)
         let role1 = Role.create(managedObjectContext: uiMOC, name: "role1", team: team)
@@ -53,7 +53,7 @@ final class ZMConversationTests_Creation : ZMConversationTestsBase {
         user1.name = "user1"
         let user2 = ZMUser.insertNewObject(in: self.uiMOC)
         user2.name = "user2"
-        
+
         // when
         let conversation = ZMConversation.insertGroupConversation(
             moc: self.uiMOC,
@@ -62,10 +62,10 @@ final class ZMConversationTests_Creation : ZMConversationTestsBase {
             team: team,
             participantsRole: role1
             )!
-        
+
         // then
         let selfUser = ZMUser.selfUser(in: self.uiMOC)
         XCTAssertEqual(conversation.localParticipants, Set([selfUser, user1, user2]))
     }
-    
+
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+CreationSystemMessages.swift
@@ -75,7 +75,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
 
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [], name: name, team: nil)
             let nameMessage = conversation?.lastMessage as? ZMSystemMessage
-            
+
             XCTAssertNotNil(nameMessage)
             XCTAssertEqual(nameMessage?.systemMessageType, .newConversation)
             XCTAssertEqual(nameMessage?.text, name)
@@ -84,7 +84,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
     }
-    
+
     func testThatItDoesNotSetAllTeamUsersAddedWhenItIsNotTheCaseForTeamUser() {
         syncMOC.performGroupedBlockAndWait {
             // given
@@ -93,14 +93,14 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
-            
+
             let user1 = self.createTeamMember(in: self.syncMOC, for: team)
             self.createTeamMember(in: self.syncMOC, for: team)
-            
+
             // when
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [user1], name: self.name, team: team)
             guard let nameMessage = conversation?.lastMessage as? ZMSystemMessage else { return XCTFail() }
-            
+
             XCTAssertNotNil(nameMessage)
             XCTAssertEqual(nameMessage.systemMessageType, .newConversation)
             XCTAssertEqual(nameMessage.text, self.name)
@@ -109,7 +109,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             XCTAssertEqual(nameMessage.numberOfGuestsAdded, 0)
         }
     }
-    
+
     func testThatItDoesSetAllTeamUsersAddedWhenItIsTheCaseForTeamUser() {
         syncMOC.performGroupedBlockAndWait {
             // given
@@ -117,14 +117,14 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
-            
+
             let user1 = self.createTeamMember(in: self.syncMOC, for: team)
             let user2 = self.createTeamMember(in: self.syncMOC, for: team)
-            
+
             // when
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [user1, user2], name: self.name, team: team)
             guard let nameMessage = conversation?.lastMessage as? ZMSystemMessage else { return XCTFail() }
-            
+
             XCTAssertNotNil(nameMessage)
             XCTAssertEqual(nameMessage.systemMessageType, .newConversation)
             XCTAssertEqual(nameMessage.text, self.name)
@@ -133,7 +133,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             XCTAssertEqual(nameMessage.numberOfGuestsAdded, 0)
         }
     }
-    
+
     func testThatItIncludesNumberOfGuestsAddedInNewConversationSystemMessageWithAllTeamUsers() {
         syncMOC.performGroupedBlockAndWait {
             // given
@@ -141,12 +141,12 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
-            
+
             let user1 = self.createTeamMember(in: self.syncMOC, for: team)
             let user2 = self.createTeamMember(in: self.syncMOC, for: team)
             let guest1 = self.createUser(onMoc: self.syncMOC)
             let guest2 = self.createUser(onMoc: self.syncMOC)
-            
+
             // when
             let conversation = ZMConversation.insertGroupConversation(
                 moc: self.syncMOC,
@@ -154,7 +154,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
                 name: self.name,
                 team: team)
             guard let nameMessage = conversation?.lastMessage as? ZMSystemMessage else { return XCTFail() }
-            
+
             XCTAssertNotNil(nameMessage)
             XCTAssertEqual(nameMessage.systemMessageType, .newConversation)
             XCTAssertEqual(nameMessage.text, self.name)
@@ -163,7 +163,7 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             XCTAssertEqual(nameMessage.numberOfGuestsAdded, 2)
         }
     }
-    
+
     func testThatItIncludesNumberOfGuestsAddedInNewConversationSystemMessageWithoutAllTeamUsers() {
         syncMOC.performGroupedBlockAndWait {
             // given
@@ -171,16 +171,16 @@ class ZMConversationCreationSystemMessageTests: ZMConversationTestsBase {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let membership = self.createMembership(in: self.syncMOC, user: selfUser, team: team)
             membership.permissions = .admin
-            
+
             let user1 = self.createTeamMember(in: self.syncMOC, for: team)
             self.createTeamMember(in: self.syncMOC, for: team)
             let guest1 = self.createUser(onMoc: self.syncMOC)
             let guest2 = self.createUser(onMoc: self.syncMOC)
-            
+
             // when
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [user1, guest1, guest2], name: self.name, team: team)
             guard let nameMessage = conversation?.lastMessage as? ZMSystemMessage else { return XCTFail() }
-            
+
             XCTAssertNotNil(nameMessage)
             XCTAssertEqual(nameMessage.systemMessageType, .newConversation)
             XCTAssertEqual(nameMessage.text, self.name)

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Deletion.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Deletion.swift
@@ -28,10 +28,10 @@ class ZMConversationTests_Deletion: ZMConversationTestsBase {
         let cacheKey = FileAssetCache.cacheKeyForAsset(message)!
         self.uiMOC.zm_fileAssetCache.storeAssetData(message, encrypted: false, data: Data.secureRandomData(ofLength: 100))
         XCTAssertNotNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
-        
+
         // WHEN
         uiMOC.delete(sut)
-        
+
         // THEN
         XCTAssertNil(uiMOC.zm_fileAssetCache.assetData(cacheKey))
     }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+DraftMessage.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+DraftMessage.swift
@@ -20,80 +20,80 @@ import Foundation
 @testable import WireDataModel
 
 class ConversationTests_DraftMessage: ZMConversationTestsBase {
-    
+
     override func setUp() {
         super.setUp()
-        
+
         createSelfClient(onMOC: uiMOC)
     }
-    
+
     // MARK: Persist encrypted draft message
-    
+
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatItEncryptsDraftMessage_WhenEncryptionAtRestIsEnabled() {
         // GIVEN
         uiMOC.encryptMessagesAtRest = true
         uiMOC.encryptionKeys = validEncryptionKeys
-        
+
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
-        
+
         // WHEN
         conversation.draftMessage = DraftMessage(text: "Draft test", mentions: [], quote: nil)
-        
+
         // THEN
         XCTAssertNotNil(conversation.draftMessage)
         XCTAssertNotNil(conversation.draftMessageNonce)
     }
-    
+
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatItDiscardsDraftMessage_WhenEncryptionAtRestIsEnabled_And_DatabaseKeyIsMissing() {
         // GIVEN
         uiMOC.encryptMessagesAtRest = true
         uiMOC.encryptionKeys = nil
-        
+
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
-        
+
         // WHEN
         conversation.draftMessage = DraftMessage(text: "Draft test", mentions: [], quote: nil)
-        
+
         // THEN
         XCTAssertNil(conversation.draftMessage)
         XCTAssertNil(conversation.draftMessageNonce)
     }
-    
+
     // MARK: Access encrypted draft message
-    
+
     func testThatEncryptedDraftMessageCanBeAccessed_WhenDatabaseKeyIsAvailable() {
         // GIVEN
         uiMOC.encryptMessagesAtRest = true
         uiMOC.encryptionKeys = validEncryptionKeys
-        
+
         let draftText = "Draft test"
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.draftMessage = DraftMessage(text: draftText, mentions: [], quote: nil)
-        
+
         // WHEN
         XCTAssertNotNil(uiMOC.encryptionKeys)
-        
+
         // THEN
         XCTAssertEqual(conversation.draftMessage?.text, draftText)
     }
-    
+
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatEncryptedDraftMessageCantBeAccessed_WhenDatabaseKeyIsMissing() {
         // GIVEN
         uiMOC.encryptMessagesAtRest = true
         uiMOC.encryptionKeys = validEncryptionKeys
-        
+
         let draftText = "Draft test"
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.draftMessage = DraftMessage(text: draftText, mentions: [], quote: nil)
-        
+
         // WHEN
         uiMOC.encryptionKeys = nil
-        
+
         // THEN
         XCTAssertNil(conversation.draftMessage)
     }
-    
+
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Ephemeral.swift
@@ -19,9 +19,9 @@
 import Foundation
 @testable import WireDataModel
 
-final class MessageDestructionTimeoutValueTests : XCTestCase {
+final class MessageDestructionTimeoutValueTests: XCTestCase {
 
-    func testThatItReturnsTheCorrectTimeouts(){
+    func testThatItReturnsTheCorrectTimeouts() {
         XCTAssertEqual(MessageDestructionTimeoutValue.none.rawValue, 0)
         XCTAssertEqual(MessageDestructionTimeoutValue.tenSeconds.rawValue, 10)
         XCTAssertEqual(MessageDestructionTimeoutValue.fiveMinutes.rawValue, 300)
@@ -49,7 +49,7 @@ final class MessageDestructionTimeoutValueTests : XCTestCase {
 // Tests for displayString of MessageDestructionTimeoutValue
 extension MessageDestructionTimeoutValueTests {
 
-    func testThatItReturnsTheCorrectShortDisplayString(){
+    func testThatItReturnsTheCorrectShortDisplayString() {
         XCTAssertEqual(MessageDestructionTimeoutValue.none.displayString, NSLocalizedString("input.ephemeral.timeout.none", comment: ""))
         XCTAssertEqual(MessageDestructionTimeoutValue.tenSeconds.shortDisplayString, "10")
         XCTAssertEqual(MessageDestructionTimeoutValue.fiveMinutes.shortDisplayString, "5")
@@ -58,7 +58,7 @@ extension MessageDestructionTimeoutValueTests {
         XCTAssertEqual(MessageDestructionTimeoutValue.fourWeeks.shortDisplayString, "4")
     }
 
-    func testThatItReturnsTheCorrectFormattedString(){
+    func testThatItReturnsTheCorrectFormattedString() {
         XCTAssertEqual(MessageDestructionTimeoutValue.none.displayString, NSLocalizedString("input.ephemeral.timeout.none", comment: ""))
         XCTAssertEqual(MessageDestructionTimeoutValue.tenSeconds.displayString, "10 seconds")
         XCTAssertEqual(MessageDestructionTimeoutValue.fiveMinutes.displayString, "5 minutes")
@@ -69,39 +69,39 @@ extension MessageDestructionTimeoutValueTests {
 
 }
 
-class ZMConversationTests_Ephemeral : BaseZMMessageTests {
+class ZMConversationTests_Ephemeral: BaseZMMessageTests {
 
-    func testThatItAllowsSettingTimeoutsOnGroupConversations(){
+    func testThatItAllowsSettingTimeoutsOnGroupConversations() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
-        
+
         // when
         conversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .selfUser)
-        
+
         // then
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutType, .selfUser)
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutValue, .tenSeconds)
     }
 
-    func testThatItAllowsSettingSyncedTimeoutsOnGroupConversations(){
+    func testThatItAllowsSettingSyncedTimeoutsOnGroupConversations() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
-        
+
         // when
         conversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .groupConversation)
-        
+
         // then
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutType, .groupConversation)
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutValue, .tenSeconds)
     }
-    
-    func testThatItAllowsSettingTimeoutsOnOneOnOneConversations(){
+
+    func testThatItAllowsSettingTimeoutsOnOneOnOneConversations() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .oneOnOne
-        
+
         // when
         conversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .selfUser)
 
@@ -109,32 +109,32 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutType, .selfUser)
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutValue, .tenSeconds)
     }
-    
+
     func testThatItHasDestructionTimeout() {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
         XCTAssertFalse(conversation.hasSyncedMessageDestructionTimeout)
         XCTAssertFalse(conversation.hasLocalMessageDestructionTimeout)
-        
+
         // when
         conversation.setMessageDestructionTimeoutValue(.fiveMinutes, for: .selfUser)
-        
+
         // then
         XCTAssertTrue(conversation.hasLocalMessageDestructionTimeout)
         XCTAssertFalse(conversation.hasSyncedMessageDestructionTimeout)
-        
+
         // and when
         conversation.setMessageDestructionTimeoutValue(.tenSeconds, for: .groupConversation)
-        
+
         // then both timeouts exist, but synced timeout dominates
         XCTAssertTrue(conversation.hasSyncedMessageDestructionTimeout)
         XCTAssertTrue(conversation.hasLocalMessageDestructionTimeout)
         XCTAssertEqual(conversation.activeMessageDestructionTimeoutType, .groupConversation)
-        
+
         // and when
         conversation.setMessageDestructionTimeoutValue(.none, for: .groupConversation)
-        
+
         // then local timeout persists
         XCTAssertFalse(conversation.hasSyncedMessageDestructionTimeout)
         XCTAssertTrue(conversation.hasLocalMessageDestructionTimeout)
@@ -188,4 +188,3 @@ class ZMConversationTests_Ephemeral : BaseZMMessageTests {
     }
 
 }
-

--- a/Tests/Source/Model/Conversation/ZMConversationTests+HasMessages.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+HasMessages.swift
@@ -20,64 +20,64 @@ import XCTest
 @testable import WireDataModel
 
 class ZMConversationTests_HasMessages: ZMConversationTestsBase {
-    
+
     func testThatItHasMessages_ReadButNotCleared() {
         // Given
         let sut = ZMConversation.insertNewObject(in: uiMOC)
         sut.lastReadServerTimeStamp = Date(timeIntervalSinceNow: -10)
-        
+
         XCTAssertNotNil(sut.lastReadServerTimeStamp)
         XCTAssertNil(sut.clearedTimeStamp)
-        
+
         // Then
         XCTAssertTrue(sut.estimatedHasMessages)
     }
-    
+
     func testThatItHasMessages_ReadAfterCleared() {
         // Given
         let sut = ZMConversation.insertNewObject(in: uiMOC)
         sut.clearedTimeStamp = Date(timeIntervalSinceNow: -15)
         sut.lastReadServerTimeStamp = Date(timeIntervalSinceNow: -10)
-        
+
         XCTAssertNotNil(sut.clearedTimeStamp)
         XCTAssertNotNil(sut.lastReadServerTimeStamp)
-        
+
         // Then
         XCTAssertTrue(sut.estimatedHasMessages)
     }
-    
+
     func testThatItHasNoMessages_NotRead() {
         // Given
         let sut = ZMConversation.insertNewObject(in: uiMOC)
-        
+
         XCTAssertNil(sut.lastReadServerTimeStamp)
-        
+
         // Then
         XCTAssertFalse(sut.estimatedHasMessages)
     }
-    
+
     func testThatItHasNoMessages_ReadAndCleared() {
         // Given
         let sut = ZMConversation.insertNewObject(in: uiMOC)
         sut.lastReadServerTimeStamp = Date(timeIntervalSinceNow: -10)
         sut.clearedTimeStamp = Date(timeIntervalSinceNow: -10)
-        
+
         XCTAssertNotNil(sut.lastReadServerTimeStamp)
         XCTAssertNotNil(sut.clearedTimeStamp)
-        
+
         // Then
         XCTAssertFalse(sut.estimatedHasMessages)
     }
-    
+
     func testThatItHasNoMessages_ReadThenCleared() {
         // Given
         let sut = ZMConversation.insertNewObject(in: uiMOC)
         sut.lastReadServerTimeStamp = Date(timeIntervalSinceNow: -10)
         sut.clearedTimeStamp = Date(timeIntervalSinceNow: -5)
-        
+
         XCTAssertNotNil(sut.lastReadServerTimeStamp)
         XCTAssertNotNil(sut.clearedTimeStamp)
-        
+
         // Then
         XCTAssertFalse(sut.estimatedHasMessages)
     }

--- a/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -242,7 +242,7 @@ extension FileAssetCacheTests {
         // then
         XCTAssertFalse(result)
     }
-    
+
     // @SF.Messages @TSFI.RESTfulAPI @S0.1 @S0.2 @S0.3
     func testThatItDoesNotDecryptAndDeletesAFileWithWrongSHA256() {
 
@@ -259,7 +259,7 @@ extension FileAssetCacheTests {
         let extractedData = sut.assetData(message, encrypted: true)
         XCTAssertNil(extractedData)
     }
-    
+
     // @SF.Messages @TSFI.RESTfulAPI @S0.1 @S0.2 @S0.3
     func testThatItDoesDecryptAndDeletesAFileWithTheRightSHA256() {
 

--- a/Tests/Source/Model/Messages/GenericMessageTests.swift
+++ b/Tests/Source/Model/Messages/GenericMessageTests.swift
@@ -21,70 +21,70 @@ import Foundation
 import XCTest
 
 class GenericMessageTests: XCTestCase {
-    
+
     func testThatConsidersTextMessageTypeAsKnownMessage() {
         let textMessageType = GenericMessage(content: Text(content: "hello"))
         XCTAssertTrue(textMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersKnockMessageTypeAsKnownMessage() {
         let knockMessageType = GenericMessage(content: Knock())
         XCTAssertTrue(knockMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersLastReadMessageTypeAsKnownMessage() {
         let lastReadMessageType = GenericMessage(content: LastRead(conversationID: UUID.create(), lastReadTimestamp: Date()))
         XCTAssertTrue(lastReadMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersClearedMessageTypeAsKnownMessage() {
         let clearedMessageType = GenericMessage(content: Cleared(timestamp: Date(), conversationID: UUID.create()))
         XCTAssertTrue(clearedMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersExternalMessageTypeAsKnownMessage() {
         let sha256 = Data(base64Encoded: "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")!
         let otrKey = Data(base64Encoded: "4H1nD6bG2sCxC/tZBnIG7avLYhkCsSfv0ATNqnfug7w=")!
         let externalMessageType = GenericMessage(content: External(withOTRKey: otrKey, sha256: sha256))
-        
+
         XCTAssertTrue(externalMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersResetSessionMessageTypeAsKnownMessage() {
         let resetSessionMessageType = GenericMessage(clientAction: .resetSession)
         XCTAssertTrue(resetSessionMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersCallingMessageTypeAsKnownMessage() {
         let callingMessageType = GenericMessage(content: Calling(content: "Calling"))
         XCTAssertTrue(callingMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersAssetMessageTypeAsKnownMessage() {
         let assetMessageType = GenericMessage(content: WireProtos.Asset(imageSize: .zero, mimeType: "image/jpeg", size: 0))
         XCTAssertTrue(assetMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersHidingMessageTypeAsKnownMessage() {
         let hideMessageType = GenericMessage(content: MessageHide(conversationId: UUID.create(), messageId: UUID.create()))
         XCTAssertTrue(hideMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersLocationMessageTypeAsKnownMessage() {
         let locationMessageType = GenericMessage(content: Location(latitude: 1, longitude: 2))
         XCTAssertTrue(locationMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersDeletionMessageTypeAsKnownMessage() {
         let deletionMessageType = GenericMessage(content: MessageDelete(messageId: UUID.create()))
         XCTAssertTrue(deletionMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersCreatingReactionMessageTypeAsKnownMessage() {
         let creatingReactionMessageType = GenericMessage(content: WireProtos.Reaction.createReaction(emoji: "test", messageID: UUID.create()))
         XCTAssertTrue(creatingReactionMessageType.knownMessage)
     }
-    
+
     func testThatItConsidersAvailabilityMessageTypeAsKnownMessage() {
         let awayAvailabilityMessageType = GenericMessage(content: WireProtos.Availability(.away))
         XCTAssertTrue(awayAvailabilityMessageType.knownMessage)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fixed warnings for multiple rules in Tests. The rules can be found below:

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. (comma_referencing)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
