### PR TITLE
feat: parse deleted key from the searchUser payload

### DIFF
--- a/Source/Model/User/ZMSearchUser.swift
+++ b/Source/Model/User/ZMSearchUser.swift
@@ -132,6 +132,7 @@ public class ZMSearchUser: NSObject, UserType {
     fileprivate var internalConnectionRequestMessage: String?
     fileprivate var internalPreviewImageData: Data?
     fileprivate var internalCompleteImageData: Data?
+    fileprivate var internalIsAccountDeleted: Bool?
 
     @objc
     public var hasTeam: Bool {
@@ -306,9 +307,13 @@ public class ZMSearchUser: NSObject, UserType {
     }
 
     public var isAccountDeleted: Bool {
-        guard let user = user else { return false }
+        if let isDeleted = internalIsAccountDeleted {
+            return isDeleted
+        } else if let user = user {
+            return user.isAccountDeleted
+        }
 
-        return user.isAccountDeleted
+        return false
     }
 
     public var isUnderLegalHold: Bool {
@@ -465,7 +470,8 @@ public class ZMSearchUser: NSObject, UserType {
                 domain: String? = nil,
                 teamIdentifier: UUID? = nil,
                 user existingUser: ZMUser? = nil,
-                contact: ZMAddressBookContact? = nil) {
+                contact: ZMAddressBookContact? = nil
+    ) {
 
         let personName = PersonName.person(withName: name, schemeTagger: nil)
 
@@ -538,11 +544,14 @@ public class ZMSearchUser: NSObject, UserType {
                   remoteIdentifier: remoteIdentifier,
                   domain: domain,
                   teamIdentifier: teamIdentifier,
-                  user: user)
+                  user: user
+        )
 
         self.providerIdentifier =  payload["provider"] as? String
         self.summary = payload["summary"] as? String
         self.assetKeys = SearchUserAssetKeys(payload: payload)
+        self.internalIsAccountDeleted = payload["deleted"] as? Bool
+
     }
 
     public var smallProfileImageCacheKey: String? {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When a user navigates via a deep link to the deleted user, it displays a screen with a connect button, which is not correct. In this case, we need to display an error message that the user is no longer exists.


### Causes (Optional)
We don't use the "deleted" key from the response payload once it's received from the backend.


### Solutions
To parse the "deleted" from the response payload.



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
