### PR TITLE
feat(mls): automatically update key material FS-547

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -209,7 +209,7 @@ public final class MLSController: MLSControllerProtocol {
         do {
             Logging.mls.info("updating key material for group (\(groupID))")
             let commit = try coreCrypto.wire_updateKeyingMaterial(conversationId: groupID.bytes)
-            try await sendMessage(commit.commit, groupID: groupID)
+            try await sendMessage(commit.commit, groupID: groupID, kind: .commit)
             staleKeyMaterialDetector.keyingMaterialUpdated(for: groupID)
         } catch {
             Logging.mls.warn("failed to update key material for group (\(groupID)): \(String(describing: error))")

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -55,27 +55,9 @@ public final class MLSController: MLSControllerProtocol {
     let actionsProvider: MLSActionsProviderProtocol
     let targetUnclaimedKeyPackageCount = 100
 
-    // we need to persist timestmaps keyed by a group id.
-    // we need to be able to know if a timestamp is too old.
-    // We also need to know all the keys.
-    // we could easily store time stamps by group id.
-    // We'd need to make sure we clean up and remove entries.
-    // We can get the group ids by querying core data.
-    // But we could also maybe store the timestamp on the conversation.
-    // But... I'd rather not have a core data object here.
-    // We could defer it to another object "KeyUpdater"
-    // We inform the KeyUpdater when a key is updated for a conversation.
-    // We ask it if it has any conversations needing an update.
-    // It's not really a key updater then.
-
-
-    // be able to store a timestamp for a conversation
-    // store the timestamp when creating a group.
-    // store the timestamp when processing a welcome message.
-    // in init, or after 24 hours, find all groups that need an update
-    // for each group that needs an update, ask cc for the commit and send it.
-    // on success, update the time stamps
-
+    // TODO: in init, or after 24 hours, find all groups that need an update
+    // TODO: for each group that needs an update, ask cc for the commit and send it.
+    // TODO: on success, update the time stamps
 
     // MARK: - Life cycle
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -68,7 +68,8 @@ class DummyCoreCryptoCallbacks: CoreCryptoCallbacks {
 
 public protocol MLSControllerDelegate: AnyObject {
 
-    func mlsControllerDidCommitPendingProposal(groupID: MLSGroupID)
+    func mlsControllerDidCommitPendingProposal(for groupID: MLSGroupID)
+    func mlsControllerDidUpdateKeyMaterialForAllGroups()
 
 }
 
@@ -230,6 +231,7 @@ public final class MLSController: MLSControllerProtocol {
         Task {
             await updateKeyMaterialForAllStaleGroups()
             lastKeyMaterialUpdateCheck = Date()
+            delegate?.mlsControllerDidUpdateKeyMaterialForAllGroups()
         }
     }
 
@@ -868,7 +870,7 @@ public final class MLSController: MLSControllerProtocol {
             throw MLSCommitPendingProposalsError.failedToCommitPendingProposals
         }
 
-        delegate?.mlsControllerDidCommitPendingProposal(groupID: groupID)
+        delegate?.mlsControllerDidCommitPendingProposal(for: groupID)
     }
 
     private func clearPendingProposalCommitDate(for groupID: MLSGroupID) {

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -580,8 +580,6 @@ public final class MLSController: MLSControllerProtocol {
             let groupIDBytes = try coreCrypto.wire_processWelcomeMessage(welcomeMessage: messageBytes)
             let groupID = MLSGroupID(groupIDBytes)
             uploadKeyPackagesIfNeeded()
-            // TODO: but the conversation may not exist yet... maybe we should update the key material
-            // when we transition from not ready to ready.
             // TODO: assert
             staleKeyMaterialDetector.keyingMaterialUpdated(for: groupID)
             return groupID

--- a/MLS/MLSGroup.swift
+++ b/MLS/MLSGroup.swift
@@ -1,0 +1,105 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import CoreData
+
+@objcMembers
+public class MLSGroup: ZMManagedObject {
+
+    public override static func entityName() -> String {
+        return "MLSGroup"
+    }
+
+    public override class func sortKey() -> String? {
+        return nil
+    }
+
+    // MARK: - Properties
+
+    public var id: MLSGroupID {
+        get {
+            willAccessValue(forKey: Self.idKey)
+
+            guard let value = primitiveID else {
+                // log
+                fatalError("trying to access MLSGroup ID before setting it")
+            }
+
+            didAccessValue(forKey: Self.idKey)
+            return MLSGroupID(value)
+        }
+
+        set {
+            willChangeValue(forKey: Self.idKey)
+            primitiveID = newValue.data
+            didChangeValue(forKey: Self.idKey)
+        }
+    }
+
+    @objc
+    static let idKey = "id"
+
+    @NSManaged
+    private var primitiveID: Data?
+
+    @NSManaged
+    public var lastKeyMaterialUpdate: Date?
+
+    // MARK: - Methods
+
+    public class func updateOrCreate(
+        id: MLSGroupID,
+        inSyncContext context: NSManagedObjectContext,
+        changes: @escaping (MLSGroup) -> Void
+    ) {
+        assert(
+            context.zm_isSyncContext,
+            "Modifications of `MLSGroupID` can only occur on the sync context"
+        )
+
+        context.performAndWait {
+            if let existing = fetch(id: id, in: context) {
+                changes(existing)
+            } else {
+                let newGroup = insertNewObject(in: context)
+                newGroup.id = id
+                changes(newGroup)
+            }
+
+            context.saveOrRollback()
+        }
+    }
+
+    class func fetch(id: MLSGroupID, in context: NSManagedObjectContext) -> MLSGroup? {
+        let request = NSFetchRequest<MLSGroup>(entityName: entityName())
+        request.predicate = NSPredicate(format: "\(idKey) == %@", argumentArray:  [id.data])
+        request.fetchLimit = 2
+
+        let result = context.fetchOrAssert(request: request)
+        require(result.count <= 1, "More than one instance of MLSGroupID with id: \(id)")
+        return result.first
+    }
+
+    class func fetchAllObjects(in context: NSManagedObjectContext) -> Set<MLSGroup> {
+        let request = NSFetchRequest<MLSGroup>(entityName: entityName())
+        let result = context.fetchOrAssert(request: request)
+        return Set(result)
+    }
+
+}

--- a/MLS/MLSGroup.swift
+++ b/MLS/MLSGroup.swift
@@ -36,7 +36,7 @@ public class MLSGroup: ZMManagedObject {
         get {
             willAccessValue(forKey: Self.idKey)
 
-            guard let value = primitiveID else {
+            guard let value = primitiveId else {
                 // log
                 fatalError("trying to access MLSGroup ID before setting it")
             }
@@ -47,7 +47,7 @@ public class MLSGroup: ZMManagedObject {
 
         set {
             willChangeValue(forKey: Self.idKey)
-            primitiveID = newValue.data
+            primitiveId = newValue.data
             didChangeValue(forKey: Self.idKey)
         }
     }
@@ -56,7 +56,7 @@ public class MLSGroup: ZMManagedObject {
     static let idKey = "id"
 
     @NSManaged
-    private var primitiveID: Data?
+    private var primitiveId: Data?
 
     @NSManaged
     public var lastKeyMaterialUpdate: Date?

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -54,7 +54,6 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
         self.context = context
     }
 
-    // TODO: test
     var groupsWithStaleKeyingMaterial: Set<MLSGroupID> {
         let result = MLSGroup.fetchAllObjects(in: context).lazy
             .filter(isKeyingMaterialStale)

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -102,7 +102,7 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
             return true
         }
 
-        guard numberOfDays(since: lastUpdateDate) > keyLifetimeInDays else {
+        guard lastUpdateDate.ageInDays > keyLifetimeInDays else {
             return false
         }
 

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -110,9 +110,4 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
         return true
     }
 
-    private func numberOfDays(since date: Date) -> Int {
-        let now = Date()
-        return Calendar.current.dateComponents([.day], from: date, to: now).day ?? 0
-    }
-
 }

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -1,0 +1,118 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol StaleMLSKeyDetectorProtocol {
+
+    /// The number of days before a key is considered stale.
+
+    var keyLifetimeInDays: UInt { get set }
+
+    /// All group IDs for groups requiring a key update.
+
+    var groupsWithStaleKeyingMaterial: Set<MLSGroupID> { get }
+
+    /// Notify the detector that keying material was updated.
+    ///
+    /// - Parameters:
+    ///   - groupID: the ID of the group in which the keying material was updated
+
+    func keyingMaterialUpdated(for groupID: MLSGroupID)
+
+}
+
+final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
+
+    // MARK: - Properties
+
+    var keyLifetimeInDays: UInt
+    let context: NSManagedObjectContext
+
+    // MARK: - Life cycle
+
+    init(
+        keyLifetimeInDays: UInt,
+        context: NSManagedObjectContext
+    ) {
+        self.keyLifetimeInDays = keyLifetimeInDays
+        self.context = context
+    }
+
+    // TODO: test
+    var groupsWithStaleKeyingMaterial: Set<MLSGroupID> {
+        let result = fetchMLSConversations().lazy
+            .filter(isKeyingMaterialStale)
+            .compactMap(\.mlsGroupID)
+
+        return Set(result)
+    }
+
+    // TODO: test
+    func keyingMaterialUpdated(for groupID: MLSGroupID) {
+        Logging.mls.info("Tracking key material update date for group (\(groupID))")
+
+        context.perform {
+            guard let conversation = ZMConversation.fetch(
+                with: groupID,
+                domain: "",
+                in: self.context
+            ) else {
+                Logging.mls.warn("Can't upload key material for group (\(groupID)): conversation not found in db")
+                return
+            }
+
+            conversation.lastMLSKeyMaterialUpdateDate = Date()
+            self.context.enqueueDelayedSave()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func fetchMLSConversations() -> Set<ZMConversation> {
+        let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+
+        request.predicate = NSPredicate(
+            format: "%@ == %@",
+            ZMConversation.messageProtocolKey, MessageProtocol.mls.rawValue
+        )
+
+        let mlsConversations = context.fetchOrAssert(request: request)
+        return Set(mlsConversations)
+    }
+
+    private func isKeyingMaterialStale(for conversation: ZMConversation) -> Bool {
+        guard let lastUpdateDate = conversation.lastMLSKeyMaterialUpdateDate else {
+            Logging.mls.info("last key material update date for group (\(String(describing: conversation.mlsGroupID)) doesn't exist... considering stale")
+            return true
+        }
+
+        guard numberOfDays(since: lastUpdateDate) > keyLifetimeInDays else {
+            return false
+        }
+
+        Logging.mls.info("key material for group (\(String(describing: conversation.mlsGroupID))) is stale")
+        return true
+    }
+
+    private func numberOfDays(since date: Date) -> Int {
+        let now = Date()
+        return Calendar.current.dateComponents([.day], from: date, to: now).day ?? 0
+    }
+
+}

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -22,7 +22,7 @@ protocol StaleMLSKeyDetectorProtocol {
 
     /// The number of days before a key is considered stale.
 
-    var keyLifetimeInDays: UInt { get set }
+    var refreshIntervalInDays: UInt { get set }
 
     /// All group IDs for groups requiring a key update.
 
@@ -41,16 +41,16 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
 
     // MARK: - Properties
 
-    var keyLifetimeInDays: UInt
+    var refreshIntervalInDays: UInt
     let context: NSManagedObjectContext
 
     // MARK: - Life cycle
 
     init(
-        keyLifetimeInDays: UInt,
+        refreshIntervalInDays: UInt,
         context: NSManagedObjectContext
     ) {
-        self.keyLifetimeInDays = keyLifetimeInDays
+        self.refreshIntervalInDays = refreshIntervalInDays
         self.context = context
     }
 
@@ -102,7 +102,7 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
             return true
         }
 
-        guard lastUpdateDate.ageInDays > keyLifetimeInDays else {
+        guard lastUpdateDate.ageInDays > refreshIntervalInDays else {
             return false
         }
 

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -70,7 +70,6 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
         context.perform {
             guard let conversation = ZMConversation.fetch(
                 with: groupID,
-                domain: "",
                 in: self.context
             ) else {
                 Logging.mls.warn("Can't upload key material for group (\(groupID)): conversation not found in db")

--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -62,7 +62,6 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
         return Set(result)
     }
 
-    // TODO: test
     func keyingMaterialUpdated(for groupID: MLSGroupID) {
         Logging.mls.info("Tracking key material update date for group (\(groupID))")
 

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G417" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.105.0">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21G83" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.105.0">
     <entity name="Action" representedClassName=".Action" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="role" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Role" inverseName="actions" inverseEntity="Role" syncable="YES"/>
@@ -62,6 +62,7 @@
         <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="language" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="lastMLSKeyMaterialUpdateDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -345,7 +346,7 @@
         <element name="ButtonState" positionX="-225" positionY="36" width="128" height="105"/>
         <element name="ClientMessage" positionX="9" positionY="153" width="128" height="90"/>
         <element name="Connection" positionX="-133.4921875" positionY="424.80859375" width="128" height="163"/>
-        <element name="Conversation" positionX="785.66015625" positionY="332.30078125" width="128" height="809"/>
+        <element name="Conversation" positionX="785.66015625" positionY="332.30078125" width="128" height="824"/>
         <element name="Feature" positionX="-286.9609375" positionY="-65" width="128" height="119"/>
         <element name="GenericMessageData" positionX="18" positionY="162" width="128" height="103"/>
         <element name="ImageMessage" positionX="5.453125" positionY="-305.99609375" width="128" height="165"/>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
@@ -63,7 +63,6 @@
         <attribute name="internalIsArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isSelfAnActiveMember" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="language" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="lastMLSKeyMaterialUpdateDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastModifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastReadServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="lastServerTimeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -197,6 +196,10 @@
         <attribute name="type" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
+    </entity>
+    <entity name="MLSGroup" representedClassName="MLSGroup" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="lastKeyMaterialUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
     </entity>
     <entity name="ParticipantRole" representedClassName=".ParticipantRole" syncable="YES">
         <attribute name="modifiedKeys" optional="YES" attributeType="Transformable" valueTransformerName="ExtendedSecureUnarchiveFromData" syncable="YES"/>
@@ -365,5 +368,6 @@
         <element name="TextMessage" positionX="-153" positionY="-117" width="128" height="60"/>
         <element name="User" positionX="-111.3671875" positionY="-41.015625" width="128" height="704"/>
         <element name="UserClient" positionX="552.40625" positionY="439.9453125" width="128" height="569"/>
+        <element name="MLSGroup" positionX="-81" positionY="-234" width="128" height="59"/>
     </elements>
 </model>

--- a/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
+++ b/Resources/zmessaging.xcdatamodeld/zmessaging2.105.0.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G730" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.105.0">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21G83" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2.105.0">
     <entity name="Action" representedClassName=".Action" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="role" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Role" inverseName="actions" inverseEntity="Role" syncable="YES"/>
@@ -198,7 +198,7 @@
         <relationship name="message" maxCount="1" deletionRule="Nullify" destinationEntity="Message" inverseName="confirmations" inverseEntity="Message" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" syncable="YES"/>
     </entity>
-    <entity name="MLSGroup" representedClassName="MLSGroup" syncable="YES">
+    <entity name="MLSGroup" representedClassName=".MLSGroup" syncable="YES">
         <attribute name="id" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="lastKeyMaterialUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
     </entity>
@@ -360,6 +360,7 @@
         <element name="Member" positionX="18" positionY="162" width="128" height="165"/>
         <element name="Message" positionX="490.6328125" positionY="-395.59765625" width="128" height="433"/>
         <element name="MessageConfirmation" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="MLSGroup" positionX="-81" positionY="-234" width="128" height="59"/>
         <element name="ParticipantRole" positionX="-207" positionY="54" width="128" height="89"/>
         <element name="Reaction" positionX="18" positionY="162" width="128" height="103"/>
         <element name="Role" positionX="-198" positionY="63" width="128" height="120"/>
@@ -369,6 +370,5 @@
         <element name="TextMessage" positionX="-153" positionY="-117" width="128" height="60"/>
         <element name="User" positionX="-111.3671875" positionY="-41.015625" width="128" height="704"/>
         <element name="UserClient" positionX="552.40625" positionY="439.9453125" width="128" height="569"/>
-        <element name="MLSGroup" positionX="-81" positionY="-234" width="128" height="59"/>
     </elements>
 </model>

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -112,6 +112,10 @@ extension ZMConversation {
         }
     }
 
+    /// The date at which the MLS key material for the group was last updated.
+
+    @NSManaged var lastMLSKeyMaterialUpdateDate: Date?
+
 }
 
 // MARK: - Fetch by group id

--- a/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -115,10 +115,6 @@ extension ZMConversation {
         }
     }
 
-    /// The date at which the MLS key material for the group was last updated.
-
-    @NSManaged var lastMLSKeyMaterialUpdateDate: Date?
-
 }
 
 // MARK: - Fetch by group id

--- a/Source/Utilis/Date+Helpers.swift
+++ b/Source/Utilis/Date+Helpers.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Date {
+
+    /// The number of days from this date til now.
+    ///
+    /// If this date is in the future, the return value will be 0.
+
+    var ageInDays: Int {
+        let now = Date()
+        return Calendar.current.dateComponents([.day], from: self, to: now).day!
+    }
+
+}

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -26,6 +26,7 @@ class MLSControllerTests: ZMConversationTestsBase {
     var mockCoreCrypto: MockCoreCrypto!
     var mockActionsProvider: MockMLSActionsProvider!
     var mockConversationEventProcessor: MockConversationEventProcessor!
+    var mockStaleMLSKeyDetector: MockStaleMLSKeyDetector!
 
     let groupID = MLSGroupID([1, 2, 3])
 
@@ -34,11 +35,13 @@ class MLSControllerTests: ZMConversationTestsBase {
         mockCoreCrypto = MockCoreCrypto()
         mockActionsProvider = MockMLSActionsProvider()
         mockConversationEventProcessor = MockConversationEventProcessor()
+        mockStaleMLSKeyDetector = MockStaleMLSKeyDetector()
 
         sut = MLSController(
             context: uiMOC,
             coreCrypto: mockCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
+            staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             actionsProvider: mockActionsProvider
         )
     }
@@ -47,6 +50,7 @@ class MLSControllerTests: ZMConversationTestsBase {
         sut = nil
         mockCoreCrypto = nil
         mockActionsProvider = nil
+        mockStaleMLSKeyDetector = nil
         super.tearDown()
     }
 
@@ -65,6 +69,7 @@ class MLSControllerTests: ZMConversationTestsBase {
             context: uiMOC,
             coreCrypto: mockCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
+            staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             actionsProvider: mockActionsProvider
         )
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -62,12 +62,17 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
     // MARK: - MLSControllerDelegate
 
     var pendingProposalCommitExpectations = [MLSGroupID: XCTestExpectation]()
+    var keyMaterialUpdatedExpectation: XCTestExpectation?
 
     // Since SUT may schedule timers to commit pending proposals, we create expectations
     // and fulfill them when SUT informs us the commit was made.
 
-    func mlsControllerDidCommitPendingProposal(groupID: MLSGroupID) {
+    func mlsControllerDidCommitPendingProposal(for: MLSGroupID) {
         pendingProposalCommitExpectations[groupID]?.fulfill()
+    }
+
+    func mlsControllerDidUpdateKeyMaterialForAllGroups() {
+        keyMaterialUpdatedExpectation?.fulfill()
     }
 
     // MARK: - Public keys

--- a/Tests/MLS/MockStaleMLSKeyDetector.swift
+++ b/Tests/MLS/MockStaleMLSKeyDetector.swift
@@ -1,9 +1,45 @@
 //
-//  MockStaleMLSKeyDetector.swift
-//  WireDataModelTests
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 12/09/22.
-//  Copyright © 2022 Wire Swiss GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation
+@testable import WireDataModel
+
+class MockStaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
+
+    // MARK: - Metrics
+
+    struct Calls: Equatable {
+
+        var keyingMaterialUpdated = [MLSGroupID]()
+
+    }
+
+    var calls = Calls()
+
+    // MARK: - Properties
+
+    var keyLifetimeInDays: UInt = 90
+    var groupsWithStaleKeyingMaterial: Set<MLSGroupID> = Set()
+
+    // MARK: - Methods
+
+    func keyingMaterialUpdated(for groupID: MLSGroupID) {
+        calls.keyingMaterialUpdated.append(groupID)
+    }
+
+}

--- a/Tests/MLS/MockStaleMLSKeyDetector.swift
+++ b/Tests/MLS/MockStaleMLSKeyDetector.swift
@@ -33,7 +33,7 @@ class MockStaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
 
     // MARK: - Properties
 
-    var keyLifetimeInDays: UInt = 90
+    var refreshIntervalInDays: UInt = 90
     var groupsWithStaleKeyingMaterial: Set<MLSGroupID> = Set()
 
     // MARK: - Methods

--- a/Tests/MLS/StaleMLSKeyDetectorTests.swift
+++ b/Tests/MLS/StaleMLSKeyDetectorTests.swift
@@ -1,0 +1,78 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class StaleMLSKeyDetectorTests: ZMBaseManagedObjectTest {
+
+    func test_GroupsWithStaleKeyingMaterial() throws {
+        syncMOC.performGroupedAndWait { context in
+            // Given
+            let sut = StaleMLSKeyDetector(
+                refreshIntervalInDays: 5,
+                context: context
+            )
+
+            let staleGroup1 = self.createMLSGroup(in: context)
+            staleGroup1.lastKeyMaterialUpdate = .distantPast
+
+            let staleGroup2 = self.createMLSGroup(in: context)
+            staleGroup2.lastKeyMaterialUpdate = Date().addingTimeInterval(.oneDay * -6)
+
+            let nonStaleGroup = self.createMLSGroup(in: context)
+            nonStaleGroup.lastKeyMaterialUpdate = Date().addingTimeInterval(.oneDay * -2)
+
+            // When
+            let result = sut.groupsWithStaleKeyingMaterial
+
+            // Then
+            XCTAssertTrue(result.contains(staleGroup1.id))
+            XCTAssertTrue(result.contains(staleGroup2.id))
+            XCTAssertFalse(result.contains(nonStaleGroup.id))
+        }
+
+    }
+
+    func test_KeyingMaterialUpdated() throws {
+        try syncMOC.performGroupedAndWait { context in
+            // Given
+            let sut = StaleMLSKeyDetector(
+                refreshIntervalInDays: 5,
+                context: context
+            )
+
+            let group = self.createMLSGroup(in: context)
+            XCTAssertNil(group.lastKeyMaterialUpdate)
+
+            // When
+            sut.keyingMaterialUpdated(for: group.id)
+
+            // Then
+            let lastUpdate = try XCTUnwrap(group.lastKeyMaterialUpdate)
+
+            XCTAssertEqual(
+                lastUpdate.timeIntervalSinceNow,
+                Date().timeIntervalSinceNow,
+                accuracy: 0.1
+            )
+        }
+    }
+
+}

--- a/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
+++ b/Tests/Source/Helper/ZMBaseManagedObjectTest+Helpers.swift
@@ -29,6 +29,13 @@ extension ZMBaseManagedObjectTest {
         return conversation
     }
 
+    @discardableResult
+    func createMLSGroup(in moc: NSManagedObjectContext) -> MLSGroup {
+        let group = MLSGroup.insertNewObject(in: moc)
+        group.id = MLSGroupID(.random(length: 32))
+        return group
+    }
+
     func createTeam(in moc: NSManagedObjectContext) -> Team {
         let team = Team.insertNewObject(in: moc)
         team.remoteIdentifier = UUID()

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		EE002F202878312F0027D63A /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE002F1F2878312F0027D63A /* MessageProtocol.swift */; };
 		EE002F222878345C0027D63A /* store2-104-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE002F212878345C0027D63A /* store2-104-0.wiredatabase */; };
 		EE04084C28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */; };
+		EE04084E28CA85B2009E4B8D /* Date+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE04084D28CA85B2009E4B8D /* Date+Helpers.swift */; };
 		EE08B345284E2B450022830B /* CoreCryptoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE08B344284E2B450022830B /* CoreCryptoTypes.swift */; };
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE128A66286DE31200558550 /* UserClient+MLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */; };
@@ -1280,6 +1281,7 @@
 		EE002F1F2878312F0027D63A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
 		EE002F212878345C0027D63A /* store2-104-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-104-0.wiredatabase"; sourceTree = "<group>"; };
 		EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyMaterialDetector.swift; sourceTree = "<group>"; };
+		EE04084D28CA85B2009E4B8D /* Date+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Helpers.swift"; sourceTree = "<group>"; };
 		EE08B344284E2B450022830B /* CoreCryptoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoTypes.swift; sourceTree = "<group>"; };
 		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+MLSPublicKeys.swift"; sourceTree = "<group>"; };
@@ -2495,6 +2497,7 @@
 				630B4C9527D8C899005D6F30 /* APIVersion.swift */,
 				EE128A67286DE35F00558550 /* CodableHelpers.swift */,
 				6312162E287DB7D900FF9A56 /* String+Bytes.swift */,
+				EE04084D28CA85B2009E4B8D /* Date+Helpers.swift */,
 			);
 			name = Utilis;
 			path = Source/Utilis;
@@ -3456,6 +3459,7 @@
 				BF989D0A1E8A6A120052BF8F /* SearchUserAsset.swift in Sources */,
 				066328602428D01C005BB3BE /* ZMClientMessage+GenericMessage.swift in Sources */,
 				5E36B45E21CA5BBA00B7063B /* UnverifiedCredentials.swift in Sources */,
+				EE04084E28CA85B2009E4B8D /* Date+Helpers.swift in Sources */,
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
 				55C40BCE22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift in Sources */,
 				EE5E2C1926DFC67900C3928A /* MessageDestructionTimeoutValue.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
 		EEF6E3C828D88A33001C1799 /* MLSGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C728D88A33001C1799 /* MLSGroup.swift */; };
+		EEF6E3CA28D89251001C1799 /* StaleMLSKeyDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */; };
 		EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */; };
 		EEFC3EE922083B0900D3091A /* ZMConversationTests+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */; };
 		EF17175B22D4CC8E00697EB0 /* Team+MockTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */; };
@@ -1369,6 +1370,7 @@
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
 		EEF4010623A9213B007B1A97 /* UserType+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Team.swift"; sourceTree = "<group>"; };
 		EEF6E3C728D88A33001C1799 /* MLSGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSGroup.swift; sourceTree = "<group>"; };
+		EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyDetectorTests.swift; sourceTree = "<group>"; };
 		EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+HasMessages.swift"; sourceTree = "<group>"; };
 		EEFC3EE822083B0900D3091A /* ZMConversationTests+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+HasMessages.swift"; sourceTree = "<group>"; };
 		EF17175A22D4CC8E00697EB0 /* Team+MockTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Team+MockTeam.swift"; sourceTree = "<group>"; };
@@ -2047,6 +2049,7 @@
 			isa = PBXGroup;
 			children = (
 				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
+				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EE98879128882C8F002340D2 /* MockMLSController.swift */,
 				EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */,
 				EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */,
@@ -3921,6 +3924,7 @@
 				F1517922212DAE2E00BA3EBD /* ZMConversationTests+Services.swift in Sources */,
 				BFCF31DB1DA50C650039B3DC /* GenericMessageTests+NativePush.swift in Sources */,
 				F9B71FF21CB2C4C6001DB03F /* AnyClassTupleTests.swift in Sources */,
+				EEF6E3CA28D89251001C1799 /* StaleMLSKeyDetectorTests.swift in Sources */,
 				F9A7083A1CAEEB7500C2F5FE /* MockEntity.m in Sources */,
 				F963E9741D9BF9ED00098AD3 /* ProtosTests.swift in Sources */,
 				16746B081D2EAF8E00831771 /* ZMClientMessageTests+ZMImageOwner.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
 		EE3EFE9725305A84009499E5 /* ModifiedObjects+Mergeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */; };
 		EE3EFEA1253090E0009499E5 /* PotentialChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */; };
+		EE403ECC28D4A26600F78A36 /* MLSGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE403ECB28D4A26600F78A36 /* MLSGroup.swift */; };
 		EE404EA2287317CB00B3653F /* MLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE404EA1287317CB00B3653F /* MLSController.swift */; };
 		EE42938A252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE429389252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift */; };
 		EE42938C252C443000E70670 /* ManagedObjectObserverToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE42938B252C443000E70670 /* ManagedObjectObserverToken.swift */; };
@@ -1301,6 +1302,7 @@
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
 		EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModifiedObjects+Mergeable.swift"; sourceTree = "<group>"; };
 		EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetectorTests.swift; sourceTree = "<group>"; };
+		EE403ECB28D4A26600F78A36 /* MLSGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSGroup.swift; sourceTree = "<group>"; };
 		EE404EA1287317CB00B3653F /* MLSController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSController.swift; sourceTree = "<group>"; };
 		EE429389252C437900E70670 /* Notification.Name+ManagedObjectObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+ManagedObjectObservation.swift"; sourceTree = "<group>"; };
 		EE42938B252C443000E70670 /* ManagedObjectObserverToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectObserverToken.swift; sourceTree = "<group>"; };
@@ -2003,6 +2005,7 @@
 				7AFC6A272876E935000FF1A1 /* Actions */,
 				EE404EA1287317CB00B3653F /* MLSController.swift */,
 				EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */,
+				EE403ECB28D4A26600F78A36 /* MLSGroup.swift */,
 				EE002F1D2878308F0027D63A /* MLSGroupID.swift */,
 				7ABAD027287D92BF002071A1 /* MLSQualifiedClientID.swift */,
 				EE9BC5CB287C6D5000AF9AEE /* MLSClientID.swift */,
@@ -3432,6 +3435,7 @@
 				54563B761E0161730089B1D7 /* ZMMessage+Categorization.swift in Sources */,
 				1670D0172317F92B003A143B /* ZMConversation+Team.swift in Sources */,
 				EE28991E26B4422800E7BAF0 /* Feature.ConferenceCalling.swift in Sources */,
+				EE403ECC28D4A26600F78A36 /* MLSGroup.swift in Sources */,
 				F963E9831D9C0DC400098AD3 /* ZMMessageDestructionTimer.swift in Sources */,
 				63AFE2D6244F49A90003F619 /* GenericMessage+MessageCapable.swift in Sources */,
 				A901DE8C23A2A31B00B4DDC6 /* ZMConnection+Role.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		EEC47ED627A81EF60020B599 /* Feature+ClassifiedDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */; };
 		EEC8064A28CF4BAD00DD58E9 /* FetchBackendMLSPublicKeysAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8064928CF4BAD00DD58E9 /* FetchBackendMLSPublicKeysAction.swift */; };
 		EEC8064C28CF4BBF00DD58E9 /* BackendMLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8064B28CF4BBF00DD58E9 /* BackendMLSPublicKeys.swift */; };
+		EEC8064E28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */; };
 		EECFAA3826D52EB700D9E100 /* Feature.SelfDeletingMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECFAA3726D52EB700D9E100 /* Feature.SelfDeletingMessages.swift */; };
 		EEDA9C0E2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C0D2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift */; };
 		EEDA9C1225121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C1125121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift */; };
@@ -1353,6 +1354,7 @@
 		EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feature+ClassifiedDomains.swift"; sourceTree = "<group>"; };
 		EEC8064928CF4BAD00DD58E9 /* FetchBackendMLSPublicKeysAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchBackendMLSPublicKeysAction.swift; sourceTree = "<group>"; };
 		EEC8064B28CF4BBF00DD58E9 /* BackendMLSPublicKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendMLSPublicKeys.swift; sourceTree = "<group>"; };
+		EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStaleMLSKeyDetector.swift; sourceTree = "<group>"; };
 		EECFAA3726D52EB700D9E100 /* Feature.SelfDeletingMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.SelfDeletingMessages.swift; sourceTree = "<group>"; };
 		EEDA9C0D2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EEDA9C1125121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContextTests+EncryptionAtRest.swift"; sourceTree = "<group>"; };
@@ -2044,6 +2046,7 @@
 				EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */,
 				EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */,
 				EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */,
+				EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -3821,6 +3824,7 @@
 				EE715B7D256D153E00087A22 /* FeatureServiceTests.swift in Sources */,
 				F1B025621E53500400900C65 /* ZMConversationTests+PrepareToSend.swift in Sources */,
 				54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */,
+				EEC8064E28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift in Sources */,
 				D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */,
 				54A885A81F62EEB600AFBA95 /* ZMConversationTests+Messages.swift in Sources */,
 				54ED3A9D1F38CB6A0066AD47 /* DatabaseMigrationTests.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 		EE002F1E2878308F0027D63A /* MLSGroupID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE002F1D2878308F0027D63A /* MLSGroupID.swift */; };
 		EE002F202878312F0027D63A /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE002F1F2878312F0027D63A /* MessageProtocol.swift */; };
 		EE002F222878345C0027D63A /* store2-104-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE002F212878345C0027D63A /* store2-104-0.wiredatabase */; };
+		EE04084C28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */; };
 		EE08B345284E2B450022830B /* CoreCryptoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE08B344284E2B450022830B /* CoreCryptoTypes.swift */; };
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE128A66286DE31200558550 /* UserClient+MLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */; };
@@ -1278,6 +1279,7 @@
 		EE002F1D2878308F0027D63A /* MLSGroupID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSGroupID.swift; sourceTree = "<group>"; };
 		EE002F1F2878312F0027D63A /* MessageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
 		EE002F212878345C0027D63A /* store2-104-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-104-0.wiredatabase"; sourceTree = "<group>"; };
+		EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyMaterialDetector.swift; sourceTree = "<group>"; };
 		EE08B344284E2B450022830B /* CoreCryptoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoTypes.swift; sourceTree = "<group>"; };
 		EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserTests+AnalyticsIdentifier.swift"; sourceTree = "<group>"; };
 		EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+MLSPublicKeys.swift"; sourceTree = "<group>"; };
@@ -1991,6 +1993,7 @@
 			children = (
 				7AFC6A272876E935000FF1A1 /* Actions */,
 				EE404EA1287317CB00B3653F /* MLSController.swift */,
+				EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */,
 				EE002F1D2878308F0027D63A /* MLSGroupID.swift */,
 				7ABAD027287D92BF002071A1 /* MLSQualifiedClientID.swift */,
 				EE9BC5CB287C6D5000AF9AEE /* MLSClientID.swift */,
@@ -3608,6 +3611,7 @@
 				F1FDF2FA21B1555A00E037A1 /* ZMClientMessage+Location.swift in Sources */,
 				63D5654B28B4D18D00BDFB49 /* MLSGroupStatus.swift in Sources */,
 				EE002F1E2878308F0027D63A /* MLSGroupID.swift in Sources */,
+				EE04084C28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift in Sources */,
 				F92C992A1DAFBC910034AFDD /* ZMConversation+SelfDeletingMessages.swift in Sources */,
 				63D41E4F2452EA080076826F /* ZMConversation+SelfConversation.swift in Sources */,
 				F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-547" title="FS-547" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-547</a>  [iOS] Send commit(UpdatePath) periodically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds functionality to automatically update key material for each MLS group with key material older than 90 days. Changes include:

- Add new entity `MLSGroup`, which is just an MLS Group id and `lastKeyMaterialUpdate`. It can be used in the future to contain other MLS group metadata.
- Store the last key update date when the key material is first created (new group, joined group) or updated
- Add `StaleMLSKeyMaterialDetector` which is responsible for returning all `MLSGroups`s with stale keys
- Perform a check to update all stale groups when `MLSController` is created, then every 24 hours after that.

### Testing

#### Test Coverage 

- Unit tests for updating key material
- Unit tests for `StaleMLSKeyMaterialDetector`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
