### PR TITLE
feat: add api version accessors for domain and federation flag - FS-422

### DIFF
--- a/Source/Utilis/APIVersion.swift
+++ b/Source/Utilis/APIVersion.swift
@@ -1,0 +1,88 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// MARK: - Current
+
+extension APIVersion {
+
+    private enum Keys: String {
+        case apiVersion = "currentAPIVersion"
+        case domain = "APIVersionDomain"
+        case federation = "APIVersionFederation"
+    }
+
+    /// The API version against which all new backend requests should be made.
+    ///
+    /// The current version should be the highest value in common between the set
+    /// of supported versions of the client (represented by `APIVersion` cases)
+    /// and the set of supported versions of the backend (obtainable via `GET /api-version`).
+    ///
+    /// A `nil` value indicates that no version is selected yet and therefore one
+    /// should be (re-)negotiated with the backend.
+
+    public static var current: Self? {
+        get {
+            let key = Keys.apiVersion.rawValue
+            // Fetching an integer will default to 0 if no value exists for the key,
+            // so explicitly check there is a value.
+            guard UserDefaults.standard.hasValue(for: key) else { return nil }
+            let storedValue = UserDefaults.standard.integer(forKey: key)
+            return APIVersion(rawValue: Int32(storedValue))
+        }
+
+        set {
+            UserDefaults.standard.set(newValue?.rawValue, forKey: Keys.apiVersion.rawValue)
+        }
+    }
+
+    /// The domain of the backend
+    public static var domain: String? {
+        get { UserDefaults.standard.string(forKey: Keys.domain.rawValue) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.domain.rawValue) }
+    }
+
+    /// Wether or not the backend supports federation endpoints
+    public static var isFederationEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.federation.rawValue) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.federation.rawValue) }
+    }
+
+}
+
+// MARK: - Find the highest common version
+
+extension APIVersion {
+
+    public static func highestSupportedVersion(in versions: [Int32]) -> Self? {
+        versions
+            .compactMap { APIVersion(rawValue: Int32($0)) }
+            .max()
+    }
+
+}
+
+// MARK: - Helper
+
+private extension UserDefaults {
+
+    func hasValue(for key: String) -> Bool {
+        return object(forKey: key) != nil
+    }
+
+}

--- a/Source/Utilis/APIVersion.swift
+++ b/Source/Utilis/APIVersion.swift
@@ -51,13 +51,17 @@ extension APIVersion {
         }
     }
 
-    /// The domain of the backend
+    /// The domain of the backend to which the app is connected to.
+
     public static var domain: String? {
         get { UserDefaults.standard.string(forKey: Keys.domain.rawValue) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.domain.rawValue) }
     }
 
-    /// Wether or not the backend supports federation endpoints
+    /// Whether the connected backend has federation enabled.
+    ///
+    /// If the backend has federation enabled, then it may be federating with other backends.
+
     public static var isFederationEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Keys.federation.rawValue) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.federation.rawValue) }

--- a/Tests/Source/Utils/APIVersionTests.swift
+++ b/Tests/Source/Utils/APIVersionTests.swift
@@ -1,0 +1,69 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireDataModel
+
+final class APIVersionTests: XCTestCase {
+
+    private var lowestVersion: APIVersion!
+    private var highestVersion: APIVersion!
+
+    override func setUp() {
+        lowestVersion = APIVersion.allCases.first
+        highestVersion = APIVersion.allCases.last
+    }
+
+    override func tearDown() {
+        lowestVersion = nil
+        highestVersion = nil
+    }
+
+    func testThatTheCommonVersionIsNil_whenBackendSupportsHigherVersionsOnly() {
+        // given
+        let backendVersions = (1...5).map { highestVersion.rawValue + $0 }
+
+        // when
+        let commonVersion = APIVersion.highestSupportedVersion(in: backendVersions)
+
+        // then
+        XCTAssertNil(commonVersion)
+    }
+
+    func testThatTheCommonVersionIsNil_whenBackendSupportsLowerVersionsOnly() {
+        // given
+        let backendVersions = ((-5)...(-1)).map { lowestVersion.rawValue + $0 }
+
+        // when
+        let commonVersion = APIVersion.highestSupportedVersion(in: backendVersions)
+
+        // then
+        XCTAssertNil(commonVersion)
+    }
+
+    func testThatTheCommonVersionIsTheHighestVersion_whenBackendSupportsTheHighestVersion() {
+        // given
+        let backendVersions = APIVersion.allCases.map(\.rawValue)
+
+        // when
+        let commonVersion = APIVersion.highestSupportedVersion(in: backendVersions)
+
+        // then
+        XCTAssertEqual(commonVersion, highestVersion)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -262,6 +262,8 @@
 		5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */; };
 		5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */; };
 		5EFE9C0F2126D3FA007932A6 /* NormalizationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */; };
+		630B4C9627D8C899005D6F30 /* APIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630B4C9527D8C899005D6F30 /* APIVersion.swift */; };
+		630B4C9827D8C920005D6F30 /* APIVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630B4C9727D8C920005D6F30 /* APIVersionTests.swift */; };
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
 		63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D992434D04D006B6018 /* GenericMessage+External.swift */; };
@@ -1000,6 +1002,8 @@
 		5EFE9C082126BF9D007932A6 /* ZMPropertyNormalizationResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMPropertyNormalizationResult.m; sourceTree = "<group>"; };
 		5EFE9C0B2126CB71007932A6 /* UnregisteredUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnregisteredUserTests.swift; sourceTree = "<group>"; };
 		5EFE9C0E2126D3FA007932A6 /* NormalizationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizationResult.swift; sourceTree = "<group>"; };
+		630B4C9527D8C899005D6F30 /* APIVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIVersion.swift; sourceTree = "<group>"; };
+		630B4C9727D8C920005D6F30 /* APIVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIVersionTests.swift; sourceTree = "<group>"; };
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
 		63298D992434D04D006B6018 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
@@ -1723,6 +1727,7 @@
 				169315F025AC501300709F15 /* MigrateSenderClientTests.swift */,
 				EE2BA00725CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift */,
 				16827AF12732AB2E0079405D /* InvalidDomainRemovalTests.swift */,
+				630B4C9727D8C920005D6F30 /* APIVersionTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -2299,6 +2304,7 @@
 				162207F7272291CA0041EDE8 /* String+NilEmpty.swift */,
 				16E6F26324B614DC0015B249 /* EncryptionKeys.swift */,
 				EE997A1325062295008336D2 /* Logging.swift */,
+				630B4C9527D8C899005D6F30 /* APIVersion.swift */,
 			);
 			name = Utilis;
 			path = Source/Utilis;
@@ -3166,6 +3172,7 @@
 				EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */,
 				BF1B98041EC313C600DE033B /* Team.swift in Sources */,
 				A90676E7238EAE8B006417AC /* ParticipantRole.swift in Sources */,
+				630B4C9627D8C899005D6F30 /* APIVersion.swift in Sources */,
 				165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */,
 				BF5DF5CD20F4EB3E002BCB67 /* ZMSystemMessage+NewConversation.swift in Sources */,
 				0651D00423FC46A500411A22 /* ZMClientMessage+Confirmations.swift in Sources */,
@@ -3538,6 +3545,7 @@
 				F9C8770B1E015AAF00792613 /* AssetColletionTests.swift in Sources */,
 				F18998861E7AEECF00E579A2 /* ZMUserTests+Swift.swift in Sources */,
 				16CDEBF72209897D00E74A41 /* ZMMessageTests+ShouldGenerateUnreadCount.swift in Sources */,
+				630B4C9827D8C920005D6F30 /* APIVersionTests.swift in Sources */,
 				162294A5222038FA00A98679 /* CacheAssetTests.swift in Sources */,
 				543ABF5C1F34A19C00DBE28B /* DatabaseBaseTest.swift in Sources */,
 				A9EEFEFA23A6D0CB0007828A /* RolesMigrationTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-422" title="FS-422" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-422</a>  [iOS] Clients need to know if the backend support federated endpoints or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Moved `APIVersion` from RS to DM
- Added accessors for domain and federation flag

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
