### PR TITLE
feat(mls): add support for decrypting messages FS-650

### DIFF
--- a/MLS/Bytes+Random.swift
+++ b/MLS/Bytes+Random.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Bytes {
+
+    public static func random(in range: ClosedRange<UInt8> = 1...10, length: Int = 3) -> Self {
+        var bytes = Bytes()
+
+        for _ in 1...length {
+            bytes.append(UInt8.random(in: range))
+        }
+
+        return bytes
+    }
+
+}

--- a/MLS/CoreCryptoTypes.swift
+++ b/MLS/CoreCryptoTypes.swift
@@ -123,7 +123,7 @@ public struct Invitee: Equatable {
     }
 }
 
-public enum CryptoError {
+public enum CryptoError: Error {
 
     // Simple error enums only carry a message
     case ConversationNotFound(message: String)

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -25,7 +25,7 @@ extension GenericMessage {
         switch updateEvent.type {
         case .conversationClientMessageAdd:
             base64Content = updateEvent.payload.string(forKey: "data")
-        case .conversationOtrMessageAdd:
+        case .conversationOtrMessageAdd, .conversationMLSMessageAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "text")
         case .conversationOtrAssetAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "info")

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -23,9 +23,9 @@ extension GenericMessage {
         let base64Content: String?
 
         switch updateEvent.type {
-        case .conversationClientMessageAdd:
+        case .conversationClientMessageAdd, .conversationMLSMessageAdd:
             base64Content = updateEvent.payload.string(forKey: "data")
-        case .conversationOtrMessageAdd, .conversationMLSMessageAdd:
+        case .conversationOtrMessageAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "text")
         case .conversationOtrAssetAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "info")

--- a/Source/Utilis/ZMUpdateEvent.swift
+++ b/Source/Utilis/ZMUpdateEvent.swift
@@ -27,7 +27,8 @@ extension ZMUpdateEvent {
             return payload.dictionary(forKey: "data")?["nonce"] as? UUID
         case .conversationClientMessageAdd,
              .conversationOtrMessageAdd,
-             .conversationOtrAssetAdd:
+             .conversationOtrAssetAdd,
+             .conversationMLSMessageAdd:
             let message = GenericMessage(from: self)
             guard let messageID = message?.messageID else {
                 return nil

--- a/Tests/MLS/MockCoreCrypto.swift
+++ b/Tests/MLS/MockCoreCrypto.swift
@@ -110,9 +110,15 @@ class MockCoreCrypto: CoreCryptoProtocol {
     }
 
     var mockDecryptMessage: [UInt8]??
+    var mockDecryptError: CryptoError?
 
     func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> [UInt8]? {
         calls.decryptMessage.append((conversationId, payload))
+
+        if let error = mockDecryptError {
+            throw error
+        }
+
         return try XCTUnwrap(mockDecryptMessage, "return value not mocked")
     }
 

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -35,6 +35,7 @@ class MockMLSController: MLSControllerProtocol {
         var createGroup = [(MLSGroupID, [MLSUser])]()
         var conversationExists = [MLSGroupID]()
         var processWelcomeMessage = [String]()
+        var decrypt = [(String, ZMConversation)]()
 
     }
 
@@ -71,4 +72,13 @@ class MockMLSController: MLSControllerProtocol {
         return try mock(welcomeMessage)
     }
 
+    typealias DecryptMock = (String, ZMConversation) throws -> Data
+
+    var decryptMock: DecryptMock?
+
+    func decrypt(message: String, for conversation: ZMConversation) throws -> Data {
+        calls.decrypt.append((message, conversation))
+        guard let mock = decryptMock else { throw MockError.unmockedMethodCalled }
+        return try mock(message, conversation)
+    }
 }

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -35,7 +35,7 @@ class MockMLSController: MLSControllerProtocol {
         var createGroup = [(MLSGroupID, [MLSUser])]()
         var conversationExists = [MLSGroupID]()
         var processWelcomeMessage = [String]()
-        var decrypt = [(String, ZMConversation)]()
+        var decrypt = [(String, MLSGroupID)]()
 
     }
 
@@ -72,13 +72,13 @@ class MockMLSController: MLSControllerProtocol {
         return try mock(welcomeMessage)
     }
 
-    typealias DecryptMock = (String, ZMConversation) throws -> Data
+    typealias DecryptMock = (String, MLSGroupID) throws -> Data?
 
     var decryptMock: DecryptMock?
 
-    func decrypt(message: String, for conversation: ZMConversation) throws -> Data {
-        calls.decrypt.append((message, conversation))
+    func decrypt(message: String, for groupID: MLSGroupID) throws -> Data? {
+        calls.decrypt.append((message, groupID))
         guard let mock = decryptMock else { throw MockError.unmockedMethodCalled }
-        return try mock(message, conversation)
+        return try mock(message, groupID)
     }
 }

--- a/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
+++ b/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
@@ -1,0 +1,51 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    typealias AsyncThrowingBlock = () async throws -> Void
+    typealias ThrowingBlock = () throws -> Void
+    typealias EquatableError = Error & Equatable
+
+    @available(iOS 13, *)
+    func assertItThrows<T: EquatableError>(error expectedError: T, block: AsyncThrowingBlock) async {
+        do {
+            try await block()
+            XCTFail("No error was thrown")
+        } catch {
+            assertError(error, equals: expectedError)
+        }
+    }
+
+    func assertItThrows<T: EquatableError>(error expectedError: T, block: ThrowingBlock) {
+        XCTAssertThrowsError(try block()) { error in
+            assertError(error, equals: expectedError)
+        }
+    }
+
+    func assertError<T: EquatableError>(_ error: Error, equals expectedError: T) {
+        guard
+            let error = error as? T,
+            error == expectedError
+        else {
+            return XCTFail("Unexpected error: \(String(describing: error))")
+        }
+    }
+}

--- a/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
+++ b/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
@@ -24,7 +24,6 @@ extension XCTestCase {
     typealias ThrowingBlock = () throws -> Void
     typealias EquatableError = Error & Equatable
 
-    @available(iOS 13, *)
     func assertItThrows<T: EquatableError>(error expectedError: T, block: AsyncThrowingBlock) async {
         do {
             try await block()

--- a/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
+++ b/Tests/Source/Helper/XCTestCase+ErrorAssertion.swift
@@ -41,11 +41,10 @@ extension XCTestCase {
     }
 
     func assertError<T: EquatableError>(_ error: Error, equals expectedError: T) {
-        guard
-            let error = error as? T,
-            error == expectedError
-        else {
+        guard let error = error as? T else {
             return XCTFail("Unexpected error: \(String(describing: error))")
         }
+
+        XCTAssertEqual(error, expectedError)
     }
 }

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		63370CC9242E3B990072C37F /* ZMMessage+Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */; };
 		63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */; };
 		63370CF82431F5DE0072C37F /* BaseCompositeMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */; };
+		633B396828917C9600208124 /* XCTestCase+ErrorAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B396728917C9600208124 /* XCTestCase+ErrorAssertion.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */; };
 		6354BDF32746C30900880D50 /* ZMConversation+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6354BDF22746C30900880D50 /* ZMConversation+Federation.swift */; };
@@ -1064,6 +1065,7 @@
 		63370CC8242E3B990072C37F /* ZMMessage+Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Conversation.swift"; sourceTree = "<group>"; };
 		63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContentTests.swift; sourceTree = "<group>"; };
 		63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCompositeMessageTests.swift; sourceTree = "<group>"; };
+		633B396728917C9600208124 /* XCTestCase+ErrorAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+ErrorAssertion.swift"; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Protobuf.swift"; sourceTree = "<group>"; };
 		6354BDF22746C30900880D50 /* ZMConversation+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Federation.swift"; sourceTree = "<group>"; };
@@ -2583,6 +2585,7 @@
 				16E70F97270F1F5700718E5D /* ZMConnection+Helper.h */,
 				16E70FA6270F212000718E5D /* ZMConnection+Helper.m */,
 				169FF3A427157B3800330C2E /* MockActionHandler.swift */,
+				633B396728917C9600208124 /* XCTestCase+ErrorAssertion.swift */,
 			);
 			name = Helper;
 			path = Tests/Source/Helper;
@@ -3892,6 +3895,7 @@
 				EE6CB3DE24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift in Sources */,
 				F9C348861E2CC27D0015D69D /* NewUnreadMessageObserverTests.swift in Sources */,
 				63F376DA2834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift in Sources */,
+				633B396828917C9600208124 /* XCTestCase+ErrorAssertion.swift in Sources */,
 				87A7FA25203DD1CC00AA066C /* ZMConversationTests+AccessMode.swift in Sources */,
 				F9A708601CAEEF4700C2F5FE /* MessagingTest+EventFactory.m in Sources */,
 				F9DBA5291E29162A00BE23C0 /* MessageObserverTests.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */; };
 		63370CF82431F5DE0072C37F /* BaseCompositeMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */; };
 		633B396828917C9600208124 /* XCTestCase+ErrorAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B396728917C9600208124 /* XCTestCase+ErrorAssertion.swift */; };
+		633B396E2893BB2D00208124 /* Bytes+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B396D2893BB2D00208124 /* Bytes+Random.swift */; };
 		63495DF023F6BD2A002A7C59 /* GenericMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */; };
 		63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */; };
 		6354BDF32746C30900880D50 /* ZMConversation+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6354BDF22746C30900880D50 /* ZMConversation+Federation.swift */; };
@@ -1066,6 +1067,7 @@
 		63370CF42431F3ED0072C37F /* CompositeMessageItemContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageItemContentTests.swift; sourceTree = "<group>"; };
 		63370CF72431F5DE0072C37F /* BaseCompositeMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCompositeMessageTests.swift; sourceTree = "<group>"; };
 		633B396728917C9600208124 /* XCTestCase+ErrorAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+ErrorAssertion.swift"; sourceTree = "<group>"; };
+		633B396D2893BB2D00208124 /* Bytes+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bytes+Random.swift"; sourceTree = "<group>"; };
 		63495DEF23F6BD2A002A7C59 /* GenericMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageTests.swift; sourceTree = "<group>"; };
 		63495E1A23FED9A9002A7C59 /* ZMUser+Protobuf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Protobuf.swift"; sourceTree = "<group>"; };
 		6354BDF22746C30900880D50 /* ZMConversation+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Federation.swift"; sourceTree = "<group>"; };
@@ -1983,6 +1985,7 @@
 				63DA33402869C39D00818C3C /* CoreCryptoKeyProvider.swift */,
 				EE08B344284E2B450022830B /* CoreCryptoTypes.swift */,
 				63121636288089E600FF9A56 /* Bytes.swift */,
+				633B396D2893BB2D00208124 /* Bytes+Random.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -3623,6 +3626,7 @@
 				F943BC2D1E88FEC80048A768 /* ChangedIndexes.swift in Sources */,
 				7A2778C6285223D90044A73F /* KeychainManager.swift in Sources */,
 				F9A706A31CAEE01D00C2F5FE /* ConversationListChangeInfo.swift in Sources */,
+				633B396E2893BB2D00208124 /* Bytes+Random.swift in Sources */,
 				873B88FC204044AC00FBE254 /* ConversationCreationOptions.swift in Sources */,
 				87E9508B2118B2DA00306AA7 /* ZMConversation+DeleteOlderMessages.swift in Sources */,
 				EE9AD9162696F01700DD5F51 /* FeatureService.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-650" title="FS-650" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-650</a>  [iOS] Receive an MLS message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR introduces support for decrypting MLS messages.

### Changes

- Added `decrypt` method to `MLSController`
- Added support to init a `GenericMessage` from an update event of type `.conversationMLSMessageAdd`

### Testing

- Added unit tests for the `decrypt` method
- Added mock of `decrypt` method
- Introduced `XCTestCase+ErrorAssertion` extension to help simplify errors and throws assertions 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
