### PR TITLE
feat: mls remove user from mls group FS-546

### DIFF
--- a/MLS/MLSClientID.swift
+++ b/MLS/MLSClientID.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// An ID representing a identifying a single user client.
 
-struct MLSClientID: Equatable {
+public struct MLSClientID: Equatable {
 
     // MARK: - Properties
 
@@ -59,6 +59,11 @@ struct MLSClientID: Equatable {
         self.clientID = clientID.lowercased()
         self.domain = domain.lowercased()
         self.string = "\(self.userID):\(self.clientID)@\(self.domain)"
+    }
+
+    
+    public var bytes: Bytes? {
+        string.base64EncodedString?.base64EncodedBytes
     }
 
 }

--- a/MLS/MLSClientID.swift
+++ b/MLS/MLSClientID.swift
@@ -61,9 +61,4 @@ public struct MLSClientID: Equatable {
         self.string = "\(self.userID):\(self.clientID)@\(self.domain)"
     }
 
-    
-    public var bytes: Bytes? {
-        string.base64EncodedString?.base64EncodedBytes
-    }
-
 }

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -33,7 +33,7 @@ public protocol MLSControllerProtocol {
 
     func addMembersToConversation(with users: [MLSUser], for groupID: MLSGroupID) async throws
 
-    func removeMembersFromConversation(with clientIds: [ClientId], for groupID: MLSGroupID) async throws
+    func removeMembersFromConversation(with clientIds: [MLSClientID], for groupID: MLSGroupID) async throws
 }
 
 public final class MLSController: MLSControllerProtocol {
@@ -239,13 +239,15 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     public func removeMembersFromConversation(
-        with clientIds: [ClientId],
+        with clientIds: [MLSClientID],
         for groupID: MLSGroupID
     ) async throws {
 
         guard !clientIds.isEmpty else {
             throw MLSRemoveParticipantsError.noClientsToRemove
         }
+        
+        let clientIds =  clientIds.compactMap { $0.bytes }
 
         let messageToSend = try removeMembers(id: groupID, clientIds: clientIds)
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -247,7 +247,7 @@ public final class MLSController: MLSControllerProtocol {
             throw MLSRemoveParticipantsError.noClientsToRemove
         }
         
-        let clientIds =  clientIds.compactMap { $0.bytes }
+        let clientIds =  clientIds.compactMap { $0.string.utf8Data?.bytes }
 
         let messageToSend = try removeMembers(id: groupID, clientIds: clientIds)
 

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -211,8 +211,14 @@ extension ZMConversation {
             action.send(in: context.notificationContext)
 
         case .mls:
+            var mlsController: MLSControllerProtocol?
+
+            context.zm_sync.performAndWait {
+                mlsController = context.zm_sync.mlsController
+            }
+
             guard
-                let mlsController = context.mlsController,
+                let mlsController = mlsController,
                 let groupID = mlsGroupID
 
             else {
@@ -220,9 +226,10 @@ extension ZMConversation {
                 return
             }
 
+            let clientIDs = user.clients.compactMap { MLSClientID(userClient: $0) }
+
             Task {
                 do {
-                    let clientIDs = user.clients.compactMap { MLSClientID(userClient: $0) }
 
                     try await mlsController.removeMembersFromConversation(with: clientIDs, for: groupID)
 

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -226,7 +226,7 @@ extension ZMConversation {
                 return
             }
 
-            let clientIDs = user.clients.compactMap { MLSClientID(userClient: $0) }
+            let clientIDs = user.clients.compactMap( MLSClientID.init(userClient:))
 
             Task {
                 do {

--- a/Source/Utilis/String+Bytes.swift
+++ b/Source/Utilis/String+Bytes.swift
@@ -24,4 +24,8 @@ extension String {
         return Bytes(base64Encoded: self)
     }
 
+    public var base64EncodedString: String? {
+        data(using: .utf8)?.base64EncodedString()
+    }
+
 }

--- a/Source/Utilis/String+Bytes.swift
+++ b/Source/Utilis/String+Bytes.swift
@@ -24,8 +24,4 @@ extension String {
         return Bytes(base64Encoded: self)
     }
 
-    public var base64EncodedString: String? {
-        data(using: .utf8)?.base64EncodedString()
-    }
-
 }

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -405,7 +405,9 @@ class MLSControllerTests: ZMConversationTestsBase {
         let removeMembersFromConversationCalls = mockCoreCrypto.calls.removeClientsFromConversation
         XCTAssertEqual(removeMembersFromConversationCalls.count, 1)
         XCTAssertEqual(removeMembersFromConversationCalls[0].0, mlsGroupID.bytes)
-        XCTAssertEqual(removeMembersFromConversationCalls[0].1, [mlsClientID.bytes])
+
+        let mlsClientIDBytes = mlsClientID.string.data(using: .utf8)!.bytes
+        XCTAssertEqual(removeMembersFromConversationCalls[0].1, [mlsClientIDBytes])
     }
 
     func test_RemovingMembersToConversation_ThrowsNoClientsToRemove() async {

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -372,7 +372,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         // Mock return value for removing clients to conversation.
         mockCoreCrypto.mockRemoveClientsFromConversation = [0, 0, 0, 0]
 
-        // // Mock update event for member leaves from conversation
+        // Mock update event for member leaves from conversation
         var updateEvent: ZMUpdateEvent!
 
         // Mock sending message.

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -361,33 +361,30 @@ class MLSControllerTests: ZMConversationTestsBase {
 
     // MARK: - Remove participants
 
-    func test_RemoveMembersFromConversation_IsSuccessfull() async {
+    func test_RemoveMembersFromConversation_IsSuccessful() async {
         // Given
         let domain = "example.com"
         let id = UUID.create().uuidString
         let clientID = UUID.create().uuidString
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
-        let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain).string.data(using: .utf8)!.base64EncodedString().base64EncodedBytes!
+        let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain)
 
         // Mock return value for removing clients to conversation.
         mockCoreCrypto.mockRemoveClientsFromConversation = [0, 0, 0, 0]
+
+        // // Mock update event for member leaves from conversation
+        var updateEvent: ZMUpdateEvent!
 
         // Mock sending message.
         mockActionsProvider.sendMessageMocks.append({ message in
             XCTAssertEqual(message, Data([0, 0, 0, 0]))
 
-            // Mock update event for member join
-            let payload: NSDictionary = [
-                "type": "team.member-join",
+            let mockPayload: NSDictionary = [
+                "type": "conversation.member-leave",
                 "data": message
             ]
 
-            let updateEvent = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
-
-            self.mockConversationEventProcessor.processConversationEvents([updateEvent])
-
-            let processConversationEventsCalls = self.mockConversationEventProcessor.calls.processConversationEvents
-            XCTAssertEqual(processConversationEventsCalls.count, 1)
+            updateEvent = ZMUpdateEvent(fromEventStreamPayload: mockPayload, uuid: nil)!
 
             return [updateEvent]
         })
@@ -400,13 +397,18 @@ class MLSControllerTests: ZMConversationTestsBase {
             XCTFail("Unexpected error: \(String(describing: error))")
         }
 
+        // Then
+        let processConversationEventsCalls = self.mockConversationEventProcessor.calls.processConversationEvents
+        XCTAssertEqual(processConversationEventsCalls.count, 1)
+        XCTAssertEqual(processConversationEventsCalls[0], [updateEvent])
+
         let removeMembersFromConversationCalls = mockCoreCrypto.calls.removeClientsFromConversation
         XCTAssertEqual(removeMembersFromConversationCalls.count, 1)
         XCTAssertEqual(removeMembersFromConversationCalls[0].0, mlsGroupID.bytes)
-        XCTAssertEqual(removeMembersFromConversationCalls[0].1, [mlsClientID])
+        XCTAssertEqual(removeMembersFromConversationCalls[0].1, [mlsClientID.bytes])
     }
 
-    func test_AddingMembersToConversation_ThrowsNoClientsToRemove() async {
+    func test_RemovingMembersToConversation_ThrowsNoClientsToRemove() async {
         // Given
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
 
@@ -426,13 +428,13 @@ class MLSControllerTests: ZMConversationTestsBase {
         }
     }
 
-    func test_AddingMembersToConversation_FailsToSendHandShakeMessage() async {
+    func test_RemovingMembersToConversation_FailsToSendHandShakeMessage() async {
         // Given
         let domain = "example.com"
         let id = UUID.create().uuidString
         let clientID = UUID.create().uuidString
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
-        let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain).string.data(using: .utf8)!.base64EncodedString().base64EncodedBytes!
+        let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain)
 
         // Mock return value for removing clients to conversation.
         mockCoreCrypto.mockRemoveClientsFromConversation = [0, 0, 0, 0]

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -37,7 +37,7 @@ class MockMLSController: MLSControllerProtocol {
         var processWelcomeMessage = [String]()
         var decrypt = [(String, MLSGroupID)]()
         var addMembersToConversation = [([MLSUser], MLSGroupID)]()
-        var removeMembersFromConversation = [([ClientId], MLSGroupID)]()
+        var removeMembersFromConversation = [([MLSClientID], MLSGroupID)]()
 
     }
 
@@ -88,7 +88,7 @@ class MockMLSController: MLSControllerProtocol {
         calls.addMembersToConversation.append((users, groupID))
     }
 
-    func removeMembersFromConversation(with clientIds: [ClientId], for groupID: MLSGroupID) throws {
+    func removeMembersFromConversation(with clientIds: [MLSClientID], for groupID: MLSGroupID) throws {
         calls.removeMembersFromConversation.append((clientIds, groupID))
     }
 

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -37,6 +37,7 @@ class MockMLSController: MLSControllerProtocol {
         var processWelcomeMessage = [String]()
         var decrypt = [(String, MLSGroupID)]()
         var addMembersToConversation = [([MLSUser], MLSGroupID)]()
+        var removeMembersFromConversation = [([ClientId], MLSGroupID)]()
 
     }
 
@@ -85,6 +86,10 @@ class MockMLSController: MLSControllerProtocol {
 
     func addMembersToConversation(with users: [MLSUser], for groupID: MLSGroupID) throws {
         calls.addMembersToConversation.append((users, groupID))
+    }
+
+    func removeMembersFromConversation(with clientIds: [ClientId], for groupID: MLSGroupID) throws {
+        calls.removeMembersFromConversation.append((clientIds, groupID))
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-546" title="FS-546" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-546</a>  [iOS] Admin removes a user from an MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Added `removeMembersFromConversation` method in `MLSMLSController`.
- Added the call of in `ZMConversation+Participants` and handled the case for proteus and mls.

### Testing

- Added tests for `removeMembersFromConversation` in `MLSMLSController`.
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
