### PR TITLE
feat(mls): send external add proposals FS-688

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -446,14 +446,17 @@ public final class MLSController: MLSControllerProtocol {
 
     typealias PendingJoin = (groupID: MLSGroupID, epoch: UInt64)
 
-    /// TODO
-    /// - Parameter group: TODO
+    /// Registers a group to be joined via external add proposal once the app has finished processing events
+    /// - Parameter groupID: the identifier for the MLS group
     public func registerPendingJoin(_ groupID: MLSGroupID) {
         groupsPendingJoin.insert(groupID)
     }
 
 
-    /// TODO
+    /// Request to join groups still pending
+    ///
+    /// Generates a list of groups for which the `mlsStatus` is `pendingJoin`
+    /// and sends external add proposals for these groups
     public func performPendingJoins() {
         guard let context = context else {
             return

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -431,9 +431,14 @@ public final class MLSController: MLSControllerProtocol {
             do {
                 try joinGroupIfNeeded(groupID)
             } catch let error {
-                logger.warn(
-                    "failed to request to join group (\(groupID)). error: \(String(describing: error))"
-                )
+                switch error {
+                case MLSJoinGroupError.notPendingJoin:
+                    logger.info("group (\(groupID)) status isn't `.pendingJoin`")
+                default:
+                    logger.warn(
+                        "failed to request to join group (\(groupID)). error: \(String(describing: error))"
+                    )
+                }
             }
         }
     }
@@ -443,6 +448,7 @@ public final class MLSController: MLSControllerProtocol {
         case conversationNotFound
         case missingMlsStatus
         case missingContext
+        case notPendingJoin
 
     }
 
@@ -463,8 +469,7 @@ public final class MLSController: MLSControllerProtocol {
         }
 
         guard status == .pendingJoin else {
-            // Not an error, so we just log
-            return logger.info("group (\(groupID)) doesn't need to be joined. (status: \(status)")
+            throw MLSJoinGroupError.notPendingJoin
         }
 
         let epoch = conversation.epoch

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -105,7 +105,6 @@ public final class MLSController: MLSControllerProtocol {
         case failedToClaimKeyPackages
         case failedToCreateGroup
         case failedToAddMembers
-        case failedToSendHandshakeMessage
         case failedToSendWelcomeMessage
 
     }
@@ -170,8 +169,12 @@ public final class MLSController: MLSControllerProtocol {
         }
     }
 
+    enum MLSSendMessageError: Error {
+        case failedToSendMessage
+    }
+
     private func sendMessage(_ bytes: Bytes, groupID: MLSGroupID, kind: MessageKind) async throws {
-        logger.info("sending handshake message in group (\(groupID))")
+        logger.info("sending message in group (\(groupID))")
 
         var updateEvents = [ZMUpdateEvent]()
 
@@ -182,8 +185,8 @@ public final class MLSController: MLSControllerProtocol {
                 in: context.notificationContext
             )
         } catch let error {
-            logger.warn("failed to send handshake message in group (\(groupID)): \(String(describing: error))")
-            throw MLSGroupCreationError.failedToSendHandshakeMessage
+            logger.warn("failed to send message in group (\(groupID)): \(String(describing: error))")
+            throw MLSSendMessageError.failedToSendMessage
         }
 
         if kind == .commit {

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
@@ -54,6 +54,7 @@
         <attribute name="domain" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="draftMessageData" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="draftMessageNonce" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="epoch" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="hasReadReceiptsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="hasUnreadUnsentMessage" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="internalEstimatedUnreadCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -345,7 +346,7 @@
         <element name="ButtonState" positionX="-225" positionY="36" width="128" height="105"/>
         <element name="ClientMessage" positionX="9" positionY="153" width="128" height="90"/>
         <element name="Connection" positionX="-133.4921875" positionY="424.80859375" width="128" height="163"/>
-        <element name="Conversation" positionX="785.66015625" positionY="332.30078125" width="128" height="809"/>
+        <element name="Conversation" positionX="785.66015625" positionY="332.30078125" width="128" height="824"/>
         <element name="Feature" positionX="-286.9609375" positionY="-65" width="128" height="119"/>
         <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="103"/>
         <element name="ImageMessage" positionX="5.453125" positionY="-305.99609375" width="128" height="165"/>

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -31,6 +31,9 @@ extension ZMConversation {
     @objc
     static let mlsStatusKey = "mlsStatus"
 
+    @objc
+    static let epochKey = #keyPath(epoch)
+
     // MARK: - Properties
 
     @NSManaged public var epoch: UInt64

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -33,6 +33,8 @@ extension ZMConversation {
 
     // MARK: - Properties
 
+    @NSManaged public var epoch: UInt64
+
     @NSManaged private var primitiveMessageProtocol: NSNumber
 
     /// The message protocol used to exchange messages in this conversation.
@@ -120,23 +122,15 @@ public extension ZMConversation {
 
     static func fetch(
         with groupID: MLSGroupID,
-        domain: String,
         in context: NSManagedObjectContext
     ) -> ZMConversation? {
         let request = Self.fetchRequest()
         request.fetchLimit = 2
 
-        if APIVersion.isFederationEnabled {
-            request.predicate = NSPredicate(
-                format: "%K == %@ AND %K == %@",
-                argumentArray: [Self.mlsGroupIdKey, groupID.data, Self.domainKey()!, domain]
-            )
-        } else {
-            request.predicate = NSPredicate(
-                format: "%K == %@",
-                argumentArray: [Self.mlsGroupIdKey, groupID.data]
-            )
-        }
+        request.predicate = NSPredicate(
+            format: "%K == %@",
+            argumentArray: [Self.mlsGroupIdKey, groupID.data]
+        )
 
         let result = context.executeFetchRequestOrAssert(request)
         require(result.count <= 1, "More than one conversation found for a single group id")

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -106,10 +106,8 @@ extension ZMConversation {
         }
 
         set {
-            guard let status = newValue else { return }
-
             willChangeValue(forKey: Self.mlsStatusKey)
-            primitiveMlsStatus = NSNumber(value: status.rawValue)
+            primitiveMlsStatus = newValue.map { NSNumber(value: $0.rawValue) }
             didChangeValue(forKey: Self.mlsStatusKey)
         }
     }

--- a/Source/Model/Conversation/ZMConversation.m
+++ b/Source/Model/Conversation/ZMConversation.m
@@ -353,7 +353,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             ZMConversationDomainKey,
             ZMConversation.messageProtocolKey,
             ZMConversation.mlsGroupIdKey,
-            ZMConversation.mlsStatusKey
+            ZMConversation.mlsStatusKey,
+            ZMConversation.epochKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -326,7 +326,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
-    func test_AddingMembersToConversation_ThrowsFailedToSendMessage() async {
+    func test_AddingMembersToConversation_ThrowsFailedToSendCommit() async {
         // Given
         let domain = "example.com"
         let id = UUID.create()
@@ -356,7 +356,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         )
 
         // when / then
-        await assertItThrows(error: MLSController.MLSSendMessageError.failedToSendMessage) {
+        await assertItThrows(error: MLSController.MLSSendMessageError.failedToSendCommit) {
             try await sut.addMembersToConversation(with: mlsUser, for: mlsGroupID)
         }
 
@@ -489,7 +489,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         XCTAssertTrue(mockCoreCrypto.calls.commitAccepted.isEmpty)
     }
 
-    func test_RemovingMembersToConversation_FailsToSendMessage() async {
+    func test_RemovingMembersToConversation_FailsToSendCommit() async {
         // Given
         let domain = "example.com"
         let id = UUID.create().uuidString
@@ -505,7 +505,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         )
 
         // When / Then
-        await assertItThrows(error: MLSController.MLSSendMessageError.failedToSendMessage) {
+        await assertItThrows(error: MLSController.MLSSendMessageError.failedToSendCommit) {
             try await sut.removeMembersFromConversation(with: [mlsClientID], for: mlsGroupID)
         }
 

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -39,8 +39,8 @@ class MockMLSController: MLSControllerProtocol {
         var decrypt = [(String, MLSGroupID)]()
         var addMembersToConversation = [([MLSUser], MLSGroupID)]()
         var removeMembersFromConversation = [([MLSClientID], MLSGroupID)]()
-        var addGroupsPendingJoin = [MLSGroupID]()
-        var joinGroupsStillPending: [Void] = []
+        var registerPendingJoin = [MLSGroupID]()
+        var performPendingJoins: [Void] = []
 
     }
 
@@ -121,12 +121,12 @@ class MockMLSController: MLSControllerProtocol {
 
     // MARK: - Joining groups
 
-    func addGroupPendingJoin(_ group: MLSGroupID) {
-        calls.addGroupsPendingJoin.append(group)
+    func registerPendingJoin(_ groupID: MLSGroupID) {
+        calls.registerPendingJoin.append(groupID)
     }
 
-    func joinGroupsStillPending() {
-        calls.joinGroupsStillPending.append(())
+    func performPendingJoins() {
+        calls.performPendingJoins.append(())
     }
 
 }

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -39,7 +39,7 @@ class MockMLSController: MLSControllerProtocol {
         var decrypt = [(String, MLSGroupID)]()
         var addMembersToConversation = [([MLSUser], MLSGroupID)]()
         var removeMembersFromConversation = [([MLSClientID], MLSGroupID)]()
-        var addGroupsPendingJoin = [MLSGroup]()
+        var addGroupsPendingJoin = [MLSGroupID]()
         var joinGroupsStillPending: [Void] = []
 
     }
@@ -121,7 +121,7 @@ class MockMLSController: MLSControllerProtocol {
 
     // MARK: - Joining groups
 
-    func addGroupPendingJoin(_ group: MLSGroup) {
+    func addGroupPendingJoin(_ group: MLSGroupID) {
         calls.addGroupsPendingJoin.append(group)
     }
 

--- a/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -31,11 +31,10 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
             // Given
             APIVersion.isFederationEnabled = false
             let groupID = MLSGroupID([1, 2, 3])
-            let domain = "example.com"
-            let conversation = self.createConversation(groupID: groupID, domain: domain)
+            let conversation = self.createConversation(groupID: groupID)
 
             // When
-            let fetchedConversation = ZMConversation.fetch(with: groupID, domain: domain, in: syncMOC)
+            let fetchedConversation = ZMConversation.fetch(with: groupID, in: syncMOC)
 
             // Then
             XCTAssertEqual(fetchedConversation, conversation)
@@ -47,22 +46,20 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
             // Given
             APIVersion.isFederationEnabled = true
             let groupID = MLSGroupID([1, 2, 3])
-            let domain = "example.com"
-            let conversation = self.createConversation(groupID: groupID, domain: domain)
+            let conversation = self.createConversation(groupID: groupID)
 
             // When
-            let fetchedConversation = ZMConversation.fetch(with: groupID, domain: domain, in: syncMOC)
+            let fetchedConversation = ZMConversation.fetch(with: groupID, in: syncMOC)
 
             // Then
             XCTAssertEqual(fetchedConversation, conversation)
         }
     }
 
-    private func createConversation(groupID: MLSGroupID, domain: String) -> ZMConversation? {
+    private func createConversation(groupID: MLSGroupID) -> ZMConversation? {
         let conversation = ZMConversation.insertNewObject(in: syncMOC)
         conversation.remoteIdentifier = NSUUID.create()
         conversation.mlsGroupID = groupID
-        conversation.domain = domain
         XCTAssert(syncMOC.saveOrRollback())
         return conversation
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-688" title="FS-688" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-688</a>  [iOS] Send external proposal to join group I am already in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR takes care of sending external add proposals to join MLS conversations that are `pendingJoin`

### Changes

- added `epoch` property to `ZMConversation`
- added implementation to send external add proposals
- small refactor of the `sendMessage` method

### Testing

- Added tests to `MLSControllerTests`
- Updated some error-asserting tests 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
