### PR TITLE
fix(mls): add `conversationMLSMessageAdd` to missing checks FS-675

### DIFF
--- a/Source/Model/Message/ZMMessage+Conversation.swift
+++ b/Source/Model/Message/ZMMessage+Conversation.swift
@@ -41,7 +41,8 @@ extension ZMMessage {
              .conversationKnock:
             return payload.dictionary(forKey: "data")?["nonce"] as? UUID
         case .conversationClientMessageAdd,
-             .conversationOtrMessageAdd:
+             .conversationOtrMessageAdd,
+             .conversationMLSMessageAdd:
             // if event is otr message then payload should be already decrypted and should contain generic message data
             let base64Content = payload.string(forKey: "data")
             let message = GenericMessage(withBase64String: base64Content)

--- a/Source/Model/Message/ZMMessage.m
+++ b/Source/Model/Message/ZMMessage.m
@@ -497,6 +497,7 @@ NSString * const ZMMessageDecryptionErrorCodeKey = @"decryptionErrorCode";
         (type == ZMUpdateEventTypeConversationClientMessageAdd) ||
         (type == ZMUpdateEventTypeConversationOtrMessageAdd) ||
         (type == ZMUpdateEventTypeConversationOtrAssetAdd) ||
+        (type == ZMUpdateEventTypeConversationMLSMessageAdd) ||
         (type == ZMUpdateEventTypeConversationKnock) ||
         [ZMSystemMessage doesEventTypeGenerateSystemMessage:type];
 }

--- a/Source/Utilis/ZMUpdateEvent+WireDataModel.m
+++ b/Source/Utilis/ZMUpdateEvent+WireDataModel.m
@@ -61,7 +61,7 @@
 
 - (NSString *)senderClientID
 {
-    if (self.type == ZMUpdateEventTypeConversationOtrMessageAdd || self.type == ZMUpdateEventTypeConversationOtrAssetAdd) {
+    if (self.type == ZMUpdateEventTypeConversationOtrMessageAdd || self.type == ZMUpdateEventTypeConversationOtrAssetAdd || self.type == ZMUpdateEventTypeConversationMLSMessageAdd) {
         return [[self.payload optionalDictionaryForKey:@"data"] optionalStringForKey:@"sender"];
     }
     return nil;
@@ -79,7 +79,7 @@
 
 - (NSString *)recipientClientID
 {
-    if (self.type == ZMUpdateEventTypeConversationOtrMessageAdd || self.type == ZMUpdateEventTypeConversationOtrAssetAdd) {
+    if (self.type == ZMUpdateEventTypeConversationOtrMessageAdd || self.type == ZMUpdateEventTypeConversationOtrAssetAdd || self.type == ZMUpdateEventTypeConversationMLSMessageAdd) {
         return [[self.payload optionalDictionaryForKey:@"data"] optionalStringForKey:@"recipient"];
     }
     return nil;

--- a/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -347,6 +347,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
                             @(ZMUpdateEventTypeConversationClientMessageAdd),
                             @(ZMUpdateEventTypeConversationOtrMessageAdd),
                             @(ZMUpdateEventTypeConversationOtrAssetAdd),
+                            @(ZMUpdateEventTypeConversationMLSMessageAdd),
                             @(ZMUpdateEventTypeConversationAssetAdd),
                             @(ZMUpdateEventTypeConversationKnock),
                             ];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-675" title="FS-675" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-675</a>  [iOS] Distribute CONFKEY to all members of conversation [temp-M4]
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some logic around processing update events for new messages are failing for messages sent with mls.

### Causes

An example is that when receiving a call message, we rely on the sender id in the update event. The sender id is extracted from the payload, but only if the event type is `conversationOtrMessageAdd` or `conversationOtrAssetAdd`. If it's an mls message, we will always return `nil`, even though the sender id exists.

### Solutions

We add the `conversationMLSMessageAdd` event type not only to this check to get the sender id, but in other checks where we also check OTR messages.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
