### PR TITLE
fix: Introduce mapping for accessRole and accessRoleV2 for the separation of access controls for guests and services SQSERVICES-1052

### DIFF
--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -80,6 +80,46 @@ public enum ConversationAccessRole: String {
     case activated = "activated"
     /// Any user can join.
     case nonActivated = "non_activated"
+    case `private` = "private"
+
+    static func fromAccessRoleV2(_ accessRoles: Set<ConversationAccessRoleV2>) -> ConversationAccessRole {
+        switch accessRoles {
+        case []:
+            return .private
+        case [.teamMember]:
+            return .team
+        case [.teamMember, .nonTeamMember]:
+            return .activated
+        case [.teamMember, .nonTeamMember, .guest]:
+            return .nonActivated
+        case [.teamMember, .nonTeamMember, .guest, .service]:
+            return .nonActivated
+        case [.teamMember, .nonTeamMember, .service]:
+            return activated
+        case [.teamMember, .guest]:
+            return.nonActivated
+        case [.teamMember, .guest, .service]:
+            return .nonActivated
+        case [.teamMember, .service]:
+            return .activated
+        case [.nonTeamMember]:
+            return .activated
+        case [.nonTeamMember, .guest]:
+            return .nonActivated
+        case [.nonTeamMember, .guest, .service]:
+            return nonActivated
+        case [.nonTeamMember, .service]:
+            return activated
+        case [.guest]:
+            return nonActivated
+        case [.guest, .service]:
+            return nonActivated
+        case [.service]:
+            return activated
+        default:
+            return .team
+        }
+    }
 }
 
 /// The issue:
@@ -105,7 +145,22 @@ public enum ConversationAccessRoleV2: String {
     case guest = "guest"
     /// A service pseudo-user, aka a non-human bot.
     case service = "service"
+
+    static func fromLegacyAccessRole(_ accessRole: ConversationAccessRole) -> Set<Self> {
+        switch accessRole {
+        case .team:
+            return [.teamMember]
+        case .activated:
+            return [.teamMember, .nonTeamMember, guest]
+        case .nonActivated:
+            return [.teamMember, .nonTeamMember, guest, .service]
+        case .private:
+            return []
+        }
+    }
 }
+
+
 
 public extension ConversationAccessRole {
     static func value(forAllowGuests allowGuests: Bool) -> ConversationAccessRole {

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -84,43 +84,17 @@ public enum ConversationAccessRole: String {
     case `private` = "private"
 
     public static func fromAccessRoleV2(_ accessRoles: Set<ConversationAccessRoleV2>) -> ConversationAccessRole {
-        switch accessRoles {
-        case []:
-            return .private
-        case [.teamMember]:
-            return .team
-        case [.teamMember, .nonTeamMember]:
-            return .activated
-        case [.teamMember, .nonTeamMember, .guest]:
-            return .nonActivated
-        case [.teamMember, .nonTeamMember, .guest, .service]:
-            return .nonActivated
-        case [.teamMember, .nonTeamMember, .service]:
-            return activated
-        case [.teamMember, .guest]:
-            return.nonActivated
-        case [.teamMember, .guest, .service]:
-            return .nonActivated
-        case [.teamMember, .service]:
-            return .activated
-        case [.nonTeamMember]:
-            return .activated
-        case [.nonTeamMember, .guest]:
-            return .nonActivated
-        case [.nonTeamMember, .guest, .service]:
-            return nonActivated
-        case [.nonTeamMember, .service]:
-            return activated
-        case [.guest]:
-            return nonActivated
-        case [.guest, .service]:
-            return nonActivated
-        case [.service]:
-            return activated
-        default:
-            return .team
+        if accessRoles.contains(.guest) {
+          return .nonActivated
+        } else if accessRoles.contains(.nonTeamMember) || accessRoles.contains(.service) {
+          return .activated
+        } else if accessRoles.contains(.teamMember) {
+          return .team
+        } else {
+          return .private
         }
     }
+    
 }
 
 /// The issue:

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -80,6 +80,7 @@ public enum ConversationAccessRole: String {
     case activated = "activated"
     /// Any user can join.
     case nonActivated = "non_activated"
+    // 1:1 conversation
     case `private` = "private"
 
     public static func fromAccessRoleV2(_ accessRoles: Set<ConversationAccessRoleV2>) -> ConversationAccessRole {

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -160,8 +160,6 @@ public enum ConversationAccessRoleV2: String {
     }
 }
 
-
-
 public extension ConversationAccessRole {
     static func value(forAllowGuests allowGuests: Bool) -> ConversationAccessRole {
         return allowGuests ? ConversationAccessRole.nonActivated : ConversationAccessRole.team

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -82,7 +82,7 @@ public enum ConversationAccessRole: String {
     case nonActivated = "non_activated"
     case `private` = "private"
 
-    static func fromAccessRoleV2(_ accessRoles: Set<ConversationAccessRoleV2>) -> ConversationAccessRole {
+    public static func fromAccessRoleV2(_ accessRoles: Set<ConversationAccessRoleV2>) -> ConversationAccessRole {
         switch accessRoles {
         case []:
             return .private
@@ -146,7 +146,7 @@ public enum ConversationAccessRoleV2: String {
     /// A service pseudo-user, aka a non-human bot.
     case service = "service"
 
-    static func fromLegacyAccessRole(_ accessRole: ConversationAccessRole) -> Set<Self> {
+    public static func fromLegacyAccessRole(_ accessRole: ConversationAccessRole) -> Set<Self> {
         switch accessRole {
         case .team:
             return [.teamMember]

--- a/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
+++ b/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
@@ -1,0 +1,94 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class AccessRoleMappingTests: XCTestCase {
+
+    // MARK: Test Access Role Mapping from AccessRoleV2 to Access Role
+
+    func testAccessRoleMappingFromAccessRoleV2ToAccessRole() {
+        
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([]), .private)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember]), .team)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .nonTeamMember]), .activated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .nonTeamMember, .guest]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .nonTeamMember, .guest, .service]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .nonTeamMember, .service]), .activated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .guest]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .guest, .service]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.teamMember, .service]), .activated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.nonTeamMember]), .activated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.nonTeamMember, .guest]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.nonTeamMember, .guest, .service]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.nonTeamMember, .service]), .activated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.guest]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.guest, .service]), .nonActivated)
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([.service]), .activated)
+    }
+
+    // MARK: Test Access Role Mapping from AccessRole to AccessRoleV2
+
+    func testAccessRoleMappingFromAccessRoleToAccessRoleV2() {
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.team), [.teamMember])
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.activated), [.teamMember, .nonTeamMember, guest])
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.nonActivated), [.teamMember, .nonTeamMember, guest, .service])
+
+        // WHEN & THEN
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.private), [])
+    }
+
+}

--- a/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
+++ b/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
@@ -82,10 +82,10 @@ class AccessRoleMappingTests: XCTestCase {
         XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.team), [.teamMember])
 
         // WHEN & THEN
-        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.activated), [.teamMember, .nonTeamMember, guest])
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.activated), [.teamMember, .nonTeamMember, .guest])
 
         // WHEN & THEN
-        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.nonActivated), [.teamMember, .nonTeamMember, guest, .service])
+        XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.nonActivated), [.teamMember, .nonTeamMember, .guest, .service])
 
         // WHEN & THEN
         XCTAssertEqual(ConversationAccessRoleV2.fromLegacyAccessRole(.private), [])

--- a/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
+++ b/Tests/Source/Model/Conversation/AccessRoleMappingTests.swift
@@ -25,7 +25,7 @@ class AccessRoleMappingTests: XCTestCase {
     // MARK: Test Access Role Mapping from AccessRoleV2 to Access Role
 
     func testAccessRoleMappingFromAccessRoleV2ToAccessRole() {
-        
+
         // WHEN & THEN
         XCTAssertEqual(ConversationAccessRole.fromAccessRoleV2([]), .private)
 

--- a/Tests/Source/Utils/RolesMigrationTests.swift
+++ b/Tests/Source/Utils/RolesMigrationTests.swift
@@ -122,5 +122,5 @@ class RolesMigrationTests: DiskDatabaseTest {
         XCTAssertEqual(groupConvo.localParticipants, Set([user1, user2]))
         XCTAssertEqual((groupConvo.value(forKey: oldKey) as! NSOrderedSet).count, 0)
     }
-    
+
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
 		E90AAE34279719D8003C7DB0 /* store2-98-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = E90AAE33279719D8003C7DB0 /* store2-98-0.wiredatabase */; };
 		E97A542827B122D80009DCCF /* AccessRoleMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97A542727B122D80009DCCF /* AccessRoleMigrationTests.swift */; };
+		E9C7DD9B27B533D000FB9AE8 /* AccessRoleMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C7DD9A27B533D000FB9AE8 /* AccessRoleMappingTests.swift */; };
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
 		EE28991E26B4422800E7BAF0 /* Feature.ConferenceCalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28991D26B4422800E7BAF0 /* Feature.ConferenceCalling.swift */; };
@@ -1195,6 +1196,7 @@
 		E90AAE33279719D8003C7DB0 /* store2-98-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-98-0.wiredatabase"; sourceTree = "<group>"; };
 		E97A542727B122D80009DCCF /* AccessRoleMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessRoleMigrationTests.swift; sourceTree = "<group>"; };
 		E9A61E3A27957F6700B96E50 /* zmessaging2.98.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.98.0.xcdatamodel; sourceTree = "<group>"; };
+		E9C7DD9A27B533D000FB9AE8 /* AccessRoleMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessRoleMappingTests.swift; sourceTree = "<group>"; };
 		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
 		EE28991D26B4422800E7BAF0 /* Feature.ConferenceCalling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.ConferenceCalling.swift; sourceTree = "<group>"; };
@@ -2465,6 +2467,7 @@
 				A927F52623A029250058D744 /* ParticipantRoleTests.swift */,
 				6354BDF42747BD9600880D50 /* ZMConversationTests+Federation.swift */,
 				63E313D2274D5F57002EAF1D /* ZMConversationTests+Team.swift */,
+				E9C7DD9A27B533D000FB9AE8 /* AccessRoleMappingTests.swift */,
 			);
 			name = Conversation;
 			path = Tests/Source/Model/Conversation;
@@ -3664,6 +3667,7 @@
 				1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */,
 				F9A708341CAEEB7500C2F5FE /* ManagedObjectContextSaveNotificationTests.m in Sources */,
 				63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */,
+				E9C7DD9B27B533D000FB9AE8 /* AccessRoleMappingTests.swift in Sources */,
 				BF491CEC1F063F4B0055EE44 /* AccountStoreTests.swift in Sources */,
 				164A55D320F3AF6700AE62A6 /* ZMSearchUserTests+ProfileImages.swift in Sources */,
 				F9B71FA01CB2BF2B001DB03F /* ZMConversationListTests.m in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1052" title="SQSERVICES-1052" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQSERVICES-1052</a>  [iOS] Separate access controls for guests and services
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR, introduces the mapping between the old access role and the new one. This is an essential part for the separation of access controls for guests and services. The reason why is because backend and clients should implement the same logic (send both fields, accept either, and translate everything to the new values). The mapping will help us achieve just that.

These two methods are going to be used across our frameworks.

### TODO:

- [x] Add Unit Tests

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
