### PR TITLE
fix: SwiftLint warnings for multiple rules in Source Part 2

### DIFF
--- a/Source/Model/Message/ZMClientMessage+Location.swift
+++ b/Source/Model/Message/ZMClientMessage+Location.swift
@@ -24,11 +24,11 @@ public protocol LocationMessageData: NSObjectProtocol {
     var latitude: Float { get }
     var longitude: Float { get }
     var name: String? { get }
-    var zoomLevel: Int32 { get } 
+    var zoomLevel: Int32 { get }
 }
 
 extension ZMClientMessage: LocationMessageData {
-    
+
     public override var locationMessageData: LocationMessageData? {
         guard let content = underlyingMessage?.content else {
             return nil
@@ -47,32 +47,31 @@ extension ZMClientMessage: LocationMessageData {
             return nil
         }
     }
-    
+
     @objc public var latitude: Float {
         return self.underlyingMessage?.locationData?.latitude ?? 0
     }
-    
+
     @objc public var longitude: Float {
         return self.underlyingMessage?.locationData?.longitude ?? 0
     }
-    
+
     @objc public var name: String? {
         return self.underlyingMessage?.locationData?.name
     }
-    
+
     @objc public var zoomLevel: Int32 {
         return self.underlyingMessage?.locationData?.zoom ?? 0
     }
 }
 
 public extension LocationMessageData {
-    
+
     var coordinate: CLLocationCoordinate2D {
         return CLLocationCoordinate2D(
             latitude: CLLocationDegrees(latitude),
             longitude: CLLocationDegrees(longitude)
         )
     }
-    
-}
 
+}

--- a/Source/Model/Message/ZMClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMClientMessage+Quotes.swift
@@ -19,13 +19,13 @@
 import Foundation
 
 extension ZMClientMessage {
-    
+
     override func updateQuoteRelationships() {
         guard let text = underlyingMessage?.textData, text.hasQuote else {
             return
         }
-        
+
         establishRelationshipsForInsertedQuote(text.quote)
     }
-    
+
 }

--- a/Source/Model/Message/ZMClientMessage+TextMessageData.swift
+++ b/Source/Model/Message/ZMClientMessage+TextMessageData.swift
@@ -19,39 +19,39 @@
 import Foundation
 
 extension ZMClientMessage: ZMTextMessageData {
-    
+
     @NSManaged public var quote: ZMMessage?
-    
+
     public var quoteMessage: ZMConversationMessage? {
         return quote
     }
-    
-    public override var textMessageData: ZMTextMessageData? {        
+
+    public override var textMessageData: ZMTextMessageData? {
         guard underlyingMessage?.textData != nil else {
             return nil
         }
         return self
     }
-    
-    public var isQuotingSelf: Bool{
+
+    public var isQuotingSelf: Bool {
         return quote?.sender?.isSelfUser ?? false
     }
-    
+
     public var hasQuote: Bool {
         return underlyingMessage?.textData?.hasQuote ?? false
     }
-    
+
     public var messageText: String? {
         return underlyingMessage?.textData?.content.removingExtremeCombiningCharacters
     }
-    
+
     public var mentions: [Mention] {
         return Mention.mentions(from: underlyingMessage?.textData?.mentions, messageText: messageText, moc: managedObjectContext)
     }
-    
+
     public func editText(_ text: String, mentions: [Mention], fetchLinkPreview: Bool) {
         guard let nonce = nonce, isEditableMessage else { return }
-        
+
         // Quotes are ignored in edits but keep it to mark that the message has quote for us locally
         let editedText = Text(content: text, mentions: mentions, linkPreviews: [], replyingTo: self.quote as? ZMOTRMessage)
         let editNonce = UUID()
@@ -66,7 +66,7 @@ extension ZMClientMessage: ZMTextMessageData {
         }
 
         updateNormalizedText()
-        
+
         self.nonce = editNonce
         self.updatedTimestamp = Date()
         self.reactions.removeAll()
@@ -74,6 +74,5 @@ extension ZMClientMessage: ZMTextMessageData {
         self.linkAttachments = nil
         self.delivered = false
     }
-    
-}
 
+}

--- a/Source/Model/Message/ZMClientMessage.swift
+++ b/Source/Model/Message/ZMClientMessage.swift
@@ -21,20 +21,20 @@ import Foundation
 @objcMembers
 public class ZMClientMessage: ZMOTRMessage {
 
-    @objc public static let linkPreviewStateKey = "linkPreviewState"
-    @objc public static let linkPreviewKey = "linkPreview"
-    
+    public static let linkPreviewStateKey = "linkPreviewState"
+    public static let linkPreviewKey = "linkPreview"
+
     //// From https://github.com/wearezeta/generic-message-proto:
     //// "If payload is smaller then 256KB then OM can be sent directly"
     //// Just to be sure we set the limit lower, to 128KB (base 10)
-    @objc public static let byteSizeExternalThreshold: UInt = 128000
-    
+    public static let byteSizeExternalThreshold: UInt = 128000
+
     /// Link Preview state
     @NSManaged public var updatedTimestamp: Date?
-    
+
     /// In memory cache
-    var cachedUnderlyingMessage: GenericMessage? = nil
-    
+    var cachedUnderlyingMessage: GenericMessage?
+
     public override static func entityName() -> String {
         return "ClientMessage"
     }
@@ -43,8 +43,8 @@ public class ZMClientMessage: ZMOTRMessage {
         return (super.ignoredKeys ?? Set())
             .union([#keyPath(updatedTimestamp)])
     }
-    
-    public override var updatedAt : Date? {
+
+    public override var updatedAt: Date? {
         return updatedTimestamp
     }
 
@@ -57,22 +57,22 @@ public class ZMClientMessage: ZMOTRMessage {
 
     public override func awakeFromFetch() {
         super.awakeFromFetch()
-        
+
         cachedUnderlyingMessage = nil
     }
-    
+
     public override func awake(fromSnapshotEvents flags: NSSnapshotEventType) {
         super.awake(fromSnapshotEvents: flags)
-        
+
         cachedUnderlyingMessage = nil
     }
-    
+
     public override func didTurnIntoFault() {
         super.didTurnIntoFault()
-        
+
         cachedUnderlyingMessage = nil
     }
-    
+
     public override var isUpdatingExistingMessage: Bool {
         guard let content = underlyingMessage?.content else {
                 return false
@@ -97,7 +97,7 @@ public class ZMClientMessage: ZMOTRMessage {
                 super.expire()
                 return
         }
-        
+
         switch content {
         case .edited:
             // Replace the nonce with the original
@@ -129,8 +129,8 @@ public class ZMClientMessage: ZMOTRMessage {
         }
         super.resend()
     }
-    
-    public override func update(withPostPayload payload: [AnyHashable : Any], updatedKeys: Set<AnyHashable>?) {
+
+    public override func update(withPostPayload payload: [AnyHashable: Any], updatedKeys: Set<AnyHashable>?) {
         // we don't want to update the conversation if the message is a confirmation message
         guard
             let genericMessage = underlyingMessage,
@@ -147,7 +147,7 @@ public class ZMClientMessage: ZMOTRMessage {
                 let conversation = conversation else {
                     return
             }
-            
+
             let original = ZMMessage.fetch(withNonce: originalID, for: conversation, in: managedObjectContext)
             original?.sender = nil
             original?.senderClientID = nil
@@ -157,7 +157,7 @@ public class ZMClientMessage: ZMOTRMessage {
                 Logging.messageProcessing.error("sent message response nonce does not match")
                 return
             }
-            
+
             if let serverTimestamp = (payload as NSDictionary).optionalDate(forKey: "time") {
                 updatedTimestamp = serverTimestamp
             }
@@ -171,10 +171,10 @@ public class ZMClientMessage: ZMOTRMessage {
         let notExpired = NSPredicate(format: "%K == 0", ZMMessageIsExpiredKey)
         return NSCompoundPredicate(andPredicateWithSubpredicates: [encryptedNotSynced, notExpired])
     }
-    
+
     public override func markAsSent() {
         super.markAsSent()
-        
+
         if linkPreviewState == ZMLinkPreviewState.uploaded {
             linkPreviewState = ZMLinkPreviewState.done
         }
@@ -204,10 +204,10 @@ public class ZMClientMessage: ZMOTRMessage {
         }
         // processed or downloaded
         let hasMedium = managedObjectContext.zm_fileAssetCache.hasDataOnDisk(self, format: ZMImageFormat.medium, encrypted: false)
-        
+
         // original
         let hasOriginal = managedObjectContext.zm_fileAssetCache.hasDataOnDisk(self, format: ZMImageFormat.original, encrypted: false)
-        
+
         return hasMedium || hasOriginal
     }
 }
@@ -221,7 +221,7 @@ extension ZMClientMessage {
     public override var fileMessageData: ZMFileMessageData? {
         return nil
     }
-    
+
     public override var isSilenced: Bool {
         return conversation?.isMessageSilenced(underlyingMessage, senderID: sender?.remoteIdentifier) ?? true
     }

--- a/Source/Model/Message/ZMFileMetadata.swift
+++ b/Source/Model/Message/ZMFileMetadata.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import MobileCoreServices
 import WireSystem
@@ -24,88 +23,86 @@ import WireUtilities
 
 private let zmLog = ZMSLog(tag: "ZMFileMetadata")
 
-
 @objcMembers
-open class ZMFileMetadata : NSObject {
-    
-    public let fileURL : URL
-    public let thumbnail : Data?
-    public let filename : String
-    
+open class ZMFileMetadata: NSObject {
+
+    public let fileURL: URL
+    public let thumbnail: Data?
+    public let filename: String
+
     required public init(fileURL: URL, thumbnail: Data? = nil, name: String? = nil) {
         self.fileURL = fileURL
         self.thumbnail = thumbnail?.count > 0 ? thumbnail : nil
         let endName = name ?? (fileURL.lastPathComponent.isEmpty ? "unnamed" :  fileURL.lastPathComponent)
-        
+
         self.filename = endName.removingExtremeCombiningCharacters
         super.init()
     }
-    
+
     convenience public init(fileURL: URL, thumbnail: Data? = nil) {
         self.init(fileURL: fileURL, thumbnail: thumbnail, name: nil)
     }
-    
+
     var asset: WireProtos.Asset {
         return WireProtos.Asset(self)
     }
 }
 
+open class ZMAudioMetadata: ZMFileMetadata {
 
-open class ZMAudioMetadata : ZMFileMetadata {
-    
-    public let duration : TimeInterval
-    public let normalizedLoudness : [Float]
-    
+    public let duration: TimeInterval
+    public let normalizedLoudness: [Float]
+
     required public init(fileURL: URL, duration: TimeInterval, normalizedLoudness: [Float] = [], thumbnail: Data? = nil) {
         self.duration = duration
         self.normalizedLoudness = normalizedLoudness
-        
+
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: nil)
     }
-    
+
     required public init(fileURL: URL, thumbnail: Data?, name: String? = nil) {
         self.duration = 0
         self.normalizedLoudness = []
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: name)
     }
-    
+
     override var asset: WireProtos.Asset {
         return WireProtos.Asset(self)
     }
-    
+
 }
 
-open class ZMVideoMetadata : ZMFileMetadata {
-    
-    public let duration : TimeInterval
-    public let dimensions : CGSize
-    
+open class ZMVideoMetadata: ZMFileMetadata {
+
+    public let duration: TimeInterval
+    public let dimensions: CGSize
+
     required public init(fileURL: URL, duration: TimeInterval, dimensions: CGSize, thumbnail: Data? = nil) {
         self.duration = duration
         self.dimensions = dimensions
-        
+
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: nil)
     }
-    
+
     required public init(fileURL: URL, thumbnail: Data?, name: String? = nil) {
         self.duration = 0
         self.dimensions = CGSize.zero
-        
+
         super.init(fileURL: fileURL, thumbnail: thumbnail, name: name)
     }
-    
+
     override var asset: WireProtos.Asset {
         return WireProtos.Asset(self)
     }
-    
+
 }
 
 extension ZMFileMetadata {
-    
+
     var mimeType: String {
         return UTIHelper.convertToMime(fileExtension: fileURL.pathExtension) ?? "application/octet-stream"
     }
-    
+
     var size: UInt64 {
         do {
             let attributes = try fileURL.resourceValues(forKeys: [.fileSizeKey])
@@ -116,5 +113,5 @@ extension ZMFileMetadata {
             return 0
         }
     }
-    
+
 }

--- a/Source/Model/Message/ZMMessage+Conversation.swift
+++ b/Source/Model/Message/ZMMessage+Conversation.swift
@@ -34,7 +34,7 @@ extension ZMMessage {
 
 extension ZMMessage {
     @objc(nonceFromPostPayload:)
-    func nonce(fromPostPayload payload: [AnyHashable : Any]) -> UUID? {
+    func nonce(fromPostPayload payload: [AnyHashable: Any]) -> UUID? {
         let eventType = ZMUpdateEvent.updateEventType(for: payload.optionalString(forKey: "type") ?? "")
         switch eventType {
         case .conversationMessageAdd,
@@ -42,7 +42,7 @@ extension ZMMessage {
             return payload.dictionary(forKey: "data")?["nonce"] as? UUID
         case .conversationClientMessageAdd,
              .conversationOtrMessageAdd:
-            //if event is otr message then payload should be already decrypted and should contain generic message data
+            // if event is otr message then payload should be already decrypted and should contain generic message data
             let base64Content = payload.string(forKey: "data")
             let message = GenericMessage(withBase64String: base64Content)
             guard let  messageID = message?.messageID else {

--- a/Source/Model/Message/ZMMessage+DataRetention.swift
+++ b/Source/Model/Message/ZMMessage+DataRetention.swift
@@ -19,14 +19,14 @@
 import Foundation
 
 extension ZMMessage {
-    
+
     class func predicateForMessagesOlderThan(_ date: Date) -> NSPredicate {
         return NSPredicate(format: "%K < %@", ZMMessageServerTimestampKey, date as NSDate)
     }
-    
+
     public class func deleteMessagesOlderThan(_ date: Date, context: NSManagedObjectContext) throws {
         context.zm_fileAssetCache.deleteAssetsOlderThan(date)
         try context.batchDeleteEntities(named: ZMMessage.entityName(), matching: predicateForMessagesOlderThan(date))
     }
-    
+
 }

--- a/Source/Model/Message/ZMMessage+Insert.swift
+++ b/Source/Model/Message/ZMMessage+Insert.swift
@@ -22,7 +22,7 @@ extension ZMMessage {
     @objc public func prepareToSend() {
         expireAndNotifyIfInsertingIntoDegradedConversation()
     }
-    
+
     /// If we are adding the message to a degraded conversation we want to expire it immediately
     /// and fire a notification on conversation security level change so that UI could act accordingly
     fileprivate func expireAndNotifyIfInsertingIntoDegradedConversation() {

--- a/Source/Model/Message/ZMMessage+Quotes.swift
+++ b/Source/Model/Message/ZMMessage+Quotes.swift
@@ -19,10 +19,10 @@
 import Foundation
 
 extension ZMMessage {
-    
+
     @objc
     func updateQuoteRelationships() {
         assertionFailure("Subclasses should override this method")
     }
-    
+
 }

--- a/Source/Model/Message/ZMMessage+Reaction.swift
+++ b/Source/Model/Message/ZMMessage+Reaction.swift
@@ -27,7 +27,7 @@ extension ZMMessage {
         else {
             return
         }
-        
+
         localMessage.addReaction(reaction.emoji, forUser: user)
         localMessage.updateCategoryCache()
     }

--- a/Source/Model/Message/ZMOTRMessage+Confirmations.swift
+++ b/Source/Model/Message/ZMOTRMessage+Confirmations.swift
@@ -19,16 +19,16 @@
 import Foundation
 
 extension ZMOTRMessage {
-    
+
     private static let deliveryConfirmationDayThreshold = 7
-    
-    @NSManaged @objc dynamic var expectsReadConfirmation: Bool
-    
+
+    @NSManaged dynamic var expectsReadConfirmation: Bool
+
     @objc
     var needsDeliveryConfirmation: Bool {
         return needsDeliveryConfirmationAtCurrentDate()
     }
-    
+
     func needsDeliveryConfirmationAtCurrentDate(_ currentDate: Date = Date()) -> Bool {
         guard let conversation = conversation, conversation.conversationType == .oneOnOne,
               let sender = sender, !sender.isSelfUser,
@@ -37,13 +37,13 @@ extension ZMOTRMessage {
               deliveryState != .delivered,
               deliveryState != .read
         else { return false }
-        
+
         return daysElapsed <= ZMOTRMessage.deliveryConfirmationDayThreshold
     }
-    
+
     func needsReadConfirmation(_ genericMessage: GenericMessage) -> Bool {
         guard let conversation = conversation, let managedObjectContext = managedObjectContext else { return false }
-        
+
         if conversation.conversationType == .oneOnOne {
             var expectsReadConfirmation: Bool {
                 switch genericMessage.content {
@@ -70,7 +70,7 @@ extension ZMOTRMessage {
         } else if conversation.conversationType == .group {
             return expectsReadConfirmation
         }
-        
+
         return false
     }
 }

--- a/Source/Model/Message/ZMOTRMessage+ContentHashing.swift
+++ b/Source/Model/Message/ZMOTRMessage+ContentHashing.swift
@@ -20,18 +20,18 @@ import Foundation
 
 @objc
 protocol ContentHashing {
-    
+
     /// SHA-256 hash of the message content (text, image, location, ...)
     var hashOfContent: Data? { get }
-    
+
 }
 
 @objc
 extension ZMOTRMessage: ContentHashing {
-    
+
     var hashOfContent: Data? {
         assertionFailure("Subclasses should override this method")
         return nil
     }
-    
+
 }

--- a/Source/Model/Message/ZMOTRMessage+Quotes.swift
+++ b/Source/Model/Message/ZMOTRMessage+Quotes.swift
@@ -16,25 +16,24 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 private var log = ZMSLog(tag: "event-processing")
 
 extension ZMOTRMessage {
-    
+
     func establishRelationshipsForInsertedQuote(_ quote: Quote) {
-        
+
         guard let managedObjectContext = managedObjectContext,
               let conversation = conversation,
               let quotedMessageId = UUID(uuidString: quote.quotedMessageID),
               let quotedMessage = ZMOTRMessage.fetch(withNonce: quotedMessageId, for: conversation, in: managedObjectContext) else { return }
-        
+
         if quotedMessage.hashOfContent == quote.quotedMessageSha256 {
             quotedMessage.replies.insert(self)
         } else {
             log.warn("Rejecting quote since local hash \(quotedMessage.hashOfContent?.zmHexEncodedString() ?? "N/A") doesn't match \(quote.quotedMessageSha256.zmHexEncodedString())")
         }
     }
-    
+
 }

--- a/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
+++ b/Source/Model/Message/ZMOTRMessage+SecurityDegradation.swift
@@ -16,16 +16,15 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMOTRMessage {
-    
+
     /// Whether the message caused security level degradation (from verified to unverified)
     /// in this user session (i.e. since the app was started. This will be kept in memory
     /// and not persisted). This flag can be set only from the sync context. It can be read
     /// from any context.
-    override public var causedSecurityLevelDegradation : Bool {
+    override public var causedSecurityLevelDegradation: Bool {
         get {
             guard let conversation = self.conversation, let moc = self.managedObjectContext else { return false }
             let messagesByConversation = moc.messagesThatCausedSecurityLevelDegradationByConversation
@@ -35,7 +34,7 @@ extension ZMOTRMessage {
         set {
             guard let conversation = self.conversation, let moc = self.managedObjectContext else { return }
             guard moc.zm_isSyncContext else { fatal("Cannot mark message as degraded security on non-sync moc") }
-            
+
             // make sure it's persisted
             if self.objectID.isTemporaryID {
                 try! moc.obtainPermanentIDs(for: [self])
@@ -43,7 +42,7 @@ extension ZMOTRMessage {
             if conversation.objectID.isTemporaryID {
                 try! moc.obtainPermanentIDs(for: [conversation])
             }
-            
+
             // set
             var dictionary = moc.messagesThatCausedSecurityLevelDegradationByConversation
             var messagesForConversation = dictionary[conversation.objectID] ?? Set()
@@ -64,18 +63,18 @@ extension ZMOTRMessage {
 }
 
 extension ZMConversation {
-    
+
     /// List of messages that were not sent because of security level degradation in the conversation
     /// in this user session (i.e. since the app was started. This will be kept in memory
     /// and not persisted).
-    public var messagesThatCausedSecurityLevelDegradation : [ZMOTRMessage] {
+    public var messagesThatCausedSecurityLevelDegradation: [ZMOTRMessage] {
         guard let moc = self.managedObjectContext else { return [] }
         guard let messageIds = moc.messagesThatCausedSecurityLevelDegradationByConversation[self.objectID] else { return [] }
         return messageIds.compactMap {
             (try? moc.existingObject(with: $0)) as? ZMOTRMessage
         }
     }
-    
+
     public func clearMessagesThatCausedSecurityLevelDegradation() {
         guard let moc = self.managedObjectContext else { return }
         var currentMessages = moc.messagesThatCausedSecurityLevelDegradationByConversation
@@ -87,12 +86,12 @@ extension ZMConversation {
 
 private let messagesThatCausedSecurityLevelDegradationKey = "ZM_messagesThatCausedSecurityLevelDegradation"
 
-typealias SecurityDegradingMessagesByConversation = [NSManagedObjectID : Set<NSManagedObjectID>]
+typealias SecurityDegradingMessagesByConversation = [NSManagedObjectID: Set<NSManagedObjectID>]
 
 extension NSManagedObjectContext {
-    
+
     /// Non-persisted list of messages that caused security level degradation, indexed by conversation
-    fileprivate(set) var messagesThatCausedSecurityLevelDegradationByConversation : SecurityDegradingMessagesByConversation {
+    fileprivate(set) var messagesThatCausedSecurityLevelDegradationByConversation: SecurityDegradingMessagesByConversation {
         get {
             return self.userInfo[messagesThatCausedSecurityLevelDegradationKey] as? SecurityDegradingMessagesByConversation ?? SecurityDegradingMessagesByConversation()
         }
@@ -101,7 +100,7 @@ extension NSManagedObjectContext {
             self.zm_hasUserInfoChanges = true
         }
     }
-    
+
     /// Merge list of messages that caused security level degradation from one context to another
     func mergeSecurityLevelDegradationInfo(fromUserInfo userInfo: [String: Any]) {
         guard self.zm_isUserInterfaceContext else { return } // we don't merge anything to sync, sync is autoritative

--- a/Source/Model/Message/ZMOTRMessage+Unarchive.swift
+++ b/Source/Model/Message/ZMOTRMessage+Unarchive.swift
@@ -21,7 +21,7 @@ import Foundation
 extension ZMConversation {
     fileprivate func unarchive(with message: ZMOTRMessage) {
         self.internalIsArchived = false
-        
+
         if let _ = self.lastServerTimeStamp, let serverTimestamp = message.serverTimestamp {
             self.updateArchived(serverTimestamp, synchronize: false)
         }
@@ -29,7 +29,7 @@ extension ZMConversation {
 }
 
 extension ZMOTRMessage {
-    
+
     @objc(unarchiveIfNeeded:)
     func unarchiveIfNeeded(_ conversation: ZMConversation) {
         if let clearedTimestamp = conversation.clearedTimeStamp,
@@ -37,14 +37,14 @@ extension ZMOTRMessage {
             serverTimestamp.compare(clearedTimestamp) == ComparisonResult.orderedAscending {
                 return
         }
-        
+
         unarchiveIfCurrentUserIsMentionedOrQuoted(conversation)
-        
+
         unarchiveIfNotSilenced(conversation)
     }
-    
+
     private func unarchiveIfCurrentUserIsMentionedOrQuoted(_ conversation: ZMConversation) {
-        
+
         if conversation.isArchived,
             let sender = self.sender,
             !sender.isSelfUser,
@@ -54,7 +54,7 @@ extension ZMOTRMessage {
             conversation.unarchive(with: self)
         }
     }
-    
+
     private func unarchiveIfNotSilenced(_ conversation: ZMConversation) {
         if conversation.isArchived, conversation.mutedMessageTypes == .none {
             conversation.unarchive(with: self)

--- a/Source/Model/Message/ZMOTRMessage+VerifySender.swift
+++ b/Source/Model/Message/ZMOTRMessage+VerifySender.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ZMConversation {
-    
+
     /// Verifies that a sender of an update event is part of the conversation. If they are not,
     /// it means that our local state is out of sync and we need to update the list of participants.
     @objc

--- a/Source/Model/Message/ZMSystemMessage+ChildMessages.swift
+++ b/Source/Model/Message/ZMSystemMessage+ChildMessages.swift
@@ -19,17 +19,17 @@
 import Foundation
 
 extension ZMSystemMessage {
-    
+
     @objc
     static func updateEventParticipantsRemovedReason(_ updateEvent: ZMUpdateEvent) -> ZMParticipantsRemovedReason {
-        
+
         // FUTUREWORK: OCMock no longer work after XCFramework is used. We should remove the OCMock dependency in the tests SQPIT-601
         #if targetEnvironment(simulator)
         guard updateEvent.description != "OCMockObject(WireTransport.ZMUpdateEvent)" else {
             return .none
         }
         #endif
-        
+
         return updateEvent.participantsRemovedReason
     }
 

--- a/Source/Model/NSSecureCoding+Swift.swift
+++ b/Source/Model/NSSecureCoding+Swift.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 /// Helper to conveniently use the `NSSecureCoding` method

--- a/Source/Model/PersistentMetadataKeys.swift
+++ b/Source/Model/PersistentMetadataKeys.swift
@@ -19,11 +19,10 @@
 import Foundation
 
 public enum PersistentMetadataKey: String {
-    
+
     case lastUpdateEventID = "LastUpdateEventID"
     case pushToken = "pushToken"
     case pushKitToken = "ZMPushKitToken"
     case encryptMessagesAtRest = "encryptMessagesAtRest"
     case appLock = "appLock"
 }
-

--- a/Source/Model/Reaction/Reaction.swift
+++ b/Source/Model/Reaction/Reaction.swift
@@ -22,19 +22,17 @@ public let ZMReactionUnicodeValueKey    = "unicodeValue"
 public let ZMReactionMessageValueKey    = "message"
 public let ZMReactionUsersValueKey      = "users"
 
-@objc public enum TransportReaction : UInt32 {
+@objc public enum TransportReaction: UInt32 {
     case none  = 0
     case heart = 1
 }
 
+@objcMembers open class Reaction: ZMManagedObject {
 
-@objcMembers open class Reaction : ZMManagedObject {
-    
-    @NSManaged var unicodeValue : String?
-    @NSManaged var message      : ZMMessage?
-    @NSManaged var users        : Set<ZMUser>
-    
-    
+    @NSManaged var unicodeValue: String?
+    @NSManaged var message: ZMMessage?
+    @NSManaged var users: Set<ZMUser>
+
     public static func insertReaction(_ unicodeValue: String, users: [ZMUser], inMessage message: ZMMessage) -> Reaction {
         let reaction = insertNewObject(in: message.managedObjectContext!)
         reaction.message = message
@@ -42,21 +40,20 @@ public let ZMReactionUsersValueKey      = "users"
         reaction.mutableSetValue(forKey: ZMReactionUsersValueKey).addObjects(from: users)
         return reaction
     }
-    
-    
+
     open override func keysTrackedForLocalModifications() -> Set<String> {
         return [ZMReactionUsersValueKey]
     }
-    
+
     open override class func entityName() -> String {
         return "Reaction"
     }
-    
+
     open override class func sortKey() -> String? {
         return ZMReactionUnicodeValueKey
     }
-    
-    @objc public static func transportReaction(from unicode: String) -> TransportReaction {
+
+    public static func transportReaction(from unicode: String) -> TransportReaction {
         switch unicode {
         case MessageReaction.like.unicodeValue:
             return .heart
@@ -65,7 +62,7 @@ public let ZMReactionUsersValueKey      = "users"
         }
 
     }
-    
+
     public static func validate(unicode: String) -> Bool {
         let isDelete = unicode.count == 0
         let isValidReaction = Reaction.transportReaction(from: unicode) != .none

--- a/Source/Model/User/SearchUserAsset.swift
+++ b/Source/Model/User/SearchUserAsset.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 public enum SearchUserAsset: ExpressibleByNilLiteral, Hashable {
     case none
     case assetKey(String)
@@ -25,7 +24,6 @@ public enum SearchUserAsset: ExpressibleByNilLiteral, Hashable {
         self = .none
     }
 }
-
 
 public func ==(lhs: SearchUserAsset, rhs: SearchUserAsset) -> Bool {
     switch (lhs, rhs) {

--- a/Source/Model/User/UserType+External.swift
+++ b/Source/Model/User/UserType+External.swift
@@ -23,5 +23,5 @@ public extension UserType {
     var isExternalPartner: Bool {
         return teamRole == .partner
     }
-    
+
 }

--- a/Source/Model/User/UserType+Materialize.swift
+++ b/Source/Model/User/UserType+Materialize.swift
@@ -19,30 +19,30 @@
 import Foundation
 
 extension Sequence where Element: UserType {
-    
+
     /// Materialize a sequence of UserType into concrete ZMUser instances.
     ///
     /// - parameter context: NSManagedObjectContext on which users should be created.
     ///
     /// - Returns: List of concrete users which could be materialized.
-    
+
     public func materialize(in context: NSManagedObjectContext) -> [ZMUser] {
         precondition(context.zm_isUserInterfaceContext, "You can only materialize users on the UI context")
-        
+
         let nonExistingUsers = self.compactMap({ $0 as? ZMSearchUser }).filter({ $0.user == nil })
         nonExistingUsers.createLocalUsers(in: context.zm_sync)
-        
+
         return self.compactMap({ $0.unbox(in: context) })
     }
-    
+
 }
 
 extension UserType {
-    
+
     public func materialize(in context: NSManagedObjectContext) -> ZMUser? {
         return [self].materialize(in: context).first
     }
-    
+
     fileprivate func unbox(in context: NSManagedObjectContext) -> ZMUser? {
         if let user = self as? ZMUser {
             return user
@@ -53,14 +53,14 @@ extension UserType {
                 return ZMUser.fetch(with: remoteIdentifier, domain: searchUser.domain, in: context)
             }
         }
-        
+
         return nil
     }
-    
+
 }
 
 extension Sequence where Element: ZMSearchUser {
-    
+
     fileprivate func createLocalUsers(in context: NSManagedObjectContext) {
         let nonExistingUsers = filter({ $0.user == nil }).map { (userID: $0.remoteIdentifier,
                                                                  teamID: $0.teamIdentifier,
@@ -77,5 +77,5 @@ extension Sequence where Element: ZMSearchUser {
             context.saveOrRollback()
         }
     }
-    
+
 }

--- a/Source/Model/User/UserType+Team.swift
+++ b/Source/Model/User/UserType+Team.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 public extension UserType {
@@ -24,5 +23,5 @@ public extension UserType {
     func isOnSameTeam(otherUser: UserType) -> Bool {
         return canAccessCompanyInformation(of: otherUser)
     }
-    
+
 }

--- a/Source/Model/User/UserType.swift
+++ b/Source/Model/User/UserType.swift
@@ -23,16 +23,16 @@ public protocol UserType: NSObjectProtocol, UserConnections {
 
     /// The identifier which uniquely idenitifies the user in its domain
     var remoteIdentifier: UUID? { get }
-    
+
     /// The domain which the user originates from
     var domain: String? { get }
-    
+
     /// The full name
     var name: String? { get }
-    
+
     /// The "@name" handle
     var handle: String? { get }
-    
+
     /// The initials e.g. "JS" for "John Smith"
     var initials: String? { get }
 
@@ -47,37 +47,37 @@ public protocol UserType: NSObjectProtocol, UserConnections {
 
     /// Whether this user belongs to a different domain than the self user
     var isFederated: Bool { get }
-    
+
     /// The availability of the user
     var availability: AvailabilityKind { get set }
-    
+
     /// The name of the team the user belongs to.
     var teamName: String? { get }
-    
+
     /// Whether this is the member of a team
     var isTeamMember: Bool { get }
-    
+
     /// Whether the PDF digial signature is enable
     var hasDigitalSignatureEnabled: Bool { get }
 
     /// The role (and permissions) e.g. partner, member, admin, owner
     var teamRole: TeamRole { get }
-    
+
     /// Whether this is a service user (bot)
     var isServiceUser: Bool { get }
 
     /// Whether this uses uses SSO.
     var usesCompanyLogin: Bool { get }
-    
+
     /// The one-to-one conversation with this user.
     var oneToOneConversation: ZMConversation? { get }
 
     /// Whether the user is expired.
     var isExpired: Bool { get }
-    
+
     /// Whether the account of the user is deleted
     var isAccountDeleted: Bool { get }
-    
+
     /// Wheater the user is under legal hold
     var isUnderLegalHold: Bool { get }
 
@@ -85,40 +85,40 @@ public protocol UserType: NSObjectProtocol, UserConnections {
 
     /// Whether the user is a wireless user.
     var isWirelessUser: Bool { get }
-    
+
     /// The time remaining before the user expires.
     var expiresAfter: TimeInterval { get }
-    
+
     var smallProfileImageCacheKey: String? { get }
     var mediumProfileImageCacheKey: String? { get }
-    
+
     var previewImageData: Data? { get }
     var completeImageData: Data? { get }
-    
+
     /// Whether read receipts are enabled for this user.
     var readReceiptsEnabled: Bool { get }
-    
+
     /// The extended metadata for this user, provided by SCIM.
     var richProfile: [UserRichProfileField] { get }
-        
+
     /// Conversations the user is a currently a participant of
     var activeConversations: Set<ZMConversation> { get }
-    
+
     /// All clients belonging to the user
     var allClients: [UserClientType] { get }
-    
+
     /// Whether the user verified all own devices plus others
     var isVerified: Bool { get }
-    
+
     func requestPreviewProfileImage()
     func requestCompleteProfileImage()
-    
+
     /// Whether this user is a guest in a conversation
     func isGuest(in conversation: ConversationLike) -> Bool
-    
+
     /// Fetch a profile image with the given size on the given queue
     func imageData(for size: ProfileImageSize, queue: DispatchQueue, completion: @escaping (_ imageData: Data?) -> Void)
-    
+
     /// Request a refresh of the user data from the backend.
     ///
     /// This is useful for non-connected user (that we will otherwise never re-fetch)
@@ -138,29 +138,29 @@ public protocol UserType: NSObjectProtocol, UserConnections {
     ///
     /// This is useful to discover changes such as team name and logo.
     func refreshTeamData()
-        
+
     /// Determines whether the user profile is managed by Wire or other services (SCIM)
     var managedByWire: Bool { get }
-    
+
     // MARK: - Permissions
-    
+
     /// Whether the user can create conversations.
     @objc
     func canCreateConversation(type: ZMConversationType) -> Bool
-    
+
     /// Whether the user can create services
     var canCreateService: Bool { get }
-    
+
     /// Whether the user can administate the team
     var canManageTeam: Bool { get }
 
     /// Whether the user can access the private company information of the other given user.
     func canAccessCompanyInformation(of user: UserType) -> Bool
-    
+
     /// Whether the user can add services to the conversation
     @objc(canAddServiceToConversation:)
     func canAddService(to conversation: ZMConversation) -> Bool
-    
+
     /// Whether the user can remove services from the conversation
     @objc(canRemoveServiceFromConversation:)
     func canRemoveService(from conversation: ZMConversation) -> Bool
@@ -172,7 +172,7 @@ public protocol UserType: NSObjectProtocol, UserConnections {
     /// Whether the user can remove another user from the conversation.
     @objc(canRemoveUserFromConversation:)
     func canRemoveUser(from conversation: ZMConversation) -> Bool
-    
+
     /// Whether the user can delete the conversation
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool
@@ -180,23 +180,23 @@ public protocol UserType: NSObjectProtocol, UserConnections {
     /// Wheter the user can modify roles of members in the conversation.
     @objc(canModifyOtherMemberInConversation:)
     func canModifyOtherMember(in conversation: ZMConversation) -> Bool
-    
+
     /// Whether the user can toggle the read receipts setting in the conversation.
     @objc(canModifyReadReceiptSettingsInConversation:)
     func canModifyReadReceiptSettings(in conversation: ConversationLike) -> Bool
-    
+
     /// Whether the user can toggle the emphemeral setting in the conversation.
     @objc(canModifyEphemeralSettingsInConversation:)
     func canModifyEphemeralSettings(in conversation: ConversationLike) -> Bool
-    
+
     /// Whether the user can change the notification level setting in the conversation.
     @objc(canModifyNotificationSettingsInConversation:)
     func canModifyNotificationSettings(in conversation: ConversationLike) -> Bool
-    
+
     /// Whether the user can toggle the access level setting in the conversation.
     @objc(canModifyAccessControlSettingsInConversation:)
     func canModifyAccessControlSettings(in conversation: ConversationLike) -> Bool
-    
+
     /// Whether the user can update the title of the conversation.
     @objc(canModifyTitleInConversation:)
     func canModifyTitle(in conversation: ConversationLike) -> Bool
@@ -208,10 +208,10 @@ public protocol UserType: NSObjectProtocol, UserConnections {
     /// Whether the user is group admin in the conversation.
     @objc(isGroupAdminInConversation:)
     func isGroupAdmin(in conversation: ConversationLike) -> Bool
-        
+
     /// Whether all user's devices are verified by the selfUser
     var isTrusted: Bool { get }
-    
+
     /// the user has team or not
     @objc
     var hasTeam: Bool { get }
@@ -221,28 +221,28 @@ public protocol UserType: NSObjectProtocol, UserConnections {
 
 @objc
 public protocol UserConnections {
-    
+
     ///  Whether the user has been blocked by the self user
     var isBlocked: Bool { get }
 
     ///  The user block state
     var blockState: ZMBlockState { get }
-    
+
     ///  Whether the user has ignored an incoming connection request from this user.
     var isIgnored: Bool { get }
-    
+
     /// Whether the user is pending connection approval from the self user.
     var isPendingApprovalBySelfUser: Bool { get }
-    
+
     /// Whether the user is pending connection approval from another user.
     var isPendingApprovalByOtherUser: Bool { get }
-    
+
     /// Is `false` if we can send a connection request to this user.
     var isConnected: Bool { get }
-    
+
     /// Whether the user can be connected by the self user.
     var canBeConnected: Bool { get }
-    
+
     /// Sends a connection request to the given user. May be a no-op, eg. if we're already connected.
     /// A ZMUserChangeNotification with the searchUser as object will be sent notifiying about the connection status change
     /// You should stop from observing the searchUser and start observing the user from there on

--- a/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
+++ b/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 
-
 extension ZMUser {
 
     /// Underlying storage of the analytics identifier.

--- a/Source/Model/User/ZMUser+Availability.swift
+++ b/Source/Model/User/ZMUser+Availability.swift
@@ -16,15 +16,14 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 @objc
-public enum AvailabilityKind : Int, CaseIterable {
+public enum AvailabilityKind: Int, CaseIterable {
     case none, available, busy, away
-    
+
     public init(proto: WireProtos.Availability) {
-        ///TODO: change ZMAvailabilityType to NS_CLOSED_ENUM
+        /// TODO: change ZMAvailabilityType to NS_CLOSED_ENUM
         switch proto.type {
         case .none:
             self = .none
@@ -41,20 +40,20 @@ public enum AvailabilityKind : Int, CaseIterable {
 
 /// Describes how the user should be notified about a change.
 public struct NotificationMethod: OptionSet {
-    
+
     public let rawValue: Int
-    
+
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    
+
     /// Alert user by local notification
     public static let notification = NotificationMethod(rawValue: 1 << 0)
     /// Alert user by alert dialogue
     public static let alert = NotificationMethod(rawValue: 1 << 1)
-    
+
     public static let all: NotificationMethod = [.notification, .alert]
-    
+
 }
 
 extension ZMUser {
@@ -91,7 +90,7 @@ extension ZMUser {
             .prefix(remainingSlots)
 
         recipients.formUnion(teamUsers)
-        
+
         recipients = recipients.filter { !$0.isFederated }
 
         return recipients
@@ -127,44 +126,44 @@ extension ZMUser {
         return Set(result)
     }
 
-    @objc public var availability : AvailabilityKind {
+    @objc public var availability: AvailabilityKind {
         get {
             self.willAccessValue(forKey: AvailabilityKey)
             let value = (self.primitiveValue(forKey: AvailabilityKey) as? NSNumber) ?? NSNumber(value: 0)
             self.didAccessValue(forKey: AvailabilityKey)
-            
+
             return AvailabilityKind(rawValue: value.intValue) ?? .none
         }
-        
+
         set {
             guard isSelfUser else { return } // TODO move this setter to ZMEditableUser
-            
+
             updateAvailability(newValue)
         }
     }
-        
-    internal func updateAvailability(_ newValue : AvailabilityKind) {
+
+    internal func updateAvailability(_ newValue: AvailabilityKind) {
         self.willChangeValue(forKey: AvailabilityKey)
         self.setPrimitiveValue(NSNumber(value: newValue.rawValue), forKey: AvailabilityKey)
         self.didChangeValue(forKey: AvailabilityKey)
     }
-    
-    public func updateAvailability(from genericMessage : GenericMessage) {
+
+    public func updateAvailability(from genericMessage: GenericMessage) {
         updateAvailability(AvailabilityKind(proto: genericMessage.availability))
     }
-    
+
     private static let needsToNotifyAvailabilityBehaviourChangeKey = "needsToNotifyAvailabilityBehaviourChange"
-    
+
     /// Returns an option set describing how we should notify the user about the change in behaviour for the availability feature
     public var needsToNotifyAvailabilityBehaviourChange: NotificationMethod {
         get {
             guard let rawValue = managedObjectContext?.persistentStoreMetadata(forKey: type(of: self).needsToNotifyAvailabilityBehaviourChangeKey) as? Int else { return [] }
-            
+
             return NotificationMethod(rawValue: rawValue)
         }
         set {
             managedObjectContext?.setPersistentStoreMetadata(newValue.rawValue, key: type(of: self).needsToNotifyAvailabilityBehaviourChangeKey)
         }
     }
-    
+
 }

--- a/Source/Model/User/ZMUser+Create.swift
+++ b/Source/Model/User/ZMUser+Create.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 public extension ZMUser {
 
     /// Fetch an existing user or create a new one if it doesn't already exist.

--- a/Source/Model/User/ZMUser+Filename.swift
+++ b/Source/Model/User/ZMUser+Filename.swift
@@ -19,27 +19,27 @@
 import Foundation
 
 public extension ZMUser {
-    fileprivate static let dateFormatter : DateFormatter = {
+    fileprivate static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd-hh.mm.ss"
         return formatter
     }()
-    
+
     /// return a file name with length <= 255 - 4(reserve for extension) - 37(reserve for WireDataModel UUID prefix for meta) characters
     ///
     /// - Returns: a string <= 214 characters
-    func filename(suffix: String? = nil)-> String {
+    func filename(suffix: String? = nil) -> String {
         let dateString = "-" + ZMUser.dateFormatter.string(from: Date())
         let normalizedFilename = name!.normalizedFilename
-        
+
         var numReservedChar = dateString.count
-        
+
         if let suffixUnwrapped = suffix {
             numReservedChar += suffixUnwrapped.count
         }
-        
+
         let trimmedFilename = normalizedFilename.trimmedFilename(numReservedChar: numReservedChar)
-        
+
         if let suffixUnwrapped = suffix {
             return "\(trimmedFilename)\(dateString)\(suffixUnwrapped)"
         }

--- a/Source/Model/User/ZMUser+LegalHoldRequest.swift
+++ b/Source/Model/User/ZMUser+LegalHoldRequest.swift
@@ -31,7 +31,7 @@ public protocol SelfLegalHoldSubject {
 
     /// Whether the user needs to acknowledge the current legal hold status.
     var needsToAcknowledgeLegalHoldStatus: Bool { get }
-    
+
     /// Call this method a pending legal hold request was cancelled
     func legalHoldRequestWasCancelled()
 
@@ -86,19 +86,19 @@ public struct LegalHoldRequest: Codable, Hashable {
         }
 
     }
-    
+
     /**
      * Represent a client in the legal hold request.
      */
-    
+
     private struct Client: Codable, Hashable {
-        
+
         /// The ID of the client
         let id: String
     }
-    
+
     private let client: Client
-    
+
     /// The ID of the legal hold client.
     public var clientIdentifier: String {
         get {
@@ -187,11 +187,11 @@ extension ZMUser: SelfLegalHoldSubject {
             didChangeValue(forKey: ZMUserKeys.legalHoldRequest)
         }
     }
-    
+
     /**
      * Call this method a pending legal hold request was cancelled
      */
-    
+
     public func legalHoldRequestWasCancelled() {
         legalHoldRequest = nil
         needsToAcknowledgeLegalHoldStatus = false

--- a/Source/Model/User/ZMUser+Permissions.swift
+++ b/Source/Model/User/ZMUser+Permissions.swift
@@ -28,7 +28,7 @@ enum ConversationAction {
     case modifyOtherConversationMember
     case leaveConversation
     case deleteConvesation
-    
+
     var name: String {
         switch self {
         case .addConversationMember: return "add_conversation_member"
@@ -45,43 +45,43 @@ enum ConversationAction {
 }
 
 public extension ZMUser {
-    
+
     var teamRole: TeamRole {
         return TeamRole(rawPermissions: permissions?.rawValue ?? 0)
     }
-    
+
     private var permissions: Permissions? {
         return membership?.permissions
     }
-    
+
     @objc(canAddServiceToConversation:)
     func canAddService(to conversation: ZMConversation) -> Bool {
         guard !isGuest(in: conversation), conversation.conversationType == .group else { return false }
         return hasRoleWithAction(actionName: ConversationAction.addConversationMember.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canRemoveServiceFromConversation:)
     func canRemoveService(from conversation: ZMConversation) -> Bool {
         guard !isGuest(in: conversation), conversation.conversationType == .group else { return false }
         return hasRoleWithAction(actionName: ConversationAction.removeConversationMember.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canAddUserToConversation:)
     func canAddUser(to conversation: ConversationLike) -> Bool {
         guard conversation.conversationType == .group else { return false }
         return hasRoleWithAction(actionName: ConversationAction.addConversationMember.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canRemoveUserFromConversation:)
     func canRemoveUser(from conversation: ZMConversation) -> Bool {
         guard conversation.conversationType == .group else { return false }
         return hasRoleWithAction(actionName: ConversationAction.removeConversationMember.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canDeleteConversation:)
     func canDeleteConversation(_ conversation: ZMConversation) -> Bool {
         guard conversation.conversationType == .group else { return false }
@@ -97,14 +97,14 @@ public extension ZMUser {
         return hasRoleWithAction(actionName: ConversationAction.modifyOtherConversationMember.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canModifyReadReceiptSettingsInConversation:)
     func canModifyReadReceiptSettings(in conversation: ConversationLike) -> Bool {
         guard conversation.conversationType == .group else { return false }
         return hasRoleWithAction(actionName: ConversationAction.modifyConversationReceiptMode.name,
                                  conversation: conversation)
     }
-    
+
     @objc(canModifyEphemeralSettingsInConversation:)
     func canModifyEphemeralSettings(in conversation: ConversationLike) -> Bool {
         if conversation.conversationType == .group {
@@ -124,20 +124,20 @@ public extension ZMUser {
 
         return isTeamMember
     }
-    
+
     @objc(canModifyAccessControlSettingsInConversation:)
     func canModifyAccessControlSettings(in conversation: ConversationLike) -> Bool {
         guard conversation.conversationType == .group,
             conversation.teamRemoteIdentifier != nil
             else { return false }
-        
+
         return hasRoleWithAction(actionName: ConversationAction.modifyConversationAccess.name, conversation: conversation)
     }
-    
+
     @objc(canModifyTitleInConversation:)
     func canModifyTitle(in conversation: ConversationLike) -> Bool {
         guard conversation.conversationType == .group else { return false }
-        
+
         return hasRoleWithAction(actionName: ConversationAction.modifyConversationName.name, conversation: conversation)
     }
 
@@ -151,22 +151,22 @@ public extension ZMUser {
     func canCreateConversation(type: ZMConversationType) -> Bool {
         switch type {
         case .oneOnOne:
-            ///all users are allow to open 1-on-1 conversation
+            /// all users are allow to open 1-on-1 conversation
             return true
         default:
             /// partner is not allowed to create non 1-on-1 convo
             return permissions?.contains(.member) ?? true
         }
     }
-    
+
     @objc var canCreateService: Bool {
         return permissions?.contains(.member) ?? false
     }
-    
+
     @objc var canManageTeam: Bool {
         return permissions?.contains(.admin) ?? false
     }
-    
+
     func canAccessCompanyInformation(of user: UserType) -> Bool {
         guard
             let otherUser = user as? ZMUser,
@@ -178,7 +178,7 @@ public extension ZMUser {
 
         return selfUserTeamID == otherUserTeamID && !isFederating(with: otherUser)
     }
-    
+
     @objc func _isGuest(in conversation: ConversationLike) -> Bool {
         guard let conversation = conversation as? ZMConversation else { return false }
         if isSelfUser {
@@ -214,7 +214,7 @@ public extension ZMUser {
                 && membership == nil
         }
     }
-    
+
     private func hasRoleWithAction(actionName: String, conversation: ConversationLike) -> Bool {
         guard conversation.isSelfAnActiveMember,
             let role = self.role(in: conversation)

--- a/Source/Model/User/ZMUser+Predicates.swift
+++ b/Source/Model/User/ZMUser+Predicates.swift
@@ -20,12 +20,12 @@ import Foundation
 import WireUtilities
 
 extension ZMUser {
-    
+
     /// Retrieves all users (excluding bots), having ZMConnectionStatusAccepted connection statuses.
     @objc static var predicateForConnectedNonBotUsers: NSPredicate {
         return predicateForUsers(withSearch: "", connectionStatuses: [ZMConnectionStatus.accepted.rawValue])
     }
-    
+
     /// Retrieves connected users with name or handle matching search string
     ///
     /// - Parameter query: search string
@@ -34,7 +34,7 @@ extension ZMUser {
     public static func predicateForConnectedUsers(withSearch query: String) -> NSPredicate {
         return predicateForUsers(withSearch: query, connectionStatuses: [ZMConnectionStatus.accepted.rawValue])
     }
-    
+
     /// Retrieves all users with name or handle matching search string
     ///
     /// - Parameter query: search string
@@ -42,7 +42,7 @@ extension ZMUser {
     public static func predicateForAllUsers(withSearch query: String) -> NSPredicate {
         return predicateForUsers(withSearch: query, connectionStatuses: nil)
     }
-    
+
     /// Retrieves users with name or handle matching search string, having one of given connection statuses
     ///
     /// - Parameters:
@@ -55,18 +55,18 @@ extension ZMUser {
         if let statuses = connectionStatuses {
             allPredicates.append([predicateForUsers(withConnectionStatuses: statuses)])
         }
-        
+
         if !query.isEmpty {
-            let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName) : "%K MATCHES %@"], matchingSearch: query)
+            let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName): "%K MATCHES %@"], matchingSearch: query)
             let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), query.strippingLeadingAtSign())
             allPredicates.append([namePredicate, handlePredicate].compactMap {$0})
         }
-        
+
         let orPredicates = allPredicates.map { NSCompoundPredicate(orPredicateWithSubpredicates: $0) }
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: orPredicates)
     }
-    
+
     @objc(predicateForUsersWithConnectionStatusInArray:)
     public static func predicateForUsers(withConnectionStatuses connectionStatuses: [Int16]) -> NSPredicate {
         return NSPredicate(format: "(%K IN (%@))", #keyPath(ZMUser.connection.status), connectionStatuses)

--- a/Source/Model/User/ZMUser+RichProfile.swift
+++ b/Source/Model/User/ZMUser+RichProfile.swift
@@ -29,11 +29,11 @@ public enum ZMUserKeys {
         self.type = type
         self.value = value
     }
-    
+
     public static func == (lhs: UserRichProfileField, rhs: UserRichProfileField) -> Bool {
         return lhs.type == rhs.type && lhs.value == rhs.value
     }
-    
+
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? UserRichProfileField else { return false }
         return self == other
@@ -44,14 +44,14 @@ extension ZMUser {
     private enum Keys {
         static let RichProfile = "richProfile"
     }
-    
+
     @NSManaged private var primitiveRichProfile: Data?
     public var richProfile: [UserRichProfileField] {
         get {
             self.willAccessValue(forKey: ZMUserKeys.RichProfile)
             let fields: [UserRichProfileField]
             if let data = primitiveRichProfile {
-                fields = (try? JSONDecoder().decode([UserRichProfileField].self, from:data)) ?? []
+                fields = (try? JSONDecoder().decode([UserRichProfileField].self, from: data)) ?? []
             } else {
                 fields = []
             }

--- a/Source/Model/User/ZMUser+Teams.swift
+++ b/Source/Model/User/ZMUser+Teams.swift
@@ -16,12 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 public extension ZMUser {
     @objc var team: Team? {
         return membership?.team
     }
-        
+
     @objc static func keyPathsForValuesAffectingTeam() -> Set<String> {
          return [#keyPath(ZMUser.membership)]
     }
@@ -29,20 +28,20 @@ public extension ZMUser {
     @objc var isWirelessUser: Bool {
         return self.expiresAt != nil
     }
-    
+
     @objc var isExpired: Bool {
         guard let expiresAt = self.expiresAt else {
             return false
         }
-        
+
         return expiresAt.compare(Date()) != .orderedDescending
     }
-    
+
     @objc var expiresAfter: TimeInterval {
         guard let expiresAt = self.expiresAt else {
             return 0
         }
-        
+
         if expiresAt.timeIntervalSinceNow < 0 {
             return 0
         }
@@ -50,7 +49,7 @@ public extension ZMUser {
             return expiresAt.timeIntervalSinceNow
         }
     }
-    
+
     @objc func createOrDeleteMembershipIfBelongingToTeam() {
         guard
             let teamIdentifier = self.teamIdentifier,

--- a/Source/Model/User/ZMUser+Validation.swift
+++ b/Source/Model/User/ZMUser+Validation.swift
@@ -19,34 +19,34 @@
 import Foundation
 
 public extension ZMUser {
-    
+
     // Name
-    
+
     static func validate(name: inout String?) throws -> Bool {
-        
+
         var mutableName: Any? = name
-        
+
         try ExtremeCombiningCharactersValidator.validateCharactersValue(&mutableName)
-        
+
         // The backend limits to 128. We'll fly just a bit below the radar.
         let validate = try StringLengthValidator.validateStringValue(&mutableName, minimumStringLength: 2, maximumStringLength: 100, maximumByteLength: UInt32.max)
-        
+
         name = mutableName as? String
-        
+
         return name == nil || validate
     }
-    
+
     // Accent color
-    
+
     static func validate(accentColor: inout Int?) throws -> Bool {
         var mutableAccentColor: Any? = accentColor
         let result = try ZMAccentColorValidator.validateValue(&mutableAccentColor)
         accentColor = mutableAccentColor as? Int
         return result
     }
-    
+
     // E-mail address
-    
+
     static func validate(emailAddress: inout String?) throws -> Bool {
         var mutableEmailAddress: Any? = emailAddress
         let result = try ZMEmailAddressValidator.validateValue(&mutableEmailAddress)
@@ -54,9 +54,9 @@ public extension ZMUser {
         return result
 
     }
-    
+
     // Password
-    
+
     static func validate(password: inout String?) throws -> Bool {
         var mutablePassword: Any? = password
         let result = try StringLengthValidator.validateStringValue(&mutablePassword,
@@ -66,22 +66,22 @@ public extension ZMUser {
         password = mutablePassword as? String
         return result
     }
-    
+
     // Phone number
-    
+
     static func validate(phoneNumber: inout String?) throws -> Bool {
         guard var mutableNumber: Any? = phoneNumber,
             phoneNumber?.count ?? 0 >= 1 else {
                 return false
         }
-        
+
         let result = try ZMPhoneNumberValidator.validateValue(&mutableNumber)
         phoneNumber = mutableNumber as? String
         return result
     }
-    
+
     // Verification code
-    
+
     static func validate(phoneVerificationCode: inout String?) throws -> Bool {
         var mutableCode: Any? = phoneVerificationCode
         let result = try StringLengthValidator.validateStringValue(&mutableCode, minimumStringLength: 6, maximumStringLength: 6, maximumByteLength: UInt32.max)
@@ -89,4 +89,3 @@ public extension ZMUser {
         return result
     }
 }
-

--- a/Source/Model/User/ZMUser.swift
+++ b/Source/Model/User/ZMUser.swift
@@ -32,34 +32,34 @@ extension ZMUser: UserType {
         let selfUser = managedObjectContext.map(ZMUser.selfUser)
         let selfClient = selfUser?.selfClient()
         let hasUntrustedClients = self.clients.contains(where: { ($0 != selfClient) && !(selfClient?.trustedClients.contains($0) ?? false) })
-        
+
         return !hasUntrustedClients
     }
-    
+
     public func isGuest(in conversation: ConversationLike) -> Bool {
         return _isGuest(in: conversation)
     }
-    
+
     public var teamName: String? {
         return team?.name
     }
-    
+
     public var hasDigitalSignatureEnabled: Bool {
         return team?.fetchFeatureFlag(with: .digitalSignature)?.isEnabled ?? false
     }
-    
+
     public var previewImageData: Data? {
         return imageSmallProfileData
     }
-    
+
     public var completeImageData: Data? {
         return imageMediumData
     }
-    
+
     public var activeConversations: Set<ZMConversation> {
         return Set(self.participantRoles.compactMap {$0.conversation})
     }
-    
+
     public var isVerified: Bool {
         guard let selfUser = managedObjectContext.map(ZMUser.selfUser) else {
             return false
@@ -99,7 +99,7 @@ extension ZMUser: UserType {
     @objc class func keyPathsForValuesAffectingIsUnderLegalHold() -> Set<String> {
         return [UserClientsKey, "clients.deviceClass"]
     }
-    
+
     public var allClients: [UserClientType] {
         return Array(clients)
     }
@@ -117,13 +117,13 @@ extension ZMUser: UserType {
     public func refreshTeamData() {
         team?.refreshMetadata()
     }
-    
+
 }
 
 public struct AssetKey {
-    
+
     static let legalCharacterSet = CharacterSet.alphanumerics.union(CharacterSet.punctuationCharacters)
-    
+
     public init?(_ string: String) {
         if AssetKey.validate(string: string) {
             stringValue = string
@@ -131,10 +131,10 @@ public struct AssetKey {
             return nil
         }
     }
-    
-    let stringValue : String
-    
-    fileprivate static func validate(string : String) -> Bool {
+
+    let stringValue: String
+
+    fileprivate static func validate(string: String) -> Bool {
         return CharacterSet(charactersIn: string).isSubset(of: legalCharacterSet)
     }
 }
@@ -142,7 +142,7 @@ public struct AssetKey {
 @objc public enum ProfileImageSize: Int {
     case preview
     case complete
-    
+
     public var imageFormat: ZMImageFormat {
         switch self {
         case .preview:
@@ -166,7 +166,7 @@ public struct AssetKey {
         case .complete: return "complete"
         }
     }
-    
+
     public static var allSizes: [ProfileImageSize] {
         return [.preview, .complete]
     }
@@ -194,37 +194,37 @@ public extension Notification.Name {
 }
 
 extension ZMUser {
-    
+
     @objc static public let previewProfileAssetIdentifierKey = #keyPath(ZMUser.previewProfileAssetIdentifier)
     @objc static public let completeProfileAssetIdentifierKey = #keyPath(ZMUser.completeProfileAssetIdentifier)
 
     @NSManaged public var previewProfileAssetIdentifier: String?
     @NSManaged public var completeProfileAssetIdentifier: String?
-    
+
     /// Conversations created by this user
     @NSManaged var conversationsCreated: Set<ZMConversation>
-    
+
     /// Team membership for this user
     @NSManaged public internal(set) var membership: Member?
 
     /// Reactions expressed by this user
     @NSManaged var reactions: Set<Reaction>
-    
+
     /// System messages referencing this user
     @NSManaged var systemMessages: Set<ZMSystemMessage>
-    
+
     @NSManaged public var expiresAt: Date?
-    
+
     /// `accountIsDeleted` is true if this account has been deleted on the backend
     @NSManaged public internal(set) var isAccountDeleted: Bool
-    
+
     @NSManaged public var usesCompanyLogin: Bool
-    
+
     /// If `needsToRefetchLabels` is true we need to refetch the conversation labels (favorites & folders)
     @NSManaged public var needsToRefetchLabels: Bool
-    
+
     @NSManaged public var domain: String?
-    
+
     @objc(setImageData:size:)
     public func setImage(data: Data?, size: ProfileImageSize) {
         guard let imageData = data else {
@@ -232,29 +232,29 @@ extension ZMUser {
             return
         }
         managedObjectContext?.zm_userImageCache?.setUserImage(self, imageData: imageData, size: size)
-        
+
         if let uiContext = managedObjectContext?.zm_userInterface {
             let changedKey = size == .preview ? #keyPath(ZMUser.previewImageData) : #keyPath(ZMUser.completeImageData)
             NotificationDispatcher.notifyNonCoreDataChanges(objectID: objectID, changedKeys: [changedKey], uiContext: uiContext)
         }
     }
-    
+
     public func imageData(for size: ProfileImageSize, queue: DispatchQueue, completion: @escaping (_ imageData: Data?) -> Void) {
         managedObjectContext?.zm_userImageCache?.userImage(self, size: size, queue: queue, completion: completion)
     }
-    
+
     @objc(imageDataforSize:)
     public func imageData(for size: ProfileImageSize) -> Data? {
         return managedObjectContext?.zm_userImageCache?.userImage(self, size: size)
     }
-    
+
     public static var previewImageDownloadFilter: NSPredicate {
         let assetIdExists = NSPredicate(format: "(%K != nil)", ZMUser.previewProfileAssetIdentifierKey)
         let assetIdIsValid = NSPredicate { (user, _) -> Bool in
             guard let user = user as? ZMUser else { return false }
             return user.previewProfileAssetIdentifier?.isValidAssetID ?? false
         }
-        let notCached = NSPredicate() { (user, _) -> Bool in
+        let notCached = NSPredicate { (user, _) -> Bool in
             guard let user = user as? ZMUser else { return false }
             return user.imageSmallProfileData == nil
         }
@@ -267,23 +267,23 @@ extension ZMUser {
             guard let user = user as? ZMUser else { return false }
             return user.completeProfileAssetIdentifier?.isValidAssetID ?? false
         }
-        let notCached = NSPredicate() { (user, _) -> Bool in
+        let notCached = NSPredicate { (user, _) -> Bool in
             guard let user = user as? ZMUser else { return false }
             return user.imageMediumData == nil
         }
         return NSCompoundPredicate(andPredicateWithSubpredicates: [assetIdExists, assetIdIsValid, notCached])
     }
-    
+
     public func updateAndSyncProfileAssetIdentifiers(previewIdentifier: String, completeIdentifier: String) {
         guard isSelfUser else { return }
         previewProfileAssetIdentifier = previewIdentifier
         completeProfileAssetIdentifier = completeIdentifier
         setLocallyModifiedKeys([ZMUser.previewProfileAssetIdentifierKey, ZMUser.completeProfileAssetIdentifierKey])
     }
-    
+
     @objc public func updateAssetData(with assets: NSArray?, authoritative: Bool) {
         guard !hasLocalModifications(forKeys: [ZMUser.previewProfileAssetIdentifierKey, ZMUser.completeProfileAssetIdentifierKey]) else { return }
-        guard let assets = assets as? [[String : String]], !assets.isEmpty else {
+        guard let assets = assets as? [[String: String]], !assets.isEmpty else {
             if authoritative {
                 previewProfileAssetIdentifier = nil
                 completeProfileAssetIdentifier = nil
@@ -305,30 +305,30 @@ extension ZMUser {
             }
         }
     }
-    
+
     @objc public func requestPreviewProfileImage() {
         guard let moc = self.managedObjectContext, moc.zm_isUserInterfaceContext, !moc.zm_userImageCache.hasUserImage(self, size: .preview) else { return }
-        
+
         NotificationInContext(name: .userDidRequestPreviewAsset,
                               context: moc.notificationContext,
                               object: self.objectID).post()
     }
-    
+
     @objc public func requestCompleteProfileImage() {
         guard let moc = self.managedObjectContext, moc.zm_isUserInterfaceContext, !moc.zm_userImageCache.hasUserImage(self, size: .complete) else { return }
-        
+
         NotificationInContext(name: .userDidRequestCompleteAsset,
                               context: moc.notificationContext,
                               object: self.objectID).post()
     }
-    
+
     /// Mark the user's account as having been deleted. This will also remove the user from any conversations he/she
     /// is still a participant of.
     @objc public func markAccountAsDeleted(at timestamp: Date) {
         isAccountDeleted = true
         removeFromAllConversations(at: timestamp)
     }
-    
+
     /// Remove user from all group conversations he is a participant of
     fileprivate func removeFromAllConversations(at timestamp: Date) {
         let allGroupConversations: [ZMConversation] = participantRoles.compactMap {
@@ -336,7 +336,7 @@ extension ZMUser {
                 convo.conversationType == .group else { return nil}
             return convo
         }
-        
+
         allGroupConversations.forEach { conversation in
             if isTeamMember && conversation.team == team {
                 conversation.appendTeamMemberRemovedSystemMessage(user: self, at: timestamp)
@@ -350,23 +350,23 @@ extension ZMUser {
 
 extension ZMUser {
     // MARK: - Participant role
-    
+
     @objc
     public var conversations: Set<ZMConversation> {
-        return Set(participantRoles.compactMap{ return $0.conversation })
+        return Set(participantRoles.compactMap { return $0.conversation })
     }
 }
 
 extension NSManagedObject: SafeForLoggingStringConvertible {
     public var safeForLoggingDescription: String {
         let moc: String = self.managedObjectContext?.description ?? "nil"
-        
+
         return "\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque()): moc=\(moc) objectID=\(self.objectID)"
     }
 }
 
 extension ZMUser {
-    
+
     /// The initials e.g. "JS" for "John Smith"
     @objc public var initials: String? {
         return PersonName.person(withName: self.name ?? "", schemeTagger: nil).initials
@@ -431,4 +431,3 @@ extension ZMUser: UserConnections {
     }
 
 }
-

--- a/Source/Model/UserClient/UserClient+Patches.swift
+++ b/Source/Model/UserClient/UserClient+Patches.swift
@@ -19,13 +19,13 @@
 import Foundation
 
 extension UserClient {
-    
+
     /// Migrate client sessions from using the client identifier only as session identifier
     /// to new client sessions  useing user identifier + client identifier as session identifier.
     /// These have less chances of collision.
     static func migrateAllSessionsClientIdentifiersV2(in moc: NSManagedObjectContext) {
         let request = UserClient.sortedFetchRequest()
-        
+
         guard let selfClient = ZMUser.selfUser(in: moc).selfClient(),
             let allClients = moc.fetchOrAssert(request: request) as? [UserClient] else {
                 // no client? no migration needed
@@ -39,10 +39,10 @@ extension UserClient {
             }
         }
     }
-    
+
     static func migrateAllSessionsClientIdentifiersV3(in moc: NSManagedObjectContext) {
         let request = UserClient.sortedFetchRequest()
-        
+
         guard let selfClient = ZMUser.selfUser(in: moc).selfClient(),
             let allClients = moc.fetchOrAssert(request: request) as? [UserClient] else {
                 // no client? no migration needed

--- a/Source/Model/UserClient/UserClient+Protobuf.swift
+++ b/Source/Model/UserClient/UserClient+Protobuf.swift
@@ -16,19 +16,18 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireProtos
 
 extension UserClient {
-    
+
     var hexRemoteIdentifier: UInt64 {
         let pointer = UnsafeMutablePointer<UInt64>.allocate(capacity: 1)
         defer { pointer.deallocate() }
         Scanner(string: self.remoteIdentifier!).scanHexInt64(pointer)
         return UInt64(pointer.pointee)
     }
-    
+
     public var clientId: Proteus_ClientId {
         return Proteus_ClientId.with {
             $0.client = self.hexRemoteIdentifier

--- a/Source/Model/UserClient/UserClientType.swift
+++ b/Source/Model/UserClient/UserClientType.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 @objc public protocol UserClientType: NSObjectProtocol {
-    
+
     /// Free-form string decribing the client, this information is only available for your own clients.
     var label: String? { get }
     /// Remote identifier of the client
@@ -44,10 +44,10 @@ import Foundation
     var fingerprint: Data? { get }
     /// True if the self user has verfied the client
     var verified: Bool { get }
-    
+
     /// Delete any existing session with client and establish a new one.
     func resetSession()
-    
+
     /// Returns true if this is the active client of the self user
     func isSelfClient() -> Bool
 

--- a/Source/Model/Validation/PBMessage+Validation.swift
+++ b/Source/Model/Validation/PBMessage+Validation.swift
@@ -89,7 +89,7 @@ extension String {
 extension GenericMessage {
     public func validatingFields() -> GenericMessage? {
         guard UUID.isValid(object: messageID), let content = self.content else { return nil }
-        
+
         switch content {
         case .text:
             guard text.validatingFields() != nil else { return nil }
@@ -189,11 +189,11 @@ extension MessageEdit {
 extension Confirmation {
     public func validatingFields() -> Confirmation? {
         guard UUID.isValid(object: firstMessageID) else { return nil }
-        
+
         if !moreMessageIds.isEmpty {
             guard UUID.isValid(array: moreMessageIds) else { return nil }
         }
-        
+
         return self
     }
 }
@@ -225,7 +225,7 @@ extension WireProtos.Asset {
         if case .uploaded? = status {
             guard uploaded.validatingFields() != nil else { return nil }
         }
-        
+
         return self
     }
 }

--- a/Source/Model/ZMManagedObject+Grouping.swift
+++ b/Source/Model/ZMManagedObject+Grouping.swift
@@ -85,7 +85,7 @@ extension NSManagedObjectContext {
                 zmLog.error("findDuplicated<T> does not support in-memory store")
             return [:]
         }
-        
+
         guard let entity = NSEntityDescription.entity(forEntityName: T.entityName(), in: self),
               let attribute = entity.attributesByName[keyPath] else {
                 fatal("Cannot preapare the fetch")
@@ -93,7 +93,7 @@ extension NSManagedObjectContext {
 
         let keyPathExpression = NSExpression(forKeyPath: keyPath)
         let countExpression = NSExpression(forFunction: "count:", arguments: [keyPathExpression])
-        
+
         let countExpressionDescription = NSExpressionDescription()
         countExpressionDescription.name = "count"
         countExpressionDescription.expression = countExpression
@@ -104,26 +104,26 @@ extension NSManagedObjectContext {
         request.propertiesToFetch = [attribute, countExpressionDescription]
         request.propertiesToGroupBy = [attribute]
         request.resultType = .dictionaryResultType
-        
+
         do {
             let distinctIDAndCount = try self.execute(request) as! NSAsynchronousFetchResult<NSDictionary>
-            
+
             guard let finalResult = distinctIDAndCount.finalResult else {
                 return [:]
             }
-            
+
             let ids = finalResult.filter {
                 ($0["count"] as? Int ?? 0) > 1
             }.compactMap {
                 $0[keyPath]
             }
-            
+
             let fetchAllDuplicatesRequest = NSFetchRequest<T>()
             fetchAllDuplicatesRequest.entity = entity
             fetchAllDuplicatesRequest.predicate = NSPredicate(format: "%K IN %@", argumentArray: [keyPath, ids])
 
             return self.fetchOrAssert(request: fetchAllDuplicatesRequest).group(by: keyPath)
-            
+
         } catch let error {
             fatal("Cannot perform the fetch: \(error)")
         }
@@ -141,7 +141,7 @@ extension Array where Element: NSObject {
                 }
                 return TupleKeyArray(key: valueForKey, value: [$0])
             }
-        
+
         return tuples.compactMap { $0 }.merge()
     }
 }

--- a/Source/Notifications/Change detection/ChangeDetector.swift
+++ b/Source/Notifications/Change detection/ChangeDetector.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 protocol ChangeDetector {

--- a/Source/Notifications/Change detection/ExplicitChangeDetector.swift
+++ b/Source/Notifications/Change detection/ExplicitChangeDetector.swift
@@ -90,7 +90,7 @@ class ExplicitChangeDetector: ChangeDetector {
     private func getChangedKeysSinceLastSave(object: ZMManagedObject) -> UpdatedObject {
         var changedKeys = object.changedKeys
 
-        if changedKeys.isEmpty || object.isFault  {
+        if changedKeys.isEmpty || object.isFault {
             // If the object is a fault, calling changedValues() will return an empty set.
             // Luckily we created a snapshot of the object before the merge happend which
             // we can use to compare the values.

--- a/Source/Notifications/ObjectObserverTokens/Helpers/AnyClassTuple.swift
+++ b/Source/Notifications/ObjectObserverTokens/Helpers/AnyClassTuple.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public struct AnyClassTuple<T : Hashable>: Hashable {
+public struct AnyClassTuple<T: Hashable>: Hashable {
 
     public let classOfObject: AnyClass
     public let secondElement: T


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix warnings for multiple rules in Source:

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`
- **Vertical Parameter Alignment Violation**: Function parameters should be aligned vertically if they're in multiple lines in a declaration. `(vertical_parameter_alignment)`
- **Redundant @objc Attribute Violation**: Objective-C attribute (@objc) is redundant in declaration. `(redundant_objc_attribute)`
- **Comment Spacing Violation**: Prefer at least one space after slashes for comments. `(comment_spacing)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
