### PR TITLE
feat(mls): add helpers for bytes conversions

### DIFF
--- a/Source/Utilis/Bytes.swift
+++ b/Source/Utilis/Bytes.swift
@@ -1,0 +1,55 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public typealias Bytes = [UInt8]
+
+public protocol BytesConvertible {
+    var bytes: Bytes { get }
+    static func from(bytes: Bytes) -> Self
+}
+
+extension BytesConvertible {
+    public var bytes: Bytes {
+        return Data(from: self).bytes
+    }
+
+    public static func from(bytes: Bytes) -> Self {
+        return bytes.data.object()
+    }
+}
+
+extension Data {
+    var bytes: Bytes { Bytes(self) }
+
+    func object<T: BytesConvertible>() -> T {
+        self.withUnsafeBytes { $0.load(as: T.self) }
+    }
+
+    init<T: BytesConvertible>(from object: T) {
+        self = Swift.withUnsafeBytes(of: object) { Data($0) }
+    }
+}
+
+extension Bytes {
+    var data: Data { Data(self) }
+}
+
+extension UUID: BytesConvertible {}
+extension String: BytesConvertible {}
+

--- a/Tests/Source/Utils/BytesConversionTests.swift
+++ b/Tests/Source/Utils/BytesConversionTests.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class BytesConversionTests: XCTestCase {
+    func test_stringConversions() {
+        // Given
+        let string = "Hello World"
+        let bytes = string.bytes
+
+        // When
+        let converted = String.from(bytes: bytes)
+
+        // Then
+        XCTAssertEqual(string, converted)
+    }
+
+    func test_uuidConversions() {
+        // Given
+        let uuid = UUID()
+        let bytes = uuid.bytes
+
+        // When
+        let converted = UUID.from(bytes: bytes)
+
+        // Then
+        XCTAssertEqual(uuid, converted)
+    }
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -300,6 +300,8 @@
 		63D9A19E282AA0050074C20C /* NSManagedObjectContext+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D9A19D282AA0050074C20C /* NSManagedObjectContext+Federation.swift */; };
 		63DA33412869C39D00818C3C /* CoreCryptoKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA33402869C39D00818C3C /* CoreCryptoKeyProvider.swift */; };
 		63DA335E286C9CF000818C3C /* NSManagedObjectContext+CoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA335D286C9CF000818C3C /* NSManagedObjectContext+CoreCrypto.swift */; };
+		63DA3375286CA51900818C3C /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA3374286CA51900818C3C /* Bytes.swift */; };
+		63DA33AC2874656E00818C3C /* BytesConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA33AB2874656E00818C3C /* BytesConversionTests.swift */; };
 		63E313D3274D5F57002EAF1D /* ZMConversationTests+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E313D2274D5F57002EAF1D /* ZMConversationTests+Team.swift */; };
 		63F376DA2834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F376D92834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift */; };
 		63F65F01246B073900534A69 /* GenericMessage+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F00246B073900534A69 /* GenericMessage+Content.swift */; };
@@ -1060,6 +1062,8 @@
 		63D9A19D282AA0050074C20C /* NSManagedObjectContext+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Federation.swift"; sourceTree = "<group>"; };
 		63DA33402869C39D00818C3C /* CoreCryptoKeyProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreCryptoKeyProvider.swift; sourceTree = "<group>"; };
 		63DA335D286C9CF000818C3C /* NSManagedObjectContext+CoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+CoreCrypto.swift"; sourceTree = "<group>"; };
+		63DA3374286CA51900818C3C /* Bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bytes.swift; sourceTree = "<group>"; };
+		63DA33AB2874656E00818C3C /* BytesConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesConversionTests.swift; sourceTree = "<group>"; };
 		63E313D2274D5F57002EAF1D /* ZMConversationTests+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Team.swift"; sourceTree = "<group>"; };
 		63F376D92834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContextTests+Federation.swift"; sourceTree = "<group>"; };
 		63F65F00246B073900534A69 /* GenericMessage+Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Content.swift"; sourceTree = "<group>"; };
@@ -1774,6 +1778,7 @@
 				16827AF12732AB2E0079405D /* InvalidDomainRemovalTests.swift */,
 				630B4C9727D8C920005D6F30 /* APIVersionTests.swift */,
 				E97A542727B122D80009DCCF /* AccessRoleMigrationTests.swift */,
+				63DA33AB2874656E00818C3C /* BytesConversionTests.swift */,
 			);
 			name = Utils;
 			path = Tests/Source/Utils;
@@ -2391,6 +2396,7 @@
 				7A2778C5285223D90044A73F /* KeychainManager.swift */,
 				EE997A1325062295008336D2 /* Logging.swift */,
 				630B4C9527D8C899005D6F30 /* APIVersion.swift */,
+				63DA3374286CA51900818C3C /* Bytes.swift */,
 			);
 			name = Utilis;
 			path = Source/Utilis;
@@ -3349,6 +3355,7 @@
 				5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */,
 				BF10B5971E64591600E7036E /* AnalyticsType.swift in Sources */,
 				16313D621D227DC1001B2AB3 /* LinkPreview+ProtocolBuffer.swift in Sources */,
+				63DA3375286CA51900818C3C /* Bytes.swift in Sources */,
 				F1FDF2F721B152BC00E037A1 /* GenericMessage+Helper.swift in Sources */,
 				16030DC521AEE25500F8032E /* ZMOTRMessage+Confirmations.swift in Sources */,
 				D5FA30C52063DC2D00716618 /* BackupMetadata.swift in Sources */,
@@ -3725,6 +3732,7 @@
 				0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */,
 				068D610324629AB900A110A2 /* ZMBaseManagedObjectTest.swift in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,
+				63DA33AC2874656E00818C3C /* BytesConversionTests.swift in Sources */,
 				16E6F26624B8952F0015B249 /* EncryptionKeysTests.swift in Sources */,
 				16F6BB3C1EDEDEFD009EA803 /* ZMConversationTests+ObservationHelper.swift in Sources */,
 				1639A8512264B91E00868AB9 /* AvailabilityBehaviourChangeTests.swift in Sources */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds helpers for conversions between the byte buffers used by the core crypto library and Swift types used in our project.

### Testing

- [ ] Added tests for back and forth conversions of `String` and `UUID` types

### Notes 

We may want to support more types 
