### PR TITLE
fix: SwiftLint warnings for multiple rules in Source Part 4

### DIFF
--- a/Source/Model/Account.swift
+++ b/Source/Model/Account.swift
@@ -16,10 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-extension Account : NotificationContext { }
+extension Account: NotificationContext { }
 
 extension Notification.Name {
     public static let AccountUnreadCountDidChangeNotification = Notification.Name("AccountUnreadCountDidChangeNotification")
@@ -71,7 +70,7 @@ public final class Account: NSObject, Codable {
         self.loginCredentials = loginCredentials
         super.init()
     }
-    
+
     /// Updates the properties of the receiver with the given account. Use this method
     /// when you wish to update an exisiting account object with newly fetched properties
     /// from the account store.

--- a/Source/Model/AccountDeletedObserver.swift
+++ b/Source/Model/AccountDeletedObserver.swift
@@ -19,21 +19,21 @@
 import Foundation
 
 public protocol AccountDeletedObserver: AnyObject {
-    func accountDeleted(accountId : UUID)
+    func accountDeleted(accountId: UUID)
 }
 
 public struct AccountDeletedNotification {
     public static let notificationName = Notification.Name("AccountDeletedNotification")
-    public static var userInfoKey : String { return notificationName.rawValue }
+    public static var userInfoKey: String { return notificationName.rawValue }
 
-    weak var context : NSManagedObjectContext?
+    weak var context: NSManagedObjectContext?
 
     public init(context: NSManagedObjectContext) {
         self.context = context
     }
 
     public func post(in context: NotificationContext, object: AnyObject? = nil) {
-        NotificationInContext(name: type(of:self).notificationName, context: context, object:object, userInfo: [type(of:self).userInfoKey : self]).post()
+        NotificationInContext(name: type(of: self).notificationName, context: context, object: object, userInfo: [type(of: self).userInfoKey: self]).post()
     }
 }
 

--- a/Source/Model/AccountManager.swift
+++ b/Source/Model/AccountManager.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 private let log = ZMSLog(tag: "Accounts")
 
@@ -36,7 +34,6 @@ fileprivate extension UserDefaults {
 
 }
 
-
 /// Class used to safely access and change stored accounts and the current selected account.
 @objcMembers public final class AccountManager: NSObject {
 
@@ -45,7 +42,7 @@ fileprivate extension UserDefaults {
     private(set) public var selectedAccount: Account? // The currently selected account or `nil` in case there is none
 
     private var store: AccountStore
-    
+
     /// Returns the sum of unread conversations in all accounts.
     public var totalUnreadCount: Int {
         return accounts.reduce(0) { return $0 + $1.unreadConversationCount }
@@ -104,14 +101,14 @@ fileprivate extension UserDefaults {
     /// This method should be called each time accounts are added or
     /// removed, or when the selectedAccountIdentifier has been changed.
     private func updateAccounts() {
-        
+
         // since some objects (eg. AccountView) observe changes in the account, we must
         // make sure their object addresses are maintained after updating, i.e if
         // exisiting objects need to be updated from the account store, we just update
         // their properties and not replace the whole object.
         //
         var updatedAccounts = [Account]()
-        
+
         for account in computeSortedAccounts() {
             if let existingAccount = self.account(with: account.userIdentifier) {
                 existingAccount.updateWith(account)
@@ -120,9 +117,9 @@ fileprivate extension UserDefaults {
                 updatedAccounts.append(account)
             }
         }
-        
+
         accounts = updatedAccounts
-        
+
         let computedAccount = computeSelectedAccount()
         if let account = computedAccount, let exisitingAccount = self.account(with: account.userIdentifier) {
             exisitingAccount.updateWith(account)
@@ -130,10 +127,10 @@ fileprivate extension UserDefaults {
         } else {
             selectedAccount = computedAccount
         }
-        
+
         NotificationCenter.default.post(name: AccountManagerDidUpdateAccountsNotificationName, object: self)
     }
-    
+
     public func account(with id: UUID) -> Account? {
         return accounts.first(where: { return $0.userIdentifier == id })
     }
@@ -160,5 +157,5 @@ fileprivate extension UserDefaults {
             }
         }
     }
-    
+
 }

--- a/Source/Model/AccountStore.swift
+++ b/Source/Model/AccountStore.swift
@@ -16,12 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-
 private let log = ZMSLog(tag: "Accounts")
-
 
 /// Persistence layer for `Account` objects.
 /// Objects are stored in files named after their identifier like this:

--- a/Source/Model/AddressBookEntry.swift
+++ b/Source/Model/AddressBookEntry.swift
@@ -20,26 +20,26 @@ import Foundation
 import Contacts
 import AddressBook
 
-@objcMembers public class AddressBookEntry : ZMManagedObject {
-    
-    public enum Fields : String {
+@objcMembers public class AddressBookEntry: ZMManagedObject {
+
+    public enum Fields: String {
         case localIdentifier = "localIdentifier"
         case user = "user"
         case cachedName = "cachedName"
     }
-    
-    @NSManaged public var localIdentifier : String?
-    @NSManaged public var user : ZMUser?
-    @NSManaged public var cachedName : String?
-    
+
+    @NSManaged public var localIdentifier: String?
+    @NSManaged public var user: ZMUser?
+    @NSManaged public var cachedName: String?
+
     public override func keysTrackedForLocalModifications() -> Set<String> {
         return []
     }
-    
+
     public override static func entityName() -> String {
         return "AddressBookEntry"
     }
-    
+
     public override static func sortKey() -> String? {
         return Fields.localIdentifier.rawValue
     }
@@ -47,11 +47,11 @@ import AddressBook
     public override static func isTrackingLocalModifications() -> Bool {
         return false
     }
-    
+
 }
 
 extension AddressBookEntry {
-    
+
     @available(iOSApplicationExtension 9.0, *)
     @objc(createFromContact:managedObjectContext:user:)
     static public func create(from contact: CNContact, managedObjectContext: NSManagedObjectContext, user: ZMUser? = nil) -> AddressBookEntry {
@@ -62,4 +62,3 @@ extension AddressBookEntry {
         return entry
     }
 }
-

--- a/Source/Model/Analytics/Analytics+UnknownMessage.swift
+++ b/Source/Model/Analytics/Analytics+UnknownMessage.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 private let unknownMessageEventName = "debug.compatibility_unknown_message"
-
 
 extension AnalyticsType {
 
@@ -29,7 +27,6 @@ extension AnalyticsType {
     }
 
 }
-
 
 /// Objective-C compatibility wrapper for the unknown message event
 class UnknownMessageAnalyticsTracker: NSObject {

--- a/Source/Model/Analytics/AnalyticsType.swift
+++ b/Source/Model/Analytics/AnalyticsType.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 @objc
@@ -38,13 +37,13 @@ public protocol AnalyticsType: NSObjectProtocol {
         print(Date(), "[ANALYTICS]", #function, event)
     }
 
-    public func tagEvent(_ event: String, attributes: [String : NSObject]) {
+    public func tagEvent(_ event: String, attributes: [String: NSObject]) {
         print(Date(), "[ANALYTICS]", #function, event, attributes)
     }
 
-    var eventAttributes = [String : [String : NSObject]]()
+    var eventAttributes = [String: [String: NSObject]]()
 
-    public func setPersistedAttributes(_ attributes: [String : NSObject]?, for event: String) {
+    public func setPersistedAttributes(_ attributes: [String: NSObject]?, for event: String) {
         if let attributes = attributes {
             eventAttributes[event] = attributes
         } else {
@@ -53,7 +52,7 @@ public protocol AnalyticsType: NSObjectProtocol {
         print(Date(), "[ANALYTICS]", #function, event, eventAttributes[event] ?? [:])
     }
 
-    public func persistedAttributes(for event: String) -> [String : NSObject]? {
+    public func persistedAttributes(for event: String) -> [String: NSObject]? {
         let value = eventAttributes[event] ?? [:]
         print(Date(), "[ANALYTICS]", #function, event, value)
         return value

--- a/Source/Model/Analytics/NSManagedObjectContext+Analytics.swift
+++ b/Source/Model/Analytics/NSManagedObjectContext+Analytics.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 private let analyticsUserInfoKey = "AnalyticsUserInfoKey"

--- a/Source/Model/ButtonState/ButtonState.swift
+++ b/Source/Model/ButtonState/ButtonState.swift
@@ -32,11 +32,11 @@ class ButtonState: ZMManagedObject {
         buttonState.state = .unselected
         return buttonState
     }
-    
+
     override static func entityName() -> String {
         return String(describing: ButtonState.self)
     }
-    
+
     override static func isTrackingLocalModifications() -> Bool {
         return false
     }
@@ -46,7 +46,7 @@ class ButtonState: ZMManagedObject {
         case selected
         case confirmed
     }
-    
+
     var state: State {
         get {
             return State(rawValue: stateValue) ?? .unselected
@@ -65,7 +65,7 @@ extension Set where Element: ButtonState {
                 .unselected
         }
     }
-    
+
     func resetExpired() {
         for button in self {
             button.isExpired = false

--- a/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -19,10 +19,9 @@
 import Foundation
 import CoreData
 
-
-@objc public enum MessageConfirmationType : Int16 {
+@objc public enum MessageConfirmationType: Int16 {
     case delivered, read
-    
+
     static func convert(_ zmConfirmationType: Confirmation.TypeEnum) -> MessageConfirmationType {
         switch zmConfirmationType {
         case .delivered:
@@ -35,7 +34,7 @@ import CoreData
 
 @objc(ZMMessageConfirmation) @objcMembers
 open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
-    
+
     @NSManaged open var type: MessageConfirmationType
     @NSManaged open var serverTimestamp: Date?
     @NSManaged open var message: ZMMessage
@@ -48,7 +47,7 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
     override open class func entityName() -> String {
         return "MessageConfirmation"
     }
-    
+
     open override var modifiedKeys: Set<AnyHashable>? {
         get {
             return Set()
@@ -56,12 +55,12 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
             // do nothing
         }
     }
-    
+
     /// Creates a ZMMessageConfirmation objects that holds a reference to a message that was confirmed and the user who confirmed it.
     /// It can have 2 types: Delivered and Read depending on the confirmation type
     @discardableResult
     public static func createMessageConfirmations(_ confirmation: Confirmation, conversation: ZMConversation, updateEvent: ZMUpdateEvent) -> [ZMMessageConfirmation] {
-        
+
         let type = MessageConfirmationType.convert(confirmation.type)
 
         guard
@@ -75,15 +74,15 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
         let sender = ZMUser.fetchOrCreate(with: senderUUID, domain: updateEvent.senderDomain, in: managedObjectContext)
         let moreMessageIds = confirmation.moreMessageIds
         let confirmedMesssageIds = ([confirmation.firstMessageID] + moreMessageIds).compactMap({ UUID(uuidString: $0) })
-        
+
         return confirmedMesssageIds.compactMap { confirmedMessageId in
             guard let message = ZMMessage.fetch(withNonce: confirmedMessageId, for: conversation, in: managedObjectContext),
                 !message.confirmations.contains(where: { $0.user == sender && $0.type == type }) else { return nil }
-            
+
             return ZMMessageConfirmation(type: type, message: message, sender: sender, serverTimestamp: serverTimestamp, managedObjectContext: managedObjectContext)
         }
     }
-    
+
     convenience init(type: MessageConfirmationType, message: ZMMessage, sender: ZMUser, serverTimestamp: Date, managedObjectContext: NSManagedObjectContext) {
         let entityDescription = NSEntityDescription.entity(forEntityName: ZMMessageConfirmation.entityName(), in: managedObjectContext)!
         self.init(entity: entityDescription, insertInto: managedObjectContext)
@@ -92,5 +91,5 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
         self.type = type
         self.serverTimestamp = serverTimestamp
     }
-    
+
 }

--- a/Source/Model/Connection/ZMConnection+Actions.swift
+++ b/Source/Model/Connection/ZMConnection+Actions.swift
@@ -93,5 +93,5 @@ public extension ZMConnection {
         action.onResult(resultHandler: completion)
         action.send(in: context.notificationContext)
     }
-    
+
 }

--- a/Source/Model/Connection/ZMConnection+Fetch.swift
+++ b/Source/Model/Connection/ZMConnection+Fetch.swift
@@ -21,9 +21,9 @@ import Foundation
 extension ZMConnection {
     @objc(connectionsInManagedObjectContext:)
     class func connections(inManagedObjectContext moc: NSManagedObjectContext) -> [NSFetchRequestResult] {
-        
+
         let request = sortedFetchRequest()
-        
+
         let result = moc.fetchOrAssert(request: request)
         return result
     }
@@ -31,8 +31,8 @@ extension ZMConnection {
     public static func fetchOrCreate(userID: UUID, domain: String?, in context: NSManagedObjectContext) -> ZMConnection {
         guard let connection = fetch(userID: userID, domain: domain, in: context) else {
             return create(userID: userID, domain: domain, in: context)
-        } 
-        
+        }
+
         return connection
     }
 

--- a/Source/Model/Connection/ZMConnection+Notification.swift
+++ b/Source/Model/Connection/ZMConnection+Notification.swift
@@ -19,13 +19,13 @@
 import Foundation
 
 extension ZMConnection {
-    
+
     @objc public static let invalidateTopConversationCacheNotificationName = Notification.Name("ZMInvalidateTopConversationCacheNotificationName")
-    
+
     @objc public func invalidateTopConversationCache() {
         guard let moc = self.managedObjectContext else { return }
         NotificationInContext(name: type(of: self).invalidateTopConversationCacheNotificationName,
                               context: moc.notificationContext).post()
     }
-    
+
 }

--- a/Source/Model/Connection/ZMConnection+Role.swift
+++ b/Source/Model/Connection/ZMConnection+Role.swift
@@ -19,8 +19,7 @@
 import Foundation
 
 extension ZMConnection {
-    
-    
+
     /// add a user to connection's conversation, if not there already
     /// - Parameter user: the user to insert
     @objc

--- a/Source/Model/Conversation/AssetCollection.swift
+++ b/Source/Model/Conversation/AssetCollection.swift
@@ -17,48 +17,47 @@
 //
 
 import Foundation
-import WireUtilities;
+import WireUtilities
 
-public enum AssetFetchResult : Int {
+public enum AssetFetchResult: Int {
     case success, failed, noAssetsToFetch
 }
 
-public protocol ZMCollection : TearDownCapable {
+public protocol ZMCollection: TearDownCapable {
     func tearDown()
     func assets(for category: CategoryMatch) -> [ZMConversationMessage]
-    var fetchingDone : Bool { get }
+    var fetchingDone: Bool { get }
 }
 
-public protocol AssetCollectionDelegate : NSObjectProtocol {
+public protocol AssetCollectionDelegate: NSObjectProtocol {
     /// The AssetCollection calls this when the fetching completes
     /// To get all messages for any category defined in `including`, call `assets(for category: CategoryMatch)`
     func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch: [ZMConversationMessage]], hasMore: Bool)
-    
-    /// This method is called when all assets in the conversation have been fetched & analyzed / categorized
-    func assetCollectionDidFinishFetching(collection: ZMCollection, result : AssetFetchResult)
-}
 
+    /// This method is called when all assets in the conversation have been fetched & analyzed / categorized
+    func assetCollectionDidFinishFetching(collection: ZMCollection, result: AssetFetchResult)
+}
 
 /// This class fetches messages and groups them by `CategoryMatch` (e.g. files, images, videos etc.)
 /// It first fetches all objects that have previously categorized and then performs consecutive request of limited batch-size and categorizes them
 /// For every categorized batch it will call the delegate with the newly categorized objects and then once again when it finished categorizing all objects
-public class AssetCollection : NSObject, ZMCollection {
+public class AssetCollection: NSObject, ZMCollection {
 
-    private unowned var delegate : AssetCollectionDelegate
-    private var assets : Dictionary<CategoryMatch, [ZMMessage]>?
-    private var lastAssetMessage : ZMAssetClientMessage?
-    private var lastClientMessage : ZMClientMessage?
+    private unowned var delegate: AssetCollectionDelegate
+    private var assets: [CategoryMatch: [ZMMessage]]?
+    private var lastAssetMessage: ZMAssetClientMessage?
+    private var lastClientMessage: ZMClientMessage?
     private let conversation: ZMConversation?
-    private let matchingCategories : [CategoryMatch]
+    private let matchingCategories: [CategoryMatch]
 
     enum MessagesToFetch {
         case client, asset
     }
-    
+
     public static let initialFetchCount = 100
     public static let defaultFetchCount = 500
-    public private (set) var doneFetchingAssets : Bool = false
-    public private (set) var doneFetchingTexts : Bool = false
+    public private (set) var doneFetchingAssets: Bool = false
+    public private (set) var doneFetchingTexts: Bool = false
 
     private var tornDown = false {
         didSet {
@@ -67,27 +66,26 @@ public class AssetCollection : NSObject, ZMCollection {
         }
     }
 
-    public var fetchingDone : Bool {
+    public var fetchingDone: Bool {
         return doneFetchingTexts && doneFetchingAssets
     }
-    
+
     private var syncMOC: NSManagedObjectContext? {
         return conversation?.managedObjectContext?.zm_sync
     }
     private var uiMOC: NSManagedObjectContext? {
         return conversation?.managedObjectContext
     }
-    
+
     /// Returns a collection that automatically fetches the assets in batches
     /// @param categoriesToFetch: The AssetCollection only returns and calls the delegate for these categories
     public init(conversation: ConversationLike,
-                matchingCategories : [CategoryMatch],
-                delegate: AssetCollectionDelegate){
+                matchingCategories: [CategoryMatch],
+                delegate: AssetCollectionDelegate) {
         self.conversation = conversation as? ZMConversation
         self.delegate = delegate
         self.matchingCategories = matchingCategories
         super.init()
-        
 
         guard let syncMOC = self.syncMOC else {
             fatal("syncMOC not accessible")
@@ -98,41 +96,41 @@ public class AssetCollection : NSObject, ZMCollection {
                 let syncConversation = (try? syncMOC.existingObject(with: conversation.objectID)) as? ZMConversation else {
                 return
             }
-            
-            let categorizedMessages : [ZMMessage] = AssetCollectionBatched.categorizedMessages(for: syncConversation, matchPairs: self.matchingCategories)
+
+            let categorizedMessages: [ZMMessage] = AssetCollectionBatched.categorizedMessages(for: syncConversation, matchPairs: self.matchingCategories)
             if categorizedMessages.count > 0 {
                 let categorized = AssetCollectionBatched.messageMap(messages: categorizedMessages, matchingCategories: self.matchingCategories)
                 self.notifyDelegate(newAssets: categorized, type: nil, didReachLastMessage: false)
             }
-            
+
             self.fetchNextIfNotTornDown(limit: AssetCollection.initialFetchCount, type: .asset, syncConversation: syncConversation)
             self.fetchNextIfNotTornDown(limit: AssetCollection.initialFetchCount, type: .client, syncConversation: syncConversation)
         }
 
     }
-    
+
     /// Cancels further fetch requests
     public func tearDown() {
         tornDown = true
         doneFetchingAssets = true
         doneFetchingTexts = true
     }
-    
+
     deinit {
         precondition(tornDown, "Call tearDown to avoid continued fetch requests")
     }
-    
+
     /// Returns all assets that have been fetched thus far
     public func assets(for category: CategoryMatch) -> [ZMConversationMessage] {
         // Remove zombie objects and return remaining
         if let values = assets?[category] {
-            let withoutZombie = values.filter{!$0.isZombieObject}
+            let withoutZombie = values.filter {!$0.isZombieObject}
             assets?[category] = withoutZombie
             return withoutZombie
         }
         return []
     }
-    
+
     private func setFetchingCompleteFor(type: MessagesToFetch) {
         if type == .client {
             doneFetchingTexts = true
@@ -142,25 +140,25 @@ public class AssetCollection : NSObject, ZMCollection {
     }
 
     // NB: Method is expected to be run only on sync queue.
-    private func fetchNextIfNotTornDown(limit: Int, type: MessagesToFetch, syncConversation: ZMConversation){
+    private func fetchNextIfNotTornDown(limit: Int, type: MessagesToFetch, syncConversation: ZMConversation) {
         guard !fetchingDone, !tornDown else { return }
         guard !syncConversation.isZombieObject else {
             self.notifyDelegateFetchingIsDone(result: .failed)
             return
         }
-        
+
         // Fetch next messages to categorize
-        let lastMessage : ZMMessage? = (type == .client) ? self.lastClientMessage : self.lastAssetMessage
-        let messagesToAnalyze : [ZMMessage]
+        let lastMessage: ZMMessage? = (type == .client) ? self.lastClientMessage : self.lastAssetMessage
+        let messagesToAnalyze: [ZMMessage]
         if  type == .client {
             // Unfortunately this is the only way to infer the type :-/
-            let clientMessages : [ZMClientMessage] = self.messages(for: syncConversation, startAfter: lastMessage, fetchLimit: limit)
+            let clientMessages: [ZMClientMessage] = self.messages(for: syncConversation, startAfter: lastMessage, fetchLimit: limit)
             messagesToAnalyze = clientMessages
         } else {
-            let assetMessages : [ZMAssetClientMessage] = self.messages(for: syncConversation, startAfter: lastMessage, fetchLimit: limit)
+            let assetMessages: [ZMAssetClientMessage] = self.messages(for: syncConversation, startAfter: lastMessage, fetchLimit: limit)
             messagesToAnalyze = assetMessages
         }
-        
+
         // Determine whether we have reached the end of the messages, if so, set flags for completeness
         let didReachLastMessage = (messagesToAnalyze.count < limit)
         if didReachLastMessage {
@@ -172,44 +170,44 @@ public class AssetCollection : NSObject, ZMCollection {
             }
             return
         }
-        
+
         // Remember last message for next fetch
         if type == .client {
             self.lastClientMessage = messagesToAnalyze.last as? ZMClientMessage
         } else {
             self.lastAssetMessage = messagesToAnalyze.last as? ZMAssetClientMessage
         }
-        
+
         // Categorize messages
         let newAssets = AssetCollectionBatched.messageMap(messages: messagesToAnalyze, matchingCategories: self.matchingCategories)
         syncConversation.managedObjectContext?.enqueueDelayedSave()
-        
+
         // Notify delegate
         self.notifyDelegate(newAssets: newAssets, type: type, didReachLastMessage: didReachLastMessage)
-        
+
         // Return if done
         if didReachLastMessage {
             return
         }
-        
+
         syncConversation.managedObjectContext?.performGroupedBlock { [weak self] in
             guard let `self` = self, !self.tornDown else { return }
             self.fetchNextIfNotTornDown(limit: AssetCollection.defaultFetchCount, type: type, syncConversation: syncConversation)
         }
     }
-    
-    private func notifyDelegate(newAssets: [CategoryMatch : [ZMMessage]], type: MessagesToFetch?, didReachLastMessage: Bool) {
+
+    private func notifyDelegate(newAssets: [CategoryMatch: [ZMMessage]], type: MessagesToFetch?, didReachLastMessage: Bool) {
         if newAssets.count == 0 {
             return
         }
 
         uiMOC?.performGroupedBlock { [weak self] in
             guard let `self` = self, !self.tornDown else { return }
-            
+
             // Map to ui assets
-            var uiAssets = [CategoryMatch : [ZMMessage]]()
+            var uiAssets = [CategoryMatch: [ZMMessage]]()
             newAssets.forEach { (category, messages) in
-                let uiValues = messages.compactMap{ (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage}
+                let uiValues = messages.compactMap { (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage}
                 uiAssets[category] = uiValues
             }
 
@@ -219,37 +217,34 @@ public class AssetCollection : NSObject, ZMCollection {
             } else {
                 self.assets = uiAssets
             }
-            
+
             // Notify delegate
             self.delegate.assetCollectionDidFetch(collection: self, messages: uiAssets, hasMore: didReachLastMessage)
-            if (self.fetchingDone) {
+            if self.fetchingDone {
                 self.notifyDelegateFetchingIsDone(result: (self.assets == nil) ? .noAssetsToFetch : .success)
             }
         }
     }
-    
-    private func notifyDelegateFetchingIsDone(result: AssetFetchResult){
+
+    private func notifyDelegateFetchingIsDone(result: AssetFetchResult) {
         self.uiMOC?.performGroupedBlock { [weak self] in
             guard let `self` = self, !self.tornDown else { return }
             self.delegate.assetCollectionDidFinishFetching(collection: self, result: result)
         }
     }
-    
-    func messages<T: ZMMessage>(for conversation: ZMConversation, startAfter previousMessage: ZMMessage?, fetchLimit: Int) -> [T]  {
-        
-        let request : NSFetchRequest <T> = AssetCollectionBatched.fetchRequestForUnCategorizedMessages(in: conversation)
+
+    func messages<T: ZMMessage>(for conversation: ZMConversation, startAfter previousMessage: ZMMessage?, fetchLimit: Int) -> [T] {
+
+        let request: NSFetchRequest <T> = AssetCollectionBatched.fetchRequestForUnCategorizedMessages(in: conversation)
         if let serverTimestamp = previousMessage?.serverTimestamp {
             let messagePredicate = NSPredicate(format: "serverTimestamp < %@", serverTimestamp as NSDate)
             request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [request.predicate!, messagePredicate])
         }
         request.fetchLimit = fetchLimit
         request.returnsObjectsAsFaults = false
-        
+
         guard let result = conversation.managedObjectContext?.fetchOrAssert(request: request) else {return []}
         return result
     }
-    
+
 }
-
-
-

--- a/Source/Model/Conversation/Calling/ZMCallState.swift
+++ b/Source/Model/Conversation/Calling/ZMCallState.swift
@@ -16,11 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import CoreData
-import WireSystem;
-
+import WireSystem
 
 private let zmLog = ZMSLog(tag: "CallState")
 
@@ -28,7 +26,7 @@ private let UserInfoCallStateKey = "ZMCallState"
 private let UserInfoHasChangesKey = "zm_userInfoHasChanges"
 
 extension NSManagedObjectContext {
-    
+
     @objc public var zm_callState: ZMCallState {
         let oldState = self.userInfo[UserInfoCallStateKey] as? ZMCallState
         return oldState ?? { () -> ZMCallState in
@@ -37,15 +35,15 @@ extension NSManagedObjectContext {
             return state
         }()
     }
-    
+
     @objc public func zm_tearDownCallState() {
         if (self.userInfo[UserInfoCallStateKey] as? ZMCallState) != nil {
-            self.userInfo.removeObject(forKey: UserInfoCallStateKey);
+            self.userInfo.removeObject(forKey: UserInfoCallStateKey)
         }
     }
-    
+
     /// True if the context has some changes in the user info that should cause a save
-    @objc public var zm_hasUserInfoChanges : Bool {
+    @objc public var zm_hasUserInfoChanges: Bool {
         get {
             return (self.userInfo[UserInfoHasChangesKey] as? Bool) ?? false
         }
@@ -53,31 +51,31 @@ extension NSManagedObjectContext {
             self.userInfo[UserInfoHasChangesKey] = newValue
         }
     }
-    
+
     /// Checks hasChanges and callStateHasChanges.
     ///
     /// The call state changes do not dirty the context's objects, hence need to be tracked / checked seperately.
     @objc public var zm_hasChanges: Bool {
         return hasChanges || self.zm_hasUserInfoChanges
     }
-    
-    @objc public func mergeCallStateChanges(fromUserInfo userInfo: [String : Any]) {
+
+    @objc public func mergeCallStateChanges(fromUserInfo userInfo: [String: Any]) {
         guard self.zm_isSyncContext else { return } // we don't merge anything to UI, UI is autoritative
-        
+
         if let callState = self.userInfo[UserInfoCallStateKey] as? ZMCallState {
             _ = callState.mergeChangesFromState(userInfo[UserInfoCallStateKey] as? ZMCallState)
         }
     }
 }
 
-// MARK : Group Calling V3
+// MARK: Group Calling V3
 // This needs to be set to display the correct conversationListIndicator
 extension ZMConversation {
-    
+
     internal var callState: ZMConversationCallState {
         return managedObjectContext!.zm_callState.stateForConversation(self)
     }
-    
+
     @objc public var isIgnoringCall: Bool {
         get {
             return callState.isIgnoringCall
@@ -89,7 +87,7 @@ extension ZMConversation {
             }
         }
     }
-    
+
     @objc public var isCallDeviceActive: Bool {
         get {
             return callState.isCallDeviceActive
@@ -104,14 +102,14 @@ extension ZMConversation {
 }
 
 @objc
-open class ZMCallState : NSObject, Sequence {
-    
-    fileprivate var conversationStates: [NSManagedObjectID:ZMConversationCallState] = [:]
-    
-    fileprivate var allObjectIDs : Set<NSManagedObjectID> {
+open class ZMCallState: NSObject, Sequence {
+
+    fileprivate var conversationStates: [NSManagedObjectID: ZMConversationCallState] = [:]
+
+    fileprivate var allObjectIDs: Set<NSManagedObjectID> {
         return Set(conversationStates.keys)
     }
-    
+
     open func allContainedConversationsInContext(_ moc: NSManagedObjectContext) -> Set<ZMConversation> {
         var r = Set<ZMConversation>()
         for oid in allObjectIDs {
@@ -119,9 +117,9 @@ open class ZMCallState : NSObject, Sequence {
         }
         return r
     }
-    
+
     open func stateForConversation(_ conversation: NSManagedObject) -> ZMConversationCallState {
-        if (conversation.objectID.isTemporaryID) {
+        if conversation.objectID.isTemporaryID {
             do {
                 try conversation.managedObjectContext!.obtainPermanentIDs(for: [conversation])
             } catch let err {
@@ -130,7 +128,7 @@ open class ZMCallState : NSObject, Sequence {
         }
         return stateForConversationID(conversation.objectID)
     }
-    
+
     func stateForConversationID(_ conversationID: NSManagedObjectID) -> ZMConversationCallState {
         return conversationStates[conversationID] ?? {
             zmLog.debug("inserting new state for conversationID \(conversationID) into \(SwiftDebugging.address(self))")
@@ -139,51 +137,50 @@ open class ZMCallState : NSObject, Sequence {
             return newState
             }()
     }
-    
+
     public typealias Iterator = DictionaryIterator<NSManagedObjectID, ZMConversationCallState>
     open func makeIterator() -> Iterator {
         return conversationStates.makeIterator()
     }
-    
+
     open var isEmpty: Bool {
     	return conversationStates.isEmpty
     }
-    
+
     open override var description: String {
         return "CallState \(SwiftDebugging.address(self)) \n" +
         " --> states : \(conversationStates) \n"
     }
-    
-    open override var debugDescription : String {
+
+    open override var debugDescription: String {
         return description
     }
 }
 
 /// This is the call state for a specific conversation.
-open class ZMConversationCallState : NSObject {
-    
+open class ZMConversationCallState: NSObject {
+
     open var isCallDeviceActive: Bool = false
     open var isIgnoringCall: Bool = false
-    
+
     /// returns true if the merge changed the current state
     open func mergeChangesFromState(_ other: ZMConversationCallState) {
         isCallDeviceActive = other.isCallDeviceActive
         isIgnoringCall = other.isIgnoringCall
     }
 
-    open override var description : String {
+    open override var description: String {
         return "CallState \(SwiftDebugging.address(self)) \n" +
         " --> isCallDeviceActive: \(isCallDeviceActive) \n"
     }
-    
-    open override var debugDescription : String {
+
+    open override var debugDescription: String {
         return description
     }
 }
 
-
 extension ZMCallState {
-    
+
     /// returns true if one of the merged states changed due to the merge
     public func mergeChangesFromState(_ other: ZMCallState?) -> Set<NSManagedObjectID> {
         if let other = other {

--- a/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
+++ b/Source/Model/Conversation/Calling/ZMConversation+Calling.swift
@@ -16,13 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 public extension ZMConversation {
 
     @discardableResult
     @objc func appendMissedCallMessage(fromUser user: ZMUser, at timestamp: Date, relevantForStatus: Bool = true) -> ZMSystemMessage {
         let associatedMessage = associatedSystemMessage(of: .missedCall, sender: user)
-        
+
         let message = appendSystemMessage(
             type: .missedCall,
             sender: user,
@@ -31,11 +30,11 @@ public extension ZMConversation {
             timestamp: timestamp,
             relevantForStatus: relevantForStatus
         )
-        
+
         if isArchived && mutedMessageTypes == .none {
             isArchived = false
         }
-        
+
         associatedMessage?.addChild(message)
 
         managedObjectContext?.enqueueDelayedSave()
@@ -45,7 +44,7 @@ public extension ZMConversation {
     @discardableResult
     @objc func appendPerformedCallMessage(with duration: TimeInterval, caller: ZMUser) -> ZMSystemMessage {
         let associatedMessage = associatedSystemMessage(of: .performedCall, sender: caller)
-        
+
         let message = appendSystemMessage(
             type: .performedCall,
             sender: caller,
@@ -58,7 +57,7 @@ public extension ZMConversation {
         if isArchived && mutedMessageTypes == .none {
             isArchived = false
         }
-        
+
         associatedMessage?.addChild(message)
 
         managedObjectContext?.enqueueDelayedSave()
@@ -70,12 +69,11 @@ public extension ZMConversation {
               lastMessage.systemMessageType == type,
               lastMessage.sender == sender
         else { return nil }
-        
+
         return lastMessage
     }
 
 }
-
 
 public extension ZMSystemMessage {
 
@@ -83,7 +81,7 @@ public extension ZMSystemMessage {
         mutableSetValue(forKey: #keyPath(ZMSystemMessage.childMessages)).add(message)
         message.visibleInConversation = nil
         message.hiddenInConversation = conversation
-        
+
         managedObjectContext?.processPendingChanges()
     }
 

--- a/Source/Model/Conversation/ConversationCreationOptions.swift
+++ b/Source/Model/Conversation/ConversationCreationOptions.swift
@@ -20,10 +20,10 @@ import Foundation
 
 public struct ConversationCreationOptions {
     var participants: [ZMUser] = []
-    var name: String? = nil
-    var team: Team? = nil
+    var name: String?
+    var team: Team?
     var allowGuests: Bool = true
-    
+
     public init(participants: [ZMUser] = [], name: String? = nil, team: Team? = nil, allowGuests: Bool = true) {
         self.participants = participants
         self.name = name

--- a/Source/Model/Conversation/ConversationLike.swift
+++ b/Source/Model/Conversation/ConversationLike.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 public typealias Conversation = ConversationLike & SwiftConversationLike
@@ -26,7 +25,7 @@ public protocol ConversationLike: NSObjectProtocol {
     var conversationType: ZMConversationType { get }
     var isSelfAnActiveMember: Bool { get }
     var teamRemoteIdentifier: UUID? { get }
-    
+
     func localParticipantsContain(user: UserType) -> Bool
     var localParticipantsCount: Int { get }
 
@@ -36,15 +35,15 @@ public protocol ConversationLike: NSObjectProtocol {
 
     var isUnderLegalHold: Bool { get }
     var securityLevel: ZMConversationSecurityLevel { get }
-    
+
     func verifyLegalHoldSubjects()
 
     var sortedActiveParticipantsUserTypes: [UserType] { get }
-    
+
     var relatedConnectionState: ZMConnectionStatus { get }
     var lastMessage: ZMConversationMessage? { get }
     var firstUnreadMessage: ZMConversationMessage? { get }
-    
+
     var areServicesPresent: Bool { get }
 }
 
@@ -64,24 +63,24 @@ extension ZMConversation: ConversationLike {
     public var localParticipantsCount: Int {
         return localParticipants.count
     }
-    
+
     public func localParticipantsContain(user: UserType) -> Bool {
         guard let user = user as? ZMUser else { return false }
         return localParticipants.contains(user)
     }
-    
+
     public var connectedUserType: UserType? {
         return connectedUser
 	}
-	
+
 	private static let userNameSorter: (UserType, UserType) -> Bool = {
 		$0.name < $1.name
 	}
-	
+
 	public var sortedOtherParticipants: [UserType] {
 		return localParticipants.filter { !$0.isServiceUser }.sorted(by: ZMConversation.userNameSorter)
 	}
-	
+
 	public var sortedServiceUsers: [UserType] {
 		return localParticipants.filter { $0.isServiceUser }.sorted(by: ZMConversation.userNameSorter)
     }

--- a/Source/Model/Conversation/Member+Patches.swift
+++ b/Source/Model/Conversation/Member+Patches.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 extension Member {
 
@@ -32,5 +30,5 @@ extension Member {
     static private func migrateUserRemoteIdentifer(for member: Member) {
         member.remoteIdentifier = member.user?.remoteIdentifier
     }
-    
+
 }

--- a/Source/Model/Conversation/Member.swift
+++ b/Source/Model/Conversation/Member.swift
@@ -16,22 +16,21 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 @objcMembers public class Member: ZMManagedObject {
 
     @NSManaged public var team: Team?
     @NSManaged public var user: ZMUser?
     @NSManaged public var createdBy: ZMUser?
     @NSManaged public var createdAt: Date?
-    @NSManaged public var remoteIdentifier_data : Data?
+    @NSManaged public var remoteIdentifier_data: Data?
     @NSManaged private var permissionsRawValue: Int64
 
     public var permissions: Permissions {
         get {
-            return Permissions(rawValue: permissionsRawValue)            
+            return Permissions(rawValue: permissionsRawValue)
         }
         set {
-            permissionsRawValue = newValue.rawValue            
+            permissionsRawValue = newValue.rawValue
         }
     }
 
@@ -46,7 +45,7 @@
     public override static func defaultSortDescriptors() -> [NSSortDescriptor] {
         return []
     }
-    
+
     public var remoteIdentifier: UUID? {
         get {
             guard let data = remoteIdentifier_data else { return nil }
@@ -60,7 +59,7 @@
     @objc(getOrCreateMemberForUser:inTeam:context:)
     public static func getOrCreateMember(for user: ZMUser, in team: Team, context: NSManagedObjectContext) -> Member {
         precondition(context.zm_isSyncContext)
-        
+
         if let existing = user.membership {
             return existing
         }
@@ -78,18 +77,15 @@
 
 }
 
-
 // MARK: - Transport
 
-
-fileprivate enum ResponseKey: String {
+private enum ResponseKey: String {
     case user, permissions, createdBy = "created_by", createdAt = "created_at"
 
     enum Permissions: String {
         case `self`, copy
     }
 }
-
 
 extension Member {
 
@@ -101,11 +97,11 @@ extension Member {
         let createdAt = (payload[ResponseKey.createdAt.rawValue] as? String).flatMap(NSDate.init(transport:)) as Date?
         let createdBy = (payload[ResponseKey.createdBy.rawValue] as? String).flatMap(UUID.init)
         let member = getOrCreateMember(for: user, in: team, context: context)
-        
+
         member.updatePermissions(with: payload)
         member.createdAt = createdAt
         member.createdBy = createdBy.flatMap({ ZMUser.fetchOrCreate(with: $0, domain: nil, in: context) })
-        
+
         return member
     }
 

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 /// An optionSet indicates a user's permissions
 public struct Permissions: OptionSet {
 
@@ -48,17 +47,15 @@ public struct Permissions: OptionSet {
     // corresponding to one of these four bitmasks (roles). This is necessary
     // to establish a bijective mapping between these four bitmasks and the four
     // cases of the TeamRole enum.
-    
+
     public static let partner: Permissions = [.createConversation, .getTeamConversations]
-    public static let member:  Permissions = [.partner, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
-    public static let admin:   Permissions = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
-    public static let owner:   Permissions = [.admin, .getBilling, .setBilling, .deleteTeam]
+    public static let member: Permissions = [.partner, .deleteConversation, .addRemoveConversationMember, .modifyConversationMetaData, .getMemberPermissions]
+    public static let admin: Permissions = [.member, .addTeamMember, .removeTeamMember, .setTeamData, .setMemberPermissions]
+    public static let owner: Permissions = [.admin, .getBilling, .setBilling, .deleteTeam]
 
 }
 
-
 // MARK: - Debugging
-
 
 extension Permissions: CustomDebugStringConvertible {
 
@@ -71,7 +68,7 @@ extension Permissions: CustomDebugStringConvertible {
         .modifyConversationMetaData: "ModifyConversationMetaData",
         .getMemberPermissions: "GetMemberPermissions",
         .getTeamConversations: "GetTeamConversations",
-        .getBilling : "GetBilling",
+        .getBilling: "GetBilling",
         .setBilling: "SetBilling",
         .setTeamData: "SetTeamData",
         .deleteTeam: "DeleteTeam",
@@ -84,10 +81,9 @@ extension Permissions: CustomDebugStringConvertible {
 
 }
 
-
 extension Permissions: Hashable {
 
-    public var hashValue : Int {
+    public var hashValue: Int {
         return rawValue.hashValue
     }
 
@@ -102,7 +98,7 @@ extension Permissions: Hashable {
 ///
 @objc public enum TeamRole: Int {
     case none, partner, member, admin, owner
-    
+
     public init(rawPermissions: Int64) {
         switch rawPermissions {
         case Permissions.partner.rawValue:
@@ -117,7 +113,7 @@ extension Permissions: Hashable {
             self = .none
         }
     }
-    
+
     /// The permissions granted to this role.
     public var permissions: Permissions {
         switch self {
@@ -128,14 +124,13 @@ extension Permissions: Hashable {
         case .owner:   return .owner
         }
     }
-    
+
     /// Returns true if the role encompasses the given role.
     /// E.g An admin is a member, but a member is not an admin.
     public func isA(role: TeamRole) -> Bool {
         return hasPermissions(role.permissions)
     }
-    
-    
+
     /// Returns true if the role contains (all) the permissions.
     public func hasPermissions(_ permissions: Permissions) -> Bool {
         return self.permissions.isSuperset(of: permissions)
@@ -143,7 +138,7 @@ extension Permissions: Hashable {
 }
 
 extension Member {
-    
+
     @objc public func setTeamRole(_ role: TeamRole) {
         permissions = role.permissions
     }

--- a/Source/Model/Conversation/SelfDeletingMessages/MessageDestructionTimeoutValue.swift
+++ b/Source/Model/Conversation/SelfDeletingMessages/MessageDestructionTimeoutValue.swift
@@ -88,7 +88,6 @@ public enum MessageDestructionTimeoutValue: RawRepresentable, Hashable {
         }
     }
 
-
 }
 
 public extension MessageDestructionTimeoutValue {
@@ -164,7 +163,7 @@ public extension MessageDestructionTimeoutValue {
 
 }
 
-fileprivate let longStyleFormatter: DateComponentsFormatter = {
+private let longStyleFormatter: DateComponentsFormatter = {
     let formatter = DateComponentsFormatter()
     formatter.includesApproximationPhrase = false
     formatter.maximumUnitCount = 1

--- a/Source/Model/Conversation/SharedObjectStore.swift
+++ b/Source/Model/Conversation/SharedObjectStore.swift
@@ -16,13 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
-
 fileprivate extension Notification {
 
-    var contextDidSaveData: [AnyHashable : AnyObject] {
+    var contextDidSaveData: [AnyHashable: AnyObject] {
         guard let info = userInfo else { return [:] }
-        var changes = [AnyHashable : AnyObject]()
+        var changes = [AnyHashable: AnyObject]()
         for (key, value) in info {
             guard let set = value as? NSSet else { continue }
             changes[key] = set.compactMap {
@@ -108,7 +106,6 @@ fileprivate extension Notification {
     }
 }
 
-
 private let zmLog = ZMSLog(tag: "shared object store")
 
 // This class is needed to test unarchiving data saved before project rename
@@ -132,7 +129,7 @@ public class SharedObjectStore<T>: NSObject, NSKeyedUnarchiverDelegate {
         self.directory = accountContainer.appendingPathComponent(directoryName)
         self.url = directory.appendingPathComponent(fileName)
         super.init()
-        FileManager.default.createAndProtectDirectory(at:directory)
+        FileManager.default.createAndProtectDirectory(at: directory)
     }
 
     @discardableResult public func store(_ object: T) -> Bool {
@@ -167,7 +164,7 @@ public class SharedObjectStore<T>: NSObject, NSKeyedUnarchiverDelegate {
             return []
         }
     }
-    
+
     public func unarchiver(_ unarchiver: NSKeyedUnarchiver, cannotDecodeObjectOfClassName name: String, originalClasses classNames: [String]) -> Swift.AnyClass? {
         let oldModulePrefix = "ZMCDataModel"
         if let modulePrefixRange = name.range(of: oldModulePrefix) {
@@ -186,5 +183,5 @@ public class SharedObjectStore<T>: NSObject, NSKeyedUnarchiverDelegate {
             zmLog.error("Failed to remove item at url: \(url), error: \(error)")
         }
     }
-    
+
 }

--- a/Source/Model/Conversation/Team+Patches.swift
+++ b/Source/Model/Conversation/Team+Patches.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 extension Team {
 
@@ -27,11 +25,11 @@ extension Team {
     // deletion rule (Team → Member). Conversations will be preserved but their teams realtion will be nullified.
     static func deleteLocalTeamsAndMembers(in context: NSManagedObjectContext) {
         let request = Team.sortedFetchRequest()
-        
+
         guard let teams = context.fetchOrAssert(request: request) as? [NSManagedObject] else {
             return
         }
-        
+
         teams.forEach(context.delete)
     }
 

--- a/Source/Model/Conversation/Team.swift
+++ b/Source/Model/Conversation/Team.swift
@@ -94,7 +94,7 @@ public class Team: ZMManagedObject, TeamType {
 }
 
 extension Team {
-    
+
     public func members(matchingQuery query: String) -> [Member] {
         let searchPredicate = ZMUser.predicateForAllUsers(withSearch: query)
 
@@ -112,7 +112,6 @@ extension Team {
         return featureFlags.first(where: {$0.identifier == type.rawValue})
     }
 }
-
 
 // MARK: - Logo Image
 extension Team {
@@ -132,7 +131,7 @@ extension Team {
                     NotificationDispatcher.notifyNonCoreDataChanges(objectID: objectID, changedKeys: [#keyPath(Team.imageData)], uiContext: uiContext)
                 }
             }
-            
+
             guard let newValue = newValue else {
                 managedObjectContext?.zm_fileAssetCache.deleteAssetData(for: self, format: Team.defaultLogoFormat, encrypted: false)
                 return
@@ -152,7 +151,7 @@ extension Team {
 
     public static var imageDownloadFilter: NSPredicate {
         let assetIdExists = NSPredicate(format: "(%K != nil)", Team.pictureAssetIdKey)
-        let notCached = NSPredicate() { (team, _) -> Bool in
+        let notCached = NSPredicate { (team, _) -> Bool in
             guard let team = team as? Team else { return false }
             return team.imageData == nil
         }

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -21,7 +21,7 @@ import Foundation
 /// Defines how users can join a conversation.
 public struct ConversationAccessMode: OptionSet {
     public let rawValue: Int
-    
+
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
@@ -33,7 +33,7 @@ public struct ConversationAccessMode: OptionSet {
     public static let link      = ConversationAccessMode(rawValue: 1 << 2)
     /// Internal value that indicates the conversation that cannot be joined (1-1).
     public static let `private` = ConversationAccessMode(rawValue: 1 << 3)
-    
+
     public static let legacy    = invite
     public static let teamOnly  = ConversationAccessMode()
     public static let allowGuests: ConversationAccessMode = [.invite, .code]
@@ -50,11 +50,11 @@ public extension ConversationAccessMode {
                                                                           .code: "code",
                                                                           .link: "link",
                                                                           .`private`: "private"]
-    
+
     var stringValue: [String] {
         return ConversationAccessMode.stringValues.compactMap { self.contains($0) ? $1 : nil }
     }
-    
+
     init(values: [String]) {
         var result = ConversationAccessMode()
         ConversationAccessMode.stringValues.forEach {
@@ -89,9 +89,9 @@ public extension ConversationAccessRole {
 }
 
 extension ZMConversation: SwiftConversationLike {
-    @NSManaged @objc dynamic internal var accessModeStrings: [String]?
-    @NSManaged @objc dynamic internal var accessRoleString: String?
-    
+    @NSManaged dynamic internal var accessModeStrings: [String]?
+    @NSManaged dynamic internal var accessRoleString: String?
+
     public var sortedActiveParticipantsUserTypes: [UserType] {
         return sortedActiveParticipants
     }
@@ -112,9 +112,9 @@ extension ZMConversation: SwiftConversationLike {
             accessRole = ConversationAccessRole.value(forAllowGuests: newValue)
         }
     }
-    
+
     // The conversation access mode is stored as an array of string in CoreData, cf. `acccessModeStrings`.
-    
+
     /// Defines how users can join a conversation.
     public var accessMode: ConversationAccessMode? {
         get {
@@ -132,14 +132,14 @@ extension ZMConversation: SwiftConversationLike {
             accessModeStrings = value.stringValue
         }
     }
-    
+
     /// Defines who can join the conversation.
     public var accessRole: ConversationAccessRole? {
         get {
             guard let strings = self.accessRoleString else {
                 return nil
             }
-            
+
             return ConversationAccessRole(rawValue: strings)
         }
         set {
@@ -151,4 +151,3 @@ extension ZMConversation: SwiftConversationLike {
         }
     }
 }
-

--- a/Source/Model/Conversation/ZMConversation+Confirmations.swift
+++ b/Source/Model/Conversation/ZMConversation+Confirmations.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 extension ZMConversation {
-    
-    @NSManaged @objc dynamic public var hasReadReceiptsEnabled: Bool
-    
+
+    @NSManaged dynamic public var hasReadReceiptsEnabled: Bool
+
     /// Confirm unread received messages as read.
     ///
     /// - Parameters:
@@ -31,7 +31,7 @@ extension ZMConversation {
     func confirmUnreadMessagesAsRead(in range: ClosedRange<Date>) -> [ZMClientMessage] {
         let unreadMessagesNeedingConfirmation = unreadMessages(in: range).filter(\.needsReadConfirmation)
         var confirmationMessages: [ZMClientMessage] = []
-        
+
         for messages in unreadMessagesNeedingConfirmation.partition(by: \.sender).values {
             guard
                 !messages.isEmpty,
@@ -48,10 +48,10 @@ extension ZMConversation {
             }
 
         }
-        
+
         return confirmationMessages
     }
-    
+
     @discardableResult @objc
     public func appendMessageReceiptModeChangedMessage(fromUser user: ZMUser, timestamp: Date, enabled: Bool) -> ZMSystemMessage {
         let message = appendSystemMessage(
@@ -61,14 +61,14 @@ extension ZMConversation {
             clients: nil,
             timestamp: timestamp
         )
-        
+
         if isArchived && mutedMessageTypes == .none {
             isArchived = false
         }
-        
+
         return message
     }
-    
+
     @discardableResult @objc
     public func appendMessageReceiptModeIsOnMessage(timestamp: Date) -> ZMSystemMessage {
         let message = appendSystemMessage(
@@ -78,8 +78,8 @@ extension ZMConversation {
             clients: nil,
             timestamp: timestamp
         )
-        
+
         return message
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+DeleteOlderMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+DeleteOlderMessages.swift
@@ -16,25 +16,24 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMConversation {
     @objc public func deleteOlderMessages() {
-        
+
         guard let managedObjectContext = self.managedObjectContext,
               let clearedTimeStamp = self.clearedTimeStamp,
               managedObjectContext.zm_isSyncContext else {
             return
         }
-        
+
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ZMMessage.entityName())
         fetchRequest.predicate = NSPredicate(format: "(%K == %@ OR %K == %@) AND %K <= %@",
                                              ZMMessageConversationKey, self,
                                              ZMMessageHiddenInConversationKey, self,
                                              #keyPath(ZMMessage.serverTimestamp),
                                              clearedTimeStamp as CVarArg)
-        
+
         let result = try! managedObjectContext.fetch(fetchRequest) as! [ZMMessage]
 
         for element in result {

--- a/Source/Model/Conversation/ZMConversation+Deletion.swift
+++ b/Source/Model/Conversation/ZMConversation+Deletion.swift
@@ -19,11 +19,11 @@
 import Foundation
 
 extension ZMConversation {
-    
+
     open override func prepareForDeletion() {
         super.prepareForDeletion()
-        
-        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache?.deleteAssetData($0)} )
+
+        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache?.deleteAssetData($0)})
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+DisplayName.swift
+++ b/Source/Model/Conversation/ZMConversation+DisplayName.swift
@@ -16,13 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 public extension ZMConversation {
 
     @objc static private var emptyConversationEllipsis: String {
         return "…"
     }
-    
+
     @objc static private var emptyGroupConversationName: String {
         return NSLocalizedString("conversation.displayname.emptygroup", comment: "")
     }
@@ -39,7 +38,7 @@ public extension ZMConversation {
         case .self, .invalid: return result ?? ""
         }
     }
-    
+
     /// A meaningful display name is one that can be constructed from the conversation
     /// data, rather than relying on a fallback placeholder name, such as "…" or "Empty conversation".
     ///
@@ -52,7 +51,7 @@ public extension ZMConversation {
         case .invalid: return nil
         }
     }
-    
+
     private func connectionDisplayName() -> String? {
         precondition(conversationType == .connection)
 
@@ -69,8 +68,7 @@ public extension ZMConversation {
     private var selfUser: ZMUser? {
         return managedObjectContext.map(ZMUser.selfUser)
     }
-    
-    
+
     /// Get the group name from the participants
     ///
     /// - Returns: a group name with creator at the first and other users sorted by name
@@ -80,12 +78,12 @@ public extension ZMConversation {
         if let userDefined = userDefinedName, !userDefined.isEmpty {
             return userDefined
         }
-        
+
         let activeNames: [String] = localParticipants.compactMap { (user) -> String? in
             guard user != selfUser else { return nil }
             return user.name
         }
-        
+
         return activeNames.isEmpty ? nil : activeNames.sorted().joined(separator: ", ")
     }
 

--- a/Source/Model/Conversation/ZMConversation+EncryptionAtRest.swift
+++ b/Source/Model/Conversation/ZMConversation+EncryptionAtRest.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMConversation: EncryptionAtRestMigratable {

--- a/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -59,7 +59,7 @@ extension ZMConversation {
         guard conversationType == .group else { return [] }
 
         // Exception 2) If there is only one user in the group and it's a service, we don't consider it as external
-        let participants = Set(self.localParticipants) 
+        let participants = Set(self.localParticipants)
         let selfUser = ZMUser.selfUser(in: managedObjectContext!)
         let otherUsers = participants.subtracting([selfUser])
 

--- a/Source/Model/Conversation/ZMConversation+HasMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+HasMessages.swift
@@ -19,21 +19,21 @@
 import Foundation
 
 @objc public extension ZMConversation {
-    
+
     /// Specifies whether the conversation has content.
     ///
     /// This is an optimized O(1) computation that avoids making Core Data fetch
     /// requests, however it does not guarantee the validity of the result. Use
     /// this in when the need for permformance outweighs the need for accuracy.
     ///
-    @objc var estimatedHasMessages: Bool {
+    var estimatedHasMessages: Bool {
         // If we haven't read any messages, then we don't have any.
         guard let lastRead = lastReadServerTimeStamp else { return false }
-        
+
         // If we've read something, but have never cleared, then we have
         // messages.
         guard let cleared = clearedTimeStamp else { return true }
-        
+
         // If we've read messages after the cleared date, then we have
         // messages.
         return lastRead > cleared

--- a/Source/Model/Conversation/ZMConversation+Labels.swift
+++ b/Source/Model/Conversation/ZMConversation+Labels.swift
@@ -19,14 +19,14 @@
 import Foundation
 
 extension ZMConversation {
-    
+
     @objc
     public var isFavorite: Bool {
         set {
             guard let managedObjectContext = managedObjectContext else { return }
-            
+
             let favoriteLabel = Label.fetchFavoriteLabel(in: managedObjectContext)
-            
+
             if newValue {
                 assignLabel(favoriteLabel)
             } else {
@@ -37,36 +37,36 @@ extension ZMConversation {
             return labels.any({ $0.kind == .favorite })
         }
     }
-    
+
     @objc
     public var folder: LabelType? {
         return labels.first(where: { $0.kind == .folder })
     }
-    
+
     @objc
     public func moveToFolder(_ folder: LabelType) {
         guard let label = folder as? Label, !label.isZombieObject, label.kind == .folder else { return }
-        
+
         removeFromFolder()
         assignLabel(label)
     }
-    
+
     @objc
     public func removeFromFolder() {
         let existingFolders = labels.filter({ $0.kind == .folder })
         labels.subtract(existingFolders)
-        
-        for emptyFolder in existingFolders.filter({ $0.conversations.isEmpty} ) {
+
+        for emptyFolder in existingFolders.filter({ $0.conversations.isEmpty}) {
             emptyFolder.markForDeletion()
         }
     }
-    
+
     func assignLabel(_ label: Label) {
         labels.insert(label)
     }
-    
+
     func removeLabel(_ label: Label) {
         labels.remove(label)
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+LastMessages.swift
+++ b/Source/Model/Conversation/ZMConversation+LastMessages.swift
@@ -21,7 +21,7 @@ import Foundation
 extension ZMConversation {
     public var visibleMessagesPredicate: NSPredicate? {
         var allPredicates: [NSPredicate] = []
-        
+
         if let clearedTimeStamp = self.clearedTimeStamp {
             // This must filter out:
             // 1. Messages that are older than clearedTimeStamp.
@@ -30,9 +30,9 @@ extension ZMConversation {
             let messageIsNotCleared = NSPredicate(format: "%K > %@", #keyPath(ZMMessage.serverTimestamp), clearedTimeStamp as CVarArg)
             allPredicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: [deliveryIsPendingPredicate, messageIsNotCleared]))
         }
-        
+
         allPredicates.append(NSPredicate(format: "%K == %@", #keyPath(ZMMessage.visibleInConversation), self))
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: allPredicates)
     }
 }
@@ -42,28 +42,28 @@ extension ZMConversation {
     /// Returns a list of the most recent messages in the conversation, ordered from most recent to oldest.
     @objc public func lastMessages(limit: Int = 256) -> [ZMMessage] {
         guard let managedObjectContext = managedObjectContext else { return [] }
-        
+
         let fetchRequest = NSFetchRequest<ZMMessage>(entityName: ZMMessage.entityName())
         fetchRequest.fetchLimit = limit
         fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(ZMMessage.visibleInConversation), self)
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(ZMMessage.serverTimestamp), ascending: false)]
-        
+
         return managedObjectContext.fetchOrAssert(request: fetchRequest)
     }
-    
+
     /// Returns the most recent message in the conversation.
     @objc public var lastMessage: ZMConversationMessage? {
         return lastMessages(limit: 1).first
     }
-    
+
     /// Returns the most recent message sent by a particular user in the conversation.
     public func lastMessageSent(by user: ZMUser) -> ZMMessage? {
         let fetchRequest = NSFetchRequest<ZMMessage>(entityName: ZMMessage.entityName())
         fetchRequest.fetchLimit = 1
         fetchRequest.predicate = NSPredicate(format: "%K == %@ AND %K == %@", #keyPath(ZMMessage.visibleInConversation), self, #keyPath(ZMMessage.sender), user)
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(ZMMessage.serverTimestamp), ascending: false)]
-        
+
         return self.managedObjectContext?.fetchOrAssert(request: fetchRequest).first
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/Source/Model/Conversation/ZMConversation+Message.swift
@@ -58,7 +58,6 @@ extension ZMConversation {
 
     }
 
-
     /// Appends a button action message.
     ///
     /// - Parameters:
@@ -181,7 +180,7 @@ extension ZMConversation {
     ///     The appended message.
 
     @discardableResult
-    public func appendImage(at URL: URL, nonce: UUID = UUID()) throws -> ZMConversationMessage  {
+    public func appendImage(at URL: URL, nonce: UUID = UUID()) throws -> ZMConversationMessage {
         guard
             URL.isFileURL,
             ZMImagePreprocessor.sizeOfPrerotatedImage(at: URL) != .zero,
@@ -260,7 +259,6 @@ extension ZMConversation {
             }
         }
     }
-
 
     private func append(asset: WireProtos.Asset,
                         nonce: UUID,
@@ -376,19 +374,18 @@ extension ZMConversation {
         }
     }
 
-
 }
 
-@objc 
+@objc
 extension ZMConversation {
-    
+
     // MARK: - Objective-C compability methods
-    
+
     @discardableResult @objc(appendMessageWithText:)
     public func _appendText(content: String) -> ZMConversationMessage? {
         return try? appendText(content: content)
     }
-    
+
     @discardableResult @objc(appendMessageWithText:fetchLinkPreview:)
     public func _appendText(content: String, fetchLinkPreview: Bool) -> ZMConversationMessage? {
         return try? appendText(content: content, fetchLinkPreview: fetchLinkPreview)
@@ -419,17 +416,17 @@ extension ZMConversation {
                                fetchLinkPreview: fetchLinkPreview,
                                nonce: nonce)
     }
-    
+
     @discardableResult @objc(appendKnock)
     public func _appendKnock() -> ZMConversationMessage? {
         return try? appendKnock()
     }
-    
+
     @discardableResult @objc(appendMessageWithLocationData:)
     public func _appendLocation(with locationData: LocationData) -> ZMConversationMessage? {
         return try? appendLocation(with: locationData)
     }
-    
+
     @discardableResult @objc(appendMessageWithImageData:)
     public func _appendImage(from imageData: Data) -> ZMConversationMessage? {
         return try? appendImage(from: imageData)

--- a/Source/Model/Conversation/ZMConversation+MessageDeletion.swift
+++ b/Source/Model/Conversation/ZMConversation+MessageDeletion.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
 extension ZMConversation {
@@ -28,6 +27,6 @@ extension ZMConversation {
                                  users: nil,
                                  clients: nil,
                                  timestamp: date)
-        
+
     }
 }

--- a/Source/Model/Conversation/ZMConversation+Mute.swift
+++ b/Source/Model/Conversation/ZMConversation+Mute.swift
@@ -37,37 +37,37 @@ public enum MutedMessageOptionValue: Int32 {
 /// +--------------------+----------------+----------------------------------------+--------+
 public struct MutedMessageTypes: OptionSet {
     public let rawValue: Int32
-    
+
     public init(rawValue: Int32) {
         self.rawValue = rawValue
     }
-    
+
     /// None of the messages are muted.
     public static let none = MutedMessageTypes(rawValue: MutedMessageOptionValue.none.rawValue)
 
     /// All messages, including mentions and replies, are muted.
     public static let all: MutedMessageTypes = [.regular, .mentionsAndReplies]
-    
+
     /// Only regular messages (no mentions nor replies) are muted.
     public static let regular = MutedMessageTypes(rawValue: MutedMessageOptionValue.regular.rawValue)
-    
+
     /// Only mentions and replies are muted. Only used to check the bits in the bitmask.
     /// Please do not set this as the value on the conversation.
     public static let mentionsAndReplies = MutedMessageTypes(rawValue: MutedMessageOptionValue.mentionsAndReplies.rawValue)
 }
 
 public extension ZMConversation {
-    @NSManaged @objc var mutedStatus: Int32
-    
+    @NSManaged var mutedStatus: Int32
+
     /// Returns an option set of messages types which should be muted
     var mutedMessageTypes: MutedMessageTypes {
         get {
             guard let managedObjectContext = self.managedObjectContext else {
                 return .none
             }
-            
+
             let selfUser = ZMUser.selfUser(in: managedObjectContext)
-            
+
             if selfUser.hasTeam {
                 return MutedMessageTypes(rawValue: mutedStatus)
             }
@@ -79,23 +79,23 @@ public extension ZMConversation {
             guard let managedObjectContext = self.managedObjectContext else {
                 return
             }
-            
+
             let selfUser = ZMUser.selfUser(in: managedObjectContext)
-            
+
             if selfUser.hasTeam {
                 mutedStatus = newValue.rawValue
             }
             else {
                 mutedStatus = (newValue == .none) ? MutedMessageOptionValue.none.rawValue : (MutedMessageOptionValue.all.rawValue)
             }
-            
+
             if managedObjectContext.zm_isUserInterfaceContext,
                 let lastServerTimestamp = self.lastServerTimeStamp {
                 updateMuted(lastServerTimestamp, synchronize: true)
             }
         }
     }
-    
+
     /// Returns an option set of messages types which should be muted when also considering the
     /// the availability status of the self user.
     var mutedMessageTypesIncludingAvailability: MutedMessageTypes {
@@ -103,7 +103,7 @@ public extension ZMConversation {
             guard let managedObjectContext = self.managedObjectContext else {
                 return .none
             }
-            
+
             let selfUser = ZMUser.selfUser(in: managedObjectContext)
             return selfUser.mutedMessagesTypes.union(mutedMessageTypes)
         }
@@ -111,7 +111,7 @@ public extension ZMConversation {
 }
 
 extension ZMUser {
-    
+
     var mutedMessagesTypes: MutedMessageTypes {
         switch availability {
         case .available, .none:
@@ -122,7 +122,7 @@ extension ZMUser {
             return .all
         }
     }
-    
+
 }
 
 public extension ZMConversation {

--- a/Source/Model/Conversation/ZMConversation+Notifications.swift
+++ b/Source/Model/Conversation/ZMConversation+Notifications.swift
@@ -29,7 +29,7 @@ extension ZMConversation {
         guard let userInterfaceContext = self.managedObjectContext?.zm_userInterface else {
             return
         }
-        
+
         userInterfaceContext.performGroupedBlock {
             NotificationInContext(name: name, context: userInterfaceContext.notificationContext, object: self).post()
         }

--- a/Source/Model/Conversation/ZMConversation+ObserverHelper.swift
+++ b/Source/Model/Conversation/ZMConversation+ObserverHelper.swift
@@ -18,33 +18,33 @@
 
 import Foundation
 
-class ConversationObserverToken : NSObject, ZMConversationObserver {
-    
+class ConversationObserverToken: NSObject, ZMConversationObserver {
+
     let block : () -> Void
-    let filter : (ConversationChangeInfo) -> Bool
-    var token : NSObjectProtocol? = nil
-    
+    let filter: (ConversationChangeInfo) -> Bool
+    var token: NSObjectProtocol?
+
     init(filter:  @escaping (ConversationChangeInfo) -> Bool, block: @escaping () -> Void ) {
         self.block = block
         self.filter = filter
     }
-    
+
     func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
         if filter(changeInfo) {
             block()
         }
     }
-    
+
 }
 
 public extension ZMConversation {
-    
+
     func onCreatedRemotely(_ block : @escaping () -> Void) -> NSObjectProtocol? {
         guard remoteIdentifier == nil else { block(); return nil }
-        
+
         let observer = ConversationObserverToken(filter: { $0.createdRemotelyChanged }, block: block)
         observer.token = ConversationChangeInfo.add(observer: observer, for: self)
         return observer
     }
-    
+
 }

--- a/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -25,7 +25,7 @@ extension ZMConversation {
     static func predicateSecureWithIgnored() -> NSPredicate {
         return NSPredicate(format: "%K == %d", #keyPath(ZMConversation.securityLevel), ZMConversationSecurityLevel.secureWithIgnored.rawValue)
     }
-    
+
     /// After changes to conversation security degradation logic we need
     /// to migrate all conversations from .secureWithIgnored to .notSecure
     /// so that users wouldn't get degratation prompts to conversations that 
@@ -34,7 +34,7 @@ extension ZMConversation {
         let predicate = ZMConversation.predicateSecureWithIgnored()
 
         let request = ZMConversation.sortedFetchRequest(with: predicate)
-        
+
         guard let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
             fatal("fetchOrAssert failed")
         }
@@ -43,7 +43,7 @@ extension ZMConversation {
             conversation.securityLevel = .notSecure
         }
     }
-    
+
     // Migration rules for the Model version 2.78.0
     static func introduceParticipantRoles(in moc: NSManagedObjectContext) {
         migrateUsersToParticipants(in: moc)
@@ -51,29 +51,29 @@ extension ZMConversation {
         addUserFromTheConnectionToTheParticipantRoles(in: moc)
         forceToFetchConversationRoles(in: moc)
     }
-    
+
     // Model version 2.78.0 adds a `participantRoles` attribute to the `Conversation` entity.
     // The set should contain the self user if 'isSelfAnActiveMember' is true.
     static func migrateIsSelfAnActiveMemberToTheParticipantRoles(in moc: NSManagedObjectContext) {
         let selfUser = ZMUser.selfUser(in: moc)
-        
+
         let request = ZMConversation.sortedFetchRequest()
-        
+
         guard let allConversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
             fatal("fetchOrAssert failed")
         }
-                
+
         for conversation in allConversations {
-            
+
             let oldKey = "isSelfAnActiveMember"
             conversation.willAccessValue(forKey: oldKey)
             let isSelfAnActiveMember = (conversation.primitiveValue(forKey: oldKey) as! NSNumber).boolValue
             conversation.didAccessValue(forKey: oldKey)
-            
+
             if isSelfAnActiveMember {
                 var participantRoleForSelfUser: ParticipantRole
-                let adminRole = conversation.getRoles().first(where: {$0.name == defaultAdminRoleName} )
-                
+                let adminRole = conversation.getRoles().first(where: {$0.name == defaultAdminRoleName})
+
                 if let conversationTeam = conversation.team, conversationTeam == selfUser.team, selfUser.isTeamMember {
                     participantRoleForSelfUser = getAParticipantRole(in: moc, adminRole: adminRole, user: selfUser, conversation: conversation, team: conversationTeam)
                 } else {
@@ -83,11 +83,11 @@ extension ZMConversation {
             }
         }
     }
-    
+
     static private func getAParticipantRole(in moc: NSManagedObjectContext, adminRole: Role?, user: ZMUser, conversation: ZMConversation, team: Team?) -> ParticipantRole {
         let participantRoleForUser = ParticipantRole.create(managedObjectContext: moc, user: user, conversation: conversation)
         let customRole = Role.fetchOrCreateRole(with: defaultAdminRoleName, teamOrConversation: team != nil ? .team(team!) : .conversation(conversation), in: moc)
-        
+
         if let adminRole = adminRole {
             participantRoleForUser.role = adminRole
         } else {
@@ -95,60 +95,60 @@ extension ZMConversation {
         }
         return participantRoleForUser
     }
-    
+
     // Model version 2.78.0 adds a `participantRoles` attribute to the `Conversation` entity.
     // After creating a new connection, we should add user to the participants roles, because we do not get it from the backend.
     static func addUserFromTheConnectionToTheParticipantRoles(in moc: NSManagedObjectContext) {
         guard let allConnections = ZMConnection.connections(inManagedObjectContext: moc) as? [ZMConnection] else { return }
-        
+
         for connection in allConnections {
             guard let conversation = connection.conversation,
                   let user = connection.to else { continue }
-            
+
             conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         }
     }
-    
+
     // Model version 2.78.0 adds a `participantRoles` attribute to the `Conversation` entity,
     // and `Role` to `Team` and `ZMConversation`. All group conversation memberships need to be refetched
     // in order to get which roles the users have. Additionally, we need to download the roles
     // definitions for teams and conversations.
     static func forceToFetchConversationRoles(in moc: NSManagedObjectContext) {
-        
+
         // Mark group conversation membership to be refetched
         let selfUser = ZMUser.selfUser(in: moc)
-        
+
         let groupConversationsFetch = ZMConversation.sortedFetchRequest(
             with: NSPredicate(format: "%K == %d",
                               ZMConversationConversationTypeKey,
                               ZMConversationType.group.rawValue))
-        
+
         guard let conversations = moc.fetchOrAssert(request: groupConversationsFetch) as? [ZMConversation] else {
                 fatal("fetchOrAssert failed")
         }
-        
+
         conversations.forEach {
             guard $0.isSelfAnActiveMember else { return }
             $0.needsToBeUpdatedFromBackend = true
             $0.needsToDownloadRoles = $0.team == nil || $0.team != selfUser.team
         }
-        
+
         // Mark team as need to download roles
         selfUser.team?.needsToDownloadRoles = true
     }
-    
+
     // Model version 2.78.0 adds a `participantRoles` attribute to the `Conversation` entity, and deprecates the `lastServerSyncedActiveParticipants`.
     // Those need to be migrated to the new relationship
     static func migrateUsersToParticipants(in moc: NSManagedObjectContext) {
-        
+
         let oldKey = "lastServerSyncedActiveParticipants"
-        
+
         let request = ZMConversation.sortedFetchRequest()
-        
+
         guard let conversations = moc.fetchOrAssert(request: request) as? [ZMConversation] else {
                 fatal("fetchOrAssert failed")
         }
-        
+
         conversations.forEach { convo in
             let users = (convo.value(forKey: oldKey) as! NSOrderedSet).array as? [ZMUser]
             users?.forEach { user in

--- a/Source/Model/Conversation/ZMConversation+Predicates.swift
+++ b/Source/Model/Conversation/ZMConversation+Predicates.swift
@@ -18,9 +18,8 @@
 
 import Foundation
 
-
 extension ZMConversation {
-    
+
     override open class func predicateForFilteringResults() -> NSPredicate {
         let selfType = ZMConversationType.init(rawValue: 1)!
         return NSPredicate(format: "\(ZMConversationConversationTypeKey) != \(ZMConversationType.invalid.rawValue) && \(ZMConversationConversationTypeKey) != \(selfType.rawValue)")
@@ -30,11 +29,11 @@ extension ZMConversation {
     public class func predicate(forSearchQuery searchQuery: String, selfUser: ZMUser) -> NSPredicate! {
 
         let convoNameMatching = userDefinedNamePredicate(forSearch: searchQuery)
-        
+
         let selfUserIsMember = NSPredicate(format: "%K == NULL OR (ANY %K.user == %@)", ZMConversationClearedTimeStampKey, ZMConversationParticipantRolesKey, selfUser)
-        
+
         let groupOnly = NSPredicate(format: "(\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue))")
-        
+
         let notTeamOneToOne = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForTeamOneToOneConversation())
 
         let userNamesMatching = predicateForConversationWithUsers(
@@ -43,7 +42,7 @@ extension ZMConversation {
         )
         let queryMatching = NSCompoundPredicate(
             orPredicateWithSubpredicates: [userNamesMatching, convoNameMatching])
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             queryMatching,
             selfUserIsMember,
@@ -51,16 +50,15 @@ extension ZMConversation {
             notTeamOneToOne
             ])
     }
-    
+
     private class func predicateForConversationWithUsers(matchingQuery query: String,
                                                          selfUser: ZMUser) -> NSPredicate {
         let roleNameMatchingRegexes = query.words.map { ".*\\b\(NSRegularExpression.escapedPattern(for: $0).lowercased()).*" }
-        
+
         let roleNameMatchingConditions = roleNameMatchingRegexes.map { _ in
             "$role.user.normalizedName MATCHES %@"
             }.joined(separator: " OR ")
 
-        
         return NSPredicate(
             format: "SUBQUERY(%K, $role, $role.user != %@ AND (\(roleNameMatchingConditions))).@count > 0",
             argumentArray: [
@@ -83,75 +81,75 @@ extension ZMConversation {
     class func predicateForPendingConversations() -> NSPredicate {
         let basePredicate = predicateForFilteringResults()
         let pendingConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.connection.rawValue) AND \(ZMConversationConnectionKey).status == \(ZMConnectionStatus.pending.rawValue)")
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, pendingConversationPredicate])
     }
-    
+
     @objc(predicateForClearedConversations)
     class func predicateForClearedConversations() -> NSPredicate {
         let cleared = NSPredicate(format: "\(ZMConversationClearedTimeStampKey) != NULL AND \(ZMConversationIsArchivedKey) == YES")
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [cleared, predicateForValidConversations()])
     }
 
     @objc(predicateForConversationsIncludingArchived)
     class func predicateForConversationsIncludingArchived() -> NSPredicate {
         let notClearedTimestamp = NSPredicate(format: "\(ZMConversationClearedTimeStampKey) == NULL OR \(ZMConversationLastServerTimeStampKey) > \(ZMConversationClearedTimeStampKey) OR (\(ZMConversationLastServerTimeStampKey) == \(ZMConversationClearedTimeStampKey) AND \(ZMConversationIsArchivedKey) == NO)")
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [notClearedTimestamp, predicateForValidConversations()])
     }
-    
+
     @objc(predicateForGroupConversations)
     class func predicateForGroupConversations() -> NSPredicate {
         let groupConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
         let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
         let notTeamOneToOneConveration = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForTeamOneToOneConversation())
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), groupConversationPredicate, notInFolderPredicate, notTeamOneToOneConveration])
     }
-    
+
     @objc(predicateForLabeledConversations:)
     class func predicateForLabeledConversations(_ label: Label) -> NSPredicate {
         let labelPredicate = NSPredicate(format: "%@ IN \(ZMConversationLabelsKey)", label)
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), labelPredicate])
     }
-    
+
     class func predicateForConversationsInFolders() -> NSPredicate {
         return NSPredicate(format: "ANY %K.%K == \(Label.Kind.folder.rawValue)", ZMConversationLabelsKey, #keyPath(Label.type))
     }
-    
+
     class func predicateForUnconnectedConversations() -> NSPredicate {
         return NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.connection.rawValue)")
     }
-    
+
     class func predicateForOneToOneConversation() -> NSPredicate {
         return NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.oneOnOne.rawValue)")
     }
-    
+
     class func predicateForTeamOneToOneConversation() -> NSPredicate {
         // We consider a conversation being an existing 1:1 team conversation in case the following point are true:
         //  1. It is a conversation inside a team
         //  2. The only participants are the current user and the selected user
         //  3. It does not have a custom display name
-        
+
         let isTeamConversation = NSPredicate(format: "team != NULL")
         let isGroupConversation = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
         let hasNoUserDefinedName = NSPredicate(format: "\(ZMConversationUserDefinedNameKey) == NULL")
         let hasOnlyOneParticipant = NSPredicate(format: "\(ZMConversationParticipantRolesKey).@count == 2")
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [isTeamConversation, isGroupConversation, hasNoUserDefinedName, hasOnlyOneParticipant])
     }
-    
+
     @objc(predicateForOneToOneConversations)
     class func predicateForOneToOneConversations() -> NSPredicate {
         // We consider a conversation to be one-to-one if it's of type .oneToOne, is a team 1:1 or an outgoing connection request.
         let oneToOneConversationPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicateForOneToOneConversation(), predicateForTeamOneToOneConversation(), predicateForUnconnectedConversations()])
         let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), oneToOneConversationPredicate, notInFolderPredicate])
     }
-    
+
     @objc(predicateForArchivedConversations)
     class func predicateForArchivedConversations() -> NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsIncludingArchived(), NSPredicate(format: "\(ZMConversationIsArchivedKey) == YES")])
@@ -160,41 +158,41 @@ extension ZMConversation {
     @objc(predicateForConversationsExcludingArchived)
     class func predicateForConversationsExcludingArchived() -> NSPredicate {
         let notArchivedPredicate = NSPredicate(format: "\(ZMConversationIsArchivedKey) == NO")
-        
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsIncludingArchived(), notArchivedPredicate])
     }
-    
+
     private class func predicateForValidConversations() -> NSPredicate {
         let basePredicate = predicateForFilteringResults()
         let notAConnection = NSPredicate(format: "\(ZMConversationConversationTypeKey) != \(ZMConversationType.connection.rawValue)")
         let activeConnection = NSPredicate(format: "NOT \(ZMConversationConnectionKey).status IN %@", [NSNumber(value: ZMConnectionStatus.pending.rawValue),
                                                                                                        NSNumber(value: ZMConnectionStatus.ignored.rawValue),
-                                                                                                       NSNumber(value: ZMConnectionStatus.cancelled.rawValue)]) //pending connections should be in other list, ignored and cancelled are not displayed
+                                                                                                       NSNumber(value: ZMConnectionStatus.cancelled.rawValue)]) // pending connections should be in other list, ignored and cancelled are not displayed
         let predicate1 = NSCompoundPredicate(orPredicateWithSubpredicates: [notAConnection, activeConnection]) // one-to-one conversations and not pending and not ignored connections
         let noConnection = NSPredicate(format: "\(ZMConversationConnectionKey) == nil") // group conversations
         let notBlocked = NSPredicate(format: "\(ZMConversationConnectionKey).status != \(ZMConnectionStatus.blocked.rawValue) && \(ZMConversationConnectionKey).status != \(ZMConnectionStatus.blockedMissingLegalholdConsent.rawValue)")
-        let predicate2 = NSCompoundPredicate(orPredicateWithSubpredicates: [noConnection, notBlocked]) //group conversations and not blocked connections
-        
+        let predicate2 = NSCompoundPredicate(orPredicateWithSubpredicates: [noConnection, notBlocked]) // group conversations and not blocked connections
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: [basePredicate, predicate1, predicate2])
     }
-    
+
     class func predicateForConversationsNeedingToBeCalculatedUnreadMessages() -> NSPredicate {
          return NSPredicate(format: "%K == YES", ZMConversationNeedsToCalculateUnreadMessagesKey)
     }
 }
 
 extension String {
-    
+
     var words: [String] {
         var words: [String] = []
         enumerateSubstrings(in: self.startIndex..., options: .byWords) { substring, _, _, _ in
             words.append(String(substring!))
         }
-        
+
         if words.isEmpty {
             words = [trimmingCharacters(in: .whitespacesAndNewlines)]
         }
-        
+
         return words
     }
 }

--- a/Source/Model/Conversation/ZMConversation+Role.swift
+++ b/Source/Model/Conversation/ZMConversation+Role.swift
@@ -25,7 +25,7 @@ public enum UpdateRoleError: Error {
 public class UpdateRoleAction: EntityAction {
     public var resultHandler: ResultHandler?
 
-    public typealias Result = Void    
+    public typealias Result = Void
     public typealias Failure = UpdateRoleError
 
     public let userID: NSManagedObjectID

--- a/Source/Model/FeatureConfig/ConversationGuestLinks/Feature.ConversationGuestLinks.swift
+++ b/Source/Model/FeatureConfig/ConversationGuestLinks/Feature.ConversationGuestLinks.swift
@@ -35,4 +35,3 @@ public extension Feature {
     }
 
 }
-

--- a/Source/Utilis/Protos/GenericMessage+Assets.swift
+++ b/Source/Utilis/Protos/GenericMessage+Assets.swift
@@ -268,7 +268,7 @@ extension GenericMessage {
 extension WireProtos.Asset.RemoteData {
     mutating func update(assetId: String, token: String?, domain: String?) {
         assetID = assetId
-        
+
         if let token = token {
             assetToken = token
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix warnings regarding SwiftLint rules in Source (Part 4) 

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`
- **Vertical Parameter Alignment Violation**: Function parameters should be aligned vertically if they're in multiple lines in a declaration. (`vertical_parameter_alignment)`
- **Redundant @objc Attribute Violation:** Objective-C attribute (@objc) is redundant in declaration. `(redundant_objc_attribute)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
