### PR TITLE
feat: mls conversation event processing FS-542

### DIFF
--- a/MLS/Actions/SendMLSMessageAction.swift
+++ b/MLS/Actions/SendMLSMessageAction.swift
@@ -22,7 +22,7 @@ public final class SendMLSMessageAction: EntityAction {
 
     // MARK: - Types
 
-    public typealias Result = Void
+    public typealias Result = [ZMUpdateEvent]
 
     public enum Failure: LocalizedError, Equatable {
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -159,9 +159,11 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     private func sendMessage(_ bytes: Bytes) async throws {
+        var updateEvents = [ZMUpdateEvent]()
+
         do {
             guard let context = context else { return }
-            try await actionsProvider.sendMessage(
+            updateEvents = try await actionsProvider.sendMessage(
                 bytes.data,
                 in: context.notificationContext
             )
@@ -169,6 +171,8 @@ public final class MLSController: MLSControllerProtocol {
             logger.warn("failed to send mls message: \(String(describing: error))")
             throw MLSGroupCreationError.failedToSendHandshakeMessage
         }
+
+        conversationEventProcessor.processConversationEvents(updateEvents)
     }
 
     private func sendWelcomeMessage(_ bytes:  Bytes) async throws {

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -38,21 +38,23 @@ public final class MLSController: MLSControllerProtocol {
 
     private weak var context: NSManagedObjectContext?
     private let coreCrypto: CoreCryptoProtocol
+    private let conversationEventProcessor: ConversationEventProcessorProtocol
     private let logger = ZMSLog(tag: "core-crypto")
 
-    let targetUnclaimedKeyPackageCount = 100
-
     let actionsProvider: MLSActionsProviderProtocol
+    let targetUnclaimedKeyPackageCount = 100
 
     // MARK: - Life cycle
 
     init(
         context: NSManagedObjectContext,
         coreCrypto: CoreCryptoProtocol,
+        conversationEventProcessor: ConversationEventProcessorProtocol,
         actionsProvider: MLSActionsProviderProtocol = MLSActionsProvider()
     ) {
         self.context = context
         self.coreCrypto = coreCrypto
+        self.conversationEventProcessor = conversationEventProcessor
         self.actionsProvider = actionsProvider
 
         do {
@@ -489,5 +491,11 @@ private class MLSActionsProvider: MLSActionsProviderProtocol {
         var action = SendMLSWelcomeAction(welcomeMessage: welcomeMessage)
         try await action.perform(in: context)
     }
+
+}
+
+public protocol ConversationEventProcessorProtocol {
+
+    func processConversationEvents(_ events: [ZMUpdateEvent])
 
 }

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -436,7 +436,7 @@ protocol MLSActionsProviderProtocol {
     func sendMessage(
         _ message: Data,
         in context: NotificationContext
-    ) async throws
+    ) async throws -> [ZMUpdateEvent]
 
     @available(iOS 15, *)
     func sendWelcomeMessage(
@@ -478,9 +478,9 @@ private class MLSActionsProvider: MLSActionsProviderProtocol {
     func sendMessage(
         _ message: Data,
         in context: NotificationContext
-    ) async throws {
+    ) async throws -> [ZMUpdateEvent] {
         var action = SendMLSMessageAction(message: message)
-        try await action.perform(in: context)
+        return try await action.perform(in: context)
     }
 
     @available(iOS 15, *)

--- a/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
@@ -31,10 +31,17 @@ extension NSManagedObjectContext {
         return userInfo[Self.mlsControllerUserInfoKey] as? MLSControllerProtocol
     }
 
-    public func initializeMLSController(coreCrypto: CoreCryptoProtocol) {
+    public func initializeMLSController(
+        coreCrypto: CoreCryptoProtocol,
+        conversationEventProcessor: ConversationEventProcessorProtocol
+    ) {
         precondition(zm_isSyncContext, "MLSController should only be accessed on the sync context")
-        let mlsController = MLSController(context: self, coreCrypto: coreCrypto)
-        userInfo[Self.mlsControllerUserInfoKey] = mlsController
+
+        userInfo[Self.mlsControllerUserInfoKey] = MLSController(
+            context: self,
+            coreCrypto: coreCrypto,
+            conversationEventProcessor: conversationEventProcessor
+        )
     }
 
     /// Test helper for setting a mock controller.

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -26,15 +26,18 @@ class MLSControllerTests: ZMConversationTestsBase {
     var sut: MLSController!
     var mockCoreCrypto: MockCoreCrypto!
     var mockActionsProvider: MockMLSActionsProvider!
+    var mockConversationEventProcessor: MockConversationEventProcessor!
 
     override func setUp() {
         super.setUp()
         mockCoreCrypto = MockCoreCrypto()
         mockActionsProvider = MockMLSActionsProvider()
+        mockConversationEventProcessor = MockConversationEventProcessor()
 
         sut = MLSController(
             context: uiMOC,
             coreCrypto: mockCoreCrypto,
+            conversationEventProcessor: mockConversationEventProcessor,
             actionsProvider: mockActionsProvider
         )
     }

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -120,6 +120,9 @@ class MLSControllerTests: ZMConversationTestsBase {
         // Mock sending message.
         mockActionsProvider.sendMessageMocks.append({ message in
             XCTAssertEqual(message, Data([0, 0, 0, 0]))
+            // TODO: mock the update events for member join.
+            // TODO: assert that conversation event processor receives the events.
+            return []
         })
 
         // Mock sending welcome message.

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -123,6 +123,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         // Mock sending message.
         mockActionsProvider.sendMessageMocks.append({ message in
             XCTAssertEqual(message, Data([0, 0, 0, 0]))
+            return []
         })
 
         // Mock sending welcome message.

--- a/Tests/MLS/MockConversationEventProcessor.swift
+++ b/Tests/MLS/MockConversationEventProcessor.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+
+class MockConversationEventProcessor: ConversationEventProcessorProtocol {
+
+    // MARK: - Types
+
+    struct Calls {
+
+        var processConversationEvents = [[ZMUpdateEvent]]()
+
+    }
+
+    // MARK: - Properties
+
+    var calls = Calls()
+
+    // MARK: - Methods
+
+    func processConversationEvents(_ events: [ZMUpdateEvent]) {
+        calls.processConversationEvents.append(events)
+    }
+
+}

--- a/Tests/MLS/MockMLSActionsProvider.swift
+++ b/Tests/MLS/MockMLSActionsProvider.swift
@@ -63,13 +63,13 @@ class MockMLSActionsProvider: MLSActionsProviderProtocol {
         return mock(userID, domain, excludedSelfClientID)
     }
 
-    typealias SendMessageMock = (Data) -> Void
+    typealias SendMessageMock = (Data) -> [ZMUpdateEvent]
     var sendMessageMocks = [SendMessageMock]()
 
     func sendMessage(
         _ message: Data,
         in context: NotificationContext
-    ) async throws {
+    ) async throws -> [ZMUpdateEvent] {
         guard let mock = sendMessageMocks.first else { throw MockError.unmockedMethodInvoked }
         sendMessageMocks.removeFirst()
         return mock(message)

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		EE128A66286DE31200558550 /* UserClient+MLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */; };
 		EE128A68286DE35F00558550 /* CodableHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A67286DE35F00558550 /* CodableHelpers.swift */; };
 		EE174FCE2522756700482A70 /* ZMConversationPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */; };
+		EE22185E2892C22C008EF6ED /* MockConversationEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */; };
 		EE28991E26B4422800E7BAF0 /* Feature.ConferenceCalling.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28991D26B4422800E7BAF0 /* Feature.ConferenceCalling.swift */; };
 		EE2B874624D9A11A00936A4E /* ContextProvider+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2B874524D9A11A00936A4E /* ContextProvider+EncryptionAtRest.swift */; };
 		EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */; };
@@ -1269,6 +1270,7 @@
 		EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+MLSPublicKeys.swift"; sourceTree = "<group>"; };
 		EE128A67286DE35F00558550 /* CodableHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableHelpers.swift; sourceTree = "<group>"; };
 		EE174FCD2522756700482A70 /* ZMConversationPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZMConversationPerformanceTests.swift; path = Conversation/ZMConversationPerformanceTests.swift; sourceTree = "<group>"; };
+		EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConversationEventProcessor.swift; sourceTree = "<group>"; };
 		EE28991D26B4422800E7BAF0 /* Feature.ConferenceCalling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.ConferenceCalling.swift; sourceTree = "<group>"; };
 		EE2B874524D9A11A00936A4E /* ContextProvider+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContextProvider+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EE2BA00525CB3AA8001EB606 /* InvalidFeatureRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidFeatureRemoval.swift; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
 				EE98879128882C8F002340D2 /* MockMLSController.swift */,
 				EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */,
+				EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */,
 				EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */,
 			);
 			path = MLS;
@@ -3714,6 +3717,7 @@
 				F9B720041CB2C770001DB03F /* UserClientTests.swift in Sources */,
 				872A2E8A1FFD2FBF00900B22 /* ZMSearchUserPayloadParsingTests.swift in Sources */,
 				163D01E22472E44000984999 /* InvalidConnectionRemovalTests.swift in Sources */,
+				EE22185E2892C22C008EF6ED /* MockConversationEventProcessor.swift in Sources */,
 				1672A5FE23434FA200380537 /* ZMConversationTests+Labels.swift in Sources */,
 				BF0D07FB1E4C7B7A00B934EB /* TextSearchQueryTests.swift in Sources */,
 				060ED6DC2499F78700412C4A /* ZMUpdateEvent+Helper.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-542" title="FS-542" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-542</a>  [iOS] Add a user to an MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We forgot to implement the update events that are returned when posting the mls handshake messages. This PR:
- Changes the result type of `SendMLSMessageAction` from `Void` to `[ZMUpdateEvent]`.
- Defines a `ConversationEventProcessorProtocol` which is some object that will process the events.
- Adds an instance of the event processor to the `MLSController`, it will be injected from other layers.
- Pass the events received from the message action to the event processor.

### Testing

Testing will come in another PR.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
