### PR TITLE
fix: SwiftLint warnings for multiple rules in Source Part 1

### DIFF
--- a/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -18,9 +18,8 @@
 
 import Foundation
 
-
 extension NSOrderedSet {
-    
+
     public func toOrderedSetState<T: Hashable>() -> OrderedSetState<T> {
         guard let objects = array as? [T] else {
             fatal("Could not cast contents of NSOrderedSet \(type(of: self)) to expected type \(T.self)")
@@ -29,18 +28,18 @@ extension NSOrderedSet {
     }
 }
 
-extension Array where Element : Hashable {
+extension Array where Element: Hashable {
 
     public func toOrderedSetState() -> OrderedSetState<Element> {
         return OrderedSetState(array: self)
     }
 }
 
-public struct OrderedSetState<T: Hashable> : Equatable {
+public struct OrderedSetState<T: Hashable>: Equatable {
 
-    public private(set) var array : [T]
-    public private(set) var order : [T : Int]
-    
+    public private(set) var array: [T]
+    public private(set) var order: [T : Int]
+
     public init(array: [T]) {
         guard array.count == Set(array).count else {
             fatalError("Array contains duplicate items")
@@ -49,15 +48,15 @@ public struct OrderedSetState<T: Hashable> : Equatable {
         for (idx, item) in array.enumerated() {
             order[item] = idx
         }
-        
+
         self.array = array
         self.order = order
     }
-    
+
     @discardableResult
     public mutating func move(item: T, to: Int) -> Int? {
         guard let oldIndex = order[item] else { return nil }
-        
+
         array.remove(at: oldIndex)
         array.insert(item, at: to)
         for i in [oldIndex, to].sorted() {
@@ -65,11 +64,11 @@ public struct OrderedSetState<T: Hashable> : Equatable {
         }
         return oldIndex
     }
-    
+
     static public func==<T>(lhs: OrderedSetState<T>, rhs: OrderedSetState<T>) -> Bool {
         return lhs.array as [T] == rhs.array as [T]
     }
-    
+
     public func map<U>(_ transform: (T) throws -> U) rethrows -> [U] {
         return try array.map(transform)
     }
@@ -79,53 +78,52 @@ public enum SetChangeMoveType {
     case uiTableView, uiCollectionView
 }
 
-public struct MovedIndex : Equatable {
-    public let from : Int
+public struct MovedIndex: Equatable {
+    public let from: Int
     public let to: Int
-    
+
     public static func==(lhs: MovedIndex, rhs: MovedIndex) -> Bool {
         return lhs.from == rhs.from && lhs.to == rhs.to
     }
 }
 
+public struct ChangedIndexes<T: Hashable> {
 
-public struct ChangedIndexes<T : Hashable> {
-
-    public let startState : OrderedSetState<T>
-    public let endState : OrderedSetState<T>
-    public let updatedObjects : Set<T>
+    public let startState: OrderedSetState<T>
+    public let endState: OrderedSetState<T>
+    public let updatedObjects: Set<T>
 
     /// deletedIndexes refer to the indexes in the startSet
-    public let deletedIndexes : IndexSet
-    
+    public let deletedIndexes: IndexSet
+
     /// insertedIndexes refer to the indexes after deleting deletedIndexes
-    public let insertedIndexes : IndexSet
-    
+    public let insertedIndexes: IndexSet
+
     /// updatedIndexes refer to the position of the item after the move 
     /// Reloads using these indexes must be performed AFTER inserts / deletes and moves have COMPLETED
-    public let updatedIndexes : IndexSet
-    
+    public let updatedIndexes: IndexSet
+
     /// Depending on the moveType, the `from` index either refers to the position of the item in the original set (uiCollectionView) or to the position in the intermediate set as moves are iteratively applied (uiTableView)
-    public let movedIndexes : [MovedIndex]
-    
-    public let moveType : SetChangeMoveType
-    
-    public let deletedObjects : Set<T>
-    public let insertedObjects : Set<T>
-    
+    public let movedIndexes: [MovedIndex]
+
+    public let moveType: SetChangeMoveType
+
+    public let deletedObjects: Set<T>
+    public let insertedObjects: Set<T>
+
     /// Calculates the inserts, deletes, moves and updates comparing two sets of ordered, distinct objects
     /// @param startState: State before the updates
     /// @param endState: State after the updates
     /// @param updatedObjects: Objects that need to be reloaded
     /// @param moveType: depending on viewController, default is uiCollectionView
-    public init(start: OrderedSetState<T>, end : OrderedSetState<T>, updated: Set<T>, moveType: SetChangeMoveType = .uiCollectionView) {
+    public init(start: OrderedSetState<T>, end: OrderedSetState<T>, updated: Set<T>, moveType: SetChangeMoveType = .uiCollectionView) {
         self.startState = start
         self.endState = end
         self.updatedObjects = updated
         self.moveType = moveType
 
-        let result = type(of:self).calculateDeletesInsertsUpdates(start: start, end: end, updated: updated)
-        let movedIndexes = type(of:self).calculateMoves(start: start, end: end, afterDeletesAndInserts: result.intermediateState, moveType: moveType)
+        let result = type(of: self).calculateDeletesInsertsUpdates(start: start, end: end, updated: updated)
+        let movedIndexes = type(of: self).calculateMoves(start: start, end: end, afterDeletesAndInserts: result.intermediateState, moveType: moveType)
         self.movedIndexes = movedIndexes
 
         self.updatedIndexes = result.updatedIndexes
@@ -135,40 +133,38 @@ public struct ChangedIndexes<T : Hashable> {
         self.deletedObjects = Set(result.deletedObjects.keys)
         self.insertedObjects = Set(result.insertedObjects.keys)
     }
-    
+
     static func calculateDeletesInsertsUpdates(start: OrderedSetState<T>, end: OrderedSetState<T>, updated: Set<T>)
-        -> (insertedObjects: [T: Int], deletedObjects: [T:Int], updatedIndexes: IndexSet, intermediateState: [T])
-    {
+        -> (insertedObjects: [T: Int], deletedObjects: [T: Int], updatedIndexes: IndexSet, intermediateState: [T]) {
         var updatedIndexes = IndexSet()
         var insertedObjects = end.order
-        var deletedObjects = [T : Int]()
+        var deletedObjects = [T: Int]()
         var intermediateState = [T]()
-        
+
         for (idx, item) in start.array.enumerated() {
             if let newIdx = insertedObjects.removeValue(forKey: item) {
                 intermediateState.append(item)
-                if updated.contains(item){
+                if updated.contains(item) {
                     updatedIndexes.insert(newIdx)
                 }
             } else {
                 deletedObjects[item] = idx
             }
         }
-        
+
         // When iterating through the collection we removed the items we found in the endState from its copy.
         // This way the only items remaining will be inserted objects
         // We need to sort inserted indexes in ascending order to avoid out of bounds inserts
         let ascInsertedIndexes = insertedObjects.values.sorted()
-        ascInsertedIndexes.forEach{intermediateState.insert(end.array[$0], at: $0)}
+        ascInsertedIndexes.forEach {intermediateState.insert(end.array[$0], at: $0)}
 
         return (insertedObjects, deletedObjects, updatedIndexes, intermediateState)
     }
-    
-    static func calculateMoves(start: OrderedSetState<T>, end: OrderedSetState<T>, afterDeletesAndInserts: [T], moveType: SetChangeMoveType) -> [MovedIndex]
-    {
+
+    static func calculateMoves(start: OrderedSetState<T>, end: OrderedSetState<T>, afterDeletesAndInserts: [T], moveType: SetChangeMoveType) -> [MovedIndex] {
         var intermediateState = afterDeletesAndInserts
         var movedIndexes = [MovedIndex]()
-        
+
         if moveType == .uiCollectionView {
             // Moved `from` indexes are referring to the index in the startState
             // Moves must be calculated comparing the endState the immediately updated intermediate state
@@ -216,11 +212,10 @@ public struct ChangedIndexes<T : Hashable> {
         }
         return movedIndexes
     }
-    
+
     public func enumerateMovedIndexes(block: (_ from: Int, _ to: Int) -> Void) {
         for pair in movedIndexes {
             block(Int(pair.from), Int(pair.to))
         }
     }
 }
-

--- a/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -38,7 +38,7 @@ extension Array where Element: Hashable {
 public struct OrderedSetState<T: Hashable>: Equatable {
 
     public private(set) var array: [T]
-    public private(set) var order: [T : Int]
+    public private(set) var order: [T: Int]
 
     public init(array: [T]) {
         guard array.count == Set(array).count else {

--- a/Source/Notifications/Changes.swift
+++ b/Source/Notifications/Changes.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 
-
 struct Changes: Mergeable {
 
     // MARK: - Properties

--- a/Source/Notifications/ClassIdentifier.swift
+++ b/Source/Notifications/ClassIdentifier.swift
@@ -16,8 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 public typealias ClassIdentifier = String

--- a/Source/Notifications/DependencyKeyStore.swift
+++ b/Source/Notifications/DependencyKeyStore.swift
@@ -21,34 +21,34 @@ import Foundation
 private var zmLog = ZMSLog(tag: "DependencyKeyStore")
 
 struct Observable {
-    
+
     private let affectingKeyStore: DependencyKeyStore
-    let classIdentifier : String
-    private let affectingKeys : [String : Set<String>]
-    private let affectedKeys : [String : Set<String>]
-    
+    let classIdentifier: String
+    private let affectingKeys: [String: Set<String>]
+    private let affectedKeys: [String: Set<String>]
+
     /// Keys that we want to report changes for
-    var observableKeys : Set<String> {
+    var observableKeys: Set<String> {
         return affectingKeyStore.observableKeys[classIdentifier] ?? Set()
     }
-    
+
     /// Union of observable keys and their affecting keys
-    var allKeys : Set<String> {
+    var allKeys: Set<String> {
         return affectingKeyStore.allKeys[classIdentifier] ?? Set()
     }
-    
+
     init(classIdentifier: String, affectingKeyStore: DependencyKeyStore) {
         self.classIdentifier = classIdentifier
         self.affectingKeyStore = affectingKeyStore
         self.affectingKeys = affectingKeyStore.affectingKeys[classIdentifier] ?? [:]
         self.affectedKeys = affectingKeyStore.effectedKeys[classIdentifier] ?? [:]
     }
-    
-    func keyPathsForValuesAffectingValue(for key: String) -> Set<String>{
+
+    func keyPathsForValuesAffectingValue(for key: String) -> Set<String> {
         return affectingKeys[key] ?? Set()
     }
-    
-    func observableKeysAffectedByValue(for key: String) -> Set<String>{
+
+    func observableKeysAffectedByValue(for key: String) -> Set<String> {
         var keys = affectedKeys[key] ?? Set()
         if observableKeys.contains(key) {
             keys.insert(key)
@@ -57,36 +57,35 @@ struct Observable {
     }
 }
 
-
 /// Maps the observable keys to affectedKeys and vice versa
 /// You should create this only once
 class DependencyKeyStore {
-    
+
     /// Keys that are needed to create a changeInfo
-    let observableKeys : [String: Set<String>]
-    
+    let observableKeys: [String: Set<String>]
+
     /// All keys that will create a changeInfo
-    let allKeys : [String : Set<String>]
-    
+    let allKeys: [String: Set<String>]
+
     /// Maps observable keys to keys whose values affect them
-    let affectingKeys : [String : [String : Set<String>]]
-    
+    let affectingKeys: [String: [String: Set<String>]]
+
     /// Maps keys that affect the observables to their respective observables
-    let effectedKeys : [String : [String : Set<String>]]
-    
+    let effectedKeys: [String: [String: Set<String>]]
+
     /// Returns a store mapping observable keys and their affecting keys
     /// @param classIdentifier: Identifiers for each class, e.g. entityName
     init(classIdentifiers: [String]) {
-        let observable = classIdentifiers.mapToDictionary{DependencyKeyStore.setupObservableKeys(classIdentifier: $0)}
-        let affecting = classIdentifiers.mapToDictionary{DependencyKeyStore.setupAffectedKeys(classIdentifier: $0, observableKeys: observable[$0]!)}
-        let all = classIdentifiers.mapToDictionary{DependencyKeyStore.setupAllKeys(observableKeys: observable[$0]!, affectingKeys: affecting[$0]!)}
-        effectedKeys = classIdentifiers.mapToDictionary{DependencyKeyStore.setupEffectedKeys(affectingKeys: affecting[$0]!)}
-        
+        let observable = classIdentifiers.mapToDictionary {DependencyKeyStore.setupObservableKeys(classIdentifier: $0)}
+        let affecting = classIdentifiers.mapToDictionary {DependencyKeyStore.setupAffectedKeys(classIdentifier: $0, observableKeys: observable[$0]!)}
+        let all = classIdentifiers.mapToDictionary {DependencyKeyStore.setupAllKeys(observableKeys: observable[$0]!, affectingKeys: affecting[$0]!)}
+        effectedKeys = classIdentifiers.mapToDictionary {DependencyKeyStore.setupEffectedKeys(affectingKeys: affecting[$0]!)}
+
         self.observableKeys = observable
         self.affectingKeys = affecting
         self.allKeys = all
     }
-    
+
     /// When adding objects that are to be observed, add keys that are supposed to be reported on in here
     private static func setupObservableKeys(classIdentifier: String) -> Set<String> {
         switch classIdentifier {
@@ -127,70 +126,70 @@ class DependencyKeyStore {
             return Set()
         }
     }
-    
+
     /// Creates a dictionary mapping the observable keys to keys affecting their values
     /// ["foo" : keysAffectingValueForKey(foo), "bar" : keysAffectingValueForKey(bar)]
-    private static func setupAffectedKeys(classIdentifier: String, observableKeys: Set<String>) -> [String : Set<String>] {
+    private static func setupAffectedKeys(classIdentifier: String, observableKeys: Set<String>) -> [String: Set<String>] {
         switch classIdentifier {
         case ZMConversation.entityName():
-            return observableKeys.mapToDictionary{ZMConversation.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMConversation.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMUser.entityName():
-            return observableKeys.mapToDictionary{ZMUser.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMUser.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMConnection.entityName():
             return [:]
         case UserClient.entityName():
-            return observableKeys.mapToDictionary{UserClient.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {UserClient.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMMessage.entityName():
-            return observableKeys.mapToDictionary{ZMMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMMessage.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMAssetClientMessage.entityName():
-            return observableKeys.mapToDictionary{ZMAssetClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMAssetClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMSystemMessage.entityName():
-            return observableKeys.mapToDictionary{ZMSystemMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMSystemMessage.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMClientMessage.entityName():
-            return observableKeys.mapToDictionary{ZMClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
         case Reaction.entityName():
-            return observableKeys.mapToDictionary{Reaction.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {Reaction.keyPathsForValuesAffectingValue(forKey: $0)}
         case ZMGenericMessageData.entityName():
-            return observableKeys.mapToDictionary{ZMGenericMessageData.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ZMGenericMessageData.keyPathsForValuesAffectingValue(forKey: $0)}
         case Team.entityName():
-            return observableKeys.mapToDictionary{Team.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {Team.keyPathsForValuesAffectingValue(forKey: $0)}
         case Member.entityName():
             return [:]
         case Label.entityName():
-            return observableKeys.mapToDictionary{Label.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {Label.keyPathsForValuesAffectingValue(forKey: $0)}
         case ParticipantRole.entityName():
-            return observableKeys.mapToDictionary{ParticipantRole.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ParticipantRole.keyPathsForValuesAffectingValue(forKey: $0)}
         case ButtonState.entityName():
-            return observableKeys.mapToDictionary{ButtonState.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary {ButtonState.keyPathsForValuesAffectingValue(forKey: $0)}
         default:
             zmLog.warn("There is no path to affecting keys defined for \(classIdentifier)")
             return [:]
         }
     }
-    
+
     /// Combines observed keys and all affecting keys in one giant Set
-    private static func setupAllKeys(observableKeys: Set<String>, affectingKeys: [String : Set<String>]) -> Set<String> {
-        let allAffectingKeys : Set<String> = affectingKeys.reduce(Set()){$0.union($1.value)}
+    private static func setupAllKeys(observableKeys: Set<String>, affectingKeys: [String: Set<String>]) -> Set<String> {
+        let allAffectingKeys: Set<String> = affectingKeys.reduce(Set()) {$0.union($1.value)}
         return observableKeys.union(allAffectingKeys)
     }
-    
+
     /// Creates a dictionary mapping keys affecting values for key into the opposite direction
     /// ["foo" : Set("affectingKey1", "affectingKey2")] --> ["affectingKey1" : Set("foo"), "affectingKey2" : Set("foo")]
-    private static func setupEffectedKeys(affectingKeys: [String : Set<String>]) -> [String : Set<String>] {
-        var allEffectedKeys = [String : Set<String>]()
-        affectingKeys.forEach{ key, values in
-            values.forEach{
+    private static func setupEffectedKeys(affectingKeys: [String: Set<String>]) -> [String: Set<String>] {
+        var allEffectedKeys = [String: Set<String>]()
+        affectingKeys.forEach { key, values in
+            values.forEach {
                 allEffectedKeys[$0] = (allEffectedKeys[$0] ?? Set()).union(Set(arrayLiteral: key))
             }
         }
         return allEffectedKeys
     }
-    
+
     /// Returns keyPathsForValuesAffectingValueForKey for specified `key`
-    func keyPathsForValuesAffectingValue(_ classIdentifier: String, key: String) -> Set<String>{
+    func keyPathsForValuesAffectingValue(_ classIdentifier: String, key: String) -> Set<String> {
         return affectingKeys[classIdentifier]?[key] ?? Set()
     }
-    
+
     /// Returns the inverse of keyPathsForValuesAffectingValueForKey, all observable keys that are affected by `key`
     ///
     /// - Parameters:
@@ -204,7 +203,7 @@ class DependencyKeyStore {
         }
         return keys
     }
-    
+
     /// Returns a set of keys that need to be present in the changesValues of the object so that the object changes will be included in the changeInfo of the specified classIdentifier
     func requiredKeysForIncludingRawChanges(classIdentifier: String, for object: ZMManagedObject) -> Set<String> {
         switch (classIdentifier, object) {

--- a/Source/Notifications/Dictionary+Mapping.swift
+++ b/Source/Notifications/Dictionary+Mapping.swift
@@ -18,10 +18,10 @@
 
 import Foundation
 
-extension Array where Element : Hashable {
-    
-    public func mapToDictionary<Value>(with block: (Element) -> Value?) -> Dictionary<Element, Value> {
-        var dict = Dictionary<Element, Value>()
+extension Array where Element: Hashable {
+
+    public func mapToDictionary<Value>(with block: (Element) -> Value?) -> [Element: Value] {
+        var dict = [Element: Value]()
         forEach {
             if let value = block($0) {
                 dict.updateValue(value, forKey: $0)
@@ -29,8 +29,8 @@ extension Array where Element : Hashable {
         }
         return dict
     }
-    public func mapToDictionaryWithOptionalValue<Value>(with block: (Element) -> Value?) -> Dictionary<Element, Value?> {
-        var dict = Dictionary<Element, Value?>()
+    public func mapToDictionaryWithOptionalValue<Value>(with block: (Element) -> Value?) -> [Element: Value?] {
+        var dict = [Element: Value?]()
         forEach {
             dict.updateValue(block($0), forKey: $0)
         }
@@ -39,9 +39,9 @@ extension Array where Element : Hashable {
 }
 
 extension Set {
-    
-    public func mapToDictionary<Value>(with block: (Element) -> Value?) -> Dictionary<Element, Value> {
-        var dict = Dictionary<Element, Value>()
+
+    public func mapToDictionary<Value>(with block: (Element) -> Value?) -> [Element: Value] {
+        var dict = [Element: Value]()
         forEach {
             if let value = block($0) {
                 dict.updateValue(value, forKey: $0)
@@ -55,11 +55,11 @@ public protocol Mergeable {
     func merged(with other: Self) -> Self
 }
 
-extension Dictionary where Value : Mergeable {
-    
+extension Dictionary where Value: Mergeable {
+
     public func merged(with other: Dictionary) -> Dictionary {
         var newDict = self
-        other.forEach{ (key, value) in
+        other.forEach { (key, value) in
             newDict[key] = newDict[key]?.merged(with: value) ?? value
         }
         return newDict

--- a/Source/Notifications/ManagedObjectObserver.swift
+++ b/Source/Notifications/ManagedObjectObserver.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 @objc final public class ManagedObjectContextChangeObserver: NSObject {
 

--- a/Source/Notifications/ManagedObjectObserverToken.swift
+++ b/Source/Notifications/ManagedObjectObserverToken.swift
@@ -19,7 +19,6 @@
 import Foundation
 import CoreData
 
-
 /// A helper class to automatically register and unregister an observer for a notification with
 /// the notification center.
 ///

--- a/Source/Notifications/Notification.Name+ManagedObjectObservation.swift
+++ b/Source/Notifications/Notification.Name+ManagedObjectObservation.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 
-
 extension Notification.Name {
 
     static let ConversationChange = Notification.Name("ZMConversationChangedNotification")

--- a/Source/Notifications/NotificationDispatcher.OperationMode.swift
+++ b/Source/Notifications/NotificationDispatcher.OperationMode.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 public extension NotificationDispatcher {

--- a/Source/Notifications/NotificationDispatcher.swift
+++ b/Source/Notifications/NotificationDispatcher.swift
@@ -19,7 +19,6 @@
 import Foundation
 import CoreData
 
-
 /// The `NotificationDispatcher` listens for changes to observable entities (e.g message, users, and conversations),
 /// extracts information about those changes (e.g which properties changed), and posts notifications about those
 /// changes.
@@ -74,7 +73,7 @@ import CoreData
     private var changeInfoConsumers = [UnownedNSObject]()
 
     private var allChangeInfoConsumers: [ChangeInfoConsumer] {
-        var consumers = changeInfoConsumers.compactMap{$0.unbox as? ChangeInfoConsumer}
+        var consumers = changeInfoConsumers.compactMap {$0.unbox as? ChangeInfoConsumer}
         consumers.append(searchUserObserverCenter)
         consumers.append(conversationListObserverCenter)
         return consumers
@@ -94,9 +93,8 @@ import CoreData
 
     private var unreadMessages = UnreadMessages()
 
-
     // MARK: - Life cycle
-    
+
     public init(managedObjectContext: NSManagedObjectContext) {
         assert(
             managedObjectContext.zm_isUserInterfaceContext,
@@ -143,14 +141,14 @@ import CoreData
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(NotificationDispatcher.objectsDidChange),
-            name:.NSManagedObjectContextObjectsDidChange,
+            name: .NSManagedObjectContextObjectsDidChange,
             object: managedObjectContext
         )
 
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(NotificationDispatcher.contextDidSave),
-            name:.NSManagedObjectContextDidSave,
+            name: .NSManagedObjectContextDidSave,
             object: managedObjectContext
         )
 
@@ -179,28 +177,28 @@ import CoreData
 
     /// Call this when the application enters the background to stop sending notifications and clear current changes.
 
-    @objc func applicationDidEnterBackground() {
+    func applicationDidEnterBackground() {
         isEnabled = false
     }
-    
+
     /// Call this when the application will enter the foreground to start sending notifications again.
 
-    @objc func applicationWillEnterForeground() {
+    func applicationWillEnterForeground() {
         isEnabled = true
     }
 
     // Called when objects in the context change, it may be called several times between saves.
 
-    @objc func objectsDidChange(_ note: Notification) {
+    func objectsDidChange(_ note: Notification) {
         guard isEnabled else { return }
         process(note: note)
     }
 
-    @objc func contextDidSave(_ note: Notification) {
+    func contextDidSave(_ note: Notification) {
         guard isEnabled else { return }
         fireAllNotificationsIfAllowed()
     }
-    
+
     /// This will be called if a change to an object does not cause a change in Core Data,
     /// e.g. downloading the asset and adding it to the cache.
 
@@ -229,7 +227,7 @@ import CoreData
 
     /// Add the given consumer to receive forwarded `ChangeInfo`s.
 
-    @objc public func addChangeInfoConsumer(_ consumer: ChangeInfoConsumer) {
+    public func addChangeInfoConsumer(_ consumer: ChangeInfoConsumer) {
         let boxed = UnownedNSObject(consumer as! NSObject)
         changeInfoConsumers.append(boxed)
     }
@@ -290,7 +288,7 @@ import CoreData
         conversationListObserverCenter.conversationsChanges(inserted: insertedConversations, deleted: deletedConversations)
     }
 
-    private func checkForUnreadMessages(insertedObjects: Set<ZMManagedObject>, updatedObjects: Set<ZMManagedObject>){
+    private func checkForUnreadMessages(insertedObjects: Set<ZMManagedObject>, updatedObjects: Set<ZMManagedObject>) {
         let unreadUnsent = updatedObjects.lazy
             .compactMap { $0 as? ZMMessage }
             .filter { $0.deliveryState == .failedToSend }
@@ -354,7 +352,7 @@ import CoreData
             postNotification(name: $0, changeInfo: $1)
         }
     }
-    
+
     private func forwardNotificationToObserverCenters(changeInfos: [ClassIdentifier: [ObjectChangeInfo]]) {
         allChangeInfoConsumers.forEach {
             $0.objectsDidChange(changes: changeInfos)
@@ -375,7 +373,6 @@ import CoreData
     }
 
 }
-
 
 // MARK: - Helper extensions
 

--- a/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -16,12 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-extension ZMConversation : ObjectInSnapshot {
-    
-    @objc public static var observableKeys : Set<String> {
+extension ZMConversation: ObjectInSnapshot {
+
+    @objc public static var observableKeys: Set<String> {
         return Set([#keyPath(ZMConversation.allMessages),
                     #keyPath(ZMConversation.lastModifiedDate),
                     #keyPath(ZMConversation.isArchived),
@@ -55,7 +54,6 @@ extension ZMConversation : ObjectInSnapshot {
 
 }
 
-
 ////////////////////
 ////
 //// ConversationObserverToken
@@ -63,59 +61,58 @@ extension ZMConversation : ObjectInSnapshot {
 ////
 ////////////////////
 
+@objcMembers public final class ConversationChangeInfo: ObjectChangeInfo {
 
-@objcMembers public final class ConversationChangeInfo : ObjectChangeInfo {
-
-    public var languageChanged : Bool {
+    public var languageChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.language))
     }
 
-    public var messagesChanged : Bool {
+    public var messagesChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.allMessages))
     }
 
-    public var participantsChanged : Bool {
+    public var participantsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.localParticipantRoles),
                                         #keyPath(ZMConversation.isSelfAnActiveMember),
                                         #keyPath(ZMConversation.participantRoles)
         )
     }
 
-    public var activeParticipantsChanged : Bool {
+    public var activeParticipantsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.isSelfAnActiveMember),
                                         #keyPath(ZMConversation.localParticipants))
     }
-    
-    public var nameChanged : Bool {
+
+    public var nameChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.displayName),
                                         #keyPath(ZMConversation.userDefinedName)) || activeParticipantsChanged
     }
 
-    public var lastModifiedDateChanged : Bool {
+    public var lastModifiedDateChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.lastModifiedDate))
     }
 
-    public var unreadCountChanged : Bool {
+    public var unreadCountChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.estimatedUnreadCount))
     }
 
-    public var connectionStateChanged : Bool {
+    public var connectionStateChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.relatedConnectionState))
     }
 
-    public var isArchivedChanged : Bool {
+    public var isArchivedChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.isArchived))
     }
 
-    public var mutedMessageTypesChanged : Bool {
+    public var mutedMessageTypesChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.mutedStatus))
     }
 
-    public var conversationListIndicatorChanged : Bool {
+    public var conversationListIndicatorChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.conversationListIndicator))
     }
 
-    public var clearedChanged : Bool {
+    public var clearedChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.clearedTimeStamp))
     }
 
@@ -123,25 +120,25 @@ extension ZMConversation : ObjectInSnapshot {
         return changedKeysContain(keys: #keyPath(ZMConversation.team))
     }
 
-    public var securityLevelChanged : Bool {
+    public var securityLevelChanged: Bool {
         return changedKeysContain(keys: SecurityLevelKey)
     }
-        
-    public var createdRemotelyChanged : Bool {
+
+    public var createdRemotelyChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.remoteIdentifier))
     }
-    
-    public var allowGuestsChanged : Bool {
+
+    public var allowGuestsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.accessModeStrings)) ||
                changedKeysContain(keys: #keyPath(ZMConversation.accessRoleString))
     }
-    
-    public var destructionTimeoutChanged : Bool {
+
+    public var destructionTimeoutChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.localMessageDestructionTimeout)) ||
                 changedKeysContain(keys: #keyPath(ZMConversation.syncedMessageDestructionTimeout))
     }
-    
-    public var hasReadReceiptsEnabledChanged : Bool {
+
+    public var hasReadReceiptsEnabledChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.hasReadReceiptsEnabled))
     }
 
@@ -152,15 +149,15 @@ extension ZMConversation : ObjectInSnapshot {
     public var legalHoldStatusChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.legalHoldStatus))
     }
-    
+
     public var labelsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMConversation.labels))
     }
-    
-    public var conversation : ZMConversation { return self.object as! ZMConversation }
-    
-    public override var description : String { return self.debugDescription }
-    public override var debugDescription : String {
+
+    public var conversation: ZMConversation { return self.object as! ZMConversation }
+
+    public override var description: String { return self.debugDescription }
+    public override var debugDescription: String {
 
         return ["allMessagesChanged: \(messagesChanged)",
                 "participantsChanged: \(participantsChanged)",
@@ -184,20 +181,19 @@ extension ZMConversation : ObjectInSnapshot {
                 "labelsChanged: \(labelsChanged)"
             ].joined(separator: ", ")
     }
-    
+
     public required init(object: NSObject) {
         super.init(object: object)
     }
-    
+
     static func changeInfo(for conversation: ZMConversation, changes: Changes) -> ConversationChangeInfo? {
         return ConversationChangeInfo(object: conversation, changes: changes)
     }
 }
 
-@objc public protocol ZMConversationObserver : NSObjectProtocol {
+@objc public protocol ZMConversationObserver: NSObjectProtocol {
     func conversationDidChange(_ changeInfo: ConversationChangeInfo)
 }
-
 
 extension ConversationChangeInfo {
 
@@ -207,17 +203,15 @@ extension ConversationChangeInfo {
     public static func add(observer: ZMConversationObserver, for conversation: ZMConversation) -> NSObjectProtocol {
         return ManagedObjectObserverToken(name: .ConversationChange,
                                           managedObjectContext: conversation.managedObjectContext!,
-                                          object: conversation)
-        { [weak observer] (note) in
+                                          object: conversation) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? ConversationChangeInfo
                 else { return }
-            
+
             observer.conversationDidChange(changeInfo)
-        } 
+        }
     }
 }
-
 
 /// Conversation degraded
 extension ConversationChangeInfo {
@@ -231,9 +225,9 @@ extension ConversationChangeInfo {
 
         return false
     }
-    
+
     /// Users that caused the conversation to degrade
-    @objc public var usersThatCausedConversationToDegrade : Set<ZMUser> {
+    @objc public var usersThatCausedConversationToDegrade: Set<ZMUser> {
         let untrustedParticipants = self.conversation.localParticipants.filter { user -> Bool in
             return !user.isTrusted
         }

--- a/Source/Notifications/ObjectObserverTokens/Helpers/AnyClassTuple.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/AnyClassTuple.swift
@@ -16,13 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-public struct AnyClassTuple<T : Hashable> : Hashable {
-    
-    public let classOfObject : AnyClass
-    public let secondElement : T
+public struct AnyClassTuple<T : Hashable>: Hashable {
+
+    public let classOfObject: AnyClass
+    public let secondElement: T
 
     public init(classOfObject: AnyClass, secondElement: T) {
         self.classOfObject = classOfObject

--- a/Source/Notifications/ObjectObserverTokens/Helpers/DependentObjectsKeysForObservedObjectKeysCache.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/DependentObjectsKeysForObservedObjectKeysCache.swift
@@ -16,40 +16,38 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 /// Used to map keys
 struct DependentObjectsKeysForObservedObjectKeysCache {
-    
+
     // keyPathsOnDependentObjectForKeyOnObservedObject : [displayName : [userDefinedName, user.name, connection.status]]
     // affectedKeysOnObservedObjectForChangedKeysOnDependentObject : [connection.status : [displayName, relatedConnectionStatus, etc.]]
     //
-    let keyPathsOnDependentObjectForKeyOnObservedObject : [StringKeyPath : KeySet]
-    let affectedKeysOnObservedObjectForChangedKeysOnDependentObject : [StringKeyPath : KeySet]
-    
-    static var cachedValues : [AnyClassTuple<KeySet> : DependentObjectsKeysForObservedObjectKeysCache] = [:]
-    
-    static func mappingForObject(_ observedObject : NSObject, keysToObserve : KeySet) -> DependentObjectsKeysForObservedObjectKeysCache {
-     
+    let keyPathsOnDependentObjectForKeyOnObservedObject: [StringKeyPath: KeySet]
+    let affectedKeysOnObservedObjectForChangedKeysOnDependentObject: [StringKeyPath: KeySet]
+
+    static var cachedValues: [AnyClassTuple<KeySet>: DependentObjectsKeysForObservedObjectKeysCache] = [:]
+
+    static func mappingForObject(_ observedObject: NSObject, keysToObserve: KeySet) -> DependentObjectsKeysForObservedObjectKeysCache {
+
         let tuple = AnyClassTuple(classOfObject: type(of: observedObject), secondElement: keysToObserve)
-        
-        if let cachedKeysToPathsToObserve = cachedValues[tuple]
-        {
+
+        if let cachedKeysToPathsToObserve = cachedValues[tuple] {
             return cachedKeysToPathsToObserve
         }
-        
-        var keysToPathsToObserve : [StringKeyPath : KeySet] = [:]
-        var observedKeyPathToAffectedKey : [StringKeyPath: KeySet] = [:]
-        
+
+        var keysToPathsToObserve: [StringKeyPath: KeySet] = [:]
+        var observedKeyPathToAffectedKey: [StringKeyPath: KeySet] = [:]
+
         for key in keysToObserve {
             var keyPaths = KeySet(type(of: observedObject).keyPathsForValuesAffectingValue(forKey: key.rawValue))
             keyPaths = keyPaths.filter { $0.isPath }
-            
-            var objectKeysWithPathsToObserve : [StringKeyPath : KeySet] = [:]
-            
+
+            var objectKeysWithPathsToObserve: [StringKeyPath: KeySet] = [:]
+
             for keyPath in keyPaths {
-                
+
                 if let (objectKey, pathToObserveInObject) = keyPath.decompose, let pathToObserve = pathToObserveInObject {
                     let previousPathToObserve = objectKeysWithPathsToObserve[objectKey] ?? KeySet()
                     objectKeysWithPathsToObserve[objectKey] = previousPathToObserve.union(KeySet(key: pathToObserve))
@@ -60,7 +58,7 @@ struct DependentObjectsKeysForObservedObjectKeysCache {
                     observedKeyPathToAffectedKey[keyPath] = KeySet(key: key)
                 }
             }
-            
+
             for (objectKey, pathsToObserveInObject) in objectKeysWithPathsToObserve {
                 if let p = keysToPathsToObserve[objectKey] {
                     keysToPathsToObserve[objectKey] = p.union(pathsToObserveInObject)
@@ -69,11 +67,11 @@ struct DependentObjectsKeysForObservedObjectKeysCache {
                 }
             }
         }
-        
+
         let result = DependentObjectsKeysForObservedObjectKeysCache(keyPathsOnDependentObjectForKeyOnObservedObject: keysToPathsToObserve, affectedKeysOnObservedObjectForChangedKeysOnDependentObject: observedKeyPathToAffectedKey)
-        
+
         cachedValues[tuple] = result
-        return result 
+        return result
     }
-    
+
 }

--- a/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
@@ -16,14 +16,13 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireUtilities
 
-public enum AffectedKeys : Equatable {
+public enum AffectedKeys: Equatable {
     case some(KeySet)
     case all
-    
+
     func combinedWith(_ other: AffectedKeys) -> AffectedKeys {
         switch (self, other) {
         case let (.some(k1), .some(k2)):
@@ -32,9 +31,9 @@ public enum AffectedKeys : Equatable {
             return .all
         }
     }
-    
+
     func containsKey(_ key: StringKeyPath) -> Bool {
-        switch(self) {
+        switch self {
         case let .some(keySet):
             return keySet.contains(key)
         case .all:
@@ -54,16 +53,16 @@ public func ==(lhs: AffectedKeys, rhs: AffectedKeys) -> Bool {
     }
 }
 
-public struct KeySet : Sequence {
+public struct KeySet: Sequence {
     public typealias Key = StringKeyPath
     public typealias Iterator = Set<StringKeyPath>.Iterator
     fileprivate let backing: Set<StringKeyPath>
-    
+
     public init() {
         backing = Set()
     }
-    
-    public init(_ set : NSSet) {
+
+    public init(_ set: NSSet) {
         var a: [StringKeyPath] = []
         for s in set {
             if let ss = s as? String {
@@ -74,15 +73,15 @@ public struct KeySet : Sequence {
         }
         backing = Set(a)
     }
-    public init (_ set : Set<Key>) {
+    public init (_ set: Set<Key>) {
         backing = set
     }
-    
-    public init (_ keys : Set<String>) {
+
+    public init (_ keys: Set<String>) {
         self.init(Array(keys))
     }
-    
-    public init(_ a : [String]) {
+
+    public init(_ a: [String]) {
         var aa: [StringKeyPath] = []
         for s in a {
             aa.append(StringKeyPath.keyPathForString(s))
@@ -101,25 +100,25 @@ public struct KeySet : Sequence {
     public init(arrayLiteral elements: String...) {
         self.init(elements)
     }
-    init<S : Sequence>(_ seq: S) where S.Iterator.Element == Key {
+    init<S: Sequence>(_ seq: S) where S.Iterator.Element == Key {
         backing = Set<Key>(seq)
     }
-    public func contains(_ i : StringKeyPath) -> Bool {
+    public func contains(_ i: StringKeyPath) -> Bool {
         return backing.contains(i)
     }
-    public func contains(_ i : String) -> Bool {
+    public func contains(_ i: String) -> Bool {
         return backing.contains(StringKeyPath.keyPathForString(i))
     }
     public func makeIterator() -> Set<StringKeyPath>.Iterator {
         return backing.makeIterator()
     }
-    
-    public var count : Int {
+
+    public var count: Int {
         return backing.count
     }
 }
 
-extension KeySet : Hashable {
+extension KeySet: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(backing.hashValue)
     }
@@ -128,7 +127,6 @@ extension KeySet : Hashable {
 public func ==(lhs: KeySet, rhs: KeySet) -> Bool {
     return lhs.backing == rhs.backing
 }
-
 
 extension KeySet {
     func union(_ set: KeySet) -> KeySet {
@@ -145,10 +143,10 @@ extension KeySet {
     }
 }
 
-extension KeySet : CustomDebugStringConvertible {
+extension KeySet: CustomDebugStringConvertible {
     public var description: String {
-        let a = Array<StringKeyPath>(backing)
-        let ss = a.map { $0.rawValue }.sorted() {
+        let a = [StringKeyPath](backing)
+        let ss = a.map { $0.rawValue }.sorted {
             (lhs, rhs) in lhs < rhs
         }
         return "KeySet {" + ss.joined(separator: " ") + "}"

--- a/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
@@ -16,68 +16,66 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireUtilities
 
 public struct SetStateUpdate<T: Hashable> {
-    
-    public let newSnapshot : SetSnapshot<T>
-    public let changeInfo : SetChangeInfo<T>
-    
-    let removedObjects : Set<T>
-    let insertedObjects : Set<T>
+
+    public let newSnapshot: SetSnapshot<T>
+    public let changeInfo: SetChangeInfo<T>
+
+    let removedObjects: Set<T>
+    let insertedObjects: Set<T>
 
 }
 
 public protocol SetChangeInfoOwner {
-    associatedtype ChangeInfoContent : Hashable
-    var orderedSetState : OrderedSetState<ChangeInfoContent> { get }
-    var setChangeInfo : SetChangeInfo<ChangeInfoContent> { get }
-    var insertedIndexes : IndexSet { get }
-    var deletedIndexes : IndexSet { get }
+    associatedtype ChangeInfoContent: Hashable
+    var orderedSetState: OrderedSetState<ChangeInfoContent> { get }
+    var setChangeInfo: SetChangeInfo<ChangeInfoContent> { get }
+    var insertedIndexes: IndexSet { get }
+    var deletedIndexes: IndexSet { get }
     var deletedObjects: Set<AnyHashable> { get }
-    var updatedIndexes : IndexSet { get }
-    var movedIndexPairs : [MovedIndex] { get }
-    var zm_movedIndexPairs : [ZMMovedIndex] { get }
-    
-    func enumerateMovedIndexes(_ block:@escaping (_ from: Int, _ to : Int) -> Void)
+    var updatedIndexes: IndexSet { get }
+    var movedIndexPairs: [MovedIndex] { get }
+    var zm_movedIndexPairs: [ZMMovedIndex] { get }
+
+    func enumerateMovedIndexes(_ block:@escaping (_ from: Int, _ to: Int) -> Void)
 
 }
 
-open class SetChangeInfo<T: Hashable> : NSObject {
-    
-    let changeSet : ChangedIndexes<T>
-    public let orderedSetState : OrderedSetState<T>
-    
-    public let observedObject : NSObject
-    open var insertedIndexes : IndexSet { return changeSet.insertedIndexes }
-    open var deletedIndexes : IndexSet { return changeSet.deletedIndexes }
+open class SetChangeInfo<T: Hashable>: NSObject {
+
+    let changeSet: ChangedIndexes<T>
+    public let orderedSetState: OrderedSetState<T>
+
+    public let observedObject: NSObject
+    open var insertedIndexes: IndexSet { return changeSet.insertedIndexes }
+    open var deletedIndexes: IndexSet { return changeSet.deletedIndexes }
     open var deletedObjects: Set<AnyHashable> { return changeSet.deletedObjects }
-    open var updatedIndexes : IndexSet { return changeSet.updatedIndexes }
-    open var movedIndexPairs : [MovedIndex] { return changeSet.movedIndexes }
+    open var updatedIndexes: IndexSet { return changeSet.updatedIndexes }
+    open var movedIndexPairs: [MovedIndex] { return changeSet.movedIndexes }
     // for temporary objC-compatibility
-    open var zm_movedIndexPairs : [ZMMovedIndex] { return changeSet.movedIndexes.map{ZMMovedIndex(from: UInt($0.from), to: UInt($0.to))}}
+    open var zm_movedIndexPairs: [ZMMovedIndex] { return changeSet.movedIndexes.map {ZMMovedIndex(from: UInt($0.from), to: UInt($0.to))}}
     convenience init(observedObject: NSObject) {
         let orderSetState = OrderedSetState<T>(array: [])
         self.init(observedObject: observedObject,
                   changeSet: ChangedIndexes(start: orderSetState, end: orderSetState, updated: Set()),
                   orderedSetState: orderSetState)
     }
-    
+
     public init(observedObject: NSObject, changeSet: ChangedIndexes<T>, orderedSetState: OrderedSetState<T>) {
         self.changeSet = changeSet
         self.orderedSetState = orderedSetState
         self.observedObject = observedObject
     }
 
-    
-    open func enumerateMovedIndexes(_ block:@escaping (_ from: Int, _ to : Int) -> Void) {
+    open func enumerateMovedIndexes(_ block:@escaping (_ from: Int, _ to: Int) -> Void) {
         self.changeSet.enumerateMovedIndexes(block: block)
     }
-    
-    open override var description : String { return self.debugDescription }
-    open override var debugDescription : String {
+
+    open override var description: String { return self.debugDescription }
+    open override var debugDescription: String {
         return "deleted: \(deletedIndexes), inserted: \(insertedIndexes), " +
         "updated: \(updatedIndexes), moved: \(movedIndexPairs)"
     }
@@ -85,25 +83,25 @@ open class SetChangeInfo<T: Hashable> : NSObject {
 }
 
 public struct SetSnapshot<T: Hashable> {
-    
-    public let set : OrderedSetState<T>
-    public let moveType : SetChangeMoveType
-    
-    public init(set: OrderedSetState<T>, moveType : SetChangeMoveType) {
+
+    public let set: OrderedSetState<T>
+    public let moveType: SetChangeMoveType
+
+    public init(set: OrderedSetState<T>, moveType: SetChangeMoveType) {
         self.set = set
         self.moveType = moveType
     }
-    
+
     // Returns the new state and the notification to send after some changes in messages
     public func updatedState(_ updatedObjects: Set<T>, observedObject: NSObject, newSet: OrderedSetState<T>) -> SetStateUpdate<T>? {
-    
+
         if self.set == newSet && updatedObjects.count == 0 {
             return nil
         }
-        
-        let changeSet = ChangedIndexes(start:self.set, end:newSet, updated:updatedObjects, moveType:self.moveType)
+
+        let changeSet = ChangedIndexes(start: self.set, end: newSet, updated: updatedObjects, moveType: self.moveType)
         let changeInfo = SetChangeInfo(observedObject: observedObject, changeSet: changeSet, orderedSetState: newSet)
-        
+
         if changeInfo.insertedIndexes.count == 0 && changeInfo.deletedIndexes.count == 0 && changeInfo.updatedIndexes.count == 0 && changeInfo.movedIndexPairs.count == 0 {
             return nil
         }

--- a/Source/Notifications/ObjectObserverTokens/Helpers/StringKeyPath.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/StringKeyPath.swift
@@ -16,20 +16,18 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-
 /// A key path (as in key-value-coding).
-public final class StringKeyPath : Hashable {
-    
+public final class StringKeyPath: Hashable {
+
     public let rawValue: String
     public let count: Int
 
-    static private var KeyPathCache : [String : StringKeyPath] = [:]
-    
+    static private var KeyPathCache: [String: StringKeyPath] = [:]
+
     public class func keyPathForString(_ string: String) -> StringKeyPath {
-        
+
         if let keyPath = KeyPathCache[string] {
             return keyPath
         }
@@ -39,7 +37,7 @@ public final class StringKeyPath : Hashable {
             return instance
         }
     }
-    
+
     private init(_ s: String) {
         rawValue = s
         count = rawValue.filter {
@@ -51,7 +49,6 @@ public final class StringKeyPath : Hashable {
         hasher.combine(rawValue.hashValue)
     }
 
-    
     public var isPath: Bool {
         return 1 < count
     }
@@ -60,7 +57,7 @@ public final class StringKeyPath : Hashable {
         if 1 <= self.count {
             if let i = self.rawValue.firstIndex(of: ".") {
                 let head = self.rawValue[..<i]
-                var tail : StringKeyPath?
+                var tail: StringKeyPath?
                 if i != self.rawValue.endIndex {
                     let nextIndex = self.rawValue.index(after: i)
                     let result = self.rawValue[nextIndex...]
@@ -74,14 +71,14 @@ public final class StringKeyPath : Hashable {
     }()
 }
 
-extension StringKeyPath : Equatable {
+extension StringKeyPath: Equatable {
 }
 public func ==(lhs: StringKeyPath, rhs: StringKeyPath) -> Bool {
     // We store the hash which makes comparison very cheap.
     return (lhs.hashValue == rhs.hashValue) && (lhs.rawValue == rhs.rawValue)
 }
 
-extension StringKeyPath : CustomDebugStringConvertible {
+extension StringKeyPath: CustomDebugStringConvertible {
     public var description: String {
         return rawValue
     }

--- a/Source/Notifications/ObjectObserverTokens/LabelChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/LabelChangeInfo.swift
@@ -18,55 +18,55 @@
 
 import Foundation
 
-extension Label : ObjectInSnapshot {
-    
-    static public var observableKeys : Set<String> {
+extension Label: ObjectInSnapshot {
+
+    static public var observableKeys: Set<String> {
         return [
             #keyPath(Label.name), #keyPath(Label.markedForDeletion), #keyPath(Label.conversations)
         ]
     }
-    
-    public var notificationName : Notification.Name {
+
+    public var notificationName: Notification.Name {
         return .LabelChange
     }
-    
+
 }
 
-@objcMembers public class LabelChangeInfo : ObjectChangeInfo {
-    
+@objcMembers public class LabelChangeInfo: ObjectChangeInfo {
+
     public let label: LabelType
-    
+
     static func changeInfo(for label: Label, changes: Changes) -> LabelChangeInfo? {
         return LabelChangeInfo(object: label, changes: changes)
     }
-    
+
     public required init(object: NSObject) {
         self.label = object as! Label
         super.init(object: object)
     }
-    
-    public var nameChanged : Bool {
+
+    public var nameChanged: Bool {
         return changedKeys.contains(#keyPath(Label.name))
     }
-    
+
     public var markedForDeletion: Bool {
         return changedKeys.contains(#keyPath(Label.markedForDeletion))
     }
-    
+
     public var conversationsChanged: Bool {
         return changedKeys.contains(#keyPath(Label.conversations))
     }
-    
+
 }
 
-@objc public protocol LabelObserver : NSObjectProtocol {
+@objc public protocol LabelObserver: NSObjectProtocol {
     func labelDidChange(_ changeInfo: LabelChangeInfo)
 }
 
 // MARK: Registering Label observers
 
 extension LabelChangeInfo {
-    
+
     /// Adds an observer for a label
     ///
     /// You must hold on to the token and use it to unregister
@@ -75,20 +75,19 @@ extension LabelChangeInfo {
         guard let label = label as? Label else { return nil }
         return add(observer: observer, for: label, managedObjectContext: label.managedObjectContext!)
     }
-    
+
     /// Adds an observer for the label if one is specified or to all labels is none is specified
     ///
     /// You must hold on to the token and use it to unregister
     @objc(addTeamObserver:forTeam:managedObjectContext:)
     public static func add(observer: LabelObserver, for label: LabelType?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .LabelChange, managedObjectContext: managedObjectContext, object: label)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .LabelChange, managedObjectContext: managedObjectContext, object: label) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? LabelChangeInfo
                 else { return }
-            
+
             observer.labelDidChange(changeInfo)
         }
     }
-    
+
 }

--- a/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/MessageChangeInfo.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 private var zmLog = ZMSLog(tag: "MessageChangeInfo")
@@ -30,20 +29,20 @@ enum MessageKey: String {
     case underlyingMessage = "underlyingMessage"
 }
 
-extension ZMMessage : ObjectInSnapshot {
-    
-    @objc public class var observableKeys : Set<String> {
+extension ZMMessage: ObjectInSnapshot {
+
+    @objc public class var observableKeys: Set<String> {
         return [#keyPath(ZMMessage.deliveryState), #keyPath(ZMMessage.isObfuscated)]
     }
-    
-    public var notificationName : Notification.Name {
+
+    public var notificationName: Notification.Name {
         return .MessageChange
     }
 }
 
 extension ZMAssetClientMessage {
 
-    public class override var observableKeys : Set<String> {
+    public class override var observableKeys: Set<String> {
         let keys = super.observableKeys
         let additionalKeys = [#keyPath(ZMAssetClientMessage.transferState),
                               MessageKey.previewGenericMessage.rawValue,
@@ -59,8 +58,8 @@ extension ZMAssetClientMessage {
 }
 
 extension ZMClientMessage {
-    
-    public class override var observableKeys : Set<String> {
+
+    public class override var observableKeys: Set<String> {
         let keys = super.observableKeys
         let additionalKeys = [#keyPath(ZMAssetClientMessage.hasDownloadedPreview),
                               #keyPath(ZMClientMessage.linkPreviewState),
@@ -76,8 +75,8 @@ extension ZMClientMessage {
 }
 
 extension ZMImageMessage {
-    
-    public class override var observableKeys : Set<String> {
+
+    public class override var observableKeys: Set<String> {
         let keys = super.observableKeys
         let additionalKeys = [#keyPath(ZMImageMessage.mediumData),
                               #keyPath(ZMImageMessage.mediumRemoteIdentifier),
@@ -88,7 +87,7 @@ extension ZMImageMessage {
 
 extension ZMSystemMessage {
 
-    public class override var observableKeys : Set<String> {
+    public class override var observableKeys: Set<String> {
         let keys = super.observableKeys
         let additionalKeys = [#keyPath(ZMSystemMessage.childMessages),
                               #keyPath(ZMSystemMessage.systemMessageType)]
@@ -97,22 +96,21 @@ extension ZMSystemMessage {
 
 }
 
-@objcMembers final public class MessageChangeInfo : ObjectChangeInfo {
-    
+@objcMembers final public class MessageChangeInfo: ObjectChangeInfo {
+
     static let UserChangeInfoKey = "userChanges"
     static let ReactionChangeInfoKey = "reactionChanges"
     static let ButtonStateChangeInfoKey = "buttonStateChanges"
-    
+
     static func changeInfo(for message: ZMMessage, changes: Changes) -> MessageChangeInfo? {
         return MessageChangeInfo(object: message, changes: changes)
     }
-    
-    
+
     public required init(object: NSObject) {
         self.message = object as! ZMMessage
         super.init(object: object)
     }
-    
+
     public override var debugDescription: String {
         return ["deliveryStateChanged: \(deliveryStateChanged)",
                 "reactionsChanged: \(reactionsChanged)",
@@ -131,34 +129,34 @@ extension ZMSystemMessage {
                 "buttonStatesChanged: \(buttonStatesChanged)"
                 ].joined(separator: ", ")
     }
-    
-    public var deliveryStateChanged : Bool {
+
+    public var deliveryStateChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.deliveryState))
     }
-    
-    public var reactionsChanged : Bool {
+
+    public var reactionsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.reactions)) ||
                changeInfos[MessageChangeInfo.ReactionChangeInfoKey] != nil
     }
 
-    public var confirmationsChanged : Bool {
+    public var confirmationsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.confirmations))
     }
-    
-    public var underlyingMessageChanged : Bool {
+
+    public var underlyingMessageChanged: Bool {
         return changedKeysContain(keys: MessageKey.underlyingMessage.rawValue)
     }
-    
-    public var childMessagesChanged : Bool {
+
+    public var childMessagesChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMSystemMessage.childMessages))
     }
-    
+
     public var quoteChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMClientMessage.quote))
     }
 
     /// Whether the image data on disk changed
-    public var imageChanged : Bool {
+    public var imageChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMImageMessage.mediumData),
                                   #keyPath(ZMImageMessage.mediumRemoteIdentifier),
                                   #keyPath(ZMAssetClientMessage.hasDownloadedPreview),
@@ -166,16 +164,16 @@ extension ZMSystemMessage {
                                   MessageKey.previewGenericMessage.rawValue,
                                   MessageKey.mediumGenericMessage.rawValue)
     }
-    
+
     /// Whether the file on disk changed
     public var fileAvailabilityChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMAssetClientMessage.hasDownloadedFile))
     }
 
-    public var usersChanged : Bool {
+    public var usersChanged: Bool {
         return userChangeInfo != nil
     }
-    
+
     public var linkPreviewChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMClientMessage.linkPreviewState), MessageKey.linkPreview.rawValue)
     }
@@ -184,41 +182,39 @@ extension ZMSystemMessage {
         return changedKeysContain(keys: #keyPath(ZMAssetClientMessage.transferState))
     }
 
-    public var senderChanged : Bool {
-        if self.usersChanged && (self.userChangeInfo?.user as? ZMUser ==  self.message.sender){
+    public var senderChanged: Bool {
+        if self.usersChanged && (self.userChangeInfo?.user as? ZMUser ==  self.message.sender) {
             return true
         }
         return false
     }
-    
-    public var isObfuscatedChanged : Bool {
+
+    public var isObfuscatedChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.isObfuscated))
     }
 
     public var linkAttachmentsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMMessage.linkAttachments))
     }
-    
+
     public var buttonStatesChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMClientMessage.buttonStates)) || changeInfos[MessageChangeInfo.ButtonStateChangeInfoKey] != nil
     }
-    
-    public var userChangeInfo : UserChangeInfo? {
+
+    public var userChangeInfo: UserChangeInfo? {
         return changeInfos[MessageChangeInfo.UserChangeInfoKey] as? UserChangeInfo
     }
-    
-    public let message : ZMMessage
-    
+
+    public let message: ZMMessage
+
 }
 
-
-
-@objc public protocol ZMMessageObserver : NSObjectProtocol {
+@objc public protocol ZMMessageObserver: NSObjectProtocol {
     func messageDidChange(_ changeInfo: MessageChangeInfo)
 }
 
 extension MessageChangeInfo {
-    
+
     /// Adds a ZMMessageObserver to the specified message
     /// To observe messages and their users (senders, systemMessage users), observe the conversation window instead
     /// Messages observed with this call will not contain information about user changes
@@ -229,13 +225,12 @@ extension MessageChangeInfo {
                            managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
         return ManagedObjectObserverToken(name: .MessageChange,
                                           managedObjectContext: managedObjectContext,
-                                          object: message)
-        { [weak observer] (note) in
+                                          object: message) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? MessageChangeInfo
                 else { return }
-            
+
             observer.messageDidChange(changeInfo)
-        } 
+        }
     }
 }

--- a/Source/Notifications/ObjectObserverTokens/NewUnreadMessageChangeInfos.swift
+++ b/Source/Notifications/ObjectObserverTokens/NewUnreadMessageChangeInfos.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 //////////////////////////
@@ -25,31 +24,29 @@ import Foundation
 ///
 //////////////////////////
 
-public final class NewUnreadMessagesChangeInfo : ObjectChangeInfo  {
-    
+public final class NewUnreadMessagesChangeInfo: ObjectChangeInfo {
+
     public convenience init(messages: [ZMConversationMessage]) {
         self.init(object: messages as NSObject)
     }
-    
-    public var messages : [ZMConversationMessage] {
+
+    public var messages: [ZMConversationMessage] {
         return object as? [ZMConversationMessage] ?? []
     }
-    
+
 }
 
-
-@objc public protocol ZMNewUnreadMessagesObserver : NSObjectProtocol {
+@objc public protocol ZMNewUnreadMessagesObserver: NSObjectProtocol {
     func didReceiveNewUnreadMessages(_ changeInfo: NewUnreadMessagesChangeInfo)
 }
 
 extension NewUnreadMessagesChangeInfo {
-    
+
     /// Adds a ZMNewUnreadMessagesObserver
     /// You must hold on to the token and use it to unregister
     @objc(addNewMessageObserver:forManagedObjectContext:)
     public static func add(observer: ZMNewUnreadMessagesObserver, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .NewUnreadMessage, managedObjectContext: managedObjectContext)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .NewUnreadMessage, managedObjectContext: managedObjectContext) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? NewUnreadMessagesChangeInfo
                 else { return }
@@ -58,28 +55,24 @@ extension NewUnreadMessagesChangeInfo {
     }
 }
 
-
-
 //////////////////////////
 ///
 /// NewUnreadKnockMessage
 ///
 //////////////////////////
 
+@objc public final class NewUnreadKnockMessagesChangeInfo: ObjectChangeInfo {
 
-@objc public final class NewUnreadKnockMessagesChangeInfo : ObjectChangeInfo {
-    
     public convenience init(messages: [ZMConversationMessage]) {
         self.init(object: messages as NSObject)
     }
-    
-    public var messages : [ZMConversationMessage] {
+
+    public var messages: [ZMConversationMessage] {
         return object as? [ZMConversationMessage] ?? []
     }
 }
 
-
-@objc public protocol ZMNewUnreadKnocksObserver : NSObjectProtocol {
+@objc public protocol ZMNewUnreadKnocksObserver: NSObjectProtocol {
     func didReceiveNewUnreadKnockMessages(_ changeInfo: NewUnreadKnockMessagesChangeInfo)
 }
 
@@ -89,18 +82,15 @@ extension NewUnreadKnockMessagesChangeInfo {
     /// You must hold on to the token and use it to unregister
     @objc(addNewKnockObserver:forManagedObjectContext:)
     public static func add(observer: ZMNewUnreadKnocksObserver, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .NewUnreadKnock, managedObjectContext: managedObjectContext)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .NewUnreadKnock, managedObjectContext: managedObjectContext) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? NewUnreadKnockMessagesChangeInfo
                 else { return }
             observer.didReceiveNewUnreadKnockMessages(changeInfo)
-        } 
+        }
     }
 
 }
-
-
 
 //////////////////////////
 ///
@@ -108,32 +98,28 @@ extension NewUnreadKnockMessagesChangeInfo {
 ///
 //////////////////////////
 
+@objc public final class NewUnreadUnsentMessageChangeInfo: ObjectChangeInfo {
 
-@objc public final class NewUnreadUnsentMessageChangeInfo : ObjectChangeInfo {
-    
     public required convenience init(messages: [ZMConversationMessage]) {
         self.init(object: messages as NSObject)
     }
-    
-    public var messages : [ZMConversationMessage] {
+
+    public var messages: [ZMConversationMessage] {
         return  object as? [ZMConversationMessage] ?? []
     }
 }
 
-
-
-@objc public protocol ZMNewUnreadUnsentMessageObserver : NSObjectProtocol {
+@objc public protocol ZMNewUnreadUnsentMessageObserver: NSObjectProtocol {
     func didReceiveNewUnreadUnsentMessages(_ changeInfo: NewUnreadUnsentMessageChangeInfo)
 }
 
 extension NewUnreadUnsentMessageChangeInfo {
-    
+
     /// Adds a ZMNewUnreadUnsentMessageObserver
     /// You must hold on to the token and use it to unregister
     @objc(addNewUnreadUnsentMessageObserver:forManagedObjectContext:)
     public static func add(observer: ZMNewUnreadUnsentMessageObserver, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .NewUnreadUnsentMessage, managedObjectContext: managedObjectContext)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .NewUnreadUnsentMessage, managedObjectContext: managedObjectContext) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? NewUnreadUnsentMessageChangeInfo
                 else { return }
@@ -141,4 +127,3 @@ extension NewUnreadUnsentMessageChangeInfo {
         }
     }
 }
-

--- a/Source/Notifications/ObjectObserverTokens/ObjectChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ObjectChangeInfo.swift
@@ -16,13 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-
-/// MARK: Base class for observer / change info
+// MARK: Base class for observer / change info
 public protocol ObjectChangeInfoProtocol: NSObjectProtocol {
-    
+
     var changeInfos: [String: NSObject?] { get set }
 
     init(object: NSObject)
@@ -34,7 +32,7 @@ public protocol ObjectChangeInfoProtocol: NSObjectProtocol {
 }
 
 open class ObjectChangeInfo: NSObject, ObjectChangeInfoProtocol {
-    
+
     let object: NSObject
 
     open var changedKeys = Set<String>()
@@ -49,7 +47,7 @@ open class ObjectChangeInfo: NSObject, ObjectChangeInfoProtocol {
         changeInfos = changes.originalChanges
         considerAllKeysChanged = changes.mayHaveUnknownChanges
     }
-    
+
     public required init(object: NSObject) {
         self.object = object
     }
@@ -57,20 +55,18 @@ open class ObjectChangeInfo: NSObject, ObjectChangeInfoProtocol {
     func changedKeysContain(keys: String...) -> Bool {
         return considerAllKeysChanged || !changedKeys.isDisjoint(with: keys)
     }
-    
+
     var customDebugDescription: String {
         guard let managedObject = object as? NSManagedObject else {
             return "ChangeInfo for \(object) with changedKeys: \(changedKeys), changeInfos: \(changeInfos)"
         }
-        
+
         return "ChangeInfo for \(managedObject.objectID) with changedKeys: \(changedKeys), changeInfos: \(changeInfos)"
     }
 }
 
-
-
 extension ObjectChangeInfo {
-    
+
     static func changeInfo(for object: NSObject, changes: Changes) -> ObjectChangeInfo? {
         switch object {
         case let object as ZMConversation:  return ConversationChangeInfo.changeInfo(for: object, changes: changes)
@@ -84,6 +80,5 @@ extension ObjectChangeInfo {
             return nil
         }
     }
-    
-}
 
+}

--- a/Source/Notifications/ObjectObserverTokens/ParticipantRoleChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/ParticipantRoleChangeInfo.swift
@@ -16,45 +16,43 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import WireSystem
 
-extension ParticipantRole : ObjectInSnapshot {
-    
-    static public var observableKeys : Set<String> {
+extension ParticipantRole: ObjectInSnapshot {
+
+    static public var observableKeys: Set<String> {
         return [
             #keyPath(ParticipantRole.role)]
     }
-    
-    public var notificationName : Notification.Name {
+
+    public var notificationName: Notification.Name {
         return .ParticipantRoleChange
     }
 }
 
-
 @objcMembers
-final public class ParticipantRoleChangeInfo : ObjectChangeInfo {
-    
+final public class ParticipantRoleChangeInfo: ObjectChangeInfo {
+
     static let ParticipantRoleChangeInfoKey = "participantRoleChanges"
 
     static func changeInfo(for participantRole: ParticipantRole, changes: Changes) -> ParticipantRoleChangeInfo? {
         return ParticipantRoleChangeInfo(object: participantRole, changes: changes)
     }
-    
+
     public required init(object: NSObject) {
         participantRole = object as! ParticipantRole
         super.init(object: object)
     }
-    
+
     public let participantRole: ParticipantRole // TODO: create ParticipantRoleType
-    
-    public var roleChanged : Bool {
+
+    public var roleChanged: Bool {
         return changedKeys.contains(#keyPath(ParticipantRole.role))
     }
-    
+
     // MARK: Registering ParticipantRoleObservers
-    
+
     /// Adds an observer for a participantRole
     ///
     /// You must hold on to the token and use it to unregister
@@ -62,24 +60,23 @@ final public class ParticipantRoleChangeInfo : ObjectChangeInfo {
     public static func add(observer: ParticipantRoleObserver, for participantRole: ParticipantRole) -> NSObjectProtocol {
         return add(observer: observer, for: participantRole, managedObjectContext: participantRole.managedObjectContext!)
     }
-    
+
     /// Adds an observer for the participantRole if one specified or to all ParticipantRoles is none is specified
     ///
     /// You must hold on to the token and use it to unregister
     @objc(addParticipantRoleObserver:forParticipantRole:managedObjectContext:)
     public static func add(observer: ParticipantRoleObserver, for participantRole: ParticipantRole?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .ParticipantRoleChange, managedObjectContext: managedObjectContext, object: participantRole)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .ParticipantRoleChange, managedObjectContext: managedObjectContext, object: participantRole) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? ParticipantRoleChangeInfo
                 else { return }
-            
+
             observer.participantRoleDidChange(changeInfo)
         }
     }
-    
+
 }
 
-@objc public protocol ParticipantRoleObserver : NSObjectProtocol {
+@objc public protocol ParticipantRoleObserver: NSObjectProtocol {
     func participantRoleDidChange(_ changeInfo: ParticipantRoleChangeInfo)
 }

--- a/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/TeamChangeInfo.swift
@@ -16,65 +16,60 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import WireSystem
 
-extension Team : ObjectInSnapshot {
-    
-    static public var observableKeys : Set<String> {
+extension Team: ObjectInSnapshot {
+
+    static public var observableKeys: Set<String> {
         return [
             #keyPath(Team.name),
             #keyPath(Team.members),
             #keyPath(Team.imageData),
-            #keyPath(Team.pictureAssetId),
+            #keyPath(Team.pictureAssetId)
         ]
     }
-    
-    public var notificationName : Notification.Name {
+
+    public var notificationName: Notification.Name {
         return .TeamChange
     }
 }
 
+@objcMembers public class TeamChangeInfo: ObjectChangeInfo {
 
-@objcMembers public class TeamChangeInfo : ObjectChangeInfo {
-    
     static func changeInfo(for team: Team, changes: Changes) -> TeamChangeInfo? {
         return TeamChangeInfo(object: team, changes: changes)
     }
-    
+
     public required init(object: NSObject) {
         self.team = object as! Team
         super.init(object: object)
     }
-    
+
     public let team: TeamType
-    
-    public var membersChanged : Bool {
+
+    public var membersChanged: Bool {
         return changedKeys.contains(#keyPath(Team.members))
     }
 
-    public var nameChanged : Bool {
+    public var nameChanged: Bool {
         return changedKeys.contains(#keyPath(Team.name))
     }
-    
-    public var imageDataChanged : Bool {
+
+    public var imageDataChanged: Bool {
         return changedKeysContain(keys: #keyPath(Team.imageData), #keyPath(Team.pictureAssetId))
     }
 
 }
 
-
-
-@objc public protocol TeamObserver : NSObjectProtocol {
+@objc public protocol TeamObserver: NSObjectProtocol {
     func teamDidChange(_ changeInfo: TeamChangeInfo)
 }
 
-
 extension TeamChangeInfo {
-    
+
     // MARK: Registering TeamObservers
-    
+
     /// Adds an observer for a team
     ///
     /// You must hold on to the token and use it to unregister
@@ -82,25 +77,19 @@ extension TeamChangeInfo {
     public static func add(observer: TeamObserver, for team: Team) -> NSObjectProtocol {
         return add(observer: observer, for: team, managedObjectContext: team.managedObjectContext!)
     }
-    
+
     /// Adds an observer for the team if one specified or to all Teams is none is specified
     ///
     /// You must hold on to the token and use it to unregister
     @objc(addTeamObserver:forTeam:managedObjectContext:)
     public static func add(observer: TeamObserver, for team: Team?, managedObjectContext: NSManagedObjectContext) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .TeamChange, managedObjectContext: managedObjectContext, object: team)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .TeamChange, managedObjectContext: managedObjectContext, object: team) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? TeamChangeInfo
                 else { return }
-            
+
             observer.teamDidChange(changeInfo)
         }
     }
-    
+
 }
-
-
-
-
-

--- a/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserChangeInfo.swift
@@ -16,18 +16,17 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireSystem
 
 protocol ObjectInSnapshot {
-    static var observableKeys : Set<String> { get }
-    var notificationName : Notification.Name { get }
+    static var observableKeys: Set<String> { get }
+    var notificationName: Notification.Name { get }
 }
 
-extension ZMUser : ObjectInSnapshot {
-    
-    static public var observableKeys : Set<String> {
+extension ZMUser: ObjectInSnapshot {
+
+    static public var observableKeys: Set<String> {
         return [
             #keyPath(ZMUser.name),
             #keyPath(ZMUser.accentColorValue),
@@ -57,20 +56,19 @@ extension ZMUser : ObjectInSnapshot {
         ]
     }
 
-    public var notificationName : Notification.Name {
+    public var notificationName: Notification.Name {
         return .UserChange
     }
 }
 
-
-@objcMembers open class UserChangeInfo : ObjectChangeInfo {
+@objcMembers open class UserChangeInfo: ObjectChangeInfo {
 
     static let UserClientChangeInfoKey = "clientChanges"
-    
+
     static func changeInfo(for user: ZMUser, changes: Changes) -> UserChangeInfo? {
         var originalChanges = changes.originalChanges
         let clientChanges = originalChanges.removeValue(forKey: UserClientChangeInfoKey) as? [NSObject: [String: Any]]
-        
+
         if let clientChanges = clientChanges {
             var userClientChangeInfos = [UserClientChangeInfo]()
             clientChanges.forEach {
@@ -84,79 +82,79 @@ extension ZMUser : ObjectInSnapshot {
         let modifiedChanges = changes.merged(with: Changes(originalChanges: originalChanges))
         return UserChangeInfo(object: user, changes: modifiedChanges)
     }
-    
+
     public required init(object: NSObject) {
         self.user = object as! UserType
         super.init(object: object)
     }
 
-    open var nameChanged : Bool {
+    open var nameChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.name))
     }
-    
-    open var accentColorValueChanged : Bool {
+
+    open var accentColorValueChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.accentColorValue))
     }
 
-    open var imageMediumDataChanged : Bool {
+    open var imageMediumDataChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserType.completeImageData), #keyPath(ZMUser.completeProfileAssetIdentifier))
     }
 
-    open var imageSmallProfileDataChanged : Bool {
+    open var imageSmallProfileDataChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserType.previewImageData), #keyPath(ZMUser.previewProfileAssetIdentifier))
     }
 
-    open var profileInformationChanged : Bool {
+    open var profileInformationChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.emailAddress), #keyPath(ZMUser.phoneNumber))
     }
 
-    open var connectionStateChanged : Bool {
+    open var connectionStateChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.isConnected),
                                   #keyPath(ZMUser.canBeConnected),
                                   #keyPath(ZMUser.isPendingApprovalByOtherUser),
                                   #keyPath(ZMUser.isPendingApprovalBySelfUser))
     }
 
-    open var trustLevelChanged : Bool {
+    open var trustLevelChanged: Bool {
         return userClientChangeInfos.count != 0
     }
 
-    open var clientsChanged : Bool {
+    open var clientsChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.clients))
     }
 
-    public var handleChanged : Bool {
+    public var handleChanged: Bool {
         return changedKeysContain(keys: #keyPath(ZMUser.handle))
     }
 
-    public var teamsChanged : Bool {
+    public var teamsChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.team))
     }
-    
-    public var availabilityChanged : Bool {
+
+    public var availabilityChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.availability))
     }
 
-    public var readReceiptsEnabledChanged : Bool {
+    public var readReceiptsEnabledChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.readReceiptsEnabled))
     }
-    
-    public var readReceiptsEnabledChangedRemotelyChanged : Bool {
+
+    public var readReceiptsEnabledChangedRemotelyChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.readReceiptsEnabledChangedRemotely))
     }
-    
-    public var richProfileChanged : Bool {
+
+    public var richProfileChanged: Bool {
         return changedKeys.contains(ZMUserKeys.RichProfile)
     }
 
     public var legalHoldStatusChanged: Bool {
         return !changedKeys.intersection(ZMUser.keysAffectingLegalHoldStatus()).isEmpty
     }
-    
+
     public var isUnderLegalHoldChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.isUnderLegalHold))
     }
-    
+
     public var roleChanged: Bool {
         return changedKeys.contains(#keyPath(ZMUser.participantRoles))
     }
@@ -166,17 +164,14 @@ extension ZMUser : ObjectInSnapshot {
     }
 
     public let user: UserType
-    open var userClientChangeInfos : [UserClientChangeInfo] {
+    open var userClientChangeInfos: [UserClientChangeInfo] {
         return changeInfos[UserChangeInfo.UserClientChangeInfoKey] as? [UserClientChangeInfo] ?? []
     }
 }
 
-
-
-@objc public protocol ZMUserObserver : NSObjectProtocol {
+@objc public protocol ZMUserObserver: NSObjectProtocol {
     func userDidChange(_ changeInfo: UserChangeInfo)
 }
-
 
 extension UserChangeInfo {
 
@@ -190,12 +185,12 @@ extension UserChangeInfo {
             return add(searchUserObserver: observer, for: user, in: managedObjectContext)
         }
         else if let user = user as? ZMUser {
-            return add(userObserver: observer, for:user, in: managedObjectContext)
+            return add(userObserver: observer, for: user, in: managedObjectContext)
         }
 
         return nil
     }
-    
+
     // MARK: Registering SearchUserObservers
 
     /// Adds an observer for all ZMSearchUsers in the given context. You must hold on to the token and use it to unregister.
@@ -215,7 +210,7 @@ extension UserChangeInfo {
             else {
                 return
             }
-            
+
             observer.userDidChange(changeInfo)
         }
     }

--- a/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
+++ b/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
@@ -16,29 +16,26 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
-
 
 extension UserClient {
     public override var description: String {
         return "Client: \(String(describing: sessionIdentifier?.rawValue)), user name: \(String(describing: user?.name)) email: \(String(describing: user?.emailAddress)) platform: \(String(describing: deviceClass)), label: \(String(describing: label)), model: \(String(describing: model))"
     }
 
-    
 }
 
 extension UserClient: ObjectInSnapshot {
 
-    static public var observableKeys : Set<String> {
+    static public var observableKeys: Set<String> {
         return Set([#keyPath(UserClient.trustedByClients),
                     #keyPath(UserClient.ignoredByClients),
                     #keyPath(UserClient.needsToNotifyUser),
                     #keyPath(UserClient.fingerprint),
                     #keyPath(UserClient.needsToNotifyOtherUserAboutSessionReset)])
     }
-    
-    public var notificationName : Notification.Name {
+
+    public var notificationName: Notification.Name {
         return .UserClientChange
     }
 }
@@ -49,7 +46,7 @@ public enum UserClientChangeInfoKey: String {
     case FingerprintChanged = "fingerprintChanged"
 }
 
-@objcMembers open class UserClientChangeInfo : ObjectChangeInfo {
+@objcMembers open class UserClientChangeInfo: ObjectChangeInfo {
 
     public required init(object: NSObject) {
         self.userClient = object as! UserClient
@@ -59,7 +56,7 @@ public enum UserClientChangeInfoKey: String {
     open var trustedByClientsChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.trustedByClients))
     }
-    
+
     open var ignoredByClientsChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.ignoredByClients))
     }
@@ -71,41 +68,36 @@ public enum UserClientChangeInfoKey: String {
     open var needsToNotifyUserChanged: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.needsToNotifyUser))
     }
-    
+
     open var sessionHasBeenReset: Bool {
         return changedKeysContain(keys: #keyPath(UserClient.needsToNotifyOtherUserAboutSessionReset)) &&
                userClient.needsToNotifyOtherUserAboutSessionReset == false
     }
 
     public let userClient: UserClient
-    
-    
+
     static func changeInfo(for client: UserClient, changes: Changes) -> UserClientChangeInfo? {
         return UserClientChangeInfo(object: client, changes: changes)
     }
-    
+
 }
-
-
 
 @objc public protocol UserClientObserver: NSObjectProtocol {
     func userClientDidChange(_ changeInfo: UserClientChangeInfo)
 }
 
 extension UserClientChangeInfo {
-    
+
     /// Adds an observer for the specified userclient
     /// You must hold on to the token and use it to unregister
     @objc(addObserver:forClient:)
     public static func add(observer: UserClientObserver, for client: UserClient) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .UserClientChange, managedObjectContext: client.managedObjectContext!, object: client)
-        { [weak observer] (note) in
+        return ManagedObjectObserverToken(name: .UserClientChange, managedObjectContext: client.managedObjectContext!, object: client) { [weak observer] (note) in
             guard let `observer` = observer,
                 let changeInfo = note.changeInfo as? UserClientChangeInfo
                 else { return }
-            
+
             observer.userClientDidChange(changeInfo)
-        } 
+        }
     }
 }
-

--- a/Source/Notifications/SideEffectSources.swift
+++ b/Source/Notifications/SideEffectSources.swift
@@ -21,26 +21,25 @@ import Foundation
 typealias ObjectAndChanges = [ZMManagedObject: Changes]
 
 protocol SideEffectSource {
-    
+
     /// Returns a map of objects and keys that are affected by an update and it's resulting changedValues mapped by classIdentifier
     /// [classIdentifier : [affectedObject: changedKeys]]
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges
-    
+
     /// Returns a map of objects and keys that are affected by an insert or deletion mapped by classIdentifier
     /// [classIdentifier : [affectedObject: changedKeys]]
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges
 }
 
-
 extension ZMManagedObject {
-    
+
     /// Returns a map of [classIdentifier : [affectedObject: changedKeys]]
     func byInsertOrDeletionAffectedKeys(for object: ZMManagedObject?, keyStore: DependencyKeyStore, affectedKey: String) -> ObjectAndChanges {
         guard let object = object else { return [:] }
-        let classIdentifier = type(of:object).entityName()
-        return [object : Changes(changedKeys: keyStore.observableKeysAffectedByValue(classIdentifier, key: affectedKey))]
+        let classIdentifier = type(of: object).entityName()
+        return [object: Changes(changedKeys: keyStore.observableKeysAffectedByValue(classIdentifier, key: affectedKey))]
     }
-    
+
     /// Returns a map of [classIdentifier : [affectedObject: changedKeys]]
     func byUpdateAffectedKeys(for object: ZMManagedObject?,
                               knownKeys: Set<String>,
@@ -49,62 +48,61 @@ extension ZMManagedObject {
                               keyMapping: ((String) -> String)) -> ObjectAndChanges {
         guard let object = object else { return [:]}
         let classIdentifier = type(of: object).entityName()
-        
+
         var changes = changedValues()
         guard !changes.isEmpty || !knownKeys.isEmpty else { return [:] }
         let allKeys = knownKeys.union(changes.keys)
-        
-        let mappedKeys : [String] = Array(allKeys).map(keyMapping)
+
+        let mappedKeys: [String] = Array(allKeys).map(keyMapping)
         let keys = mappedKeys.map {
             keyStore.observableKeysAffectedByValue(classIdentifier, key: $0)
-            }.reduce(Set()){$0.union($1)}
-        
+            }.reduce(Set()) {$0.union($1)}
+
         guard !keys.isEmpty ||
             originalChangeKey != nil else { return [:] }
-        
-        var originalChanges = [String : NSObject?]()
+
+        var originalChanges = [String: NSObject?]()
         if let originalChangeKey = originalChangeKey {
             let requiredKeys = keyStore.requiredKeysForIncludingRawChanges(classIdentifier: classIdentifier, for: self)
             knownKeys.forEach {
                 if changes[$0] == nil {
-                    changes[$0] = .none as Optional<NSObject>
+                    changes[$0] = .none as NSObject?
                 }
             }
             if requiredKeys.isEmpty || !requiredKeys.isDisjoint(with: changes.keys) {
-                originalChanges = [originalChangeKey : [self : changes] as Optional<NSObject>]
+                originalChanges = [originalChangeKey: [self: changes] as NSObject?]
             }
         }
-        
+
         return [object: Changes(changedKeys: keys, originalChanges: originalChanges)]
     }
 }
 
+extension ZMUser: SideEffectSource {
 
-extension ZMUser : SideEffectSource {
-    
-    var allConversations : [ZMConversation] {
+    var allConversations: [ZMConversation] {
         var conversations = self.participantRoles.compactMap { $0.conversation }
         if let connectedConversation = connection?.conversation {
             conversations.append(connectedConversation)
         }
         return conversations
     }
-    
+
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
         let changes = changedValues()
         guard changes.count > 0 || knownKeys.count > 0 else { return [:] }
-        
+
         let allKeys = knownKeys.union(changes.keys)
 
         let conversations = allConversations
         guard conversations.count > 0 else { return  [:] }
-        
-        let affectedObjects = conversationChanges(changedKeys: allKeys, conversations:conversations, keyStore:keyStore)
+
+        let affectedObjects = conversationChanges(changedKeys: allKeys, conversations: conversations, keyStore: keyStore)
         return affectedObjects
     }
-    
-    func conversationChanges(changedKeys: Set<String>, conversations: [ZMConversation], keyStore: DependencyKeyStore) ->  ObjectAndChanges {
-        var affectedObjects = [ZMManagedObject : Changes]()
+
+    func conversationChanges(changedKeys: Set<String>, conversations: [ZMConversation], keyStore: DependencyKeyStore) -> ObjectAndChanges {
+        var affectedObjects = [ZMManagedObject: Changes]()
         let classIdentifier = ZMConversation.entityName()
 
         // Get all the changed keys, including the ones in the user that are affected by this change
@@ -112,10 +110,10 @@ extension ZMUser : SideEffectSource {
             keys.formUnion(keyStore.observableKeysAffectedByValue(ZMUser.entityName(), key: changedKey))
         }
 
-        let otherPartKeys = allChangedKeys.map{"\(#keyPath(ZMConversation.participantRoles.user)).\($0)"}
-        let selfUserKeys = allChangedKeys.map{"\(#keyPath(ZMConversation.connection)).\(#keyPath(ZMConnection.to)).\($0)"}
+        let otherPartKeys = allChangedKeys.map {"\(#keyPath(ZMConversation.participantRoles.user)).\($0)"}
+        let selfUserKeys = allChangedKeys.map {"\(#keyPath(ZMConversation.connection)).\(#keyPath(ZMConnection.to)).\($0)"}
         let mappedKeys = otherPartKeys + selfUserKeys
-        var keys = mappedKeys.map{keyStore.observableKeysAffectedByValue(classIdentifier, key: $0)}.reduce(Set()){$0.union($1)}
+        var keys = mappedKeys.map {keyStore.observableKeysAffectedByValue(classIdentifier, key: $0)}.reduce(Set()) {$0.union($1)}
 
         conversations.forEach {
             if $0.allUsersTrusted {
@@ -127,11 +125,11 @@ extension ZMUser : SideEffectSource {
         }
         return affectedObjects
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         let conversations = allConversations
         guard conversations.count > 0 else { return  [:] }
-        
+
         let classIdentifier = ZMConversation.entityName()
         let affectedKeys = keyStore.observableKeysAffectedByValue(classIdentifier, key: #keyPath(ZMConversation.localParticipantRoles))
         return Dictionary(keys: conversations,
@@ -148,14 +146,13 @@ extension ParticipantRole: SideEffectSource {
         }
 
         let changes = byUpdateAffectedKeys(for: conversation,
-                                               knownKeys:knownKeys,
+                                               knownKeys: knownKeys,
                                                keyStore: keyStore,
                                                keyMapping: keyMapping)
-        
+
         return changes
     }
 
-    
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         // delete a ParticipantRole should affects conversation's participants
         return byInsertOrDeletionAffectedKeys(for: conversation,
@@ -164,70 +161,69 @@ extension ParticipantRole: SideEffectSource {
     }
 }
 
-extension ZMMessage : SideEffectSource {
-    
+extension ZMMessage: SideEffectSource {
+
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
         return [:]
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return byInsertOrDeletionAffectedKeys(for: conversation, keyStore: keyStore, affectedKey: #keyPath(ZMConversation.allMessages))
     }
 }
 
-extension ZMConnection : SideEffectSource {
-    
+extension ZMConnection: SideEffectSource {
+
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        let conversationChanges = byUpdateAffectedKeys(for: conversation, knownKeys:knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMConversation.connection)).\($0)"})
-        let userChanges = byUpdateAffectedKeys(for: to, knownKeys:knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMConversation.connection)).\($0)"})
+        let conversationChanges = byUpdateAffectedKeys(for: conversation, knownKeys: knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMConversation.connection)).\($0)"})
+        let userChanges = byUpdateAffectedKeys(for: to, knownKeys: knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMConversation.connection)).\($0)"})
         return conversationChanges.updated(other: userChanges)
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return [:]
     }
 }
 
+extension UserClient: SideEffectSource {
 
-extension UserClient : SideEffectSource {
-    
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: user, knownKeys:knownKeys, keyStore: keyStore, originalChangeKey: "clientChanges", keyMapping: {"\(#keyPath(ZMUser.clients)).\($0)"})
+        return byUpdateAffectedKeys(for: user, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "clientChanges", keyMapping: {"\(#keyPath(ZMUser.clients)).\($0)"})
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return byInsertOrDeletionAffectedKeys(for: user, keyStore: keyStore, affectedKey: #keyPath(ZMUser.clients))
     }
 }
 
-extension Reaction : SideEffectSource {
+extension Reaction: SideEffectSource {
 
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: message, knownKeys:knownKeys, keyStore: keyStore, originalChangeKey: "reactionChanges", keyMapping: {"\(#keyPath(ZMMessage.reactions)).\($0)"})
+        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "reactionChanges", keyMapping: {"\(#keyPath(ZMMessage.reactions)).\($0)"})
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return byInsertOrDeletionAffectedKeys(for: message, keyStore: keyStore, affectedKey: #keyPath(ZMMessage.reactions))
     }
 }
 
-extension ButtonState : SideEffectSource {
-    
+extension ButtonState: SideEffectSource {
+
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
         return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: MessageChangeInfo.ButtonStateChangeInfoKey, keyMapping: {"\(#keyPath(ZMClientMessage.buttonStates)).\($0)"})
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return byInsertOrDeletionAffectedKeys(for: message, keyStore: keyStore, affectedKey: #keyPath(ZMClientMessage.buttonStates))
     }
 }
 
-extension ZMGenericMessageData : SideEffectSource {
-    
+extension ZMGenericMessageData: SideEffectSource {
+
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: message ?? asset, knownKeys:knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMClientMessage.dataSet)).\($0)"})
+        return byUpdateAffectedKeys(for: message ?? asset, knownKeys: knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMClientMessage.dataSet)).\($0)"})
     }
-    
+
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
         return byInsertOrDeletionAffectedKeys(for: message ?? asset, keyStore: keyStore, affectedKey: #keyPath(ZMClientMessage.dataSet))
     }

--- a/Source/Notifications/ZMManagedObject+ClassIdentifier.swift
+++ b/Source/Notifications/ZMManagedObject+ClassIdentifier.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 extension ZMManagedObject {
 

--- a/Source/Notifications/ZMMoveIndex.swift
+++ b/Source/Notifications/ZMMoveIndex.swift
@@ -17,16 +17,16 @@
 //
 
 @objcMembers public class ZMMovedIndex: NSObject {
-    
+
     public let from: UInt
     public let to: UInt
-    
+
     public init(from: UInt, to: UInt) {
         self.from = from
         self.to = to
         super.init()
     }
-    
+
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? ZMMovedIndex else { return false }
         return other.from == self.from && other.to == self.to

--- a/Source/Utilis/Dictionary+ObjectForKey.swift
+++ b/Source/Utilis/Dictionary+ObjectForKey.swift
@@ -22,11 +22,11 @@ public extension Dictionary {
     func string(forKey key: String) -> String? {
         return (self as NSDictionary).string(forKey: key)
     }
-    
+
     func optionalString(forKey key: String) -> String? {
         return (self as NSDictionary).optionalString(forKey: key)
     }
-    
+
     func dictionary(forKey key: String) -> [String: AnyObject]? {
         return (self as NSDictionary).dictionary(forKey: key)
     }

--- a/Source/Utilis/FileManager+FileLocations.swift
+++ b/Source/Utilis/FileManager+FileLocations.swift
@@ -22,42 +22,41 @@ import WireSystem
 private let zmLog = ZMSLog(tag: "FileLocation")
 
 public extension FileManager {
-    
+
     /// Returns the URL for the sharedContainerDirectory of the app
     @objc(sharedContainerDirectoryForAppGroupIdentifier:)
     static func sharedContainerDirectory(for appGroupIdentifier: String) -> URL {
         let fm = FileManager.default
         let sharedContainerURL = fm.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
-        
+
         // Seems like the shared container is not available. This could happen for series of reasons:
         // 1. The app is compiled with with incorrect provisioning profile (for example with 3rd parties)
         // 2. App is running on simulator and there is no correct provisioning profile on the system
         // 3. Bug with signing
         //
         // The app should not allow to run in all those cases.
-        
+
         require(nil != sharedContainerURL, "Unable to create shared container url using app group identifier: \(appGroupIdentifier)")
-    
+
         return sharedContainerURL!
     }
-    
-    @objc static let cachesFolderPrefix : String = "wire-account"
+
+    @objc static let cachesFolderPrefix: String = "wire-account"
 
     /// Returns the URL for caches appending the accountIdentifier if specified
     @objc func cachesURL(forAppGroupIdentifier appGroupIdentifier: String, accountIdentifier: UUID?) -> URL? {
         guard let sharedContainerURL = containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else { return nil }
         return cachesURLForAccount(with: accountIdentifier, in: sharedContainerURL)
     }
-    
+
     /// Returns the URL for caches appending the accountIdentifier if specified
     @objc func cachesURLForAccount(with accountIdentifier: UUID?, in sharedContainerURL: URL) -> URL {
         let url = sharedContainerURL.appendingPathComponent("Library", isDirectory: true)
                                     .appendingPathComponent("Caches", isDirectory: true)
         if let accountIdentifier = accountIdentifier {
-            return url.appendingPathComponent("\(type(of:self).cachesFolderPrefix)-\(accountIdentifier.uuidString)", isDirectory: true)
+            return url.appendingPathComponent("\(type(of: self).cachesFolderPrefix)-\(accountIdentifier.uuidString)", isDirectory: true)
         }
         return url
     }
-    
-    
+
 }

--- a/Source/Utilis/NormalizationResult.swift
+++ b/Source/Utilis/NormalizationResult.swift
@@ -50,7 +50,7 @@ public enum NormalizationResult<Value> {
 
 extension NormalizationResult where Value: NSObjectProtocol {
 
-    public init(_ result: ZMPropertyNormalizationResult<Value>)  {
+    public init(_ result: ZMPropertyNormalizationResult<Value>) {
         if result.isValid {
             guard let normalizedValue = result.normalizedValue else {
                 self = .unknownError
@@ -90,76 +90,76 @@ extension NormalizationResult where Value == String {
 
 }
 
-public extension ZMUser  {
-    
+public extension ZMUser {
+
     @objc static func normalizeName(_ name: String) -> ZMPropertyNormalizationResult<NSString> {
         var name: String? = name
-        var outError: Error? = nil
+        var outError: Error?
         var result: Bool = false
-        
+
         do {
             result = try ZMUser.validate(name: &name)
         } catch let error {
             outError = error
         }
-        
+
         return ZMPropertyNormalizationResult<NSString>(result: result, normalizedValue: name as NSString? ?? "", validationError: outError)
     }
-    
+
     @objc static func normalizeEmailAddress(_ emailAddress: String) -> ZMPropertyNormalizationResult<NSString> {
         var emailAddress: String? = emailAddress
-        var outError: Error? = nil
+        var outError: Error?
         var result: Bool = false
-        
+
         do {
             result = try ZMUser.validate(emailAddress: &emailAddress)
         } catch let error {
             outError = error
         }
-        
+
         return ZMPropertyNormalizationResult<NSString>(result: result, normalizedValue: emailAddress as NSString? ?? "", validationError: outError)
     }
-    
+
     @objc static func normalizePassword(_ password: String) -> ZMPropertyNormalizationResult<NSString> {
         var password: String? = password
-        var outError: Error? = nil
+        var outError: Error?
         var result: Bool = false
-        
+
         do {
             result = try ZMUser.validate(password: &password)
         } catch let error {
             outError = error
         }
-        
+
         return ZMPropertyNormalizationResult<NSString>(result: result, normalizedValue: password as NSString? ?? "", validationError: outError)
     }
- 
+
     @objc static func normalizeVerificationCode(_ verificationCode: String) -> ZMPropertyNormalizationResult<NSString> {
         var verificationCode: String? = verificationCode
-        var outError: Error? = nil
+        var outError: Error?
         var result: Bool = false
-        
+
         do {
             result = try ZMUser.validate(phoneVerificationCode: &verificationCode)
         } catch let error {
             outError = error
         }
-        
+
         return ZMPropertyNormalizationResult<NSString>(result: result, normalizedValue: verificationCode as NSString? ?? "", validationError: outError)
     }
-    
+
     @objc static func normalizePhoneNumber(_ phoneNumber: String) -> ZMPropertyNormalizationResult<NSString> {
         var phoneNumber: String? = phoneNumber
-        var outError: Error? = nil
+        var outError: Error?
         var result: Bool = false
-        
+
         do {
             result = try ZMUser.validate(phoneNumber: &phoneNumber)
         } catch let error {
             outError = error
         }
-        
+
         return ZMPropertyNormalizationResult<NSString>(result: result, normalizedValue: phoneNumber as NSString? ?? "", validationError: outError)
     }
-    
+
 }

--- a/Source/Utilis/Protos/GenericMessage+Assets.swift
+++ b/Source/Utilis/Protos/GenericMessage+Assets.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 public extension WireProtos.Asset {
@@ -29,7 +28,7 @@ public extension WireProtos.Asset {
             })
         })
     }
-    
+
     init(_ metadata: ZMAudioMetadata) {
         self = WireProtos.Asset.with({
             $0.original = WireProtos.Asset.Original.with({
@@ -41,11 +40,11 @@ public extension WireProtos.Asset {
                     $0.durationInMillis = UInt64(metadata.duration * 1000)
                     $0.normalizedLoudness = NSData(bytes: loudnessArray, length: loudnessArray.count) as Data
                 })
-                
+
             })
         })
     }
-    
+
     init(_ metadata: ZMVideoMetadata) {
         self = WireProtos.Asset.with({
             $0.original = WireProtos.Asset.Original.with({
@@ -60,7 +59,7 @@ public extension WireProtos.Asset {
             })
         })
     }
-    
+
     init(imageSize: CGSize, mimeType: String, size: UInt64) {
         self = WireProtos.Asset.with({
             $0.original = WireProtos.Asset.Original.with({
@@ -73,7 +72,7 @@ public extension WireProtos.Asset {
             })
         })
     }
-    
+
     init(original: WireProtos.Asset.Original?, preview: WireProtos.Asset.Preview?) {
         self = WireProtos.Asset.with({
             if let original = original {
@@ -84,26 +83,26 @@ public extension WireProtos.Asset {
             }
         })
     }
-    
+
     init(withUploadedOTRKey otrKey: Data, sha256: Data) {
         self = WireProtos.Asset.with {
             $0.uploaded = WireProtos.Asset.RemoteData(withOTRKey: otrKey, sha256: sha256)
         }
     }
-    
+
     init(withNotUploaded notUploaded: WireProtos.Asset.NotUploaded) {
         self = WireProtos.Asset.with {
             $0.notUploaded = notUploaded
         }
     }
-    
+
     var hasUploaded: Bool {
         guard case .uploaded? = status else {
             return false
         }
         return true
     }
-    
+
     var hasNotUploaded: Bool {
         guard case .notUploaded? = status else {
             return false
@@ -113,7 +112,7 @@ public extension WireProtos.Asset {
 }
 
 public extension WireProtos.Asset.Original {
- 
+
     init(withSize size: UInt64, mimeType: String, name: String?, imageMetaData: WireProtos.Asset.ImageMetaData? = nil) {
         self = WireProtos.Asset.Original.with {
             $0.size = size
@@ -126,7 +125,7 @@ public extension WireProtos.Asset.Original {
             }
         }
     }
-    
+
     init(withSize size: UInt64, mimeType: String, name: String?, audioDurationInMillis: UInt, normalizedLoudness: [Float]) {
         self = WireProtos.Asset.Original.with {
             $0.size = size
@@ -141,18 +140,18 @@ public extension WireProtos.Asset.Original {
             }
         }
     }
-    
+
     /// Returns the normalized loudness as floats between 0 and 1
-    var normalizedLoudnessLevels : [Float] {
-        
+    var normalizedLoudnessLevels: [Float] {
+
         guard audio.hasNormalizedLoudness else { return [] }
         guard audio.normalizedLoudness.count > 0 else { return [] }
-        
+
         let data = audio.normalizedLoudness
         let offsets = 0..<data.count
         return offsets
             .map { offset -> UInt8 in
-                var number : UInt8 = 0
+                var number: UInt8 = 0
                 data.copyBytes(to: &number, from: (0 + offset)..<(MemoryLayout<UInt8>.size+offset))
                 return number
             }
@@ -163,7 +162,7 @@ public extension WireProtos.Asset.Original {
 }
 
 public extension WireProtos.Asset.Preview {
-    
+
     init(size: UInt64, mimeType: String, remoteData: WireProtos.Asset.RemoteData?, imageMetadata: WireProtos.Asset.ImageMetaData) {
         self = WireProtos.Asset.Preview.with({
             $0.size = size
@@ -200,35 +199,35 @@ public extension WireProtos.Asset.RemoteData {
     }
 }
 
-// MARK:- Update assets
+// MARK: - Update assets
 
 extension GenericMessage {
     mutating func updateAssetOriginal(withImageProperties imageProperties: ZMIImageProperties) {
         let asset = WireProtos.Asset(imageSize: imageProperties.size, mimeType: imageProperties.mimeType, size: UInt64(imageProperties.length))
         update(asset: asset)
     }
-    
+
     mutating func updateAssetPreview(withUploadedOTRKey otrKey: Data, sha256: Data) {
         guard var preview = assetData?.preview else { return }
-        
+
         preview.remote = WireProtos.Asset.RemoteData(withOTRKey: otrKey, sha256: sha256)
         let asset = WireProtos.Asset(original: nil, preview: preview)
-        
+
         update(asset: asset)
     }
-    
+
     mutating func updateAssetPreview(withImageProperties imageProperties: ZMIImageProperties) {
         let imageMetaData = WireProtos.Asset.ImageMetaData(width: Int32(imageProperties.size.width), height: Int32(imageProperties.size.height))
         let preview = WireProtos.Asset.Preview(size: UInt64(imageProperties.length), mimeType: imageProperties.mimeType, remoteData: nil, imageMetadata: imageMetaData)
         let asset = WireProtos.Asset(original: nil, preview: preview)
         update(asset: asset)
     }
-    
+
     mutating func updateAsset(withUploadedOTRKey otrKey: Data, sha256: Data) {
         let asset = WireProtos.Asset(withUploadedOTRKey: otrKey, sha256: sha256)
         update(asset: asset)
     }
-    
+
     public mutating func updatePreview(assetId: String, token: String?) {
         updateAsset {
             $0.preview.remote.update(assetId: assetId, token: token)
@@ -240,11 +239,11 @@ extension GenericMessage {
             $0.uploaded.update(assetId: assetId, token: token)
         }
     }
-    
+
     public mutating func update(asset: WireProtos.Asset) {
         updateAsset { $0 = asset }
     }
-    
+
     mutating func updateAsset(_ block: (inout WireProtos.Asset) -> Void) {
         guard let content = content else {
             return

--- a/Source/Utilis/Protos/GenericMessage+Content.swift
+++ b/Source/Utilis/Protos/GenericMessage+Content.swift
@@ -24,59 +24,59 @@ public extension GenericMessage {
     var hasText: Bool {
         return messageData is Text
     }
-    
+
     var hasConfirmation: Bool {
         return messageData is Confirmation
     }
-    
+
     var hasReaction: Bool {
         return messageData is WireProtos.Reaction
     }
-    
+
     var hasAsset: Bool {
         return messageData is WireProtos.Asset
     }
-    
+
     var hasClientAction: Bool {
         return messageData is ClientAction
     }
-    
+
     var hasCleared: Bool {
         return messageData is Cleared
     }
-    
+
     var hasLastRead: Bool {
         return messageData is LastRead
     }
-    
+
     var hasKnock: Bool {
         return messageData is Knock
     }
-    
+
     var hasExternal: Bool {
         return messageData is External
     }
-    
+
     var hasAvailability: Bool {
         return messageData is WireProtos.Availability
     }
-    
+
     var hasEdited: Bool {
         return messageData is MessageEdit
     }
-    
+
     var hasDeleted: Bool {
         return messageData is MessageDelete
     }
-    
+
     var hasCalling: Bool {
         return messageData is Calling
     }
-    
+
     var hasHidden: Bool {
         return messageData is MessageHide
     }
-    
+
     var hasLocation: Bool {
         return messageData is Location
     }
@@ -92,7 +92,7 @@ public extension Ephemeral {
     var hasAsset: Bool {
         return messageData is WireProtos.Asset
     }
-    
+
     var hasKnock: Bool {
         return messageData is Knock
     }
@@ -100,7 +100,7 @@ public extension Ephemeral {
     var hasLocation: Bool {
         return messageData is Location
     }
-    
+
     var hasText: Bool {
         return messageData is Text
     }

--- a/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireProtos
 import SwiftProtobuf
 
-fileprivate let redactedValue = "<redacted>"
+private let redactedValue = "<redacted>"
 
 // MARK: - Text
 

--- a/Source/Utilis/Protos/GenericMessage+Flags.swift
+++ b/Source/Utilis/Protos/GenericMessage+Flags.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-// MARK:- Set message flags
+// MARK: - Set message flags
 
 extension GenericMessage {
     var legalHoldStatus: LegalHoldStatus {
@@ -40,7 +40,7 @@ extension GenericMessage {
             return .unknown
         }
     }
-    
+
     public mutating func setLegalHoldStatus(_ status: LegalHoldStatus) {
         guard let content = content else { return }
         switch content {
@@ -60,7 +60,7 @@ extension GenericMessage {
             return
         }
     }
-    
+
     public mutating func setExpectsReadConfirmation(_ value: Bool) {
         guard let content = content else { return }
         switch content {
@@ -98,7 +98,7 @@ extension Ephemeral {
             }
         }
     }
-    
+
     public mutating func updateLegalHoldStatus(_ status: LegalHoldStatus) {
         guard let content = content else { return }
         switch content {
@@ -114,7 +114,7 @@ extension Ephemeral {
             self.location.legalHoldStatus = status
         }
     }
-    
+
     public mutating func updateExpectsReadConfirmation(_ value: Bool) {
         guard let content = content else { return }
         switch content {

--- a/Source/Utilis/Protos/GenericMessage+Hashing.swift
+++ b/Source/Utilis/Protos/GenericMessage+Hashing.swift
@@ -84,47 +84,46 @@ fileprivate extension Float {
 }
 
 extension String: BigEndianDataConvertible {
-    
+
     var asBigEndianData: Data {
         var data = Data([0xFE, 0xFF]) // Byte order marker
         data.append(self.data(using: .utf16BigEndian)!)
         return data
     }
-    
+
 }
 
 extension Int: BigEndianDataConvertible {
-    
+
     public var asBigEndianData: Data {
         return withUnsafePointer(to: self.bigEndian) {
             Data(bytes: $0, count: MemoryLayout.size(ofValue: self))
         }
     }
-    
+
 }
 
 extension TimeInterval: BigEndianDataConvertible {
-    
+
     public var asBigEndianData: Data {
         let long = Int64(self).bigEndian
         return withUnsafePointer(to: long) {
             return Data(bytes: $0, count: MemoryLayout.size(ofValue: long))
         }
     }
-    
+
 }
 
 extension BigEndianDataConvertible {
-    
+
     public func dataWithTimestamp(timestamp: TimeInterval) -> Data {
         var data = self.asBigEndianData
         data.append(timestamp.asBigEndianData)
         return data
     }
-    
+
     public func hashWithTimestamp(timestamp: TimeInterval) -> Data {
         return dataWithTimestamp(timestamp: timestamp).zmSHA256Digest()
     }
-    
-}
 
+}

--- a/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import WireProtos
 
@@ -35,9 +34,9 @@ public extension GenericMessage {
     init(content: EphemeralMessageCapable, nonce: UUID = UUID(), expiresAfter timeout: MessageDestructionTimeoutValue? = nil) {
         self.init(content: content, nonce: nonce, expiresAfterTimeInterval: timeout?.rawValue)
     }
-    
+
     init(content: EphemeralMessageCapable, nonce: UUID = UUID(), expiresAfterTimeInterval timeout: TimeInterval? = nil) {
-        self = GenericMessage.with() {
+        self = GenericMessage.with {
             $0.messageID = nonce.transportString()
             let messageContent: MessageCapable
             if let timeout = timeout, timeout > 0 {
@@ -48,15 +47,15 @@ public extension GenericMessage {
             messageContent.setContent(on: &$0)
         }
     }
-    
+
     init(content: MessageCapable, nonce: UUID = UUID()) {
-        self = GenericMessage.with() {
+        self = GenericMessage.with {
             $0.messageID = nonce.transportString()
             let messageContent = content
             messageContent.setContent(on: &$0)
         }
     }
-    
+
     init(clientAction action: ClientAction, nonce: UUID = UUID()) {
         self = GenericMessage.with {
             $0.messageID = nonce.transportString()
@@ -113,7 +112,7 @@ extension GenericMessage {
             return data
         }
     }
-    
+
     var locationData: Location? {
         guard let content = content else { return nil }
         switch content {
@@ -128,9 +127,9 @@ extension GenericMessage {
             }
         default:
             return nil
-        }        
+        }
     }
-    
+
     public var compositeData: Composite? {
         guard let content = content else { return nil }
         switch content {
@@ -140,7 +139,7 @@ extension GenericMessage {
             return nil
         }
     }
-    
+
     public var imageAssetData: ImageAsset? {
         guard let content = content else { return nil }
         switch content {
@@ -155,7 +154,7 @@ extension GenericMessage {
             }
         default:
             return nil
-        }        
+        }
     }
 
     public var assetData: WireProtos.Asset? {
@@ -174,7 +173,7 @@ extension GenericMessage {
             return nil
         }
     }
-    
+
     public var knockData: Knock? {
         guard let content = content else { return nil }
         switch content {
@@ -191,7 +190,7 @@ extension GenericMessage {
             return nil
         }
     }
-    
+
     public var textData: Text? {
         guard let content = content else { return nil }
         switch content {
@@ -226,7 +225,7 @@ extension GenericMessage {
     var v3_isImage: Bool {
         return assetData?.original.hasRasterImage ?? false
     }
-    
+
     var v3_uploadedAssetId: String? {
         guard
             let assetData = assetData,
@@ -236,7 +235,7 @@ extension GenericMessage {
         }
         return assetData.uploaded.assetID
     }
-    
+
     public var previewAssetId: String? {
         guard
             let assetData = assetData,
@@ -274,12 +273,12 @@ extension GenericMessage {
 
 extension Ephemeral {
     public init(content: EphemeralMessageCapable, expiresAfter timeout: TimeInterval) {
-        self = Ephemeral.with() {
+        self = Ephemeral.with {
             $0.expireAfterMillis = Int64(timeout * 1000)
             content.setEphemeralContent(on: &$0)
         }
     }
-    
+
     public var messageData: MessageCapable? {
         guard let content = content else { return nil }
         switch content {
@@ -425,7 +424,7 @@ extension Text {
             $0.content = content
             $0.mentions = mentions.compactMap { WireProtos.Mention.createMention($0) }
             $0.linkPreview = linkPreviews.map { WireProtos.LinkPreview($0) }
-            
+
             if let quotedMessage = replyingTo,
                let quotedMessageNonce = quotedMessage.nonce,
                let quotedMessageHash = quotedMessage.hashOfContent {
@@ -436,19 +435,19 @@ extension Text {
             }
         }
     }
-    
+
     public func applyEdit(from text: Text) -> Text {
         var updatedText = text
         // Transfer read receipt expectation
         updatedText.expectsReadConfirmation = expectsReadConfirmation
-        
+
         // We always keep the quote from the original message
         hasQuote
             ? updatedText.quote = quote
             : updatedText.clearQuote()
         return updatedText
     }
-    
+
     public func updateLinkPreview(from text: Text) -> Text {
         guard !text.linkPreview.isEmpty else {
             return self
@@ -560,7 +559,7 @@ extension WireProtos.Confirmation {
             $0.type = type
         })
     }
-    
+
     public init(messageId: UUID, type: Confirmation.TypeEnum = .delivered) {
         self = WireProtos.Confirmation.with {
             $0.firstMessageID = messageId.transportString()
@@ -578,7 +577,7 @@ extension External {
             $0.sha256 = sha256
         }
     }
-    
+
     init(withKeyWithChecksum key: ZMEncryptionKeyWithChecksum) {
         self = External(withOTRKey: key.aesKey, sha256: key.sha256)
     }
@@ -594,17 +593,15 @@ public extension WireProtos.Mention {
 public extension WireDataModel.Mention {
     func convertToProtosMention() -> WireProtos.Mention? {
         guard let userID = (user as? ZMUser)?.remoteIdentifier.transportString() else { return nil }
-        
+
         return WireProtos.Mention.with {
             $0.start = Int32(range.location)
             $0.length = Int32(range.length)
             $0.userID = userID
-            
-            
-            
+
             guard let domain = user.domain else { return }
-            
-            $0.qualifiedUserID =  WireProtos.QualifiedUserId.with{
+
+            $0.qualifiedUserID =  WireProtos.QualifiedUserId.with {
                 $0.id = userID
                 $0.domain = domain
             }
@@ -647,7 +644,7 @@ public extension LinkPreview {
             }
         }
     }
-    
+
     init(articleMetadata: ArticleMetadata) {
         self = LinkPreview.with {
             $0.url = articleMetadata.originalURLString
@@ -660,7 +657,7 @@ public extension LinkPreview {
             }
         }
     }
-    
+
     init(twitterMetadata: TwitterStatusMetadata) {
         self = LinkPreview.with {
             $0.url = twitterMetadata.originalURLString
@@ -670,17 +667,17 @@ public extension LinkPreview {
             if let imageData = twitterMetadata.imageData.first {
                 $0.image = WireProtos.Asset(imageSize: CGSize(width: 0, height: 0), mimeType: "image/jpeg", size: UInt64(imageData.count))
             }
-            
+
             guard let author = twitterMetadata.author,
                 let username = twitterMetadata.username else { return }
-            
+
             $0.tweet = WireProtos.Tweet.with({
                 $0.author = author
                 $0.username = username
             })
         }
     }
-    
+
     init(withOriginalURL originalURL: String,
          permanentURL: String,
          offset: Int32,
@@ -693,7 +690,7 @@ public extension LinkPreview {
             $0.url = originalURL
             $0.permanentURL = permanentURL
             $0.urlOffset = offset
-            
+
             if let title = title {
                 $0.title = title
             }
@@ -711,19 +708,19 @@ public extension LinkPreview {
             }
         }
     }
-    
+
     mutating func update(withOtrKey otrKey: Data, sha256: Data, original: WireProtos.Asset.Original?) {
         image.uploaded = WireProtos.Asset.RemoteData(withOTRKey: otrKey, sha256: sha256)
         if let original = original {
             image.original = original
         }
     }
-    
+
     mutating func update(withAssetKey assetKey: String, assetToken: String?) {
         image.uploaded.assetID = assetKey
         image.uploaded.assetToken = assetToken ?? ""
     }
-    
+
     var hasTweet: Bool {
         switch metaData {
         case .tweet:

--- a/Source/Utilis/Protos/GenericMessage+MessageCapable.swift
+++ b/Source/Utilis/Protos/GenericMessage+MessageCapable.swift
@@ -42,7 +42,7 @@ extension Location: EphemeralMessageCapable {
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.location = self
     }
-    
+
     public func setContent(on message: inout GenericMessage) {
         message.location = self
     }
@@ -52,7 +52,7 @@ extension Knock: EphemeralMessageCapable {
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.knock = self
     }
-    
+
     public func setContent(on message: inout GenericMessage) {
         message.knock = self
     }
@@ -62,18 +62,17 @@ extension Text: EphemeralMessageCapable {
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.text = self
     }
-    
+
     public func setContent(on message: inout GenericMessage) {
         message.text = self
     }
 }
 
-
 extension WireProtos.Asset: EphemeralMessageCapable {
     public func setEphemeralContent(on ephemeral: inout Ephemeral) {
         ephemeral.asset = self
     }
-    
+
     public func setContent(on message: inout GenericMessage) {
         message.asset = self
     }
@@ -166,7 +165,6 @@ extension WireProtos.Confirmation: MessageCapable {
     }
 }
 
-
 extension External: MessageCapable {
     public func setContent(on message: inout GenericMessage) {
         message.external = self
@@ -206,7 +204,7 @@ extension Ephemeral: MessageCapable {
             }
         }
     }
-    
+
     public func setContent(on message: inout GenericMessage) {
         message.ephemeral = self
     }

--- a/Source/Utilis/Protos/GenericMessage+Obfuscation.swift
+++ b/Source/Utilis/Protos/GenericMessage+Obfuscation.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 public extension String {
-    
+
     static func randomChar() -> UnicodeScalar {
         let string = "abcdefghijklmnopqrstuvxyz"
         let chars = Array(string.unicodeScalars)
@@ -27,7 +27,7 @@ public extension String {
         // in this case we know random will fit inside int
         return chars[Int(random)]
     }
-    
+
     func obfuscated() -> String {
         var obfuscatedVersion = UnicodeScalarView()
         for char in self.unicodeScalars {
@@ -42,31 +42,31 @@ public extension String {
 }
 
 public extension GenericMessage {
-    
+
     func obfuscatedMessage() -> GenericMessage? {
         guard let messageID = (messageID as String?).flatMap(UUID.init) else { return nil }
         guard case .ephemeral? = self.content else { return nil }
-        
+
         if let someText = textData {
             let content = someText.content
             let obfuscatedContent = content.obfuscated()
-            var obfuscatedLinkPreviews : [LinkPreview] = []
+            var obfuscatedLinkPreviews: [LinkPreview] = []
             if linkPreviews.count > 0 {
                 let offset = linkPreviews.first!.urlOffset
                 let offsetIndex = obfuscatedContent.index(obfuscatedContent.startIndex, offsetBy: Int(offset), limitedBy: obfuscatedContent.endIndex) ?? obfuscatedContent.startIndex
                 let originalURL = obfuscatedContent[offsetIndex...]
                 obfuscatedLinkPreviews = linkPreviews.map { $0.obfuscated(originalURL: String(originalURL)) }
             }
-            
+
             let obfuscatedText = Text.with {
                 $0.content = obfuscatedContent
                 $0.mentions = []
                 $0.linkPreview = obfuscatedLinkPreviews
             }
-            
+
             return GenericMessage(content: obfuscatedText, nonce: messageID)
         }
-        
+
         if let someAsset = assetData {
             let obfuscatedAsset = someAsset.obfuscated()
             return GenericMessage(content: obfuscatedAsset, nonce: messageID)
@@ -94,7 +94,7 @@ extension ImageAsset {
 }
 
 extension LinkPreview {
-    
+
     func obfuscated(originalURL: String) -> LinkPreview {
         let obfTitle = hasTitle ? title.obfuscated() : ""
         let obfSummary = hasSummary ? summary.obfuscated() : ""
@@ -136,7 +136,7 @@ extension WireProtos.Asset {
     func obfuscated() -> WireProtos.Asset {
         var assetOriginal: WireProtos.Asset.Original?
         var assetPreview: WireProtos.Asset.Preview?
-        
+
         if hasOriginal {
             assetOriginal = WireProtos.Asset.Original()
             if original.hasRasterImage {
@@ -147,12 +147,12 @@ extension WireProtos.Asset {
                 }
                 assetOriginal?.image = imageMetaData
             }
-            
+
             if original.hasName {
                 let obfName = original.name.obfuscated()
                 assetOriginal?.name = obfName
             }
-            
+
             let metaData = original.metaData
             switch metaData {
             case .audio?:
@@ -161,12 +161,12 @@ extension WireProtos.Asset {
                 assetOriginal?.video = WireProtos.Asset.VideoMetaData()
             default:
                 break
-            }            
+            }
             assetOriginal?.size = 10
             assetOriginal?.mimeType = original.mimeType
         }
-        
-        if hasPreview  {
+
+        if hasPreview {
             assetPreview = WireProtos.Asset.Preview()
             let imageMetaData = WireProtos.Asset.ImageMetaData.with {
                 $0.tag = preview.image.tag

--- a/Source/Utilis/UserImageLocalCache.swift
+++ b/Source/Utilis/UserImageLocalCache.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import PINCache
 import WireTransport
@@ -29,7 +28,7 @@ extension ZMUser {
         guard let userRemoteId = remoteIdentifier?.transportString(), let suffix = suffix else { return nil }
         return (userRemoteId + "-" + suffix)
     }
-    
+
     @objc public func imageCacheKey(for size: ProfileImageSize) -> String? {
         switch size {
         case .preview:
@@ -38,19 +37,18 @@ extension ZMUser {
             return cacheIdentifier(suffix: completeProfileAssetIdentifier)
         }
     }
-    
+
 }
 
 // MARK: NSManagedObjectContext
 
 let NSManagedObjectContextUserImageCacheKey = "zm_userImageCacheKey"
-extension NSManagedObjectContext
-{
-    @objc public var zm_userImageCache : UserImageLocalCache! {
+extension NSManagedObjectContext {
+    @objc public var zm_userImageCache: UserImageLocalCache! {
         get {
             return self.userInfo[NSManagedObjectContextUserImageCacheKey] as? UserImageLocalCache
         }
-        
+
         set {
             self.userInfo[NSManagedObjectContextUserImageCacheKey] = newValue
         }
@@ -58,24 +56,23 @@ extension NSManagedObjectContext
 }
 
 // MARK: Cache
-@objcMembers open class UserImageLocalCache : NSObject {
-    
+@objcMembers open class UserImageLocalCache: NSObject {
+
     fileprivate let log = ZMSLog(tag: "UserImageCache")
-    
+
     /// Cache for large user profile image
-    fileprivate let largeUserImageCache : PINCache
-    
+    fileprivate let largeUserImageCache: PINCache
+
     /// Cache for small user profile image
-    fileprivate let smallUserImageCache : PINCache
-    
-    
+    fileprivate let smallUserImageCache: PINCache
+
     /// Create UserImageLocalCache
     /// - parameter location: where cache is persisted on disk. Defaults to caches directory if nil.
     public init(location: URL? = nil) {
-        
+
         let largeUserImageCacheName = "largeUserImages"
         let smallUserImageCacheName = "smallUserImages"
-        
+
         if let rootPath = location?.path {
             largeUserImageCache = PINCache(name: largeUserImageCacheName, rootPath: rootPath)
             smallUserImageCache = PINCache(name: smallUserImageCacheName, rootPath: rootPath)
@@ -83,15 +80,15 @@ extension NSManagedObjectContext
             largeUserImageCache = PINCache(name: largeUserImageCacheName)
             smallUserImageCache = PINCache(name: smallUserImageCacheName)
         }
-        
+
         largeUserImageCache.configureLimits(50 * MEGABYTE)
         smallUserImageCache.configureLimits(25 * MEGABYTE)
-        
+
         largeUserImageCache.makeURLSecure()
         smallUserImageCache.makeURLSecure()
         super.init()
     }
-    
+
     /// Stores image in cache and returns true if the data was stored
     private func setImage(inCache cache: PINCache, cacheKey: String?, data: Data) -> Bool {
         if let resolvedCacheKey = cacheKey {
@@ -100,13 +97,13 @@ extension NSManagedObjectContext
         }
         return false
     }
-    
+
     /// Removes all images for user
     open func removeAllUserImages(_ user: ZMUser) {
         user.imageCacheKey(for: .complete).apply(largeUserImageCache.removeObject)
         user.imageCacheKey(for: .preview).apply(smallUserImageCache.removeObject)
     }
-    
+
     open func setUserImage(_ user: ZMUser, imageData: Data, size: ProfileImageSize) {
         let key = user.imageCacheKey(for: size)
         switch size {
@@ -122,10 +119,10 @@ extension NSManagedObjectContext
             }
         }
     }
-    
+
     open func userImage(_ user: ZMUser, size: ProfileImageSize, queue: DispatchQueue, completion: @escaping (_ imageData: Data?) -> Void) {
         guard let cacheKey = user.imageCacheKey(for: size) else { return completion(nil) }
-        
+
         queue.async {
             switch size {
             case .preview:
@@ -135,7 +132,7 @@ extension NSManagedObjectContext
             }
         }
     }
-    
+
     open func userImage(_ user: ZMUser, size: ProfileImageSize) -> Data? {
         guard let cacheKey = user.imageCacheKey(for: size) else { return nil }
         let data: Data?
@@ -151,10 +148,10 @@ extension NSManagedObjectContext
 
         return data
     }
-    
+
     open func hasUserImage(_ user: ZMUser, size: ProfileImageSize) -> Bool {
         guard let cacheKey = user.imageCacheKey(for: size) else { return false }
-        
+
         switch size {
         case .preview:
             return smallUserImageCache.containsObject(forKey: cacheKey)
@@ -162,7 +159,7 @@ extension NSManagedObjectContext
             return largeUserImageCache.containsObject(forKey: cacheKey)
         }
     }
-    
+
 }
 
 public extension UserImageLocalCache {

--- a/Source/Utilis/Version.swift
+++ b/Source/Utilis/Version.swift
@@ -19,10 +19,10 @@
 import Foundation
 
 @objc(ZMVersion) final public class Version: NSObject, Comparable {
-    
+
     @objc public private(set) var versionString: String
     @objc public private(set) var arrayRepresentation: [Int]
-    
+
     @objc(initWithVersionString:)
     public init(string: String) {
         requireInternal(!string.isEmpty, "invalid version string")
@@ -30,50 +30,50 @@ import Foundation
         arrayRepresentation = Version.integerComponents(of: string)
         super.init()
     }
-    
+
     private static func integerComponents(of string: String) -> [Int] {
         return string.components(separatedBy: ".").map {
             ($0 as NSString).integerValue
         }
     }
-    
+
     @objc(compareWithVersion:)
     public func compare(with other: Version) -> ComparisonResult {
         guard other.arrayRepresentation.count > 0 else { return .orderedDescending }
         guard versionString != other.versionString else { return .orderedSame }
-        
+
         for i in 0..<arrayRepresentation.count {
             guard other.arrayRepresentation.count != i else { return .orderedDescending }
             let selfNumber = arrayRepresentation[i]
             let otherNumber = other.arrayRepresentation[i]
-            
+
             if selfNumber > otherNumber {
                 return .orderedDescending
             } else if selfNumber < otherNumber {
                 return .orderedAscending
             }
         }
-        
+
         if arrayRepresentation.count < other.arrayRepresentation.count {
             return .orderedAscending
         }
-        
+
         return .orderedSame
     }
-    
+
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Version else { return false }
         return other == self
     }
-    
+
     public override var description: String {
         return arrayRepresentation.map { "\($0)" }.joined(separator: ".")
     }
-    
+
     public override var debugDescription: String {
         return String(format: "<%@ %p> %@", NSStringFromClass(type(of: self)), self, description)
     }
-    
+
 }
 
 // MARK: - Operators

--- a/Source/Utilis/ZMUpdateEvent.swift
+++ b/Source/Utilis/ZMUpdateEvent.swift
@@ -37,7 +37,7 @@ extension ZMUpdateEvent {
             return nil
         }
     }
-    
+
     public var userIDs: [UUID] {
         guard let dataPayload = (payload as NSDictionary).dictionary(forKey: "data"),
             let userIds = dataPayload["user_ids"] as? [String] else {
@@ -55,7 +55,7 @@ extension ZMUpdateEvent {
               let userDicts = dataPayload["users"] as? [NSDictionary] else {
                 return nil
         }
-        
+
         let qualifiedIDs: [QualifiedID] = userDicts.compactMap({
             let qualifiedID = $0.optionalDictionary(forKey: "qualified_id") as NSDictionary?
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fixed warnings related to the rules below:

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`
- **Vertical Parameter Alignment Violation**: Function parameters should be aligned vertically if they're in multiple lines in a declaration. `(vertical_parameter_alignment)`
- **Redundant @objc Attribute Violation**: Objective-C attribute (@objc) is redundant in declaration. `(redundant_objc_attribute)`
- **Syntactic Sugar Violation**: Shorthand syntactic sugar should be used, i.e. [String: Int] instead of Dictionary<String, Int>. `(syntactic_sugar)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
