### PR TITLE
feat(mls): fetch conversations with mls group id FS-544

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -26,7 +26,6 @@ public protocol MLSControllerProtocol {
 
     func conversationExists(groupID: MLSGroupID) -> Bool
 
-    @discardableResult
     func processWelcomeMessage(welcomeMessage: String) throws -> MLSGroupID
 
     func decrypt(message: String, for groupID: MLSGroupID) throws -> Data?
@@ -328,7 +327,6 @@ public final class MLSController: MLSControllerProtocol {
         return coreCrypto.wire_conversationExists(conversationId: groupID.bytes)
     }
 
-    @discardableResult
     public func processWelcomeMessage(welcomeMessage: String) throws -> MLSGroupID {
         guard let messageBytes = welcomeMessage.base64EncodedBytes else {
             logger.error("failed to convert welcome message to bytes")

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -85,3 +85,29 @@ extension ZMConversation {
     @NSManaged public var isPendingWelcomeMessage: Bool
 
 }
+
+// MARK: - Fetch by group id
+
+public extension ZMConversation {
+
+    static func fetch(
+        with groupID: MLSGroupID,
+        in context: NSManagedObjectContext
+    ) -> ZMConversation? {
+        let request = Self.fetchRequest()
+
+        // TODO: Also use the domain?
+        request.predicate = NSPredicate(
+            format: "%K == %@",
+            argumentArray: [Self.mlsGroupID, groupID.data]
+        )
+
+        request.fetchLimit = 2
+
+        let result = context.executeFetchRequestOrAssert(request)
+        // TODO: assert one result
+        return result.first
+
+    }
+
+}

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -100,13 +100,13 @@ public extension ZMConversation {
 
         if APIVersion.isFederationEnabled {
             request.predicate = NSPredicate(
-                format: "%K == %@",
-                argumentArray: [Self.mlsGroupID, groupID.data]
+                format: "%K == %@ AND %K == %@",
+                argumentArray: [Self.mlsGroupID, groupID.data, Self.domainKey()!, domain]
             )
         } else {
             request.predicate = NSPredicate(
-                format: "%K == %@ AND %K == %@",
-                argumentArray: [Self.mlsGroupID, groupID.data, Self.domainKey()!, domain]
+                format: "%K == %@",
+                argumentArray: [Self.mlsGroupID, groupID.data]
             )
         }
 

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -105,9 +105,10 @@ public extension ZMConversation {
         request.fetchLimit = 2
 
         let result = context.executeFetchRequestOrAssert(request)
-        // TODO: assert one result
-        return result.first
 
+        // TODO: assert one result
+
+        return result.first as? ZMConversation
     }
 
 }

--- a/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+final class ZMConversationTests_MLS: ZMConversationTestsBase {
+
+    func testThatItFetchesConversationWithGroupID() {
+        syncMOC.performGroupedBlockAndWait { [self] in
+            // Given
+            let groupID = MLSGroupID([1, 2, 3])
+            let domain = "example.com"
+            let conversation = self.createConversation(groupID: groupID, domain: domain)
+
+            // When
+            let fetchedConversation = ZMConversation.fetch(with: groupID, domain: domain, in: syncMOC)
+
+            // Then
+            XCTAssertEqual(fetchedConversation, conversation)
+        }
+    }
+
+    private func createConversation(groupID: MLSGroupID, domain: String) -> ZMConversation? {
+        let conversation = ZMConversation.insertNewObject(in: syncMOC)
+        conversation.remoteIdentifier = NSUUID.create()
+        conversation.mlsGroupID = groupID
+        conversation.domain = domain
+        XCTAssert(syncMOC.saveOrRollback())
+        return conversation
+    }
+
+}

--- a/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -21,9 +21,31 @@ import Foundation
 
 final class ZMConversationTests_MLS: ZMConversationTestsBase {
 
-    func testThatItFetchesConversationWithGroupID() {
+    override func tearDown() {
+        APIVersion.isFederationEnabled = false
+        super.tearDown()
+    }
+
+    func testThatItFetchesConversationWithGroupID_FederationDisabled() {
         syncMOC.performGroupedBlockAndWait { [self] in
             // Given
+            APIVersion.isFederationEnabled = false
+            let groupID = MLSGroupID([1, 2, 3])
+            let domain = "example.com"
+            let conversation = self.createConversation(groupID: groupID, domain: domain)
+
+            // When
+            let fetchedConversation = ZMConversation.fetch(with: groupID, domain: domain, in: syncMOC)
+
+            // Then
+            XCTAssertEqual(fetchedConversation, conversation)
+        }
+    }
+
+    func testThatItFetchesConversationWithGroupID_FederationEnabled() {
+        syncMOC.performGroupedBlockAndWait { [self] in
+            // Given
+            APIVersion.isFederationEnabled = true
             let groupID = MLSGroupID([1, 2, 3])
             let domain = "example.com"
             let conversation = self.createConversation(groupID: groupID, domain: domain)

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		EEBACDA725B9C2C6000210AC /* AppLockType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBACDA625B9C2C6000210AC /* AppLockType.swift */; };
 		EEBACDA925B9C47E000210AC /* AppLockController.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBACDA825B9C47E000210AC /* AppLockController.Config.swift */; };
 		EEBACDAB25B9C4B0000210AC /* AppLockAuthenticationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBACDAA25B9C4B0000210AC /* AppLockAuthenticationResult.swift */; };
+		EEBF69ED28A2724800195771 /* ZMConversationTests+MLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBF69EC28A2724800195771 /* ZMConversationTests+MLS.swift */; };
 		EEC3BC742888403000BFDC35 /* MockCoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */; };
 		EEC3BC76288855C000BFDC35 /* MockMLSActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */; };
 		EEC47ED627A81EF60020B599 /* Feature+ClassifiedDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */; };
@@ -1331,6 +1332,7 @@
 		EEBACDA625B9C2C6000210AC /* AppLockType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockType.swift; sourceTree = "<group>"; };
 		EEBACDA825B9C47E000210AC /* AppLockController.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockController.Config.swift; sourceTree = "<group>"; };
 		EEBACDAA25B9C4B0000210AC /* AppLockAuthenticationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockAuthenticationResult.swift; sourceTree = "<group>"; };
+		EEBF69EC28A2724800195771 /* ZMConversationTests+MLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+MLS.swift"; sourceTree = "<group>"; };
 		EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoreCrypto.swift; sourceTree = "<group>"; };
 		EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSActionsProvider.swift; sourceTree = "<group>"; };
 		EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feature+ClassifiedDomains.swift"; sourceTree = "<group>"; };
@@ -2628,6 +2630,7 @@
 				F9B71F571CB2BC85001DB03F /* ZMConversationTests.h */,
 				F9B71F581CB2BC85001DB03F /* ZMConversationTests.m */,
 				A94166FB2680CCB5001F4E37 /* ZMConversationTests.swift */,
+				EEBF69EC28A2724800195771 /* ZMConversationTests+MLS.swift */,
 				A96E7A9725A35CEF004FAADC /* ZMConversationTests+Knock.swift */,
 				63D41E6E24573F420076826F /* ZMConversationTests+SelfConversation.swift */,
 				16F7341024F9556600AB93B1 /* ZMConversationTests+DraftMessage.swift */,
@@ -3837,6 +3840,7 @@
 				1600D944267BC5A100970F99 /* ZMManagedObjectFetchingTests.swift in Sources */,
 				F9A708531CAEEB7500C2F5FE /* ZMManagedObjectTests.m in Sources */,
 				F92C992D1DAFC5AC0034AFDD /* ZMConversationTests+Ephemeral.swift in Sources */,
+				EEBF69ED28A2724800195771 /* ZMConversationTests+MLS.swift in Sources */,
 				7A2778C8285329210044A73F /* KeychainManagerTests.swift in Sources */,
 				0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */,
 				068D610324629AB900A110A2 /* ZMBaseManagedObjectTest.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-544" title="FS-544" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-544</a>  [iOS] Process incoming welcome
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add the possibility to fetch a conversation with the group id. This is useful when we need to process the incoming welcome message and only have the group id rather than the usual remote identifier.

### Testing

#### Test Coverage

- unit test for fetching the conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
