### PR TITLE
fix: moc thread for add participants

### DIFF
--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -154,8 +154,14 @@ extension ZMConversation {
             action.send(in: context.notificationContext)
 
         case .mls:
+            var mlsController: MLSControllerProtocol?
+
+            context.zm_sync.performAndWait {
+                mlsController = context.zm_sync.mlsController
+            }
+
             guard
-                let mlsController = context.mlsController,
+                let mlsController = mlsController,
                 let groupID = mlsGroupID?.base64EncodedString,
                 let mlsGroupID = MLSGroupID(base64Encoded: groupID)
             else {

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -190,12 +190,21 @@ class MLSControllerTests: ZMConversationTestsBase {
             welcome: [1, 1, 1, 1]
         )
 
+        // Mock update event for member joins the conversation
+        var updateEvent: ZMUpdateEvent!
+
         // Mock sending message.
         mockActionsProvider.sendMessageMocks.append({ message in
             XCTAssertEqual(message, Data([0, 0, 0, 0]))
-            // TODO: mock the update events for member join.
-            // TODO: assert that conversation event processor receives the events.
-            return []
+
+            let mockPayload: NSDictionary = [
+                "type": "conversation.member-join",
+                "data": message
+            ]
+
+            updateEvent = ZMUpdateEvent(fromEventStreamPayload: mockPayload, uuid: nil)!
+
+            return [updateEvent]
         })
 
         // Mock sending welcome message.
@@ -210,6 +219,10 @@ class MLSControllerTests: ZMConversationTestsBase {
         } catch let error {
             XCTFail("Unexpected error: \(String(describing: error))")
         }
+
+        let processConversationEventsCalls = self.mockConversationEventProcessor.calls.processConversationEvents
+        XCTAssertEqual(processConversationEventsCalls.count, 1)
+        XCTAssertEqual(processConversationEventsCalls[0], [updateEvent])
 
         let addClientsToConversationCalls = mockCoreCrypto.calls.addClientsToConversation
         XCTAssertEqual(addClientsToConversationCalls.count, 1)
@@ -337,10 +350,21 @@ class MLSControllerTests: ZMConversationTestsBase {
             welcome: [1, 1, 1, 1]
         )
 
+        // Mock update event for member joins the conversation
+        var updateEvent: ZMUpdateEvent!
+
         // Mock sending message.
         mockActionsProvider.sendMessageMocks.append({ message in
             XCTAssertEqual(message, Data([0, 0, 0, 0]))
-            return []
+
+            let mockPayload: NSDictionary = [
+                "type": "conversation.member-join",
+                "data": message
+            ]
+
+            updateEvent = ZMUpdateEvent(fromEventStreamPayload: mockPayload, uuid: nil)!
+
+            return [updateEvent]
         })
 
         do {
@@ -351,6 +375,11 @@ class MLSControllerTests: ZMConversationTestsBase {
             // Then
             switch error {
             case MLSController.MLSGroupCreationError.failedToSendWelcomeMessage:
+
+                let processConversationEventsCalls = self.mockConversationEventProcessor.calls.processConversationEvents
+                XCTAssertEqual(processConversationEventsCalls.count, 1)
+                XCTAssertEqual(processConversationEventsCalls[0], [updateEvent])
+
                 break
 
             default:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Adding participants to mls conversation casing crash.

### Causes (Optional)

Calling `MLSController` `AddParticpants` method from ui MOC causing crash. 

### Solutions

Switched from ui MOC to sync MOC while creating object of `MLSController`

### Testing

Updated the tests for Adding participants.,
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
