### PR TITLE
fix: SwiftLint warnings for `legacy_constructor` and  `legacy_hashing`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,8 +19,6 @@ disabled_rules:
     - inclusive_language
     - class_delegate_protocol
     - legacy_cggeometry_functions
-    - legacy_hashing
-    - multiple_closures_with_trailing_closure
     - nesting
     - function_parameter_count
     - xctfail_message

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,7 +19,6 @@ disabled_rules:
     - inclusive_language
     - class_delegate_protocol
     - legacy_cggeometry_functions
-    - legacy_constructor
     - legacy_hashing
     - multiple_closures_with_trailing_closure
     - nesting

--- a/Source/Model/Conversation/Permissions.swift
+++ b/Source/Model/Conversation/Permissions.swift
@@ -82,9 +82,8 @@ extension Permissions: CustomDebugStringConvertible {
 }
 
 extension Permissions: Hashable {
-
-    public var hashValue: Int {
-        return rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue)
     }
 
 }

--- a/Source/Model/Conversation/ZMConversation+AccessMode.swift
+++ b/Source/Model/Conversation/ZMConversation+AccessMode.swift
@@ -40,9 +40,10 @@ public struct ConversationAccessMode: OptionSet {
 }
 
 extension ConversationAccessMode: Hashable {
-    public var hashValue: Int {
-        return self.rawValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue)
     }
+
 }
 
 public extension ConversationAccessMode {

--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -75,16 +75,16 @@ extension ZMMessage {
                                             conversation: ZMConversation? = nil) -> NSFetchRequest<NSFetchRequestResult> {
 
         let orPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: categories.map {
-                return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.rawValue, $0.rawValue)
-            }
+            return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.rawValue, $0.rawValue)
+        }
         )
 
         let excludingPredicate: NSPredicate? = (excluding != .none)
-            ? NSPredicate(format: "(%K & %d) = 0", ZMMessageCachedCategoryKey, excluding.rawValue)
-            : nil
+        ? NSPredicate(format: "(%K & %d) = 0", ZMMessageCachedCategoryKey, excluding.rawValue)
+        : nil
         let conversationPredicate: NSPredicate? = (conversation != nil)
-            ? NSPredicate(format: "%K = %@", ZMMessageConversationKey, conversation!)
-            : nil
+        ? NSPredicate(format: "%K = %@", ZMMessageConversationKey, conversation!)
+        : nil
 
         let finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [orPredicate, excludingPredicate, conversationPredicate].compactMap { $0 })
         return self.sortedFetchRequest(with: finalPredicate)
@@ -100,11 +100,11 @@ extension ZMMessage {
                                    ZMMessageCachedCategoryKey, $0.excluding.rawValue)
             }
             return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.including.rawValue, $0.including.rawValue)
-            }
+        }
         )
         let conversationPredicate: NSPredicate? = (conversation != nil)
-            ? NSPredicate(format: "%K = %@", ZMMessageConversationKey, conversation!)
-            : nil
+        ? NSPredicate(format: "%K = %@", ZMMessageConversationKey, conversation!)
+        : nil
 
         let finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [categoryPredicate, conversationPredicate].compactMap { $0 })
         return self.sortedFetchRequest(with: finalPredicate)
@@ -130,11 +130,11 @@ extension ZMMessage {
                         self.locationCategory,
                         self.knockCategory,
                         self.systemMessageCategory
-            ]
+        ]
             .reduce(MessageCategory.none) {
                 (current: MessageCategory, other: MessageCategory) in
                 return current.union(other)
-        }
+            }
         return category
     }
 
@@ -155,8 +155,8 @@ extension ZMMessage {
     fileprivate var textCategory: MessageCategory {
         guard let textData = self.textMessageData,
               let text = textData.messageText, !text.isEmpty else {
-            return .none
-        }
+                  return .none
+              }
         var category = MessageCategory.text
         if textData.linkPreview != nil {
             category.update(with: .link)
@@ -174,9 +174,9 @@ extension ZMMessage {
 
     fileprivate var fileCategory: MessageCategory {
         guard let fileData = self.fileMessageData,
-            self.imageCategory == .none else {
-            return .none
-        }
+              self.imageCategory == .none else {
+                  return .none
+              }
         var category = MessageCategory.file
         if let asset = self as? ZMAssetClientMessage, asset.transferState.isOne(of: [.uploadingFailed, .uploadingCancelled]) {
             category.update(with: .excludedFromCollection)
@@ -285,7 +285,8 @@ extension MessageCategory: CustomDebugStringConvertible {
 
 extension MessageCategory: Hashable {
 
-    public var hashValue: Int {
-        return self.rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue)
     }
+
 }

--- a/Source/Model/Message/ZMMessage+Categorization.swift
+++ b/Source/Model/Message/ZMMessage+Categorization.swift
@@ -76,8 +76,7 @@ extension ZMMessage {
 
         let orPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: categories.map {
             return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.rawValue, $0.rawValue)
-        }
-        )
+        })
 
         let excludingPredicate: NSPredicate? = (excluding != .none)
         ? NSPredicate(format: "(%K & %d) = 0", ZMMessageCachedCategoryKey, excluding.rawValue)
@@ -100,8 +99,7 @@ extension ZMMessage {
                                    ZMMessageCachedCategoryKey, $0.excluding.rawValue)
             }
             return NSPredicate(format: "(%K & %d) = %d", ZMMessageCachedCategoryKey, $0.including.rawValue, $0.including.rawValue)
-        }
-        )
+        })
         let conversationPredicate: NSPredicate? = (conversation != nil)
         ? NSPredicate(format: "%K = %@", ZMMessageConversationKey, conversation!)
         : nil

--- a/Source/Model/User/PersonName.swift
+++ b/Source/Model/User/PersonName.swift
@@ -115,7 +115,7 @@
         // If the name contains latin scheme tag, it uses the first name as the given name
         // If the name is in arab sript, we will check if the givenName consists of "servent of" + one of the names for god
         schemeTagger.string = string
-        let tags = schemeTagger.tags(in: NSMakeRange(0, schemeTagger.string!.count), scheme: convertFromNSLinguisticTagScheme(NSLinguisticTagScheme.script), options: [.omitPunctuation, .omitWhitespace, .omitOther, .joinNames], tokenRanges: nil)
+        let tags = schemeTagger.tags(in: NSRange(location: 0, length: schemeTagger.string!.count), scheme: convertFromNSLinguisticTagScheme(NSLinguisticTagScheme.script), options: [.omitPunctuation, .omitWhitespace, .omitOther, .joinNames], tokenRanges: nil)
 
         let nameOrder: NameOrder
         if tags.contains("Arab") {

--- a/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -423,7 +423,7 @@ extension ZMUserTests_Swift {
         XCTAssertTrue(filename.contains("body"))
 
         let regexp = try! NSRegularExpression(pattern: pattern, options: [])
-        let matches = regexp.matches(in: filename as String, options: [], range: NSMakeRange(0, filename.count))
+        let matches = regexp.matches(in: filename as String, options: [], range: NSRange(location: 0, length: filename.count))
 
         XCTAssertTrue(matches.count > 0)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes SwiftLint warnings related to two rules:

- **Legacy Hashing Violation**: Prefer using the `hash(into:)` function instead of overriding `hashValue` `(legacy_hashing)`
- **Legacy Constructor Violation**: Swift constructors are preferred over legacy convenience functions. `(legacy_constructor)`

In addition to that I fixed a couple of indentation issues. Last but not least I removed `multiple_closures_with_trailing_closure` from the list since it didn't produce any warnings or errors.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
