### PR TITLE
chore(mls): update core crypto to 0.3.1 FS-859

### DIFF
--- a/MLS/CoreCryptoTypes.swift
+++ b/MLS/CoreCryptoTypes.swift
@@ -23,48 +23,76 @@ import Foundation
 // interface of CoreCrypto here, link it in the UI project, and inject
 // it into this project.
 
+// VersionL 0.3.0
+
+// MARK: - Protocols
+
 public protocol CoreCryptoProtocol {
 
     func wire_setCallbacks(callbacks: CoreCryptoCallbacks) throws
     func wire_clientPublicKey() throws -> [UInt8]
     func wire_clientKeypackages(amountRequested: UInt32) throws -> [[UInt8]]
+    func wire_clientValidKeypackagesCount() throws -> UInt64
     func wire_createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws
-    func wire_conversationExists(conversationId: ConversationId) -> Bool
+    func wire_conversationExists(conversationId: ConversationId)  -> Bool
     func wire_processWelcomeMessage(welcomeMessage: [UInt8]) throws -> ConversationId
-    func wire_addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages?
-    func wire_removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> [UInt8]?
-    func wire_leaveConversation(conversationId: ConversationId, otherClients: [ClientId]) throws -> ConversationLeaveMessages
-    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> [UInt8]?
+    func wire_addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages
+    func wire_removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> CommitBundle
+    func wire_wipeConversation(conversationId: ConversationId) throws
+    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage
     func wire_encryptMessage(conversationId: ConversationId, message: [UInt8]) throws -> [UInt8]
     func wire_newAddProposal(conversationId: ConversationId, keyPackage: [UInt8]) throws -> [UInt8]
     func wire_newUpdateProposal(conversationId: ConversationId) throws -> [UInt8]
     func wire_newRemoveProposal(conversationId: ConversationId, clientId: ClientId) throws -> [UInt8]
-    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64, keyPackage: [UInt8]) throws -> [UInt8]
+    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64) throws -> [UInt8]
     func wire_newExternalRemoveProposal(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8]) throws -> [UInt8]
     func wire_updateKeyingMaterial(conversationId: ConversationId) throws -> CommitBundle
     func wire_joinByExternalCommit(groupState: [UInt8]) throws -> MlsConversationInitMessage
     func wire_exportGroupState(conversationId: ConversationId) throws -> [UInt8]
     func wire_mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws
+    func wire_randomBytes(length: UInt32) throws -> [UInt8]
+    func wire_reseedRng(seed: [UInt8]) throws
+    func wire_commitAccepted(conversationId: ConversationId) throws
+    func wire_commitPendingProposals(conversationId: ConversationId) throws -> CommitBundle
 
 }
 
-public protocol CoreCryptoCallbacks: AnyObject {
+public protocol CoreCryptoCallbacks : AnyObject {
 
-    func authorize(conversationId: [UInt8], clientId: String) -> Bool
+    func authorize(conversationId: [UInt8], clientId: String)  -> Bool
+    func isUserInGroup(identity: [UInt8], otherClients: [[UInt8]])  -> Bool
 
 }
 
-public struct ConversationConfiguration: Equatable {
+// MARK: - Structs
+
+public struct CommitBundle: Equatable, Hashable {
+
+    public var welcome: [UInt8]?
+    public var commit: [UInt8]
+    public var publicGroupState: [UInt8]
+
+    public init(
+        welcome: [UInt8]?,
+        commit: [UInt8],
+        publicGroupState: [UInt8]
+    ) {
+        self.welcome = welcome
+        self.commit = commit
+        self.publicGroupState = publicGroupState
+    }
+}
+
+public struct ConversationConfiguration: Equatable, Hashable {
+
     public var admins: [MemberId]
     public var ciphersuite: CiphersuiteName?
     public var keyRotationSpan: TimeInterval?
     public var externalSenders: [[UInt8]]
 
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
     public init(
         admins: [MemberId] = [],
-        ciphersuite: CiphersuiteName? = nil,
+        ciphersuite: CiphersuiteName,
         keyRotationSpan: TimeInterval? = nil,
         externalSenders: [[UInt8]] = []
     ) {
@@ -75,7 +103,76 @@ public struct ConversationConfiguration: Equatable {
     }
 }
 
-public enum CiphersuiteName: Equatable {
+public struct DecryptedMessage: Equatable, Hashable {
+
+    public var message: [UInt8]?
+    public var proposals: [[UInt8]]
+    public var isActive: Bool
+    public var commitDelay: UInt64?
+
+    public init(
+        message: [UInt8]?,
+        proposals: [[UInt8]],
+        isActive: Bool,
+        commitDelay: UInt64?
+    ) {
+        self.message = message
+        self.proposals = proposals
+        self.isActive = isActive
+        self.commitDelay = commitDelay
+    }
+}
+
+public struct Invitee: Equatable, Hashable {
+
+    public var id: ClientId
+    public var kp: [UInt8]
+
+    public init(
+        id: ClientId,
+        kp: [UInt8]
+    ) {
+        self.id = id
+        self.kp = kp
+    }
+}
+
+public struct MemberAddedMessages: Equatable, Hashable {
+
+    public var commit: [UInt8]
+    public var welcome: [UInt8]
+    public var publicGroupState: [UInt8]
+
+    public init(
+        commit: [UInt8],
+        welcome: [UInt8],
+        publicGroupState: [UInt8]
+    ) {
+        self.commit = commit
+        self.welcome = welcome
+        self.publicGroupState = publicGroupState
+    }
+}
+
+public struct MlsConversationInitMessage: Equatable, Hashable {
+
+    public var group: [UInt8]
+    public var commit: [UInt8]
+
+    public init(
+        group: [UInt8],
+        commit: [UInt8]
+    ) {
+        self.group = group
+        self.commit = commit
+    }
+}
+
+
+
+// MARK: - Enums
+
+public enum CiphersuiteName: Equatable, Hashable {
 
     case mls128Dhkemx25519Aes128gcmSha256Ed25519
     case mls128Dhkemp256Aes128gcmSha256P256
@@ -87,43 +184,7 @@ public enum CiphersuiteName: Equatable {
 
 }
 
-public struct MemberAddedMessages {
-
-    public var message: [UInt8]
-    public var welcome: [UInt8]
-
-    public init(message: [UInt8], welcome: [UInt8] ) {
-        self.message = message
-        self.welcome = welcome
-    }
-
-}
-
-public struct ConversationLeaveMessages {
-
-    public var selfRemovalProposal: [UInt8]
-    public var otherClientsRemovalCommit: [UInt8]?
-
-    public init(selfRemovalProposal: [UInt8], otherClientsRemovalCommit: [UInt8]?) {
-        self.selfRemovalProposal = selfRemovalProposal
-        self.otherClientsRemovalCommit = otherClientsRemovalCommit
-    }
-
-}
-
-public struct Invitee: Equatable {
-    public var id: ClientId
-    public var kp: [UInt8]
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(id: ClientId, kp: [UInt8]) {
-        self.id = id
-        self.kp = kp
-    }
-}
-
-public enum CryptoError: Error {
+public enum CryptoError: Equatable, Hashable {
 
     // Simple error enums only carry a message
     case ConversationNotFound(message: String)
@@ -144,7 +205,13 @@ public enum CryptoError: Error {
     case LockPoisonError(message: String)
 
     // Simple error enums only carry a message
+    case ImplementationError(message: String)
+
+    // Simple error enums only carry a message
     case OutOfKeyPackage(message: String)
+
+    // Simple error enums only carry a message
+    case MlsProviderError(message: String)
 
     // Simple error enums only carry a message
     case KeyStoreError(message: String)
@@ -162,6 +229,9 @@ public enum CryptoError: Error {
     case ParseIntError(message: String)
 
     // Simple error enums only carry a message
+    case ConvertIntError(message: String)
+
+    // Simple error enums only carry a message
     case InvalidByteArrayError(message: String)
 
     // Simple error enums only carry a message
@@ -170,43 +240,16 @@ public enum CryptoError: Error {
     // Simple error enums only carry a message
     case Unauthorized(message: String)
 
+    // Simple error enums only carry a message
+    case CallbacksNotSet(message: String)
+
+    // Simple error enums only carry a message
+    case ExternalAddProposalError(message: String)
+
 }
 
-public enum CoreCryptoLifecycle {
-    /**
-     * Initialize the FFI and Rust library. This should be only called once per application.
-     */
-    func initialize() {
+// MARK: - Type aliases
 
-        // No initialization code needed
-
-    }
-}
-
-public typealias ConversationId = [UInt8]
 public typealias ClientId = [UInt8]
+public typealias ConversationId = [UInt8]
 public typealias MemberId = [UInt8]
-
-public struct CommitBundle {
-    public var welcome: [UInt8]?
-    public var message: [UInt8]
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(welcome: [UInt8]?, message: [UInt8]) {
-        self.welcome = welcome
-        self.message = message
-    }
-}
-
-public struct MlsConversationInitMessage {
-    public var group: [UInt8]
-    public var message: [UInt8]
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(group: [UInt8], message: [UInt8]) {
-        self.group = group
-        self.message = message
-    }
-}

--- a/MLS/CoreCryptoTypes.swift
+++ b/MLS/CoreCryptoTypes.swift
@@ -184,7 +184,7 @@ public enum CiphersuiteName: Equatable, Hashable {
 
 }
 
-public enum CryptoError: Equatable, Hashable {
+public enum CryptoError: Error, Equatable, Hashable {
 
     // Simple error enums only carry a message
     case ConversationNotFound(message: String)

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -207,7 +207,7 @@ public final class MLSController: MLSControllerProtocol {
         let messagesToSend = try addMembers(id: groupID, invitees: invitees)
 
         guard let messagesToSend = messagesToSend else { return }
-        try await sendMessage(messagesToSend.message)
+        try await sendMessage(messagesToSend.commit)
         try await sendWelcomeMessage(messagesToSend.welcome)
 
     }
@@ -241,24 +241,19 @@ public final class MLSController: MLSControllerProtocol {
         with clientIds: [MLSClientID],
         for groupID: MLSGroupID
     ) async throws {
-
         guard !clientIds.isEmpty else {
             throw MLSRemoveParticipantsError.noClientsToRemove
         }
         
         let clientIds =  clientIds.compactMap { $0.string.utf8Data?.bytes }
-
         let messageToSend = try removeMembers(id: groupID, clientIds: clientIds)
-
-        guard let messageToSend = messageToSend else { return }
-        try await sendMessage(messageToSend)
-
+        try await sendMessage(messageToSend.commit)
     }
 
     private func removeMembers(
         id: MLSGroupID,
         clientIds: [ClientId]
-    ) throws -> Bytes? {
+    ) throws -> CommitBundle {
 
         do {
             return try coreCrypto.wire_removeClientsFromConversation(
@@ -414,11 +409,11 @@ public final class MLSController: MLSControllerProtocol {
         }
 
         do {
-            let decryptedMessageBytes = try coreCrypto.wire_decryptMessage(
+            let decryptedMessage = try coreCrypto.wire_decryptMessage(
                 conversationId: groupID.bytes,
                 payload: messageBytes
             )
-            return decryptedMessageBytes?.data
+            return decryptedMessage.message?.data
         } catch {
             logger.warn("failed to decrypt message: \(String(describing: error))")
             throw MLSMessageDecryptionError.failedToDecryptMessage

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -247,6 +247,8 @@ class MLSControllerTests: ZMConversationTestsBase {
         let actualInvitees = addClientsToConversationCalls[0].1
         XCTAssertEqual(actualInvitees.count, 1)
         XCTAssertTrue(actualInvitees.contains(invitee))
+
+        XCTAssertEqual(mockCoreCrypto.calls.commitAccepted, [mlsGroupID.bytes])
     }
 
     func test_AddingMembersToConversation_ThrowsNoParticipantsToAdd() async {
@@ -268,6 +270,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
     func test_AddingMembersToConversation_ThrowsFailedToClaimKeyPackages() async {
@@ -291,6 +295,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
     func test_AddingMembersToConversation_ThrowsFailedToSendHandshakeMessage() async {
@@ -336,6 +342,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
     func test_AddingMembersToConversation_ThrowsFailedToSendWelcomeMessage() async {
@@ -401,6 +409,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertEqual(mockCoreCrypto.calls.commitAccepted, [mlsGroupID.bytes])
     }
 
     // MARK: - Remove participants
@@ -456,6 +466,8 @@ class MLSControllerTests: ZMConversationTestsBase {
 
         let mlsClientIDBytes = mlsClientID.string.data(using: .utf8)!.bytes
         XCTAssertEqual(removeMembersFromConversationCalls[0].1, [mlsClientIDBytes])
+
+        XCTAssertEqual(mockCoreCrypto.calls.commitAccepted, [mlsGroupID.bytes])
     }
 
     func test_RemovingMembersToConversation_ThrowsNoClientsToRemove() async {
@@ -476,6 +488,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
     func test_RemovingMembersToConversation_FailsToSendHandShakeMessage() async {
@@ -507,6 +521,8 @@ class MLSControllerTests: ZMConversationTestsBase {
                 XCTFail("Unexpected error: \(String(describing: error))")
             }
         }
+
+        XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
 }

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -62,7 +62,7 @@ class MLSControllerTests: ZMConversationTestsBase {
             let encryptedMessage: Bytes = [3, 3, 3]
 
             // Mock
-            mockCoreCrypto.mockEncryptMessage = encryptedMessage
+            mockCoreCrypto.mockResultForEncryptMessage = encryptedMessage
 
             // When
             let result = try sut.encrypt(message: unencryptedMessage, for: groupID)
@@ -85,7 +85,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         let unencryptedMessage: Bytes = [2, 2, 2]
 
         // Mock
-        mockCoreCrypto.mockEncryptError = CryptoError.InvalidByteArrayError(message: "bad bytes!")
+        mockCoreCrypto.mockErrorForEncryptMessage = CryptoError.InvalidByteArrayError(message: "bad bytes!")
 
         // When / Then
         assertItThrows(error: EncryptionError.failedToEncryptMessage) {

--- a/Tests/MLS/MockCoreCrypto.swift
+++ b/Tests/MLS/MockCoreCrypto.swift
@@ -25,174 +25,388 @@ class MockCoreCrypto: CoreCryptoProtocol {
 
     struct Calls {
 
-        var setCallBacksCallCount = 0
+        var setCallbacksCount = 0
+        var clientPublicKey: [Void] = []
         var clientKeypackages = [UInt32]()
-        var createConversation = [(ConversationId, ConversationConfiguration)]()
+        var clientValidKeypackagesCount: [Void] = []
+        var createConversation = [(conversationId: ConversationId, config: ConversationConfiguration)]()
         var conversationExists = [ConversationId]()
         var processWelcomeMessage = [[UInt8]]()
-        var addClientsToConversation = [(ConversationId, [Invitee])]()
-        var removeClientsFromConversation = [(ConversationId, [ClientId])]()
-        var leaveConversation = [(ConversationId, [ClientId])]()
-        var decryptMessage = [(ConversationId, [UInt8])]()
-        var encryptMessage = [(ConversationId, [UInt8])]()
-        var newAddProposal = [(ConversationId, [UInt8])]()
+        var addClientsToConversation = [(conversationId: ConversationId, clients: [Invitee])]()
+        var removeClientsFromConversation = [(conversationId: ConversationId, clients: [ClientId])]()
+        var wipeConversation = [ConversationId]()
+        var decryptMessage = [(conversationId: ConversationId, payload: [UInt8])]()
+        var encryptMessage = [(conversationId: ConversationId, message: [UInt8])]()
+        var newAddProposal = [(conversationId: ConversationId, keyPackage: [UInt8])]()
         var newUpdateProposal = [ConversationId]()
-        var newRemoveProposal = [(ConversationId, ClientId)]()
-        var newExternalAddProposal = [(ConversationId, UInt64, [UInt8])]()
-        var newExternalRemoveProposal = [(ConversationId, UInt64, [UInt8])]()
+        var newRemoveProposal = [(conversationId: ConversationId, clientId: ClientId)]()
+        var newExternalAddProposal = [(conversationId: ConversationId, epoch: UInt64)]()
+        var newExternalRemoveProposal = [(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8])]()
         var updateKeyingMaterial = [ConversationId]()
         var joinByExternalCommit = [[UInt8]]()
         var exportGroupState = [ConversationId]()
-        var mergePendingGroupFromExternalCommit = [(ConversationId, ConversationConfiguration)]()
-
+        var mergePendingGroupFromExternalCommit = [(conversationId: ConversationId, config: ConversationConfiguration)]()
+        var randomBytes = [UInt32]()
+        var reseedRng = [[UInt8]]()
+        var commitAccepted = [ConversationId]()
+        var commitPendingProposals = [ConversationId]()
     }
 
     // MARK: - Properties
 
     var calls = Calls()
 
-    // MARK: - Methods
+    // MARK: - setCallbacks
+
+    var mockErrorForSetCallbacks: CryptoError?
 
     func wire_setCallbacks(callbacks: CoreCryptoCallbacks) throws {
-        calls.setCallBacksCallCount += 1
+        calls.setCallbacksCount += 1
+
+        if let error = mockErrorForSetCallbacks {
+            throw error
+        }
     }
 
-    var mockClientPublicKey: [UInt8]?
+    // MARK: - clientPublicKey
+
+    var mockResultForClientPublicKey: [UInt8]?
+    var mockErrorForClientPublicKey: CryptoError?
 
     func wire_clientPublicKey() throws -> [UInt8] {
-        return try XCTUnwrap(mockClientPublicKey, "return value not mocked")
+        calls.clientPublicKey.append(())
+
+        if let error = mockErrorForClientPublicKey {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForClientPublicKey, "no mocked result for `clientPublicKey`")
     }
 
-    var mockClientKeyPackages: [[UInt8]]?
+    // MARK: - clientKeypackages
+
+    var mockResultForClientKeypackages: [[UInt8]]?
+    var mockErrorForClientKeypackages: CryptoError?
 
     func wire_clientKeypackages(amountRequested: UInt32) throws -> [[UInt8]] {
         calls.clientKeypackages.append(amountRequested)
-        return try XCTUnwrap(mockClientKeyPackages, "return value not mocked")
+
+        if let error = mockErrorForClientKeypackages {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForClientKeypackages, "no mocked result for `clientKeypackages`")
     }
 
-    var mockCreateConversationError: CryptoError?
+    // MARK: - clientValidKeypackagesCount
+
+    var mockResultForClientValidKeypackagesCount: UInt64?
+    var mockErrorForClientValidKeypackagesCount: CryptoError?
+
+    func wire_clientValidKeypackagesCount() throws -> UInt64 {
+        calls.clientValidKeypackagesCount.append(())
+
+        if let error = mockErrorForClientValidKeypackagesCount {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForClientValidKeypackagesCount, "no mocked result for `clientValidKeypackagesCount`")
+    }
+
+    // MARK: - createConversation
+
+    var mockErrorForCreateConversation: CryptoError?
 
     func wire_createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         calls.createConversation.append((conversationId, config))
 
-        if let error = mockCreateConversationError {
+        if let error = mockErrorForCreateConversation {
             throw error
         }
     }
 
-    var mockConversationExists: Bool?
+    // MARK: - conversationExists
+
+    var mockResultForConversationExists: Bool?
 
     func wire_conversationExists(conversationId: ConversationId) -> Bool {
         calls.conversationExists.append(conversationId)
-        return mockConversationExists ?? false
+
+        let result = try? XCTUnwrap(mockResultForConversationExists, "no mocked result for `conversationExists`")
+        return result ?? false
     }
 
-    var mockProcessWelcomeMessage: ConversationId?
+    // MARK: - processWelcomeMessage
+
+    var mockResultForProcessWelcomeMessage: ConversationId?
+    var mockErrorForProcessWelcomeMessage: CryptoError?
 
     func wire_processWelcomeMessage(welcomeMessage: [UInt8]) throws -> ConversationId {
         calls.processWelcomeMessage.append(welcomeMessage)
-        return try XCTUnwrap(mockProcessWelcomeMessage, "return value not mocked")
-    }
 
-    var mockAddClientsToConversation: MemberAddedMessages??
-
-    func wire_addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages? {
-        calls.addClientsToConversation.append((conversationId, clients))
-        return try XCTUnwrap(mockAddClientsToConversation, "return value not mocked")
-    }
-
-    var mockRemoveClientsFromConversation: [UInt8]??
-
-    func wire_removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> [UInt8]? {
-        calls.removeClientsFromConversation.append((conversationId, clients))
-        return try XCTUnwrap(mockRemoveClientsFromConversation, "return value not mocked")
-    }
-
-    var mockLeaveConversation: ConversationLeaveMessages?
-
-    func wire_leaveConversation(conversationId: ConversationId, otherClients: [ClientId]) throws -> ConversationLeaveMessages {
-        calls.leaveConversation.append((conversationId, otherClients))
-        return try XCTUnwrap(mockLeaveConversation, "return value not mocked")
-    }
-
-    var mockDecryptMessage: [UInt8]??
-    var mockDecryptError: CryptoError?
-
-    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> [UInt8]? {
-        calls.decryptMessage.append((conversationId, payload))
-
-        if let error = mockDecryptError {
+        if let error = mockErrorForProcessWelcomeMessage {
             throw error
         }
 
-        return try XCTUnwrap(mockDecryptMessage, "return value not mocked")
+        return try XCTUnwrap(mockResultForProcessWelcomeMessage, "no mocked result for `processWelcomeMessage`")
     }
 
-    var mockEncryptMessage: [UInt8]?
+    // MARK: - addClientsToConversation
+
+    var mockResultForAddClientsToConversation: MemberAddedMessages?
+    var mockErrorForAddClientsToConversation: CryptoError?
+
+    func wire_addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages {
+        calls.addClientsToConversation.append((conversationId, clients))
+
+        if let error = mockErrorForAddClientsToConversation {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForAddClientsToConversation, "no mocked result for `addClientsToConversation`")
+    }
+
+    // MARK: - removeClientsFromConversation
+
+    var mockResultForRemoveClientsFromConversation: CommitBundle?
+    var mockErrorForRemoveClientsFromConversation: CryptoError?
+
+    func wire_removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> CommitBundle {
+        calls.removeClientsFromConversation.append((conversationId, clients))
+
+        if let error = mockErrorForRemoveClientsFromConversation {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForRemoveClientsFromConversation, "no mocked result for `removeClientsFromConversation`")
+    }
+
+    // MARK: - wipeConversation
+
+    var mockErrorForWipeConversation: CryptoError?
+
+    func wire_wipeConversation(conversationId: ConversationId) throws {
+        calls.wipeConversation.append(conversationId)
+
+        if let error = mockErrorForWipeConversation {
+            throw error
+        }
+    }
+
+    // MARK: - decryptMessage
+
+    var mockResultForDecryptMessage: DecryptedMessage?
+    var mockErrorForDecryptMessage: CryptoError?
+
+    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage {
+        calls.decryptMessage.append((conversationId, payload))
+
+        if let error = mockErrorForDecryptMessage {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForDecryptMessage, "no mocked result for `decryptMessage`")
+    }
+
+    // MARK: - encryptMessage
+
+    var mockResultForEncryptMessage: [UInt8]?
+    var mockErrorForEncryptMessage: CryptoError?
 
     func wire_encryptMessage(conversationId: ConversationId, message: [UInt8]) throws -> [UInt8] {
         calls.encryptMessage.append((conversationId, message))
-        return try XCTUnwrap(mockEncryptMessage, "return value not mocked")
+
+        if let error = mockErrorForEncryptMessage {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForEncryptMessage, "no mocked result for `encryptMessage`")
     }
 
-    var mockNewAddProposal: [UInt8]?
+    // MARK: - newAddProposal
+
+    var mockResultForNewAddProposal: [UInt8]?
+    var mockErrorForNewAddProposal: CryptoError?
 
     func wire_newAddProposal(conversationId: ConversationId, keyPackage: [UInt8]) throws -> [UInt8] {
         calls.newAddProposal.append((conversationId, keyPackage))
-        return try XCTUnwrap(mockNewAddProposal, "return value not mocked")
+
+        if let error = mockErrorForNewAddProposal {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForNewAddProposal, "no mocked result for `newAddProposal`")
     }
 
-    var mockNewUpdateProposal: [UInt8]?
+    // MARK: - newUpdateProposal
+
+    var mockResultForNewUpdateProposal: [UInt8]?
+    var mockErrorForNewUpdateProposal: CryptoError?
 
     func wire_newUpdateProposal(conversationId: ConversationId) throws -> [UInt8] {
         calls.newUpdateProposal.append(conversationId)
-        return try XCTUnwrap(mockNewUpdateProposal, "return value not mocked")
+
+        if let error = mockErrorForNewUpdateProposal {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForNewUpdateProposal, "no mocked result for `newUpdateProposal`")
     }
 
-    var mockNewRemoveProposal: [UInt8]?
+    // MARK: - newRemoveProposal
+
+    var mockResultForNewRemoveProposal: [UInt8]?
+    var mockErrorForNewRemoveProposal: CryptoError?
 
     func wire_newRemoveProposal(conversationId: ConversationId, clientId: ClientId) throws -> [UInt8] {
         calls.newRemoveProposal.append((conversationId, clientId))
-        return try XCTUnwrap(mockNewRemoveProposal, "return value not mocked")
+
+        if let error = mockErrorForNewRemoveProposal {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForNewRemoveProposal, "no mocked result for `newRemoveProposal`")
     }
 
-    var mockNewExternalAddProposal: [UInt8]?
+    // MARK: - newExternalAddProposal
 
-    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64, keyPackage: [UInt8]) throws -> [UInt8] {
-        calls.newExternalAddProposal.append((conversationId, epoch, keyPackage))
-        return try XCTUnwrap(mockNewExternalAddProposal, "return value not mocked")
+    var mockResultForNewExternalAddProposal: [UInt8]?
+    var mockErrorForNewExternalAddProposal: CryptoError?
+
+    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64) throws -> [UInt8] {
+        calls.newExternalAddProposal.append((conversationId, epoch))
+
+        if let error = mockErrorForNewExternalAddProposal {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForNewExternalAddProposal, "no mocked result for `newExternalAddProposal`")
     }
 
-    var mockNewExternalRemoveProposal: [UInt8]?
+    // MARK: - newExternalRemoveProposal
+
+    var mockResultForNewExternalRemoveProposal: [UInt8]?
+    var mockErrorForNewExternalRemoveProposal: CryptoError?
 
     func wire_newExternalRemoveProposal(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8]) throws -> [UInt8] {
         calls.newExternalRemoveProposal.append((conversationId, epoch, keyPackageRef))
-        return try XCTUnwrap(mockNewExternalRemoveProposal, "return value not mocked")
+
+        if let error = mockErrorForNewExternalRemoveProposal {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForNewExternalRemoveProposal, "no mocked result for `newExternalRemoveProposal`")
     }
 
-    var mockUpdateKeyingMaterial: CommitBundle?
+    // MARK: - updateKeyingMaterial
+
+    var mockResultForUpdateKeyingMaterial: CommitBundle?
+    var mockErrorForUpdateKeyingMaterial: CryptoError?
 
     func wire_updateKeyingMaterial(conversationId: ConversationId) throws -> CommitBundle {
         calls.updateKeyingMaterial.append(conversationId)
-        return try XCTUnwrap(mockUpdateKeyingMaterial, "return value not mocked")
+
+        if let error = mockErrorForUpdateKeyingMaterial {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForUpdateKeyingMaterial, "no mocked result for `updateKeyingMaterial`")
     }
 
-    var mockJoinByExternalCommit: MlsConversationInitMessage?
+    // MARK: - joinByExternalCommit
+
+    var mockResultForJoinByExternalCommit: MlsConversationInitMessage?
+    var mockErrorForJoinByExternalCommit: CryptoError?
 
     func wire_joinByExternalCommit(groupState: [UInt8]) throws -> MlsConversationInitMessage {
         calls.joinByExternalCommit.append(groupState)
-        return try XCTUnwrap(mockJoinByExternalCommit, "return value not mocked")
+
+        if let error = mockErrorForJoinByExternalCommit {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForJoinByExternalCommit, "no mocked result for `joinByExternalCommit`")
     }
 
-    var mockExportGroupState: [UInt8]?
+    // MARK: - exportGroupState
+
+    var mockResultForExportGroupState: [UInt8]?
+    var mockErrorForExportGroupState: CryptoError?
 
     func wire_exportGroupState(conversationId: ConversationId) throws -> [UInt8] {
         calls.exportGroupState.append(conversationId)
-        return try XCTUnwrap(mockExportGroupState, "return value not mocked")
+
+        if let error = mockErrorForExportGroupState {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForExportGroupState, "no mocked result for `exportGroupState`")
     }
+
+    // MARK: - mergePendingGroupFromExternalCommit
+
+    var mockErrorForMergePendingGroupFromExternalCommit: CryptoError?
 
     func wire_mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         calls.mergePendingGroupFromExternalCommit.append((conversationId, config))
+
+        if let error = mockErrorForMergePendingGroupFromExternalCommit {
+            throw error
+        }
+    }
+
+    // MARK: - randomBytes
+
+    var mockResultForRandomBytes: [UInt8]?
+    var mockErrorForRandomBytes: CryptoError?
+
+    func wire_randomBytes(length: UInt32) throws -> [UInt8] {
+        calls.randomBytes.append(length)
+
+        if let error = mockErrorForRandomBytes {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForRandomBytes, "no mocked result for `randomBytes`")
+    }
+
+    // MARK: - reseedRng
+
+    var mockErrorForReseedRng: CryptoError?
+
+    func wire_reseedRng(seed: [UInt8]) throws {
+        calls.reseedRng.append(seed)
+
+        if let error = mockErrorForReseedRng {
+            throw error
+        }
+    }
+
+    // MARK: - commitAccepted
+
+    var mockErrorForCommitAccepted: CryptoError?
+
+    func wire_commitAccepted(conversationId: ConversationId) throws {
+        calls.commitAccepted.append(conversationId)
+
+        if let error = mockErrorForCommitAccepted {
+            throw error
+        }
+    }
+
+    // MARK: - commitPendingProposals
+
+    var mockResultForCommitPendingProposals: CommitBundle?
+    var mockErrorForCommitPendingProposals: CryptoError?
+
+    func wire_commitPendingProposals(conversationId: ConversationId) throws -> CommitBundle {
+        calls.commitPendingProposals.append(conversationId)
+
+        if let error = mockErrorForCommitPendingProposals {
+            throw error
+        }
+
+        return try XCTUnwrap(mockResultForCommitPendingProposals, "no mocked result for `commitPendingProposals`")
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-859" title="FS-859" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-859</a>  [iOS] Update CoreCrypto
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Update CoreCrypto to 0.3.1 by updating the Core Crypto protocol wrapper.
- Updating mocks
- Updating tests
- Calling `commitAccepted` when a handshake message is successfully sent

[Change notes for 0.3.0:](https://github.com/wireapp/core-crypto/blob/v0.3.0/CHANGELOG.md#030---tbd)

### Testing

#### Test Coverage

- updated tests

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
