### PR TITLE
feat: use `APIVersion` federation flag to ignore domain when creating users and conversations FS-484

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Creation.swift
+++ b/Source/Model/Conversation/ZMConversation+Creation.swift
@@ -53,7 +53,7 @@ extension ZMConversation {
         // having two duplicates of that user, and we'd have a really hard time recovering from that.
         require(context.zm_isSyncContext, "Users are only allowed to be created on sync context")
 
-        let domain: String? = context.zm_isFederationEnabled ? domain : nil
+        let domain: String? = APIVersion.isFederationEnabled ? domain : nil
 
         if let conversation = fetch(with: remoteIdentifier, domain: domain, in: context) {
             return conversation

--- a/Source/Model/User/ZMUser+Create.swift
+++ b/Source/Model/User/ZMUser+Create.swift
@@ -51,7 +51,7 @@ public extension ZMUser {
         // having two duplicates of that user, and we'd have a really hard time recovering from that.
         require(context.zm_isSyncContext, "Users are only allowed to be created on sync context")
 
-        let domain: String? = context.zm_isFederationEnabled ? domain : nil
+        let domain: String? = APIVersion.isFederationEnabled ? domain : nil
 
         if let user = fetch(with: remoteIdentifier, domain: domain, in: context) {
             return user

--- a/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -372,56 +372,6 @@
     }];
 }
 
-- (void)testThatItTreatsEmptyDomainAsNil
-{
-    [self.syncMOC performGroupedBlockAndWait:^{
-        // given
-        NSUUID *uuid = NSUUID.createUUID;
-
-        // when
-        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
-
-        // then
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(nil, created.domain);
-    }];
-}
-
-- (void)testThatItIgnoresDomainWhenFederationIsDisabled
-{
-    // given
-    NSUUID *uuid = [NSUUID createUUID];
-
-    [self.syncMOC performBlockAndWait:^{
-        // when
-        self.syncMOC.zm_isFederationEnabled = NO;
-        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
-
-        // then
-        XCTAssertNotNil(created);
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(nil, created.domain);
-    }];
-}
-
-- (void)testThatItAssignsDomainWhenFederationIsEnabled
-{
-    // given
-    NSUUID *uuid = [NSUUID createUUID];
-    NSString *domain = @"a.com";
-
-    [self.syncMOC performBlockAndWait:^{
-        // when
-        self.syncMOC.zm_isFederationEnabled = YES;
-        ZMConversation *created = [ZMConversation fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
-
-        // then
-        XCTAssertNotNil(created);
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(domain, created.domain);
-    }];
-}
-
 - (void)testThatConversationsDoNotGetInsertedUpstreamUnlessTheyAreGroupConversations;
 {
     // given

--- a/Tests/Source/Model/Conversation/ZMConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.swift
@@ -89,4 +89,56 @@ extension ZMConversationTests {
         XCTAssertEqual(result.count, 1)
         XCTAssertTrue((result.first is ZMAssetClientMessage))
     }
+
+    // MARK: - Domain tests
+
+    func testThatItTreatsEmptyDomainAsNil() {
+        // given
+        let uuid = UUID()
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            let created = ZMConversation.fetchOrCreate(with: uuid, domain: "", in: self.syncMOC)
+
+            // then
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(nil, created.domain)
+        }
+    }
+
+    func testThatItIgnoresDomainWhenFederationIsDisabled() {
+        // given
+        let uuid = UUID()
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            APIVersion.isFederationEnabled = false
+            let created = ZMConversation.fetchOrCreate(with: uuid, domain: "a.com", in: self.syncMOC)
+
+            // then
+            XCTAssertNotNil(created)
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(nil, created.domain)
+        }
+    }
+
+    func testThatItAssignsDomainWhenFederationIsEnabled() {
+        // given
+        let uuid = UUID()
+        let domain = "a.com"
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            APIVersion.isFederationEnabled = true
+            let created = ZMConversation.fetchOrCreate(with: uuid, domain: domain, in: self.syncMOC)
+
+            // then
+            XCTAssertNotNil(created)
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(domain, created.domain)
+
+            // Since the test class is an objc class, we can't set this to false in tearDown because APIVersion is a swift enum
+            APIVersion.isFederationEnabled = false
+        }
+    }
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests.swift
@@ -94,7 +94,7 @@ extension ZMConversationTests {
 
     func testThatItTreatsEmptyDomainAsNil() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
 
         syncMOC.performGroupedBlockAndWait {
             // when
@@ -108,7 +108,7 @@ extension ZMConversationTests {
 
     func testThatItIgnoresDomainWhenFederationIsDisabled() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
 
         syncMOC.performGroupedBlockAndWait {
             // when
@@ -124,7 +124,7 @@ extension ZMConversationTests {
 
     func testThatItAssignsDomainWhenFederationIsEnabled() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
         let domain = "a.com"
 
         syncMOC.performGroupedBlockAndWait {

--- a/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -21,6 +21,12 @@ import Foundation
 
 // MARK: - Modified keys for profile picture upload
 final class ZMUserTests_Swift: ModelObjectsTests {
+
+    override func tearDown() {
+        APIVersion.isFederationEnabled = false
+        super.tearDown()
+    }
+
     func testThatSettingUserProfileAssetIdentifiersDirectlyDoesNotMarkAsModified() {
         // GIVEN
         let user = ZMUser.selfUser(in: uiMOC)
@@ -1109,4 +1115,54 @@ extension ZMUserTests_Swift {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
 
+}
+
+// MARK: - Domain tests
+extension ZMUserTests_Swift {
+    func testThatItTreatsEmptyDomainAsNil() {
+        // given
+        let uuid = UUID()
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            let created = ZMUser.fetchOrCreate(with: uuid, domain: "", in: self.syncMOC)
+
+            // then
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(nil, created.domain)
+        }
+    }
+
+    func testThatItIgnoresDomainWhenFederationIsDisabled() {
+        // given
+        let uuid = UUID()
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            APIVersion.isFederationEnabled = false
+            let created = ZMUser.fetchOrCreate(with: uuid, domain: "a.com", in: self.syncMOC)
+
+            // then
+            XCTAssertNotNil(created)
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(nil, created.domain)
+        }
+    }
+
+    func testThatItAssignsDomainWhenFederationIsEnabled() {
+        // given
+        let uuid = UUID()
+        let domain = "a.com"
+
+        syncMOC.performGroupedBlockAndWait {
+            // when
+            APIVersion.isFederationEnabled = true
+            let created = ZMUser.fetchOrCreate(with: uuid, domain: domain, in: self.syncMOC)
+
+            // then
+            XCTAssertNotNil(created)
+            XCTAssertEqual(uuid, created.remoteIdentifier)
+            XCTAssertEqual(domain, created.domain)
+        }
+    }
 }

--- a/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -1121,7 +1121,7 @@ extension ZMUserTests_Swift {
 extension ZMUserTests_Swift {
     func testThatItTreatsEmptyDomainAsNil() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
 
         syncMOC.performGroupedBlockAndWait {
             // when
@@ -1135,7 +1135,7 @@ extension ZMUserTests_Swift {
 
     func testThatItIgnoresDomainWhenFederationIsDisabled() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
 
         syncMOC.performGroupedBlockAndWait {
             // when
@@ -1151,7 +1151,7 @@ extension ZMUserTests_Swift {
 
     func testThatItAssignsDomainWhenFederationIsEnabled() {
         // given
-        let uuid = UUID()
+        let uuid = UUID.create()
         let domain = "a.com"
 
         syncMOC.performGroupedBlockAndWait {

--- a/Tests/Source/Model/User/ZMUserTests.m
+++ b/Tests/Source/Model/User/ZMUserTests.m
@@ -175,57 +175,6 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     }];
 }
 
-- (void)testThatItTreatsEmptyDomainAsNil
-{
-    // given
-    NSUUID *uuid = [NSUUID createUUID];
-
-    [self.syncMOC performBlockAndWait:^{
-        // when
-        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:@"" in:self.syncMOC];
-
-        // then
-        XCTAssertNotNil(created);
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(nil, created.domain);
-    }];
-}
-
-- (void)testThatItIgnoresDomainWhenFederationIsDisabled
-{
-    // given
-    NSUUID *uuid = [NSUUID createUUID];
-
-    [self.syncMOC performBlockAndWait:^{
-        // when
-        self.syncMOC.zm_isFederationEnabled = NO;
-        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:@"a.com" in:self.syncMOC];
-
-        // then
-        XCTAssertNotNil(created);
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(nil, created.domain);
-    }];
-}
-
-- (void)testThatItAssignsDomainWhenFederationIsEnabled
-{
-    // given
-    NSUUID *uuid = [NSUUID createUUID];
-    NSString *domain = @"a.com";
-
-    [self.syncMOC performBlockAndWait:^{
-        // when
-        self.syncMOC.zm_isFederationEnabled = YES;
-        ZMUser *created = [ZMUser fetchOrCreateWith:uuid domain:domain in:self.syncMOC];
-
-        // then
-        XCTAssertNotNil(created);
-        XCTAssertEqualObjects(uuid, created.remoteIdentifier);
-        XCTAssertEqualObjects(domain, created.domain);
-    }];
-}
-
 - (void)testThatItReturnsAnExistingUserByPhone
 {
     // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-484" title="FS-484" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-484</a>  [iOS] Use federation flag to decided when to use fully qualified ids
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

use `APIVersion` federation flag to ignore domain when creating users and conversations

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
