### PR TITLE
chore: remove old federation flag FS-514

### DIFF
--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.h
@@ -29,7 +29,6 @@ extern NSString * _Nonnull const IsUserInterfaceContextKey;
 extern NSString * _Nonnull const IsSyncContextKey;
 extern NSString * _Nonnull const IsSearchContextKey;
 extern NSString * _Nonnull const IsEventContextKey;
-extern NSString * _Nonnull const IsFederationEnabledKey;
 
 @interface NSManagedObjectContext (zmessaging)
 
@@ -51,9 +50,6 @@ extern NSString * _Nonnull const IsFederationEnabledKey;
 
 /// Returns @c YES if the context is still valid, false if it has been torn down
 @property (readonly) BOOL zm_isValidContext;
-
-/// Returns @c YES if federation is enabled
-@property (nonatomic) BOOL zm_isFederationEnabled;
 
 /// Returns @c self in case this is a sync context, or attached sync context, if present
 @property (nonatomic, null_unspecified) NSManagedObjectContext* zm_syncContext;

--- a/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -35,7 +35,6 @@ NSString * const IsSyncContextKey = @"ZMIsSyncContext";
 NSString * const IsSearchContextKey = @"ZMIsSearchContext";
 NSString * const IsUserInterfaceContextKey = @"ZMIsUserInterfaceContext";
 NSString * const IsEventContextKey = @"ZMIsEventDecoderContext";
-NSString * const IsFederationEnabledKey = @"ZMIsFederationEnabledKey";
 
 static NSString * const SyncContextKey = @"ZMSyncContext";
 static NSString * const UserInterfaceContextKey = @"ZMUserInterfaceContext";
@@ -145,14 +144,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"NSManagedObjectContext";
     }
     
     return nil;
-}
-
-- (BOOL)zm_isFederationEnabled {
-    return [[self validUserInfoValueOfClass:[NSNumber class] forKey:IsFederationEnabledKey] boolValue];
-}
-
-- (void)setZm_isFederationEnabled:(BOOL)enabled {
-    [self.userInfo setValue:[NSNumber numberWithBool:enabled] forKey:IsFederationEnabledKey];
 }
 
 - (void)setZm_syncContext:(NSManagedObjectContext *)zm_syncContext


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-514" title="FS-514" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-514</a>  [iOS] Remove old federation flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Remove the old federation feature flag since it has been replaced with API versioning.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
