### PR TITLE
fix: SwiftLint warnings for rules `shorthand_operator` and `reduce_boolean`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,7 +27,6 @@ disabled_rules:
     - xctfail_message
     - compiler_protocol_init
     - reduce_boolean
-    - shorthand_operator
     
 included:
     - Source

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,6 @@ disabled_rules:
     - function_parameter_count
     - xctfail_message
     - compiler_protocol_init
-    - reduce_boolean
     
 included:
     - Source

--- a/Source/Model/Conversation/AssetCollectionBatched.swift
+++ b/Source/Model/Conversation/AssetCollectionBatched.swift
@@ -132,9 +132,9 @@ public class AssetCollectionBatched: NSObject, ZMCollection {
         let offset = (type == .asset) ? self.assetMessageOffset : self.clientMessageOffset
         let numberToAnalyze = min(allMessages.count - offset, AssetCollectionBatched.defaultFetchCount)
         if type == .asset {
-            self.assetMessageOffset = self.assetMessageOffset + numberToAnalyze
+            self.assetMessageOffset += numberToAnalyze
         } else {
-            self.clientMessageOffset = self.clientMessageOffset + numberToAnalyze
+            self.clientMessageOffset += numberToAnalyze
         }
 
         // check if we reached the last message
@@ -280,7 +280,7 @@ extension AssetCollectionBatched {
         messageMap.forEach {
             var newValues = $1
             if let otherValues = other[$0] {
-                newValues = newValues + otherValues
+                newValues += otherValues
             }
             newSortedMessages[$0] = newValues
         }

--- a/Source/Model/User/PersonName.swift
+++ b/Source/Model/User/PersonName.swift
@@ -50,7 +50,7 @@
             lastIndex = self.components.count - 1
             guard self.components.count > 1 && self.components[1].zmIsGodName() else { break }
             guard self.components.count > 2 else { return [] }
-            startIndex = startIndex + 1
+            startIndex += 1
         }
         return Array(self.components[startIndex...lastIndex])
     }()
@@ -61,15 +61,15 @@
         var name = String()
         switch self.nameOrder {
         case .givenNameLast:
-            name = name+self.components.last!
+            name += self.components.last!
         case .givenNameFirst:
-            name = name+firstComponent
+            name += firstComponent
         case .arabicGivenName:
-            name = name+firstComponent
+            name += firstComponent
             guard self.components.count > 1 else { break }
             let comp = self.components[1]
             guard comp.zmIsGodName() else { break }
-            name = name+" "+comp
+            name = [name, comp].joined(separator: " ")
         }
         return name
     }()
@@ -80,12 +80,12 @@
         var _initials = String()
         switch self.nameOrder {
         case .givenNameLast:
-            _initials = _initials + (firstComponent.zmFirstComposedCharacter() ?? "")
-            _initials = _initials + (firstComponent.zmSecondComposedCharacter() ?? "")
+            _initials += (firstComponent.zmFirstComposedCharacter() ?? "")
+            _initials += (firstComponent.zmSecondComposedCharacter() ?? "")
         case .arabicGivenName, .givenNameFirst:
-            _initials = _initials + (firstComponent.zmFirstComposedCharacter() ?? "")
+            _initials += (firstComponent.zmFirstComposedCharacter() ?? "")
             guard self.components.count > 1, let lastComponent = self.components.last else { break }
-            _initials = _initials + (lastComponent.zmFirstComposedCharacter() ?? "")
+            _initials += (lastComponent.zmFirstComposedCharacter() ?? "")
         }
         return _initials
     }()

--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -51,7 +51,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
         var messages = [ZMMessage]()
         (0..<count).forEach { _ in
             let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMMessage
-            offset = offset + 5
+            offset += 5
             message.setValue(Date().addingTimeInterval(offset), forKey: "serverTimestamp")
             messages.append(message)
             message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)

--- a/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -353,9 +353,9 @@ class AssetColletionBatchedTests: ModelObjectsTests {
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true) { result, element in
+        XCTAssertTrue(allMessages.allSatisfy { element in
             guard let message = element as? ZMMessage else { return false }
-            return result && message.managedObjectContext!.zm_isUserInterfaceContext
+            return message.managedObjectContext!.zm_isUserInterfaceContext
         })
     }
 

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -380,9 +380,9 @@ class AssetColletionTests: ModelObjectsTests {
         // then
         let allMessages = sut.assets(for: defaultMatchPair)
         XCTAssertEqual(allMessages.count, 20)
-        XCTAssertTrue(allMessages.reduce(true) { result, element in
+        XCTAssertTrue(allMessages.allSatisfy { element in
             guard let message = element as? ZMMessage else { return false }
-            return result && message.managedObjectContext!.zm_isUserInterfaceContext
+            return message.managedObjectContext!.zm_isUserInterfaceContext
         })
     }
 

--- a/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -40,7 +40,7 @@ class MockAssetCollectionDelegate: NSObject, AssetCollectionDelegate {
 
         didCallDelegate = true
         if !hasMore {
-            finished = finished + messages.keys
+            finished += messages.keys
         }
     }
 
@@ -82,7 +82,7 @@ class AssetColletionTests: ModelObjectsTests {
         var messages = [ZMMessage]()
         (0..<count).forEach { _ in
             let message = try! conversation.appendImage(from: verySmallJPEGData()) as! ZMMessage
-            offset = offset + 5
+            offset += 5
             message.setValue(Date().addingTimeInterval(offset), forKey: "serverTimestamp")
             messages.append(message)
             message.setPrimitiveValue(NSNumber(value: 0), forKey: ZMMessageCachedCategoryKey)

--- a/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -479,7 +479,7 @@ extension ClientMessageTests_OTR {
     fileprivate func textMessageRequiringExternalMessage(_ numberOfClients: UInt) -> String {
         var string = "Exponential growth!"
         while string.data(using: String.Encoding.utf8)!.count < Int(ZMClientMessage.byteSizeExternalThreshold / numberOfClients) {
-            string = string + string
+            string += string
         }
         return string
     }

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -232,7 +232,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 4)
                 XCTAssertEqual(to, 3)
             }
-            callCount = += 1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 3)
 
@@ -271,7 +271,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 1)
             }
-            callCount = += 1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 2)
 

--- a/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -54,7 +54,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 3)
                 XCTAssertEqual(to, 2)
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 1)
 
@@ -100,7 +100,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 4)
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 3)
 
@@ -140,7 +140,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 1)
                 XCTAssertEqual(to, 1)
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 2)
 
@@ -187,7 +187,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 3)
                 XCTAssertEqual(to, 2)
             }
-            callCount = callCount+1
+            callCount += 1
         }
         XCTAssertEqual(callCount, 1)
 
@@ -232,7 +232,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 4)
                 XCTAssertEqual(to, 3)
             }
-            callCount = callCount+1
+            callCount = += 1
         }
         XCTAssertEqual(callCount, 3)
 
@@ -271,7 +271,7 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
                 XCTAssertEqual(from, 2)
                 XCTAssertEqual(to, 1)
             }
-            callCount = callCount+1
+            callCount = += 1
         }
         XCTAssertEqual(callCount, 2)
 

--- a/Tests/Source/Utils/BatchDeleteTests.swift
+++ b/Tests/Source/Utils/BatchDeleteTests.swift
@@ -142,7 +142,7 @@ class BatchDeleteTests: ZMTBaseTest {
                                    newIndexPath: IndexPath?) {
                 switch type {
                 case .delete:
-                    deletedCount = deletedCount + 1
+                    deletedCount += 1
                 case .insert:
                     break
                 case .move:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes errors and warnings related two SwiftLint rules:

**Reduce Boolean Violation**: Use `allSatisfy` instead `(reduce_boolean)`
**Shorthand Operator Violation**: Prefer shorthand operators (+=, -=, *=, /=) over doing the operation and assigning. `(shorthand_operator)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
