### PR TITLE
fix: all data model patches are run at every launch SQCORE-1289

### DIFF
--- a/Patches/PersistedDataPatches+Directory.swift
+++ b/Patches/PersistedDataPatches+Directory.swift
@@ -41,6 +41,14 @@ extension PersistedDataPatch {
         PersistedDataPatch(version: "273.2.0", block: InvalidDomainRemoval.removeDuplicatedEntitiesWithInvalidDomain),
         PersistedDataPatch(version: "279.0.4", block: InvalidFeatureRemoval.restoreDefaultConferenceCallingConfig),
         PersistedDataPatch(version: "285.0.0", block: ZMConversation.introduceAccessRoleV2)
+
+        // How to add a new patch:
+        // 1. Create the patch and set the version equal to the framework version that the patch
+        //    will be released in.
+        // 2. Append the patch here.
+        // 3. Update `currentVersion` below to equal that same version in step 1.
     ]
+
+    static var currentVersion = "287.1.1"
 
 }

--- a/Patches/PersistedDataPatches.swift
+++ b/Patches/PersistedDataPatches.swift
@@ -37,12 +37,8 @@ public final class PersistedDataPatch {
 
     /// Apply all patches to the MOC
     public static func applyAll(in moc: NSManagedObjectContext, fromVersion: String? = nil, patches: [PersistedDataPatch]? = nil) {
-        guard let currentVersion = Bundle(for: Self.self).infoDictionary!["CFBundleShortVersionString"] as? String else {
-            return zmLog.safePublic("Can't retrieve CFBundleShortVersionString for data model, skipping patches..")
-        }
-
         defer {
-            moc.setPersistentStoreMetadata(currentVersion, key: lastDataModelPatchedVersionKey)
+            moc.setPersistentStoreMetadata(Self.currentVersion, key: lastDataModelPatchedVersionKey)
             moc.saveOrRollback()
         }
         


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

TestFlight build 3.100 is showing a lot of bizarre behaviour, all seemingly related to the database. An attempt to fix this was made in https://github.com/wireapp/wire-ios-data-model/pull/1309, but that did not work.

### Causes

Database patches are made by comparing the current framework version with the previous framework version. When building with Xcode 13, TestFlight builds seem affected by a bug where the framework can't get access to it's own bundle in order to access the framework version. Instead, it gets the app version from the main bundle, which is a small number and consequently all the database patches are run because their patch versions are all large numbers.

### Solutions

Hardcode the current version, and provide instructions to keep it up to date.

### Testing

#### How to Test

We'll see it if works in a new TestFlight build.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
