### PR TITLE
fix: SwiftLint warnings for multiple rules in Source Part 3

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Services.swift
+++ b/Source/Model/Conversation/ZMConversation+Services.swift
@@ -31,10 +31,10 @@ extension ZMConversation {
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sameTeam, groupConversation, selfIsActiveMember, onlyOneOtherParticipant, hasParticipantWithServiceIdentifier, noUserDefinedName])
 
         let fetchRequest = sortedFetchRequest(with: predicate)
-        
+
         fetchRequest.fetchLimit = 1
         let result = moc.fetchOrAssert(request: fetchRequest)
-        
+
         return result.first as? ZMConversation
     }
 }

--- a/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMConversation {
@@ -28,7 +27,7 @@ extension ZMConversation {
                             clients: [client],
                             timestamp: timestamp)
     }
-    
+
     public func appendTeamMemberRemovedSystemMessage(user: ZMUser, at timestamp: Date) {
         appendSystemMessage(type: .teamMemberLeave,
                             sender: user,
@@ -36,7 +35,7 @@ extension ZMConversation {
                             clients: nil,
                             timestamp: timestamp)
     }
-    
+
     public func appendParticipantRemovedSystemMessage(user: ZMUser, sender: ZMUser? = nil, at timestamp: Date) {
         appendSystemMessage(type: .participantsRemoved,
                             sender: sender ?? user,
@@ -44,7 +43,7 @@ extension ZMConversation {
                             clients: nil,
                             timestamp: timestamp)
     }
-    
+
     @objc(appendNewConversationSystemMessageAtTimestamp:users:)
     public func appendNewConversationSystemMessage(at timestamp: Date, users: Set<ZMUser>) {
         let systemMessage = appendSystemMessage(type: .newConversation,
@@ -52,19 +51,19 @@ extension ZMConversation {
                                                 users: users,
                                                 clients: nil,
                                                 timestamp: timestamp)
-        
+
         systemMessage.text = userDefinedName
-        
+
         // Fill out team specific properties if the conversation was created in the self user team
         if let context = managedObjectContext, let selfUserTeam = ZMUser.selfUser(in: context).team, team == selfUserTeam {
-            
+
             let members = selfUserTeam.members.compactMap { $0.user }
             let guests = users.filter { !$0.isServiceUser && $0.membership == nil }
-            
+
             systemMessage.allTeamUsersAdded = users.isSuperset(of: members)
             systemMessage.numberOfGuestsAdded = Int16(guests.count)
         }
-        
+
         if hasReadReceiptsEnabled {
             appendMessageReceiptModeIsOnMessage(timestamp: timestamp.nextNearestTimestamp)
         }
@@ -78,5 +77,5 @@ extension ZMConversation {
                             timestamp: timestamp,
                             messageTimer: timer)
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+Team.swift
+++ b/Source/Model/Conversation/ZMConversation+Team.swift
@@ -19,14 +19,14 @@
 import Foundation
 
 extension ZMConversation {
-    
+
     /// Returns true if this conversation was created within the same team as the self user
-    public var isTeamConversation: Bool {        
+    public var isTeamConversation: Bool {
         guard
             let teamRemoteIdentifier = teamRemoteIdentifier,
             let managedObjectContext = managedObjectContext
         else { return false }
-        
+
         let selfUser = ZMUser.selfUser(in: managedObjectContext)
 
         return teamRemoteIdentifier == selfUser.team?.remoteIdentifier && !isFederating(with: selfUser)

--- a/Source/Model/Conversation/ZMConversation+Transport.swift
+++ b/Source/Model/Conversation/ZMConversation+Transport.swift
@@ -16,11 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import WireTransport
 
 private let zmLog = ZMSLog(tag: "event-processing")
-
 
 /// This enum matches the backend convention for type
 @objc(ZMBackendConversationType)
@@ -29,7 +27,7 @@ public enum BackendConversationType: Int {
     case `self` = 1
     case oneOnOne = 2
     case connection = 3
-    
+
     public static func clientConversationType(rawValue: Int) -> ZMConversationType {
         guard let backendType = BackendConversationType(rawValue: rawValue) else {
             return .invalid
@@ -48,42 +46,42 @@ public enum BackendConversationType: Int {
 }
 
 extension ZMConversation {
-    
+
     public struct PayloadKeys {
-        
+
         private init() {}
-        
-        public static let nameKey = "name";
-        public static let typeKey = "type";
-        public static let IDKey = "id";
-        public static let qualifiedIDKey = "qualified_id";
-        public static let targetKey = "target";
-        public static let domainKey = "domain";
-        
-        public static let othersKey = "others";
-        public static let membersKey = "members";
-        public static let selfKey = "self";
-        public static let creatorKey = "creator";
-        public static let teamIdKey = "team";
-        public static let conversationRoleKey = "conversation_role";
-        public static let accessModeKey = "access";
-        public static let accessRoleKey = "access_role";
-        public static let messageTimer = "message_timer";
-        public static let receiptMode = "receipt_mode";
-        
-        public static let OTRMutedValueKey = "otr_muted";
-        public static let OTRMutedStatusValueKey = "otr_muted_status";
-        public static let OTRMutedReferenceKey = "otr_muted_ref";
-        public static let OTRArchivedValueKey = "otr_archived";
-        public static let OTRArchivedReferenceKey = "otr_archived_ref";
+
+        public static let nameKey = "name"
+        public static let typeKey = "type"
+        public static let IDKey = "id"
+        public static let qualifiedIDKey = "qualified_id"
+        public static let targetKey = "target"
+        public static let domainKey = "domain"
+
+        public static let othersKey = "others"
+        public static let membersKey = "members"
+        public static let selfKey = "self"
+        public static let creatorKey = "creator"
+        public static let teamIdKey = "team"
+        public static let conversationRoleKey = "conversation_role"
+        public static let accessModeKey = "access"
+        public static let accessRoleKey = "access_role"
+        public static let messageTimer = "message_timer"
+        public static let receiptMode = "receipt_mode"
+
+        public static let OTRMutedValueKey = "otr_muted"
+        public static let OTRMutedStatusValueKey = "otr_muted_status"
+        public static let OTRMutedReferenceKey = "otr_muted_ref"
+        public static let OTRArchivedValueKey = "otr_archived"
+        public static let OTRArchivedReferenceKey = "otr_archived_ref"
     }
-    
+
     public func updateCleared(fromPostPayloadEvent event: ZMUpdateEvent ) {
         if let timeStamp = event.timestamp {
             updateCleared(timeStamp, synchronize: true)
         }
     }
-    
+
     @objc
     public func update(updateEvent: ZMUpdateEvent) {
         if let timeStamp = updateEvent.timestamp {
@@ -100,15 +98,15 @@ extension ZMConversation {
         accessModeStrings = accessModes
         accessRoleString = role
     }
-    
+
     public func updateReceiptMode(_ receiptMode: Int?) {
         if let receiptMode = receiptMode {
             let enabled = receiptMode > 0
             let receiptModeChanged = !self.hasReadReceiptsEnabled && enabled
-            self.hasReadReceiptsEnabled = enabled;
-            
+            self.hasReadReceiptsEnabled = enabled
+
             // We only want insert a system message if this is an existing conversation (non empty)
-            if (receiptModeChanged && self.lastMessage != nil) {
+            if receiptModeChanged && self.lastMessage != nil {
                 self.appendMessageReceiptModeIsOnMessage(timestamp: Date())
             }
         }
@@ -134,21 +132,21 @@ extension ZMConversation {
 
         updatePotentialGapSystemMessagesIfNeeded(users: localParticipants)
     }
-    
+
     public func updateTeam(identifier: UUID?) {
         guard let teamId = identifier,
             let moc = self.managedObjectContext else { return }
         self.teamRemoteIdentifier = teamId
         self.team = Team.fetchOrCreate(with: teamId, create: false, in: moc, created: nil)
     }
-    
+
     @objc func updatePotentialGapSystemMessagesIfNeeded(users: Set<ZMUser>) {
         guard let latestSystemMessage = ZMSystemMessage.fetchLatestPotentialGapSystemMessage(in: self)
             else { return }
-        
+
         let removedUsers = latestSystemMessage.users.subtracting(users)
         let addedUsers = users.subtracting(latestSystemMessage.users)
-        
+
         latestSystemMessage.addedUsers = addedUsers
         latestSystemMessage.removedUsers = removedUsers
         latestSystemMessage.updateNeedsUpdatingUsersIfNeeded()
@@ -161,7 +159,7 @@ extension ZMConversation {
 
         internalIsArchived = archived
     }
-    
+
     private func updateIsArchived(payload: [String: Any]) -> Bool {
         if let silencedRef = payload.date(fromKey: PayloadKeys.OTRArchivedReferenceKey),
             self.updateArchived(silencedRef, synchronize: false) {
@@ -201,16 +199,15 @@ extension ZMConversation {
             teamOrConversation: self.team != nil ? .team(self.team!) : .conversation(self),
             in: self.managedObjectContext!)
     }
-    
+
 }
 
-
 extension Dictionary where Key == String, Value == Any {
-    
+
     func UUID(fromKey key: String) -> UUID? {
         return (self[key] as? String).flatMap(Foundation.UUID.init)
     }
-    
+
     func date(fromKey key: String) -> Date? {
         return (self as NSDictionary).optionalDate(forKey: key)
     }
@@ -221,11 +218,11 @@ extension Dictionary where Key == String, Value == Any {
 }
 
 extension Dictionary where Key == String, Value == Any? {
-    
+
     func UUID(fromKey key: String) -> UUID? {
         return (self[key] as? String).flatMap(Foundation.UUID.init)
     }
-    
+
     func date(fromKey key: String) -> Date? {
         return (self as NSDictionary).optionalDate(forKey: key)
     }

--- a/Source/Model/Conversation/ZMConversation+UnreadCount.swift
+++ b/Source/Model/Conversation/ZMConversation+UnreadCount.swift
@@ -16,17 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMConversation {
-    
-    ///Fetch all conversation that are marked as needsToCalculateUnreadMessages and calculate unread messages for them
+
+    /// Fetch all conversation that are marked as needsToCalculateUnreadMessages and calculate unread messages for them
     public static func calculateLastUnreadMessages(in managedObjectContext: NSManagedObjectContext) {
         let fetchRequest = sortedFetchRequest(with: predicateForConversationsNeedingToBeCalculatedUnreadMessages())
-        
+
         let conversations = managedObjectContext.fetchOrAssert(request: fetchRequest) as? [ZMConversation]
         conversations?.forEach { $0.calculateLastUnreadMessages() }
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMMessage+ShouldDisplay.swift
+++ b/Source/Model/Conversation/ZMMessage+ShouldDisplay.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 @objc extension ZMMessage {
-  
+
     var shouldBeDisplayed: Bool {
         return !hasBeenDeleted && !isZombieObject
     }
-    
+
 }

--- a/Source/Model/ConversationRole/Action.swift
+++ b/Source/Model/ConversationRole/Action.swift
@@ -29,15 +29,15 @@ final public class Action: ZMManagedObject {
     public override static func entityName() -> String {
         return String(describing: Action.self)
     }
-    
+
     private static func fetchExistingAction(with name: String,
                                     role: Role,
                                     in context: NSManagedObjectContext) -> Action? {
         let fetchRequest = NSFetchRequest<Action>(entityName: self.entityName())
         fetchRequest.predicate = NSPredicate(format: "%K == %@", nameKey, name)
-        
+
         let actions = context.fetchOrAssert(request: fetchRequest)
-        return actions.first(where:{
+        return actions.first(where: {
             role.actions.contains($0)
         })
     }
@@ -50,7 +50,7 @@ final public class Action: ZMManagedObject {
         entry.name = name
         return entry
     }
-    
+
     @discardableResult
     public static func fetchOrCreate(with name: String,
                                      role: Role,

--- a/Source/Model/ConversationRole/ParticipantRole.swift
+++ b/Source/Model/ConversationRole/ParticipantRole.swift
@@ -22,7 +22,7 @@ let ZMParticipantRoleRoleValueKey           = #keyPath(ParticipantRole.role)
 
 @objcMembers
 final public class ParticipantRole: ZMManagedObject {
-    
+
     @NSManaged public var conversation: ZMConversation?
     @NSManaged public var user: ZMUser?
     @NSManaged public var role: Role?
@@ -30,12 +30,11 @@ final public class ParticipantRole: ZMManagedObject {
     public override static func entityName() -> String {
         return "ParticipantRole"
     }
-    
+
     public override static func isTrackingLocalModifications() -> Bool {
         return true
     }
-    
-    @objc
+
     @discardableResult
     static public func create(managedObjectContext: NSManagedObjectContext,
                               user: ZMUser,
@@ -46,4 +45,3 @@ final public class ParticipantRole: ZMManagedObject {
         return entry
     }
 }
-

--- a/Source/Model/ConversationRole/Role.swift
+++ b/Source/Model/ConversationRole/Role.swift
@@ -21,18 +21,18 @@ import Foundation
 public enum TeamOrConversation {
     case team(Team)
     case conversation(ZMConversation)
-    
+
     /// Creates a team if the conversation belongs to a team, or a conversation otherwise
     public static func matching(_ conversation: ZMConversation) -> TeamOrConversation {
         return self.fromTeamOrConversation(team: conversation.team, conversation: conversation)
     }
-    
+
     /// Creates a team or a conversation
     static func fromTeamOrConversation(team: Team?,
                                        conversation: ZMConversation?) -> TeamOrConversation {
         if let team = team {
             return .team(team)
-            
+
         } else if let conversation = conversation {
             return .conversation(conversation)
         }
@@ -58,12 +58,11 @@ public final class Role: ZMManagedObject {
     public override static func entityName() -> String {
         return String(describing: Role.self)
     }
-    
+
     public override static func isTrackingLocalModifications() -> Bool {
         return false
     }
-    
-    @objc
+
     @discardableResult
     static public func create(managedObjectContext: NSManagedObjectContext,
                               name: String,
@@ -72,8 +71,7 @@ public final class Role: ZMManagedObject {
                       name: name,
                       teamOrConversation: .conversation(conversation))
     }
-    
-    @objc
+
     @discardableResult
     static public func create(managedObjectContext: NSManagedObjectContext,
                               name: String,
@@ -82,11 +80,11 @@ public final class Role: ZMManagedObject {
                       name: name,
                       teamOrConversation: .team(team))
     }
-    
+
     static public func create(managedObjectContext: NSManagedObjectContext,
                               name: String,
                               teamOrConversation: TeamOrConversation) -> Role {
-        
+
         let entry = Role.insertNewObject(in: managedObjectContext)
         entry.name = name
         switch teamOrConversation {
@@ -115,10 +113,10 @@ public final class Role: ZMManagedObject {
             teamOrConvoPredicate
         ])
         fetchRequest.fetchLimit = 1
-        
+
         return context.fetchOrAssert(request: fetchRequest).first
     }
-    
+
     public static func fetchOrCreateRole(with name: String,
                                   teamOrConversation: TeamOrConversation,
                                   in context: NSManagedObjectContext) -> Role {
@@ -127,7 +125,6 @@ public final class Role: ZMManagedObject {
                                                   in: context)
         return existingRole ?? create(managedObjectContext: context, name: name, teamOrConversation: teamOrConversation)
     }
-    
 
     @discardableResult
     public static func createOrUpdate(with payload: [String: Any],
@@ -137,14 +134,14 @@ public final class Role: ZMManagedObject {
         guard let conversationRole = payload["conversation_role"] as? String,
             let actionNames = payload["actions"] as? [String]
             else { return nil }
-        
+
         let fetchedRole = fetchExistingRole(with: conversationRole,
                                             teamOrConversation: teamOrConversation,
                                             in: context)
 
         let role = fetchedRole ?? Role.insertNewObject(in: context)
-        
-        actionNames.forEach() { actionName in
+
+        actionNames.forEach { actionName in
             var created = false
             Action.fetchOrCreate(with: actionName, role: role, in: context, created: &created)
         }

--- a/Source/Model/FeatureConfig/AppLock/AppLockController.swift
+++ b/Source/Model/FeatureConfig/AppLock/AppLockController.swift
@@ -115,7 +115,7 @@ public final class AppLockController: AppLockType {
     }
 
     // MARK: - Life cycle
-    
+
     public init(userId: UUID, selfUser: ZMUser, legacyConfig: LegacyConfig? = nil) {
         precondition(selfUser.isSelfUser, "AppLockController initialized with non-self user")
 
@@ -126,7 +126,7 @@ public final class AppLockController: AppLockType {
 
         featureService = FeatureService(context: selfUser.managedObjectContext!)
     }
-    
+
     // MARK: - Methods
 
     public func beginTimer() {
@@ -224,7 +224,7 @@ public final class AppLockController: AppLockType {
     func fetchPasscode() -> Data? {
         return try? Keychain.fetchItem(keychainItem)
     }
-    
+
 }
 
 // MARK: - TEST ONLY!

--- a/Source/Model/FeatureConfig/AppLock/BiometricsState.swift
+++ b/Source/Model/FeatureConfig/AppLock/BiometricsState.swift
@@ -28,7 +28,7 @@ protocol BiometricsStateProtocol {
 final class BiometricsState: BiometricsStateProtocol {
 
     private let UserDefaultsDomainStateKey = "DomainStateKey"
-    
+
     var lastPolicyDomainState: Data? {
         get {
             return UserDefaults.standard.data(forKey: UserDefaultsDomainStateKey)
@@ -38,7 +38,7 @@ final class BiometricsState: BiometricsStateProtocol {
             UserDefaults.standard.set(newValue, forKey: UserDefaultsDomainStateKey)
         }
     }
-    
+
     var currentPolicyDomainState: Data?
 
     /// Returns `true` if the biometrics database has changed, e.g if finger prints are
@@ -49,7 +49,7 @@ final class BiometricsState: BiometricsStateProtocol {
         guard let lastState = lastPolicyDomainState else { return false }
         return currentPolicyDomainState != lastState
     }
-    
+
     /// Persists the last seen biometrics state for future comparisons.
 
      func persistState() {

--- a/Source/Model/FeatureConfig/ConferenceCalling/Feature.ConferenceCalling.swift
+++ b/Source/Model/FeatureConfig/ConferenceCalling/Feature.ConferenceCalling.swift
@@ -35,4 +35,3 @@ public extension Feature {
     }
 
 }
-

--- a/Source/Model/FeatureConfig/Feature.swift
+++ b/Source/Model/FeatureConfig/Feature.swift
@@ -49,7 +49,7 @@ public class Feature: ZMManagedObject {
     @NSManaged private var configData: Data?
     @NSManaged public var needsToNotifyUser: Bool
     @NSManaged var hasInitialDefault: Bool
-    
+
     public var config: Data? {
         get {
             return configData
@@ -62,7 +62,7 @@ public class Feature: ZMManagedObject {
             configData = newValue
         }
     }
-    
+
     public var name: Name {
         get {
             guard let name = Name(rawValue: nameValue) else {
@@ -76,7 +76,7 @@ public class Feature: ZMManagedObject {
             nameValue = newValue.rawValue
         }
     }
-    
+
     public var status: Status {
         get {
             guard let status = Status(rawValue: statusValue) else {
@@ -100,7 +100,7 @@ public class Feature: ZMManagedObject {
     }
 
     // MARK: - Methods
-    
+
     public override static func entityName() -> String {
         return "Feature"
     }
@@ -108,7 +108,6 @@ public class Feature: ZMManagedObject {
     public override static func sortKey() -> String {
         return #keyPath(Feature.nameValue)
     }
-
 
     /// Fetch the instance for the given name.
     ///

--- a/Source/Model/FeatureConfig/FeatureFlag.swift
+++ b/Source/Model/FeatureConfig/FeatureFlag.swift
@@ -25,25 +25,25 @@ public enum FeatureFlagType: String {
 @objcMembers
 public class FeatureFlag: ZMManagedObject {
     public static let teamKey = #keyPath(FeatureFlag.team)
-    
+
     @NSManaged public var identifier: String
     @NSManaged public var isEnabled: Bool
     @NSManaged public var updatedTimestamp: Date
     @NSManaged public var team: Team?
-    
+
     open override var ignoredKeys: Set<AnyHashable>? {
         return (super.ignoredKeys ?? Set())
             .union([#keyPath(updatedTimestamp)])
     }
-    
+
     public override static func entityName() -> String {
         return "FeatureFlag"
     }
-    
-    public var updatedAt : Date? {
+
+    public var updatedAt: Date? {
         return updatedTimestamp
     }
-    
+
     @discardableResult
     public static func updateOrCreate(with type: FeatureFlagType,
                                      value: Bool,
@@ -65,7 +65,7 @@ public class FeatureFlag: ZMManagedObject {
                                  context: context)
         return featureFlag
     }
-    
+
     @discardableResult
     public static func insert(with type: FeatureFlagType,
                               value: Bool,
@@ -80,7 +80,7 @@ public class FeatureFlag: ZMManagedObject {
         featureFlag.team = team
         return featureFlag
     }
-    
+
     @discardableResult
     public static func fetch(with type: FeatureFlagType,
                              team: Team,

--- a/Source/Model/FeatureConfig/FeatureService.swift
+++ b/Source/Model/FeatureConfig/FeatureService.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 /// This class facilitates storage and retrieval of feature configs to and from
@@ -148,7 +147,7 @@ public class FeatureService {
 
             case .conferenceCalling:
                 storeConferenceCalling(.init())
-                
+
             case .fileSharing:
                 storeFileSharing(.init())
 

--- a/Source/Model/FeatureConfig/FileSharing/Feature.FileSharing.swift
+++ b/Source/Model/FeatureConfig/FileSharing/Feature.FileSharing.swift
@@ -31,7 +31,7 @@ public extension Feature {
         public init(status: Feature.Status = .enabled) {
             self.status = status
         }
-        
+
     }
 
 }

--- a/Source/Model/Label/Label.swift
+++ b/Source/Model/Label/Label.swift
@@ -20,36 +20,36 @@ import Foundation
 
 @objc
 public protocol LabelType: NSObjectProtocol {
-    
+
     var remoteIdentifier: UUID? { get }
     var kind: Label.Kind { get }
     var name: String? { get }
-    
+
 }
 
 @objcMembers
 public class Label: ZMManagedObject, LabelType {
-    
+
     @objc
     public enum Kind: Int16 {
         case folder, favorite
     }
-    
+
     @NSManaged public var name: String?
     @NSManaged public var conversations: Set<ZMConversation>
     @NSManaged public private(set) var markedForDeletion: Bool
-    
+
     @NSManaged private var remoteIdentifier_data: Data?
     @NSManaged public private(set) var type: Int16
-    
+
     public override var ignoredKeys: Set<AnyHashable>? {
         var ignoredKeys = super.ignoredKeys
-        
+
         _ = ignoredKeys?.insert((#keyPath(Label.type)))
-        
+
         return ignoredKeys
     }
-    
+
     public var remoteIdentifier: UUID? {
         get {
             guard let data = remoteIdentifier_data else { return nil }
@@ -59,7 +59,7 @@ public class Label: ZMManagedObject, LabelType {
             remoteIdentifier_data = newValue?.uuidData
         }
     }
-    
+
     public var kind: Kind {
         get {
             return Kind(rawValue: type) ?? .folder
@@ -68,82 +68,81 @@ public class Label: ZMManagedObject, LabelType {
             type = newValue.rawValue
         }
     }
-    
+
     public func markForDeletion() {
         markedForDeletion = true
     }
-    
+
     public override static func entityName() -> String {
         return "Label"
     }
-    
+
     override public static func sortKey() -> String {
         return #keyPath(Label.name)
     }
-    
+
     override public static func defaultSortDescriptors() -> [NSSortDescriptor]? {
         return [NSSortDescriptor(key: sortKey(), ascending: true, selector: #selector(NSString.localizedStandardCompare(_:)))]
     }
-    
+
     public override static func predicateForFilteringResults() -> NSPredicate? {
         return NSPredicate(format: "\(#keyPath(Label.type)) == \(Label.Kind.folder.rawValue) AND \(#keyPath(Label.markedForDeletion)) == NO")
     }
-    
-    
+
     public override static func isTrackingLocalModifications() -> Bool {
         return true
     }
-    
+
     public static func fetchFavoriteLabel(in context: NSManagedObjectContext) -> Label {
         return fetchOrCreateFavoriteLabel(in: context, create: false)
     }
-    
+
     @discardableResult
     static func fetchOrCreateFavoriteLabel(in context: NSManagedObjectContext, create: Bool) -> Label {
-        
+
         // Executing a fetch request is quite expensive, because it will _always_ (1) round trip through
         // (1) the persistent store coordinator and the SQLite engine, and (2) touch the file system.
         // Looping through all objects in the context is way cheaper, because it does not involve (1)
         // taking any locks, nor (2) touching the file system.
-        
+
         guard let entity = context.persistentStoreCoordinator?.managedObjectModel.entitiesByName[entityName()] else {
             fatal("Label entity not registered in managed object model")
         }
-        
+
         for managedObject in context.registeredObjects {
             if managedObject.entity == entity, !managedObject.isFault {
                 guard let label = managedObject as? Label, label.kind == .favorite else { continue }
                 return label
             }
         }
-        
+
         let fetchRequest = NSFetchRequest<Label>(entityName: Label.entityName())
         fetchRequest.predicate = NSPredicate(format: "type = \(Kind.favorite.rawValue)")
         fetchRequest.fetchLimit = 2
-        
+
         let results = context.fetchOrAssert(request: fetchRequest)
-        
+
         require(results.count <= 1, "More than favorite label")
-        
+
         if let label = results.first {
             return label
         } else if create {
             let label = Label.insertNewObject(in: context)
             label.remoteIdentifier = UUID()
             label.kind = .favorite
-            
+
             do {
                 try context.save()
             } catch {
                 fatal("Failure creating favorite label")
             }
-            
+
             return label
         } else {
             fatal("The favorite label is always expected to exist at all times")
         }
     }
-    
+
     public static func fetchOrCreate(remoteIdentifier: UUID, create: Bool, in context: NSManagedObjectContext, created: inout Bool) -> Label? {
         if let existing = fetch(with: remoteIdentifier, in: context) {
             created = false
@@ -154,8 +153,8 @@ public class Label: ZMManagedObject, LabelType {
             created = true
             return label
         }
-        
+
         return nil
     }
-    
+
 }

--- a/Source/Model/Message/AssetCache.swift
+++ b/Source/Model/Message/AssetCache.swift
@@ -21,15 +21,15 @@ import WireSystem
 import WireImages
 
 protocol Cache {
-    
+
     /// Returns the asset data for a given key.
     ///
     /// This will probably cause I/O
     func assetData(_ key: String) -> Data?
-    
+
     /// Returns the file URL (if any) for a given key.
     func assetURL(_ key: String) -> URL?
-    
+
     /// Stores the asset data for a given key.
     ///
     /// - parameter data: Asset data which should be stored
@@ -38,7 +38,7 @@ protocol Cache {
     ///
     /// This will probably cause I/O
     func storeAssetData(_ data: Data, key: String, createdAt: Date)
-    
+
     /// Stores the asset data for a source url that must be a local file.
     ///
     /// - parameter url: URL pointing to the data which should be stored
@@ -47,16 +47,16 @@ protocol Cache {
     ///
     /// This will probably cause I/O
     func storeAssetFromURL(_ url: URL, key: String, createdAt: Date)
-    
+
     /// Deletes the data for a key.
     func deleteAssetData(_ key: String)
-    
+
     /// Deletes assets created earlier than the given date.
     ///
     /// This will cause I/O
     func deleteAssetsOlderThan(_ date: Date) throws
-    
+
     /// Checks if the data exists in the cache. Faster than checking the data itself
     func hasDataForKey(_ key: String) -> Bool
-    
+
 }

--- a/Source/Model/Message/AssetEncryption.swift
+++ b/Source/Model/Message/AssetEncryption.swift
@@ -16,12 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireProtos
 
 fileprivate extension Cache {
-    
+
     /// Decrypts an encrypted asset in the asset cache to a decrypted version in the cache. Upon completion of the decryption, deletes the encrypted
     /// original. In case of error (the digest doesn't match, or any other error), deletes the original and does not create a decrypted version.
     /// Returns whether the decryption was successful and the digest matched
@@ -35,7 +34,7 @@ fileprivate extension Cache {
         if encryptedData == nil {
             return false
         }
-        
+
         let mac = encryptedData!.zmHMACSHA256Digest(key: macKey)
         if mac != macDigest {
             self.deleteAssetData(encryptedEntryKey)
@@ -84,18 +83,18 @@ fileprivate extension Cache {
         self.deleteAssetData(encryptedEntryKey)
         return true
     }
-    
+
     /// Encrypts a plaintext cache entry to an encrypted one, also computing the digest of the encrypted entry
     func encryptFileAndComputeSHA256Digest(_ plaintextEntryKey: String, encryptedEntryKey: String) -> ZMImageAssetEncryptionKeys? {
         guard let plainData = self.assetData(plaintextEntryKey) else {
             return nil
         }
-        
+
         let encryptionKey = Data.randomEncryptionKey()
         let encryptedData = plainData.zmEncryptPrefixingPlainTextIV(key: encryptionKey)
         let hash = encryptedData.zmSHA256Digest()
         self.storeAssetData(encryptedData, key: encryptedEntryKey, createdAt: Date())
-        
+
         return ZMImageAssetEncryptionKeys(otrKey: encryptionKey, sha256: hash)
     }
 }
@@ -125,41 +124,41 @@ extension FileAssetCache {
     public func decryptImageIfItMatchesDigest(_ message: ZMConversationMessage, format: ZMImageFormat, encryptionKey: Data, sha256Digest: Data) -> Bool {
         guard let plaintextCacheKey = type(of: self).cacheKeyForAsset(message, format: format, encrypted: false),
               let encryptedCacheKey = type(of: self).cacheKeyForAsset(message, format: format, encrypted: true) else { return false }
-        
+
         return self.cache.decryptAssetIfItMatchesDigest(plaintextCacheKey,
                                                         encryptedEntryKey: encryptedCacheKey,
                                                         encryptionKey: encryptionKey,
                                                         sha256Digest: sha256Digest,
                                                         createdAt: message.serverTimestamp ?? Date())
     }
-    
+
     /// Encrypts a plaintext cache entry to an encrypted one, also computing the digest of the encrypted entry
     public func encryptImageAndComputeSHA256Digest(_ message: ZMConversationMessage, format: ZMImageFormat) -> ZMImageAssetEncryptionKeys? {
         guard let plaintextCacheKey = type(of: self).cacheKeyForAsset(message, format: format, encrypted: false),
               let encryptedCacheKey = type(of: self).cacheKeyForAsset(message, format: format, encrypted: true) else { return nil }
-        
+
         return self.cache.encryptFileAndComputeSHA256Digest(plaintextCacheKey, encryptedEntryKey: encryptedCacheKey)
     }
-    
+
     /// Decrypts an encrypted asset in the asset cache to a decrypted version in the cache. Upon completion of the decryption, deletes the encrypted
     /// original. In case of error (the digest doesn't match, or any other error), deletes the original and does not create a decrypted version.
     /// Returns whether the decryption was successful and the digest matched
     public func decryptFileIfItMatchesDigest(_ message: ZMConversationMessage, encryptionKey: Data, sha256Digest: Data) -> Bool {
         guard let plaintextCacheKey = type(of: self).cacheKeyForAsset(message, encrypted: false),
               let encryptedCacheKey = type(of: self).cacheKeyForAsset(message, encrypted: true) else { return false }
-        
+
         return self.cache.decryptAssetIfItMatchesDigest(plaintextCacheKey,
                                                         encryptedEntryKey: encryptedCacheKey,
                                                         encryptionKey: encryptionKey,
                                                         sha256Digest: sha256Digest,
                                                         createdAt: message.serverTimestamp ?? Date())
     }
-    
+
     /// Encrypts a plaintext cache entry to an encrypted one, also computing the digest of the encrypted entry
     public func encryptFileAndComputeSHA256Digest(_ message: ZMConversationMessage) -> ZMImageAssetEncryptionKeys? {
         guard let plaintextCacheKey = type(of: self).cacheKeyForAsset(message, encrypted: false),
               let encryptedCacheKey = type(of: self).cacheKeyForAsset(message, encrypted: true) else { return nil }
-        
+
         return self.cache.encryptFileAndComputeSHA256Digest(plaintextCacheKey, encryptedEntryKey: encryptedCacheKey)
     }
 }

--- a/Source/Model/Message/Composite/CompositeMessageData.swift
+++ b/Source/Model/Message/Composite/CompositeMessageData.swift
@@ -27,7 +27,7 @@ public protocol CompositeMessageData {
 public enum CompositeMessageItem {
     case text(ZMTextMessageData)
     case button(ButtonMessageData)
-    
+
     internal init?(with protoItem: Composite.Item, message: ZMClientMessage) {
         guard let content = protoItem.content else { return nil }
         let itemContent = CompositeMessageItemContent(with: protoItem, message: message)
@@ -60,7 +60,7 @@ public enum ButtonMessageState {
     case unselected
     case selected
     case confirmed
-    
+
     init(from state: ButtonState.State?) {
         guard let state = state else {
             self = .unselected
@@ -68,7 +68,7 @@ public enum ButtonMessageState {
         }
         self = ButtonMessageState(from: state)
     }
-    
+
     init(from state: ButtonState.State) {
         switch state {
         case .unselected:

--- a/Source/Model/Message/Composite/CompositeMessageItemContent.swift
+++ b/Source/Model/Message/Composite/CompositeMessageItemContent.swift
@@ -21,17 +21,17 @@ import Foundation
 class CompositeMessageItemContent: NSObject {
     private let parentMessage: ZMClientMessage
     private let item: Composite.Item
-    
+
     private var text: Text? {
         guard case .some(.text) = item.content else { return nil }
         return item.text
     }
-    
+
     private var button: Button? {
         guard case .some(.button) = item.content else { return nil }
         return item.button
     }
-    
+
     init(with item: Composite.Item, message: ZMClientMessage) {
         self.item = item
         self.parentMessage = message
@@ -43,47 +43,47 @@ extension CompositeMessageItemContent: ZMTextMessageData {
     var messageText: String? {
         return text?.content.removingExtremeCombiningCharacters
     }
-    
+
     var linkPreview: LinkMetadata? {
         return nil
     }
-    
+
     var mentions: [Mention] {
         return Mention.mentions(from: text?.mentions, messageText: messageText, moc: parentMessage.managedObjectContext)
     }
-    
+
     var quote: ZMMessage? {
         return nil
     }
-    
+
     var quoteMessage: ZMConversationMessage? {
         return quote
     }
-    
+
     var linkPreviewHasImage: Bool {
         return false
     }
-    
+
     var linkPreviewImageCacheKey: String? {
         return nil
     }
-    
+
     var isQuotingSelf: Bool {
         return false
     }
-    
+
     var hasQuote: Bool {
         return false
     }
-    
+
     func fetchLinkPreviewImageData(with queue: DispatchQueue, completionHandler: @escaping (Data?) -> Void) {
         // no op
     }
-    
+
     func requestLinkPreviewImageDownload() {
         // no op
     }
-    
+
     func editText(_ text: String, mentions: [Mention], fetchLinkPreview: Bool) {
         // no op
     }
@@ -94,21 +94,21 @@ extension CompositeMessageItemContent: ButtonMessageData {
     var title: String? {
         return button?.text
     }
-    
+
     var state: ButtonMessageState {
         return ButtonMessageState(from: buttonState?.state)
     }
-    
+
     var isExpired: Bool {
         return buttonState?.isExpired ?? false
     }
-    
+
     func touchAction() {
         guard let moc = parentMessage.managedObjectContext,
             let buttonId = button?.id,
             let messageId = parentMessage.nonce,
             !hasSelectedButton else { return }
-        
+
         moc.performGroupedBlock { [weak self] in
             guard let `self` = self else { return }
             let buttonState = self.buttonState ??
@@ -137,10 +137,10 @@ extension CompositeMessageItemContent {
     private var hasSelectedButton: Bool {
         return parentMessage.buttonStates?.contains(where: {$0.state == .selected}) ?? false
     }
-    
+
     private var buttonState: ButtonState? {
         guard let button = button else { return nil }
-        
+
         return parentMessage.buttonStates?.first(where: { buttonState in
             guard let remoteIdentifier = buttonState.remoteIdentifier else { return false }
             return remoteIdentifier == button.id

--- a/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import WireCryptobox
 
@@ -29,14 +28,14 @@ extension ZMConversation {
         else {
             return
         }
-        
+
         let genericMessage = GenericMessage(content: MessageHide(conversationId: conversationId, messageId: messageId))
         _ = try ZMConversation.appendMessageToSelfConversation(genericMessage, in: message.managedObjectContext!)
     }
 }
 
 extension ZMMessage {
-    
+
     // NOTE: This is a free function meant to be called from Obj-C because you can't call protocol extension from it
     @objc public static func hideMessage(_ message: ZMConversationMessage) {
         // when deleting ephemeral, we must delete for everyone (only self & sender will receive delete message)
@@ -45,7 +44,7 @@ extension ZMMessage {
         guard let castedMessage = message as? ZMMessage else { return }
         castedMessage.hideForSelfUser()
     }
-    
+
     @objc public func hideForSelfUser() {
         guard !isZombieObject else { return }
 
@@ -60,14 +59,14 @@ extension ZMMessage {
         removeClearingSender(true)
         managedObjectContext?.delete(self)
     }
-    
+
     @discardableResult @objc public static func deleteForEveryone(_ message: ZMConversationMessage) -> ZMClientMessage? {
         guard let castedMessage = message as? ZMMessage else { return nil }
         return castedMessage.deleteForEveryone()
     }
-    
+
     @discardableResult @objc func deleteForEveryone() -> ZMClientMessage? {
-        guard !isZombieObject, let sender = sender , (sender.isSelfUser || isEphemeral) else { return nil }
+        guard !isZombieObject, let sender = sender, (sender.isSelfUser || isEphemeral) else { return nil }
         guard let conversation = conversation, let messageNonce = nonce else { return nil}
 
         do {
@@ -81,14 +80,14 @@ extension ZMMessage {
             return nil
         }
     }
-    
-    @objc var isEditableMessage : Bool {
+
+    @objc var isEditableMessage: Bool {
         return false
     }
 }
 
 extension ZMClientMessage {
-    override var isEditableMessage : Bool {
+    override var isEditableMessage: Bool {
         guard
             let genericMessage = underlyingMessage,
             let sender = sender, sender.isSelfUser,
@@ -105,6 +104,3 @@ extension ZMClientMessage {
         }
     }
 }
-
-
-

--- a/Source/Model/Message/ConversationMessage+Reaction.swift
+++ b/Source/Model/Message/ConversationMessage+Reaction.swift
@@ -29,11 +29,11 @@ import Foundation
 }
 
 extension ZMMessage {
-    
+
     static func appendReaction(_ unicodeValue: String?, toMessage message: ZMConversationMessage) -> ZMClientMessage? {
         guard let message = message as? ZMMessage, let context = message.managedObjectContext, let messageID = message.nonce else { return nil }
         guard message.isSent else { return nil }
-        
+
         let emoji = unicodeValue ?? ""
         let reaction = WireProtos.Reaction.createReaction(emoji: emoji, messageID: messageID)
         let genericMessage = GenericMessage(content: reaction)
@@ -49,30 +49,30 @@ extension ZMMessage {
             return nil
         }
     }
-    
+
     @discardableResult
     @objc public static func addReaction(_ reaction: MessageReaction, toMessage message: ZMConversationMessage) -> ZMClientMessage? {
         // confirmation that we understand the emoji
         // the UI should never send an emoji we dont handle
-        if Reaction.transportReaction(from: reaction.unicodeValue) == .none{
+        if Reaction.transportReaction(from: reaction.unicodeValue) == .none {
             fatal("We can't append this reaction \(reaction.unicodeValue), this is a programmer error.")
         }
-        
+
         return appendReaction(reaction.unicodeValue, toMessage: message)
     }
-    
-    @objc public static func removeReaction(onMessage message:ZMConversationMessage) {
+
+    @objc public static func removeReaction(onMessage message: ZMConversationMessage) {
         _ = appendReaction(nil, toMessage: message)
     }
-    
-    @objc public func addReaction(_ unicodeValue: String?, forUser user:ZMUser) {
-        removeReaction(forUser:user)
+
+    @objc public func addReaction(_ unicodeValue: String?, forUser user: ZMUser) {
+        removeReaction(forUser: user)
         guard let unicodeValue = unicodeValue,
             unicodeValue.count > 0 else {
                 updateCategoryCache()
                 return
         }
-        
+
         guard let reaction = self.reactions.first(where: {$0.unicodeValue! == unicodeValue}) else {
             // we didn't find a reaction, need to add a new one
             let newReaction = Reaction.insertReaction(unicodeValue, users: [user], inMessage: self)
@@ -82,10 +82,10 @@ extension ZMMessage {
         }
         reaction.mutableSetValue(forKey: ZMReactionUsersValueKey).add(user)
     }
-    
+
     fileprivate func removeReaction(forUser user: ZMUser) {
         guard let reaction = self.reactions.first(where: {$0.users.contains(user)}) else {
-            return;
+            return
         }
         reaction.mutableSetValue(forKey: ZMReactionUsersValueKey).remove(user)
     }
@@ -96,7 +96,7 @@ extension ZMMessage {
         guard let moc = managedObjectContext else { return }
         oldReactions.forEach(moc.delete)
     }
-    
+
     @objc public func clearConfirmations() {
         let oldConfirmations = self.confirmations
         mutableSetValue(forKey: ZMMessageConfirmationKey).removeAllObjects()

--- a/Source/Model/Message/ConversationMessage.swift
+++ b/Source/Model/Message/ConversationMessage.swift
@@ -16,14 +16,13 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireLinkPreview
 
 private var zmLog = ZMSLog(tag: "Message")
 
 @objc
-public enum ZMDeliveryState : UInt {
+public enum ZMDeliveryState: UInt {
     case invalid = 0
     case pending = 1
     case sent = 2
@@ -34,21 +33,21 @@ public enum ZMDeliveryState : UInt {
 
 @objc
 public protocol ReadReceipt {
-    
+
     @available(*, deprecated, message: "Use `userType` instead")
     var user: ZMUser { get }
     var userType: UserType { get }
 
     var serverTimestamp: Date? { get }
-    
+
 }
 
 @objc
-public protocol ZMConversationMessage : NSObjectProtocol {
-    
+public protocol ZMConversationMessage: NSObjectProtocol {
+
     /// Unique identifier for the message
     var nonce: UUID? { get }
-        
+
     /// The user who sent the message (internal)
     @available(*, deprecated, message: "Use `senderUser` instead")
     var sender: ZMUser? { get }
@@ -58,10 +57,10 @@ public protocol ZMConversationMessage : NSObjectProtocol {
 
     /// The timestamp as received by the server
     var serverTimestamp: Date? { get }
-    
+
     @available(*, deprecated, message: "Use `conversationLike` instead")
     var conversation: ZMConversation? { get }
-    
+
     /// The conversation this message belongs to
     var conversationLike: ConversationLike? { get }
 
@@ -69,75 +68,75 @@ public protocol ZMConversationMessage : NSObjectProtocol {
     /// messages sent from this device. In any other case, it will be
     /// ZMDeliveryStateDelivered
     var deliveryState: ZMDeliveryState { get }
-    
+
     /// True if the message has been successfully sent to the server
     var isSent: Bool { get }
-    
+
     /// List of recipients who have read the message.
     var readReceipts: [ReadReceipt] { get }
 
     /// Whether the message expects read confirmations.
     var needsReadConfirmation: Bool { get }
-    
+
     /// The textMessageData of the message which also contains potential link previews. If the message has no text, it will be nil
-    var textMessageData : ZMTextMessageData? { get }
-    
+    var textMessageData: ZMTextMessageData? { get }
+
     /// The image data associated with the message. If the message has no image, it will be nil
     var imageMessageData: ZMImageMessageData? { get }
-    
+
     /// The system message data associated with the message. If the message is not a system message data associated, it will be nil
     var systemMessageData: ZMSystemMessageData? { get }
-    
+
     /// The knock message data associated with the message. If the message is not a knock, it will be nil
     var knockMessageData: ZMKnockMessageData? { get }
-    
+
     /// The file transfer data associated with the message. If the message is not the file transfer, it will be nil
     var fileMessageData: ZMFileMessageData? { get }
-    
+
     /// The location message data associated with the message. If the message is not a location message, it will be nil
     var locationMessageData: LocationMessageData? { get }
 
-    var usersReaction : Dictionary<String, [UserType]> { get }
-    
+    var usersReaction: [String: [UserType]] { get }
+
     /// In case this message failed to deliver, this will resend it
     func resend()
-    
+
     /// tell whether or not the message can be deleted
-    var canBeDeleted : Bool { get }
-    
+    var canBeDeleted: Bool { get }
+
     /// True if the message has been deleted
-    var hasBeenDeleted : Bool { get }
-    
-    var updatedAt : Date? { get }
-    
+    var hasBeenDeleted: Bool { get }
+
+    var updatedAt: Date? { get }
+
     /// Starts the "self destruction" timer if all conditions are met
     /// It checks internally if the message is ephemeral, if sender is the other user and if there is already an existing timer
     /// Returns YES if a timer was started by the message call
     func startSelfDestructionIfNeeded() -> Bool
-    
+
     /// Returns true if the message is ephemeral
-    var isEphemeral : Bool { get }
-    
+    var isEphemeral: Bool { get }
+
     /// If the message is ephemeral, it returns a fixed timeout
     /// Otherwise it returns -1
     /// Override this method in subclasses if needed
-    var deletionTimeout : TimeInterval { get }
+    var deletionTimeout: TimeInterval { get }
 
     /// Returns true if the message is an ephemeral message that was sent by the selfUser and the obfuscation timer already fired
     /// At this point the genericMessage content is already cleared. You should receive a notification that the content was cleared
-    var isObfuscated : Bool { get }
+    var isObfuscated: Bool { get }
 
     /// Returns the date when a ephemeral message will be destructed or `nil` if th message is not ephemeral
     var destructionDate: Date? { get }
-    
+
     /// Returns whether this is a message that caused the security level of the conversation to degrade in this session (since the 
     /// app was restarted)
-    var causedSecurityLevelDegradation : Bool { get }
-    
+    var causedSecurityLevelDegradation: Bool { get }
+
     /// Marks the message as the last unread message in the conversation, moving the unread mark exactly before this
     /// message.
     func markAsUnread()
-    
+
     /// Checks if the message can be marked unread
     var canBeMarkedUnread: Bool { get }
 
@@ -152,7 +151,7 @@ public protocol ZMConversationMessage : NSObjectProtocol {
 
     /// Used to trigger link attachments update for this message.
     var needsLinkAttachmentsUpdate: Bool { get set }
-    
+
     var isSilenced: Bool { get }
 
     /// Whether the asset message can not be received or shared.
@@ -170,12 +169,12 @@ public extension ZMConversationMessage {
 
     func isUserSender(_ user: UserType) -> Bool {
         guard let zmUser = user as? ZMUser else { return false }
-        
+
         return zmUser == senderUser as? ZMUser
     }
 }
 
-public extension Equatable where Self : ZMConversationMessage { }
+public extension Equatable where Self: ZMConversationMessage { }
 
 public func ==(lhs: ZMConversationMessage, rhs: ZMConversationMessage) -> Bool {
     return lhs.isEqual(rhs)
@@ -194,21 +193,20 @@ public func ==(lhs: ZMConversationMessage?, rhs: ZMConversationMessage?) -> Bool
     }
 }
 
-// MARK:- Conversation managed properties
+// MARK: - Conversation managed properties
 extension ZMMessage {
-    
-    @NSManaged public var visibleInConversation : ZMConversation?
-    @NSManaged public var hiddenInConversation : ZMConversation?
-    
-    public var conversation : ZMConversation? {
+
+    @NSManaged public var visibleInConversation: ZMConversation?
+    @NSManaged public var hiddenInConversation: ZMConversation?
+
+    public var conversation: ZMConversation? {
         return self.visibleInConversation ?? self.hiddenInConversation
     }
 }
 
+// MARK: - Conversation Message protocol implementation
 
-// MARK:- Conversation Message protocol implementation
-
-extension ZMMessage : ZMConversationMessage {
+extension ZMMessage: ZMConversationMessage {
     public var conversationLike: ConversationLike? {
         return conversation
     }
@@ -216,11 +214,11 @@ extension ZMMessage : ZMConversationMessage {
     public var senderUser: UserType? {
         return sender
     }
-    
+
     @NSManaged public var linkAttachments: [LinkAttachment]?
     @NSManaged public var needsLinkAttachmentsUpdate: Bool
     @NSManaged public var replies: Set<ZMMessage>
-    
+
     public var readReceipts: [ReadReceipt] {
         return confirmations.filter({ $0.type == .read }).sorted(by: { a, b in  a.serverTimestamp < b.serverTimestamp })
     }
@@ -228,11 +226,11 @@ extension ZMMessage : ZMConversationMessage {
     public var objectIdentifier: String {
         return nonpersistedObjectIdentifer
     }
-    
-    public var causedSecurityLevelDegradation : Bool {
+
+    public var causedSecurityLevelDegradation: Bool {
         return false
     }
-    
+
     public var canBeMarkedUnread: Bool {
         guard self.isNormal,
                 let _ = self.serverTimestamp,
@@ -241,10 +239,10 @@ extension ZMMessage : ZMConversationMessage {
                 !sender.isSelfUser else {
                 return false
         }
-        
+
         return true
     }
-    
+
     public func markAsUnread() {
         guard canBeMarkedUnread,
               let serverTimestamp = self.serverTimestamp,
@@ -256,29 +254,29 @@ extension ZMMessage : ZMConversationMessage {
                 return
         }
         let conversationID = conversation.objectID
-        
+
         conversation.lastReadServerTimeStamp = Date(timeInterval: -0.01, since: serverTimestamp)
         managedObjectContext.saveOrRollback()
-        
+
         syncContext.performGroupedBlock {
             guard let syncObject = try? syncContext.existingObject(with: conversationID), let syncConversation = syncObject as? ZMConversation else {
                 zmLog.error("Cannot mark as unread message outside of the conversation: sync conversation cannot be fetched.")
                 return
             }
-            
+
             syncConversation.calculateLastUnreadMessages()
             syncContext.saveOrRollback()
         }
     }
-    
+
     public var isSilenced: Bool {
         return conversation?.isMessageSilenced(nil, senderID: sender?.remoteIdentifier) ?? true
     }
 
     public var isRestricted: Bool {
-        guard 
+        guard
             (self.isFile || self.isImage),
-            let managedObjectContext = self.managedObjectContext 
+            let managedObjectContext = self.managedObjectContext
         else { return false }
 
         let featureService = FeatureService(context: managedObjectContext)
@@ -289,78 +287,76 @@ extension ZMMessage : ZMConversationMessage {
 }
 
 extension ZMMessage {
-    
-    @NSManaged public var sender : ZMUser?
-    @NSManaged public var serverTimestamp : Date?
 
-    @objc public var textMessageData : ZMTextMessageData? {
+    @NSManaged public var sender: ZMUser?
+    @NSManaged public var serverTimestamp: Date?
+
+    @objc public var textMessageData: ZMTextMessageData? {
         return nil
     }
-    
-    @objc public var imageMessageData : ZMImageMessageData? {
+
+    @objc public var imageMessageData: ZMImageMessageData? {
         return nil
     }
-    
-    @objc public var knockMessageData : ZMKnockMessageData? {
+
+    @objc public var knockMessageData: ZMKnockMessageData? {
         return nil
     }
-    
-    @objc public var systemMessageData : ZMSystemMessageData? {
+
+    @objc public var systemMessageData: ZMSystemMessageData? {
         return nil
     }
-    
-    @objc public var fileMessageData : ZMFileMessageData? {
+
+    @objc public var fileMessageData: ZMFileMessageData? {
         return nil
     }
-    
+
     @objc public var locationMessageData: LocationMessageData? {
         return nil
     }
-    
+
     @objc public var isSent: Bool {
         return true
     }
-    
-    @objc public var deliveryState : ZMDeliveryState {
+
+    @objc public var deliveryState: ZMDeliveryState {
         return .delivered
     }
-    
-    @objc public var usersReaction : Dictionary<String, [UserType]> {
-        var result = Dictionary<String, [ZMUser]>()
+
+    @objc public var usersReaction: [String: [UserType]] {
+        var result = [String: [ZMUser]]()
         for reaction in reactions {
             if reaction.users.count > 0 {
-                result[reaction.unicodeValue!] = Array<ZMUser>(reaction.users)
+                result[reaction.unicodeValue!] = [ZMUser](reaction.users)
             }
         }
         return result
     }
-    
-    
-    @objc public var canBeDeleted : Bool {
+
+    @objc public var canBeDeleted: Bool {
         return deliveryState != .pending
     }
-    
+
     @objc public var hasBeenDeleted: Bool {
         return isZombieObject || (visibleInConversation == nil && hiddenInConversation != nil)
     }
-    
-    @objc public var updatedAt : Date? {
+
+    @objc public var updatedAt: Date? {
         return nil
     }
- 
+
     @objc public func startSelfDestructionIfNeeded() -> Bool {
         if !isZombieObject && isEphemeral, let sender = sender, !sender.isSelfUser {
             return startDestructionIfNeeded()
         }
         return false
     }
-    
-    @objc public var isEphemeral : Bool {
+
+    @objc public var isEphemeral: Bool {
         return false
     }
-    
-    @objc public var deletionTimeout : TimeInterval {
+
+    @objc public var deletionTimeout: TimeInterval {
         return -1
     }
 }
-

--- a/Source/Model/Message/FileAssetCache.swift
+++ b/Source/Model/Message/FileAssetCache.swift
@@ -16,20 +16,17 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 private let NSManagedObjectContextFileAssetCacheKey = "zm_fileAssetCache"
 private var zmLog = ZMSLog(tag: "assets")
 
-
-extension NSManagedObjectContext
-{
-    @objc public var zm_fileAssetCache : FileAssetCache! {
+extension NSManagedObjectContext {
+    @objc public var zm_fileAssetCache: FileAssetCache! {
         get {
             return self.userInfo[NSManagedObjectContextFileAssetCacheKey] as? FileAssetCache
         }
-        
+
         set {
             self.userInfo[NSManagedObjectContextFileAssetCacheKey] = newValue
         }
@@ -41,15 +38,15 @@ extension NSManagedObjectContext
 /// Any thread can read objects that are never deleted without any problem.
 /// Objects purged from the cache folder by the OS are not a problem as the
 /// OS will terminate the app before purging the cache.
-private struct FileCache : Cache {
-    
-    private let cacheFolderURL : URL
-    
+private struct FileCache: Cache {
+
+    private let cacheFolderURL: URL
+
     /// Create FileCahe
     /// - parameter name: name of the cache
     /// - parameter location: where cache is persisted on disk. Defaults to caches directory if nil.
     init(name: String, location: URL? = nil) {
-        
+
         // Create cache at the provided location or in the defalt caches directory if omitted
         if let cacheFolderURL = location {
             self.cacheFolderURL = cacheFolderURL
@@ -58,17 +55,17 @@ private struct FileCache : Cache {
         } else {
             fatal("Can't find/access caches directory")
         }
-        
+
         // create and set attributes
         FileManager.default.createAndProtectDirectory(at: cacheFolderURL)
     }
-    
+
     func assetData(_ key: String) -> Data? {
         let url = URLForKey(key)
         let coordinator = NSFileCoordinator()
-        var data: Data? = nil
-        
-        var error : NSError? = nil
+        var data: Data?
+
+        var error: NSError?
         coordinator.coordinate(readingItemAt: url, options: .withoutChanges, error: &error) { (url) in
             do {
                 data = try Data(contentsOf: url, options: .mappedIfSafe)
@@ -79,7 +76,7 @@ private struct FileCache : Cache {
                 }
             }
         }
-        
+
         if let error = error {
             if error.code != NSFileReadNoSuchFileError {
                 zmLog.error("Failed reading asset data for key = \(key): \(error)")
@@ -88,49 +85,49 @@ private struct FileCache : Cache {
 
         return data
     }
-    
+
     func storeAssetData(_ data: Data, key: String, createdAt creationDate: Date = Date()) {
         let url = URLForKey(key)
         let coordinator = NSFileCoordinator()
-        
-        var error : NSError? = nil
+
+        var error: NSError?
         coordinator.coordinate(writingItemAt: url, options: NSFileCoordinator.WritingOptions.forReplacing, error: &error) { (url) in
-            FileManager.default.createFile(atPath: url.path, contents: data, attributes: [.protectionKey : FileProtectionType.completeUntilFirstUserAuthentication,
-                                                                                          .creationDate : creationDate])
+            FileManager.default.createFile(atPath: url.path, contents: data, attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication,
+                                                                                          .creationDate: creationDate])
         }
-        
+
         if let error = error {
             zmLog.error("Failed storing asset data for key = \(key): \(error)")
         }
     }
-    
+
     func storeAssetFromURL(_ fromUrl: URL, key: String, createdAt creationDate: Date = Date()) {
         guard fromUrl.scheme == NSURLFileScheme else { fatal("Can't save remote URL to cache: \(fromUrl)") }
-        
+
         let toUrl = URLForKey(key)
         let coordinator = NSFileCoordinator()
-        
-        var error : NSError? = nil
+
+        var error: NSError?
         coordinator.coordinate(writingItemAt: toUrl, options: .forReplacing, error: &error) { (url) in
             do {
                 try FileManager.default.copyItem(at: fromUrl, to: url)
-                try FileManager.default.setAttributes([.protectionKey : FileProtectionType.completeUntilFirstUserAuthentication,
+                try FileManager.default.setAttributes([.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication,
                                                        .creationDate: creationDate], ofItemAtPath: url.path)
             } catch {
                 fatal("Failed to copy from \(url) to \(url), \(error)")
             }
         }
-        
+
         if let error = error {
             zmLog.error("Failed to copy asset data from \(fromUrl)  for key = \(key): \(error)")
         }
     }
-    
+
     func deleteAssetData(_ key: String) {
         let url = URLForKey(key)
         let coordinator = NSFileCoordinator()
-        
-        var error : NSError? = nil
+
+        var error: NSError?
         coordinator.coordinate(writingItemAt: url, options: .forDeleting, error: &error) { (url) in
             do {
                 try FileManager.default.removeItem(at: url)
@@ -141,22 +138,22 @@ private struct FileCache : Cache {
                 }
             }
         }
-        
+
         if let error = error {
             zmLog.error("Failed deleting asset data for key = \(key): \(error)")
         }
     }
-    
+
     func assetURL(_ key: String) -> URL? {
         let url = URLForKey(key)
         let isReachable = (try? url.checkResourceIsReachable()) ?? false
         return isReachable ? url : nil
     }
-    
+
     func hasDataForKey(_ key: String) -> Bool {
         return assetURL(key) != nil
     }
-    
+
     /// Returns the expected URL of a cache entry
     fileprivate func URLForKey(_ key: String) -> URL {
         guard key != "." && key != ".." else { fatal("Can't use \(key) as cache key") }
@@ -172,7 +169,7 @@ private struct FileCache : Cache {
     func wipeCaches() {
         _ = try? FileManager.default.removeItem(at: cacheFolderURL)
     }
-    
+
     /// Deletes assets created earlier than the given date
     ///
     /// - parameter date: assets earlier than this date will be deleted
@@ -181,17 +178,17 @@ private struct FileCache : Cache {
             try FileManager.default.removeItem(at: expiredAsset)
         }
     }
-    
+
     /// Returns assets created earlier than the given date
     func assetsOlderThan(_ date: Date) throws -> [URL] {
         let fileManager = FileManager.default
         let files = try fileManager.contentsOfDirectory(at: cacheFolderURL, includingPropertiesForKeys: [.creationDateKey], options: [.skipsSubdirectoryDescendants])
-        
+
         return try files.filter { (file) -> Bool in
             let attributes = try fileManager.attributesOfItem(atPath: file.path)
-            
+
             guard let creationDate = attributes[.creationDate] as? Date else { return true }
-            
+
             return creationDate < date
         }
     }
@@ -203,21 +200,21 @@ private struct FileCache : Cache {
 /// Any thread can read objects that are never deleted without any problem.
 /// Objects purged from the cache folder by the OS are not a problem as the
 /// OS will terminate the app before purging the cache.
-@objcMembers open class FileAssetCache : NSObject {
-    
-    fileprivate let fileCache : FileCache
-    
-    var cache : Cache {
+@objcMembers open class FileAssetCache: NSObject {
+
+    fileprivate let fileCache: FileCache
+
+    var cache: Cache {
         return fileCache
     }
-    
+
     /// Creates an asset cache
     public init(location: URL? = nil) {
         self.fileCache = FileCache(name: "files", location: location)
-        
+
         super.init()
     }
-    
+
     open func assetData(_ key: String) -> Data? {
         return cache.assetData(key)
     }
@@ -229,46 +226,46 @@ private struct FileCache : Cache {
     ///   - format: the format of the image
     ///   - encrypted: encrypted or not
     /// - Returns: the image data
-    open func assetData(for team : Team, format: ZMImageFormat, encrypted: Bool) -> Data? {
+    open func assetData(for team: Team, format: ZMImageFormat, encrypted: Bool) -> Data? {
         guard let key = type(of: self).cacheKeyForAsset(for: team, format: format, encrypted: encrypted) else { return nil }
         return self.cache.assetData(key)
     }
 
     /// Returns the image asset data for a given message. This will probably cause I/O
-    open func assetData(_ message : ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) -> Data? {
+    open func assetData(_ message: ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) -> Data? {
         guard let key = type(of: self).cacheKeyForAsset(message, format: format, encrypted: encrypted) else { return nil }
         return self.cache.assetData(key)
     }
-    
+
     /// Returns the asset data for a given message. This will probably cause I/O
-    open func assetData(_ message : ZMConversationMessage, encrypted: Bool) -> Data? {
+    open func assetData(_ message: ZMConversationMessage, encrypted: Bool) -> Data? {
         guard let key = type(of: self).cacheKeyForAsset(message, encrypted: encrypted) else { return nil }
         return self.cache.assetData(key)
     }
-    
+
     /// Returns the asset URL for a given message
-    open func accessAssetURL(_ message : ZMConversationMessage) -> URL? {
+    open func accessAssetURL(_ message: ZMConversationMessage) -> URL? {
         guard let key = type(of: self).cacheKeyForAsset(message) else { return nil }
         return self.cache.assetURL(key)
     }
-    
+
     /// Returns the asset URL for a given message
-    open func accessRequestURL(_ message : ZMConversationMessage) -> URL? {
+    open func accessRequestURL(_ message: ZMConversationMessage) -> URL? {
         guard let key = type(of: self).cacheKeyForAsset(message, identifier: "request") else { return nil }
         return cache.assetURL(key)
     }
 
-    open func hasDataOnDisk(for team : Team, format: ZMImageFormat, encrypted: Bool) -> Bool {
+    open func hasDataOnDisk(for team: Team, format: ZMImageFormat, encrypted: Bool) -> Bool {
         guard let key = type(of: self).cacheKeyForAsset(for: team, format: format, encrypted: encrypted) else { return false }
         return cache.hasDataForKey(key)
     }
 
-    open func hasDataOnDisk(_ message : ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) -> Bool {
+    open func hasDataOnDisk(_ message: ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) -> Bool {
         guard let key = type(of: self).cacheKeyForAsset(message, format: format, encrypted: encrypted) else { return false }
         return cache.hasDataForKey(key)
     }
-    
-    open func hasDataOnDisk(_ message : ZMConversationMessage, encrypted: Bool) -> Bool {
+
+    open func hasDataOnDisk(_ message: ZMConversationMessage, encrypted: Bool) -> Bool {
         guard let key = type(of: self).cacheKeyForAsset(message, encrypted: encrypted) else { return false }
         return cache.hasDataForKey(key)
     }
@@ -289,26 +286,26 @@ private struct FileCache : Cache {
     }
 
     /// Sets the image asset data for a given message. This will cause I/O
-    open func storeAssetData(_ message : ZMConversationMessage, format: ZMImageFormat, encrypted: Bool, data: Data) {
+    open func storeAssetData(_ message: ZMConversationMessage, format: ZMImageFormat, encrypted: Bool, data: Data) {
         guard let key = type(of: self).cacheKeyForAsset(message, format: format, encrypted: encrypted) else { return }
         self.cache.storeAssetData(data, key: key, createdAt: message.serverTimestamp ?? Date())
     }
-    
+
     /// Sets the asset data for a given message. This will cause I/O
-    open func storeAssetData(_ message : ZMConversationMessage, encrypted: Bool, data: Data) {
+    open func storeAssetData(_ message: ZMConversationMessage, encrypted: Bool, data: Data) {
         guard let key = type(of: self).cacheKeyForAsset(message, encrypted: encrypted) else { return }
         self.cache.storeAssetData(data, key: key, createdAt: message.serverTimestamp ?? Date())
     }
-    
+
     /// Sets the request data for a given message and returns the asset url. This will cause I/O
-    open func storeRequestData(_ message : ZMConversationMessage, data: Data) -> URL? {
+    open func storeRequestData(_ message: ZMConversationMessage, data: Data) -> URL? {
         guard let key = type(of: self).cacheKeyForAsset(message, identifier: "request") else { return nil }
         cache.storeAssetData(data, key: key, createdAt: message.serverTimestamp ?? Date())
         return accessRequestURL(message)
     }
-    
+
     /// Deletes the request data for a given message. This will cause I/O
-    open func deleteRequestData(_ message : ZMConversationMessage) {
+    open func deleteRequestData(_ message: ZMConversationMessage) {
         guard let key = type(of: self).cacheKeyForAsset(message, identifier: "request") else { return }
         cache.deleteAssetData(key)
     }
@@ -319,41 +316,41 @@ private struct FileCache : Cache {
     ///   - team: the team of the logo image
     ///   - format: the format of the image
     ///   - encrypted: encrypted or not
-    open func deleteAssetData(for team : Team, format: ZMImageFormat, encrypted: Bool) {
+    open func deleteAssetData(for team: Team, format: ZMImageFormat, encrypted: Bool) {
         guard let key = type(of: self).cacheKeyForAsset(for: team, format: format, encrypted: encrypted) else { return }
         cache.deleteAssetData(key)
     }
 
     /// Deletes the image data for a given message. This will cause I/O
-    open func deleteAssetData(_ message : ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) {
+    open func deleteAssetData(_ message: ZMConversationMessage, format: ZMImageFormat, encrypted: Bool) {
         guard let key = type(of: self).cacheKeyForAsset(message, format: format, encrypted: encrypted) else { return }
         cache.deleteAssetData(key)
     }
-    
+
     /// Deletes the data for a given message. This will cause I/O
-    open func deleteAssetData(_ message : ZMConversationMessage, identifier: String? = nil, encrypted: Bool) {
+    open func deleteAssetData(_ message: ZMConversationMessage, identifier: String? = nil, encrypted: Bool) {
         guard let key = type(of: self).cacheKeyForAsset(message, identifier: identifier, encrypted: encrypted) else { return }
         self.cache.deleteAssetData(key)
     }
-    
+
     /// Deletes all associated data for a given message. This will cause I/O
-    open func deleteAssetData(_ message : ZMConversationMessage) {
-        
+    open func deleteAssetData(_ message: ZMConversationMessage) {
+
         if message.imageMessageData != nil {
-            let imageFormats : [ZMImageFormat] = [.medium, .original, .preview]
-            
+            let imageFormats: [ZMImageFormat] = [.medium, .original, .preview]
+
             imageFormats.forEach({ format in
                 deleteAssetData(message, format: format, encrypted: false)
                 deleteAssetData(message, format: format, encrypted: true)
             })
         }
-        
+
         if message.fileMessageData != nil {
             deleteAssetData(message, encrypted: false)
             deleteAssetData(message, encrypted: true)
         }
     }
-    
+
     public func deleteAssetsOlderThan(_ date: Date) {
         do {
             try cache.deleteAssetsOlderThan(date)
@@ -362,34 +359,34 @@ private struct FileCache : Cache {
         }
     }
 
-    public static func cacheKeyForAsset(_ message : ZMConversationMessage, format: ZMImageFormat, encrypted: Bool = false) -> String? {
+    public static func cacheKeyForAsset(_ message: ZMConversationMessage, format: ZMImageFormat, encrypted: Bool = false) -> String? {
         return cacheKeyForAsset(message, identifier: StringFromImageFormat(format), encrypted: encrypted)
     }
 
-    public static func cacheKeyForAsset(_ message : ZMConversationMessage, identifier: String? = nil, encrypted: Bool = false) -> String? {
+    public static func cacheKeyForAsset(_ message: ZMConversationMessage, identifier: String? = nil, encrypted: Bool = false) -> String? {
         guard let messageId = message.nonce?.transportString(),
               let senderId = message.sender?.remoteIdentifier?.transportString(),
               let conversationId = message.conversation?.remoteIdentifier?.transportString()
         else {
             return nil
         }
-        
+
         let key = [messageId, senderId, conversationId, identifier, encrypted ? "encrypted" : nil].compactMap({ $0 }).joined(separator: "_")
-        
+
         return key.data(using: .utf8)?.zmSHA256Digest().zmHexEncodedString()
     }
 
     // MARK: - Team cache key
 
-    public static func cacheKeyForAsset(for team : Team, format: ZMImageFormat, encrypted: Bool = false) -> String? {
+    public static func cacheKeyForAsset(for team: Team, format: ZMImageFormat, encrypted: Bool = false) -> String? {
         return cacheKeyForAsset(for: team, identifier: StringFromImageFormat(format), encrypted: encrypted)
     }
 
-    public static func cacheKeyForAsset(for team : Team, identifier: String? = nil, encrypted: Bool = false) -> String? {
+    public static func cacheKeyForAsset(for team: Team, identifier: String? = nil, encrypted: Bool = false) -> String? {
         guard let teamID = team.remoteIdentifier?.uuidString, let assetID = team.pictureAssetId else {
             return nil
         }
-        
+
         let key = [teamID, assetID, identifier, encrypted ? "encrypted" : nil].compactMap({ $0 }).joined(separator: "_")
 
         return key.data(using: .utf8)?.zmSHA256Digest().zmHexEncodedString()
@@ -406,9 +403,8 @@ public extension FileAssetCache {
     }
 }
 
-
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToOptionalFileAttributeKeyDictionary(_ input: [String: Any]?) -> [FileAttributeKey: Any]? {
+private func convertToOptionalFileAttributeKeyDictionary(_ input: [String: Any]?) -> [FileAttributeKey: Any]? {
 	guard let input = input else { return nil }
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (FileAttributeKey(rawValue: key), value)})
 }

--- a/Source/Model/Message/GenericMessage+External.swift
+++ b/Source/Model/Message/GenericMessage+External.swift
@@ -41,7 +41,7 @@ extension GenericMessage {
         let keys = ZMEncryptionKeyWithChecksum.key(withAES: aesKey, digest: encryptedData.zmSHA256Digest())
         return ZMExternalEncryptedDataWithKeys(data: encryptedData, keys: keys)
     }
-    
+
     /// Creates a genericMessage from a ZMUpdateEvent and  External
     /// The symetrically encrypted data (representing the original GenericMessage)
     /// contained in the update event will be decrypted using the encryption keys in the External
@@ -52,12 +52,12 @@ extension GenericMessage {
         guard let externalDataString = updateEvent.payload.optionalString(forKey: "external") else { return nil }
         let externalData = Data(base64Encoded: externalDataString)
         let externalSha256 = externalData?.zmSHA256Digest()
-        
+
         guard externalSha256 == external.sha256 else {
             zmLog.error("Invalid hash for external data: \(externalSha256 ?? Data()) != \(external.sha256), updateEvent: \(updateEvent)")
             return nil
         }
-        
+
         let decryptedData = externalData?.zmDecryptPrefixedPlainTextIV(key: external.otrKey)
         guard let message = GenericMessage(withBase64String: decryptedData?.base64String()) else {
             return nil

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -21,7 +21,7 @@ import Foundation
 extension GenericMessage {
     public init?(from updateEvent: ZMUpdateEvent) {
         let base64Content: String?
-        
+
         switch updateEvent.type {
         case .conversationClientMessageAdd:
             base64Content = updateEvent.payload.string(forKey: "data")
@@ -32,17 +32,17 @@ extension GenericMessage {
         default:
             return nil
         }
-        
+
         var message = GenericMessage(withBase64String: base64Content)
-        
+
         if case .some(.external(let external)) = message?.content {
             message = GenericMessage(from: updateEvent, withExternal: external)
         }
-        
+
         guard let unwrappedMessage = message else { return nil }
         self = unwrappedMessage
     }
-    
+
     static func entityClass(for genericMessage: GenericMessage) -> AnyClass {
         if genericMessage.imageAssetData != nil || genericMessage.assetData != nil {
             return ZMAssetClientMessage.self

--- a/Source/Model/Message/LinkPreview+ProtocolBuffer.swift
+++ b/Source/Model/Message/LinkPreview+ProtocolBuffer.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireLinkPreview
 

--- a/Source/Model/Message/LocationData.swift
+++ b/Source/Model/Message/LocationData.swift
@@ -24,11 +24,11 @@ final public class LocationData: NSObject {
     public let latitude, longitude: Float
     public let name: String?
     public let zoomLevel: Int32
-    
+
     public class func locationData(withLatitude latitude: Float, longitude: Float, name: String?, zoomLevel: Int32) -> LocationData {
         return LocationData(latitude: latitude, longitude: longitude, name: name, zoomLevel: zoomLevel)
     }
-    
+
     init(latitude: Float, longitude: Float, name: String?, zoomLevel: Int32) {
         self.latitude = latitude
         self.longitude = longitude

--- a/Source/Model/Message/Mention.swift
+++ b/Source/Model/Message/Mention.swift
@@ -20,14 +20,14 @@ import Foundation
 
 @objc
 public class Mention: NSObject {
-    
+
     public let range: NSRange
     public let user: UserType
-    
+
     init?(_ protobuf: WireProtos.Mention, context: NSManagedObjectContext) {
         let userRemoteID = protobuf.hasQualifiedUserID ? protobuf.qualifiedUserID.id : protobuf.userID
         let domain = protobuf.hasQualifiedUserID ? protobuf.qualifiedUserID.domain : nil
-        
+
         guard
             let userId = UUID(uuidString: userRemoteID),
             protobuf.length > 0,
@@ -36,22 +36,22 @@ public class Mention: NSObject {
         else {
             return nil
         }
-        
+
         self.user = user
         self.range = NSRange(location: Int(protobuf.start), length: Int(protobuf.length))
     }
-    
+
     public init(range: NSRange, user: UserType) {
         self.range = range
         self.user = user
     }
-    
+
     public override func isEqual(_ object: Any?) -> Bool {
         guard let otherMention = object as? Mention else { return false }
-        
+
         return user.isEqual(otherMention.user) && NSEqualRanges(range, otherMention.range)
     }
-        
+
 }
 
 extension Mention {
@@ -59,18 +59,18 @@ extension Mention {
         guard let protos = protos,
             let messageText = messageText,
             let managedObjectContext = moc else { return [] }
-        
+
         let mentions = Array(protos.compactMap({ Mention($0, context: managedObjectContext) }).prefix(500))
         var mentionRanges = IndexSet()
         let messageRange = NSRange(messageText.startIndex ..< messageText.endIndex, in: messageText)
-        
+
         return mentions.filter({ mention  in
             let range = mention.range.range
-            
+
             guard !mentionRanges.intersects(integersIn: range), range.upperBound <= messageRange.upperBound else { return false }
-            
+
             mentionRanges.insert(integersIn: range)
-            
+
             return true
         })
     }

--- a/Source/Model/Message/Message.swift
+++ b/Source/Model/Message/Message.swift
@@ -43,7 +43,7 @@ public extension ZMConversationMessage {
     var isPDF: Bool {
         return isFile && fileMessageData?.isPDF ?? false
     }
-    
+
     var isPass: Bool {
         return isFile && fileMessageData!.isPass
     }
@@ -133,7 +133,7 @@ public class Message: NSObject {
     public class func isPDF(_ message: ZMConversationMessage) -> Bool {
         return message.isPDF
     }
-    
+
     @objc(isVideoMessage:)
     public class func isVideo(_ message: ZMConversationMessage) -> Bool {
         return message.isVideo

--- a/Source/Model/Message/RasterImages+Protobuf.swift
+++ b/Source/Model/Message/RasterImages+Protobuf.swift
@@ -21,9 +21,9 @@ public extension WireProtos.Asset.Original {
         guard case .image? = metaData else {
             return false
         }
-        
+
         guard let uti = UTIHelper.convertToUti(mime: mimeType) else { return false }
-        
+
         return !UTIHelper.conformsToVectorType(uti: uti)
     }
 }

--- a/Source/Model/Message/TextSearchQuery.swift
+++ b/Source/Model/Message/TextSearchQuery.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import WireUtilities
-
 
 extension ZMMessage {
 
@@ -120,14 +118,11 @@ public struct TextSearchQueryFetchConfiguration {
     }
 }
 
-
 public protocol TextSearchQueryDelegate: AnyObject {
     func textSearchQueryDidReceive(result: TextQueryResult)
 }
 
-
 private let zmLog = ZMSLog(tag: "text search")
-
 
 /// This class should be used to perform a text search for messages in a conversation.
 /// Each instance can only be used to perform a search once. A running instance can be cancelled.
@@ -243,7 +238,7 @@ public class TextSearchQuery: NSObject {
             guard let `self` = self else { return }
 
             let request = ZMClientMessage.descendingFetchRequest(with: self.predicateForIndexedMessagesQueryMatch)
-            
+
             request?.fetchLimit = self.fetchConfiguration.indexedBatchSize
             request?.fetchOffset = callCount * self.fetchConfiguration.indexedBatchSize
 
@@ -342,7 +337,7 @@ public class TextSearchQuery: NSObject {
     private lazy var predicateForIndexedMessagesQueryMatch: NSPredicate = {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             self.predicateForQueryMatch,
-            ZMClientMessage.predicateForIndexedMessages(),
+            ZMClientMessage.predicateForIndexedMessages()
         ])
     }()
 
@@ -361,5 +356,5 @@ public class TextSearchQuery: NSObject {
             ZMClientMessage.predicateForMessages(inConversationWith: self.conversationRemoteIdentifier)
         ])
     }()
-    
+
 }

--- a/Source/Model/Message/V2Asset.swift
+++ b/Source/Model/Message/V2Asset.swift
@@ -16,28 +16,27 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import MobileCoreServices
 
 @objcMembers
 public class V2Asset: NSObject, ZMImageMessageData {
-    
+
     public var isDownloaded: Bool {
         return moc.zm_fileAssetCache.hasDataOnDisk(assetClientMessage, format: .medium, encrypted: false) ||
                moc.zm_fileAssetCache.hasDataOnDisk(assetClientMessage, format: .original, encrypted: false)
     }
-    
+
     public func fetchImageData(with queue: DispatchQueue, completionHandler: @escaping ((Data?) -> Void)) {
         let cache = moc.zm_fileAssetCache
         let mediumKey = FileAssetCache.cacheKeyForAsset(assetClientMessage, format: .medium)
         let originalKey = FileAssetCache.cacheKeyForAsset(assetClientMessage, format: .original)
-        
+
         queue.async {
             completionHandler([mediumKey, originalKey].lazy.compactMap({ $0 }).compactMap({ cache?.assetData($0) }).first)
         }
     }
-    
+
     fileprivate let assetClientMessage: ZMAssetClientMessage
     fileprivate let moc: NSManagedObjectContext
 
@@ -51,7 +50,7 @@ public class V2Asset: NSObject, ZMImageMessageData {
 
     public var imageMessageData: ZMImageMessageData? {
         guard assetClientMessage.mediumGenericMessage != nil || assetClientMessage.previewGenericMessage != nil else { return nil }
-        
+
         return self
     }
 
@@ -97,15 +96,15 @@ public class V2Asset: NSObject, ZMImageMessageData {
     }
 
     public var originalSize: CGSize {
-        guard let asset = assetClientMessage.mediumGenericMessage?.imageAssetData else  { return .zero }
+        guard let asset = assetClientMessage.mediumGenericMessage?.imageAssetData else { return .zero }
         let size = CGSize(width: Int(asset.originalWidth), height: Int(asset.originalHeight))
-        
+
         if size != .zero {
             return size
         }
-        
+
         return assetClientMessage.preprocessedSize
-        
+
     }
 
     // MARK: - Helper
@@ -119,7 +118,6 @@ public class V2Asset: NSObject, ZMImageMessageData {
     }
 
 }
-
 
 extension V2Asset: AssetProxyType {
 
@@ -151,11 +149,11 @@ extension V2Asset: AssetProxyType {
 
         return moc.zm_fileAssetCache.assetData(assetClientMessage, format: format, encrypted: encrypted)
     }
-    
+
     public func requestFileDownload() {
         guard assetClientMessage.fileMessageData != nil || assetClientMessage.imageMessageData != nil else { return }
         guard !assetClientMessage.objectID.isTemporaryID, let moc = self.moc.zm_userInterface else { return }
-        
+
         if assetClientMessage.imageMessageData != nil {
             NotificationInContext(name: ZMAssetClientMessage.imageDownloadNotificationName, context: moc.notificationContext, object: assetClientMessage.objectID).post()
         } else {

--- a/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Deletion.swift
@@ -29,12 +29,12 @@ extension ZMAssetClientMessage {
 
     func deleteContent() {
         managedObjectContext?.zm_fileAssetCache.deleteAssetData(self)
-        
+
         if let url = temporaryDirectoryURL,
             FileManager.default.fileExists(atPath: url.path) {
             try? FileManager.default.removeItem(at: url)
         }
-        
+
         dataSet.compactMap { $0 as? ZMGenericMessageData }.forEach {
             $0.managedObjectContext?.delete($0)
         }
@@ -44,7 +44,7 @@ extension ZMAssetClientMessage {
         associatedTaskIdentifier = nil
         preprocessedSize = CGSize.zero
     }
-    
+
     override public func removeClearingSender(_ clearingSender: Bool) {
         if !clearingSender {
             markRemoteAssetToBeDeleted()
@@ -52,17 +52,17 @@ extension ZMAssetClientMessage {
         deleteContent()
         super.removeClearingSender(clearingSender)
     }
-    
+
     private func markRemoteAssetToBeDeleted() {
         guard sender == ZMUser.selfUser(in: managedObjectContext!) else {
             return
         }
-        
+
         // Request the asset to be deleted
         if let identifier = underlyingMessage?.v3_uploadedAssetId {
             NotificationCenter.default.post(name: .deleteAssetNotification, object: identifier)
         }
-        
+
         // Request the preview asset to be deleted
         if let previewIdentifier = underlyingMessage?.previewAssetId {
             NotificationCenter.default.post(name: .deleteAssetNotification, object: previewIdentifier)

--- a/Source/Model/Message/ZMAssetClientMessage+Download.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Download.swift
@@ -16,14 +16,13 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 extension ZMAssetClientMessage {
 
     /// Name of notification fired when requesting a download of an image
     public static let imageDownloadNotificationName = NSNotification.Name(rawValue: "ZMAssetClientMessageImageDownloadNotification")
-    
+
     /// Name of notification fired when requesting a download of an asset
     public static let assetDownloadNotificationName = NSNotification.Name(rawValue: "ZMAssetClientMessageAssetDownloadNotification")
 }

--- a/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -19,13 +19,13 @@
 import Foundation
 
 extension ZMAssetClientMessage {
- 
+
     @objc override public var isEphemeral: Bool {
         return destructionDate != nil
             || ephemeral != nil
             || isObfuscated
     }
-    
+
     var ephemeral: Ephemeral? {
         return dataSet.lazy
             .compactMap { ($0 as? ZMGenericMessageData)?.underlyingMessage }
@@ -36,25 +36,25 @@ extension ZMAssetClientMessage {
                 return true
             })?.ephemeral
     }
-    
+
     @objc override public var deletionTimeout: TimeInterval {
         guard let ephemeral = self.ephemeral else {
             return -1
         }
         return TimeInterval(ephemeral.expireAfterMillis / 1000)
     }
-    
+
     @objc override public func obfuscate() {
         super.obfuscate()
-        
-        var obfuscatedMessage: GenericMessage? = nil
+
+        var obfuscatedMessage: GenericMessage?
         if let medium = mediumGenericMessage {
             obfuscatedMessage = medium.obfuscatedMessage()
         } else if fileMessageData != nil {
             obfuscatedMessage = underlyingMessage?.obfuscatedMessage()
         }
         deleteContent()
-        
+
         if let obfuscatedMessage = obfuscatedMessage {
             do {
                 _ = try createNewGenericMessageData(with: obfuscatedMessage)
@@ -63,9 +63,9 @@ extension ZMAssetClientMessage {
             }
         }
     }
-    
+
     @discardableResult @objc public override func startDestructionIfNeeded() -> Bool {
-        
+
         if imageMessageData != nil && !hasDownloadedFile {
             return false
         } else if fileMessageData != nil
@@ -73,17 +73,17 @@ extension ZMAssetClientMessage {
             && underlyingMessage?.assetData?.hasNotUploaded == false {
             return false
         }
-        
+
         return super.startDestructionIfNeeded()
     }
-    
+
     /// Extends the destruction timer to the given date, which must be later
     /// than the current destruction date. If a timer is already running,
     /// then it will be stopped and restarted with the new date, otherwise
     /// a new timer will be created.
     public func extendDestructionTimer(to date: Date) {
         let timeout = date.timeIntervalSince(Date())
-        
+
         guard
             let isSelfUser = sender?.isSelfUser,
             let destructionDate = self.destructionDate,
@@ -91,7 +91,7 @@ extension ZMAssetClientMessage {
             timeout > 0 else {
                 return
         }
-        
+
         let msg = self as ZMMessage
         if isSelfUser { msg.restartObfuscationTimer(timeout) }
         else { msg.restartDeletionTimer(timeout) }

--- a/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -23,28 +23,28 @@ extension ZMAssetClientMessage {
     func genericMessageDataFromDataSet(for format: ZMImageFormat) -> ZMGenericMessageData? {
         return self.dataSet.lazy
             .compactMap { $0 as? ZMGenericMessageData }
-            .first(where: {$0.underlyingMessage?.imageAssetData?.imageFormat() == format} )
+            .first(where: {$0.underlyingMessage?.imageAssetData?.imageFormat() == format})
     }
-    
+
     public var mediumGenericMessage: GenericMessage? {
         return self.genericMessageDataFromDataSet(for: .medium)?.underlyingMessage
     }
-    
+
     static func keyPathsForValuesAffectingMediumGenericMessage() -> Set<String> {
         return Set([#keyPath(ZMOTRMessage.dataSet), #keyPath(ZMOTRMessage.dataSet)+".data"])
     }
-    
+
     public var previewGenericMessage: GenericMessage? {
         return self.genericMessageDataFromDataSet(for: .preview)?.underlyingMessage
     }
-    
+
     static func keyPathsForValuesAffectingPreviewGenericMessage() -> Set<String> {
         return Set([#keyPath(ZMOTRMessage.dataSet), #keyPath(ZMOTRMessage.dataSet)+".data"])
     }
-    
+
     public var underlyingMessage: GenericMessage? {
         guard !isZombieObject else { return nil }
-        
+
         if cachedUnderlyingAssetMessage == nil {
             cachedUnderlyingAssetMessage = underlyingMessageMergedFromDataSet(filter: {
                 $0.assetData != nil
@@ -57,7 +57,7 @@ extension ZMAssetClientMessage {
     ///
     /// - Parameter message: The protobuf message object to be associated with this asset client message.
     /// - Throws `ProcessingError` if the protobuf data can't be processed.
-    
+
     public func setUnderlyingMessage(_ message: GenericMessage) throws {
         try mergeWithExistingData(message: message)
     }
@@ -98,27 +98,27 @@ extension ZMAssetClientMessage {
             throw ProcessingError.failedToProcessMessageData(reason: error.localizedDescription)
         }
     }
-    
-    func underlyingMessageMergedFromDataSet(filter: (GenericMessage)->Bool) -> GenericMessage? {
+
+    func underlyingMessageMergedFromDataSet(filter: (GenericMessage) -> Bool) -> GenericMessage? {
         let filteredData = self.dataSet
             .compactMap { ($0 as? ZMGenericMessageData)?.underlyingMessage }
             .filter(filter)
             .compactMap { try? $0.serializedData() }
-        
+
         guard !filteredData.isEmpty else {
             return nil
         }
-        
+
         var message = GenericMessage()
         filteredData.forEach {
             try? message.merge(serializedData: $0)
         }
         return message
     }
-    
+
     /// Returns the generic message for the given representation
     func genericMessage(dataType: AssetClientMessageDataType) -> GenericMessage? {
-        
+
         if self.fileMessageData != nil {
             switch dataType {
             case .fullAsset:
@@ -146,7 +146,7 @@ extension ZMAssetClientMessage {
                 })
             }
         }
-        
+
         if self.imageMessageData != nil {
             switch dataType {
             case .fullAsset:
@@ -157,15 +157,14 @@ extension ZMAssetClientMessage {
                 return nil
             }
         }
-        
+
         return nil
     }
-    
-    
+
     override public var imageMessageData: ZMImageMessageData? {
         return self.asset?.imageMessageData
     }
-    
+
     override public var fileMessageData: ZMFileMessageData? {
         let isFileMessage = underlyingMessage?.assetData != nil
         return isFileMessage ? self : nil

--- a/Source/Model/Message/ZMAssetClientMessage+Quotes.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+Quotes.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 extension ZMAssetClientMessage {
-    
+
     override func updateQuoteRelationships() {
         // Asset messages don't support quotes at the moment
     }
-    
+
 }

--- a/Source/Model/Message/ZMAssetClientMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMAssetClientMessage+UpdateEvent.swift
@@ -30,14 +30,14 @@ extension ZMAssetClientMessage {
         }
 
         version = 3 // We assume received assets are V3 since backend no longer supports sending V2 assets.
-        
+
         guard
             let assetData = message.assetData,
             let status = assetData.status
         else {
             return
         }
-        
+
         switch status {
         case .uploaded(let data) where data.hasAssetID:
             updateTransferState(.uploaded, synchronize: false)

--- a/Source/Model/Message/ZMClientMessage+Composite.swift
+++ b/Source/Model/Message/ZMClientMessage+Composite.swift
@@ -53,7 +53,7 @@ extension ZMClientMessage {
         let message = ZMClientMessage.fetch(withNonce: nonce, for: conversation, in: moc)
         message?.updateButtonStates(withConfirmation: confirmation)
     }
-    
+
     static func expireButtonState(forButtonAction buttonAction: ButtonAction,
                                         forConversation conversation: ZMConversation,
                                         inContext moc: NSManagedObjectContext) {
@@ -67,17 +67,17 @@ extension ZMClientMessage {
 extension ZMClientMessage {
     private func updateButtonStates(withConfirmation confirmation: ButtonActionConfirmation) {
         guard let moc = managedObjectContext else { return }
-        
+
         if !containsButtonState(withId: confirmation.buttonID) {
             ButtonState.insert(with: confirmation.buttonID, message: self, inContext: moc)
         }
         buttonStates?.confirmButtonState(withId: confirmation.buttonID)
     }
-    
+
     private func containsButtonState(withId buttonId: String) -> Bool {
         return buttonStates?.contains(where: { $0.remoteIdentifier == buttonId }) ?? false
     }
-    
+
     private func expireButtonState(withButtonAction buttonAction: ButtonAction) {
         let state = buttonStates?.first(where: { $0.remoteIdentifier == buttonAction.buttonID })
         managedObjectContext?.performGroupedBlock { [managedObjectContext] in

--- a/Source/Model/Message/ZMClientMessage+Confirmations.swift
+++ b/Source/Model/Message/ZMClientMessage+Confirmations.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ZMClientMessage {
-    
+
     override open var needsReadConfirmation: Bool {
         guard let genericMessage = underlyingMessage else { return false }
         return needsReadConfirmation(genericMessage)

--- a/Source/Model/Message/ZMClientMessage+Deletion.swift
+++ b/Source/Model/Message/ZMClientMessage+Deletion.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ZMClientMessage {
-    
+
     func deleteContent() {
         cachedUnderlyingMessage = nil
         dataSet.compactMap { $0 as? ZMGenericMessageData }.forEach {
@@ -29,7 +29,7 @@ extension ZMClientMessage {
         normalizedText = nil
         quote = nil
     }
-    
+
     public override func removeClearingSender(_ clearingSender: Bool) {
         deleteContent()
         super.removeClearingSender(clearingSender)

--- a/Source/Model/Message/ZMClientMessage+Editing.swift
+++ b/Source/Model/Message/ZMClientMessage+Editing.swift
@@ -34,13 +34,13 @@ extension ZMClientMessage {
         editedMessage.updateCategoryCache()
         return editedMessage
     }
-    
+
     /// Apply a message edit update
     ///
     /// - parameter messageEdit: Message edit update
     /// - parameter updateEvent: Update event which delivered the message edit update
     /// - Returns: true if edit was succesfully applied
-    
+
     func processMessageEdit(_ messageEdit: MessageEdit, from updateEvent: ZMUpdateEvent) -> Bool {
         guard
             let nonce = updateEvent.messageNonce,
@@ -51,7 +51,7 @@ extension ZMClientMessage {
         else {
             return false
         }
-        
+
         do {
             let genericMessage = GenericMessage(content: originalText.applyEdit(from: messageEdit.text), nonce: nonce)
             try setUnderlyingMessage(genericMessage)
@@ -65,8 +65,8 @@ extension ZMClientMessage {
         updatedTimestamp = updateEvent.timestamp
         reactions.removeAll()
         linkAttachments = nil
-        
+
         return true
     }
-    
+
 }

--- a/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -185,12 +185,10 @@ extension ZMAssetClientMessage: EncryptedPayloadGenerator {
     public var debugInfo: String {
         return "\(String(describing: underlyingMessage))"
     }
-    
+
 }
 
-
 extension GenericMessage {
-
 
     public func encryptForProteus(for recipients: [ZMUser: Set<UserClient>],
                                   with missingClientsStrategy: MissingClientsStrategy,
@@ -226,9 +224,8 @@ extension GenericMessage {
         return (data, missingClientsStrategy)
     }
 
-
     /// Attempts to generate an encrypted payload for the given set of users.
-    
+
     public func encryptForTransport(forBroadcastRecipients recipients: Set<ZMUser>,
                                     useQualifiedIdentifiers: Bool = false,
                                     in context: NSManagedObjectContext) -> EncryptedPayloadGenerator.Payload? {
@@ -264,7 +261,6 @@ extension GenericMessage {
         return (data, missingClientsStrategy)
     }
 
-
     private func encrypt(for recipients: [ZMUser: Set<UserClient>],
                          with missingClientsStrategy: MissingClientsStrategy,
                          externalData: Data? = nil,
@@ -277,10 +273,10 @@ extension GenericMessage {
         else {
             return nil
         }
-        
+
         let encryptionContext = selfClient.keysStore.encryptionContext
         var messageData: Data?
-        
+
         encryptionContext.perform { sessionsDirectory in
             if useQualifiedIdentifiers, let selfDomain = ZMUser.selfUser(in: context).domain {
                 let message = proteusMessage(selfClient,
@@ -310,7 +306,7 @@ extension GenericMessage {
                                                                            in: context)
             }
         }
-        
+
         // Reset all failed sessions.
         recipients.values
             .flatMap { $0 }
@@ -341,7 +337,7 @@ extension GenericMessage {
                                               missingClientsStrategy: missingClientsStrategy,
                                               blob: externalData)
     }
-    
+
     /// Returns a message for the given recipients.
 
     private func otrMessage(_ selfClient: UserClient,
@@ -349,21 +345,21 @@ extension GenericMessage {
                             missingClientsStrategy: MissingClientsStrategy,
                             externalData: Data?,
                             sessionDirectory: EncryptionSessionsDirectory) -> Proteus_NewOtrMessage {
-        
+
         let userEntries = userEntriesWithEncryptedData(selfClient,
                                                        recipients: recipients,
                                                        sessionDirectory: sessionDirectory)
 
         // We do not want to send pushes for delivery receipts.
         let nativePush = !hasConfirmation
-        
+
         var message = Proteus_NewOtrMessage(withSender: selfClient,
                                             nativePush: nativePush,
                                             recipients: userEntries,
                                             blob: externalData)
 
         if case .ignoreAllMissingClientsNotFromUsers(let users) = missingClientsStrategy {
-            message.reportMissing = Array(users.map{ $0.userId })
+            message.reportMissing = Array(users.map { $0.userId })
         }
 
         return message
@@ -402,7 +398,7 @@ extension GenericMessage {
 
         return recipients.compactMap { (user, clients) in
             guard !user.isAccountDeleted else { return nil }
-            
+
             let clientEntries = clientEntriesWithEncryptedData(selfClient,
                                                                userClients: clients,
                                                                sessionDirectory: sessionDirectory)
@@ -462,7 +458,7 @@ extension GenericMessage {
             guard
                 hasConfirmation,
                 let managedObjectContext = conversation.managedObjectContext,
-                let message = ZMMessage.fetch(withNonce:UUID(uuidString: confirmation.firstMessageID), for:conversation, in:managedObjectContext),
+                let message = ZMMessage.fetch(withNonce: UUID(uuidString: confirmation.firstMessageID), for: conversation, in: managedObjectContext),
                 let sender = message.sender
                 else {
                     return nil
@@ -473,7 +469,7 @@ extension GenericMessage {
 
         func recipientForOtherUsers() -> Set<ZMUser>? {
             guard conversation.connectedUser != nil || (otherUsers.isEmpty == false) else { return nil }
-            if let connectedUser = conversation.connectedUser { return Set(arrayLiteral:connectedUser) }
+            if let connectedUser = conversation.connectedUser { return Set(arrayLiteral: connectedUser) }
             return Set(otherUsers)
         }
 
@@ -489,7 +485,7 @@ extension GenericMessage {
 
             guard
                 let managedObjectContext = conversation.managedObjectContext,
-                let message = ZMMessage.fetch(withNonce:nonce, for:conversation, in: managedObjectContext),
+                let message = ZMMessage.fetch(withNonce: nonce, for: conversation, in: managedObjectContext),
                 message.destructionDate != nil
             else {
                 return nil
@@ -556,7 +552,7 @@ extension GenericMessage {
 // MARK: - External
 
 extension GenericMessage {
-    
+
     /// Returns a message with recipients, with the content stored externally, and a strategy to handle missing clients.
 
     private func encryptForTransportWithExternalDataBlob(for conversation: ZMConversation) -> EncryptedPayloadGenerator.Payload? {
@@ -564,7 +560,7 @@ extension GenericMessage {
         let externalGenericMessage = GenericMessage(content: External(withKeyWithChecksum: encryptedDataWithKeys.keys))
         return externalGenericMessage.encryptForTransport(for: conversation, externalData: encryptedDataWithKeys.data)
     }
-    
+
     private func encryptForTransportWithExternalDataBlob(for recipients: [ZMUser: Set<UserClient>],
                                                          with missingClientsStrategy: MissingClientsStrategy,
                                                          useQualifiedIdentifiers: Bool = false,

--- a/Source/Model/Message/ZMClientMessage+Ephemeral.swift
+++ b/Source/Model/Message/ZMClientMessage+Ephemeral.swift
@@ -25,7 +25,7 @@ extension ZMClientMessage {
             || ephemeral != nil
             || isObfuscated
     }
-    
+
     var ephemeral: Ephemeral? {
         return dataSet.lazy
             .compactMap { ($0 as? ZMGenericMessageData)?.underlyingMessage }
@@ -45,4 +45,3 @@ extension ZMClientMessage {
         return TimeInterval(ephemeral.expireAfterMillis / 1000)
     }
 }
-

--- a/Source/Model/Message/ZMClientMessage+GenericMessage.swift
+++ b/Source/Model/Message/ZMClientMessage+GenericMessage.swift
@@ -19,28 +19,28 @@
 import Foundation
 
 extension ZMClientMessage {
-    
+
     public var underlyingMessage: GenericMessage? {
         guard !isZombieObject else {
             return nil
         }
-        
+
         if cachedUnderlyingMessage == nil {
             cachedUnderlyingMessage = underlyingMessageMergedFromDataSet()
         }
         return cachedUnderlyingMessage
     }
-    
+
     private func underlyingMessageMergedFromDataSet() -> GenericMessage? {
         let filteredData = dataSet.lazy
             .compactMap { ($0 as? ZMGenericMessageData)?.underlyingMessage }
             .filter { $0.knownMessage && $0.imageAssetData == nil }
             .compactMap { try? $0.serializedData() }
-        
+
         guard !Array(filteredData).isEmpty else {
             return nil
         }
-        
+
         var message = GenericMessage()
         filteredData.forEach {
             try? message.merge(serializedData: $0)
@@ -55,7 +55,7 @@ extension ZMClientMessage {
 
     public func setUnderlyingMessage(_ message: GenericMessage) throws {
         let messageData = try mergeWithExistingData(message)
-        
+
         if nonce == .none, let messageID = messageData.underlyingMessage?.messageID {
             nonce = UUID(uuidString: messageID)
         }

--- a/Source/Model/Message/ZMClientMessage+Knock.swift
+++ b/Source/Model/Message/ZMClientMessage+Knock.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ZMClientMessage: ZMKnockMessageData {
-    
+
     public override var knockMessageData: ZMKnockMessageData? {
         guard underlyingMessage?.knockData != nil else {
             return nil


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes warnings for the following rules:

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`
- **Vertical Parameter Alignment Violation**: Function parameters should be aligned vertically if they're in multiple lines in a declaration. (`vertical_parameter_alignment)`
- **Redundant @objc Attribute Violation:** Objective-C attribute (@objc) is redundant in declaration. `(redundant_objc_attribute)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
