### PR TITLE
chore: annotate federation M2 test cases FS-336

### DIFF
--- a/Tests/Source/Model/Conversation/ZMConversationTests+Team.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+Team.swift
@@ -20,6 +20,7 @@ import Foundation
 @testable import WireDataModel
 
 class ConversationTests_Team: ZMConversationTestsBase {
+
     var sut: ZMConversation!
 
     override func setUp() {
@@ -34,7 +35,7 @@ class ConversationTests_Team: ZMConversationTestsBase {
         super.tearDown()
     }
 
-    func testThatItReturnsFalse_WhenTeamIdIsNil() {
+    func test_ConversationIsNotATeamConversation_WhenTeamIdIsNil() {
         // Given
         sut.teamRemoteIdentifier = nil
 
@@ -42,7 +43,7 @@ class ConversationTests_Team: ZMConversationTestsBase {
         XCTAssertFalse(sut.isTeamConversation)
     }
 
-    func testThatItReturnsFalse_WhenConversationIsNotFederated_AndTeamIdIsDifferentFromSelfUser() {
+    func test_ConversationIsNotATeamConversation_WhenTeamIdIsDifferentFromSelfUser() {
         // Given
         let team = createTeam(in: uiMOC)
         createMembership(in: uiMOC, user: selfUser, team: team, with: nil)
@@ -52,19 +53,8 @@ class ConversationTests_Team: ZMConversationTestsBase {
         XCTAssertFalse(sut.isTeamConversation)
     }
 
-    func testThatItReturnsTrue_WhenConversationIsNotFederated_AndTeamIdIsSameAsSelfUser_() {
-        // Given
-        let teamId = UUID()
-        let team = createTeam(in: uiMOC)
-        team.remoteIdentifier = teamId
-        createMembership(in: uiMOC, user: selfUser, team: team, with: nil)
-        sut.teamRemoteIdentifier = teamId
-
-        // When / Then
-        XCTAssertTrue(sut.isTeamConversation)
-    }
-
-    func testThatItReturnsFalse_WhenConversationIsFederated() {
+    // @SF.Federation @SF.Separation @TSFI.UserInterface @S0.2
+    func test_ConversationIsNotATeamConversation_WhenItIsFederated() {
         // Given
         let teamId = UUID()
         let team = createTeam(in: uiMOC)
@@ -78,4 +68,18 @@ class ConversationTests_Team: ZMConversationTestsBase {
         // When / Then
         XCTAssertFalse(sut.isTeamConversation)
     }
+
+    // @SF.Federation @SF.Separation @TSFI.UserInterface @S0.2
+    func test_ConversationIsATeamConversation_WhenTeamIdIsTheSameAsSelfUser_AndItIsNotFederated() {
+        // Given
+        let teamId = UUID()
+        let team = createTeam(in: uiMOC)
+        team.remoteIdentifier = teamId
+        createMembership(in: uiMOC, user: selfUser, team: team, with: nil)
+        sut.teamRemoteIdentifier = teamId
+
+        // When / Then
+        XCTAssertTrue(sut.isTeamConversation)
+    }
+
 }

--- a/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -266,6 +266,7 @@ final class ZMUserTests_Permissions: ModelObjectsTests {
         XCTAssertFalse(user2CanSeeUser1)
     }
 
+    // @SF.Federation @SF.Separation @TSFI.UserInterface @S0.2
     func testThatItDoesNotAllowSeeingCompanyInformationBetweenUsers_WhenTeamIsTheSame_AndDomainIsDifferent() {
         // given
         let (team, _) = createTeamAndMember(for: .selfUser(in: uiMOC), with: .member)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds test annotations for tests that assert federated conversations aren't considered team conversations  (https://github.com/wireapp/wire-ios-data-model/pull/1288) and that a user from another backend isn't considered to be on the same team as the self user  (https://github.com/wireapp/wire-ios-data-model/pull/1269).

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
