### PR TITLE
feat(mls): leave conversation

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -39,6 +39,8 @@ public protocol MLSControllerProtocol {
     func registerPendingJoin(_ group: MLSGroupID)
 
     func performPendingJoins()
+
+    func wipeGroup(_ groupID: MLSGroupID)
 }
 
 public final class MLSController: MLSControllerProtocol {
@@ -317,6 +319,18 @@ public final class MLSController: MLSControllerProtocol {
         } catch let error {
             logger.warn("failed to remove members from group (\(id)): \(String(describing: error))")
             throw MLSRemoveParticipantsError.failedToRemoveMembers
+        }
+    }
+
+    // MARK: - Remove group
+
+    public func wipeGroup(_ groupID: MLSGroupID) {
+        logger.info("wiping group (\(groupID))")
+
+        do {
+            try coreCrypto.wire_wipeConversation(conversationId: groupID.bytes)
+        } catch {
+            logger.warn("failed to wipe group (\(groupID)): \(String(describing: error))")
         }
     }
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -946,12 +946,17 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         // Given
         let groupID = MLSGroupID(.random())
 
+        var count = 0
+        mockCoreCrypto.mockWipeConversation = { (id: ConversationId) in
+            count += 1
+            XCTAssertEqual(id, groupID.bytes)
+        }
+
         // When
         sut.wipeGroup(groupID)
 
         // Then
-        XCTAssertEqual(mockCoreCrypto.calls.wipeConversation.count, 1)
-        XCTAssertEqual(mockCoreCrypto.calls.wipeConversation.first, groupID.bytes)
+        XCTAssertEqual(count, 1)
     }
 
     // MARK: - Key Packages

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -627,6 +627,20 @@ class MLSControllerTests: ZMConversationTestsBase {
         XCTAssertEqual(mockCoreCrypto.calls.newExternalAddProposal.count, 0)
     }
 
+    // MARK: - Wipe Groups
+
+    func test_WipeGroup_IsSuccessfull() {
+        // Given
+        let groupID = MLSGroupID(.random())
+
+        // When
+        sut.wipeGroup(groupID)
+
+        // Then
+        XCTAssertEqual(mockCoreCrypto.calls.wipeConversation.count, 1)
+        XCTAssertEqual(mockCoreCrypto.calls.wipeConversation.first, groupID.bytes)
+    }
+
     // MARK: - Key Packages
 
     func test_UploadKeyPackages_IsSuccessfull() {

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -118,8 +118,14 @@ class MockMLSController: MLSControllerProtocol {
 
     // MARK: - Remove members
 
+    typealias RemoveMembersMock = ([MLSClientID], MLSGroupID) throws -> Void
+
+    var removeMembersMock: RemoveMembersMock?
+
     func removeMembersFromConversation(with clientIds: [MLSClientID], for groupID: MLSGroupID) throws {
         calls.removeMembersFromConversation.append((clientIds, groupID))
+        guard let mock = removeMembersMock else { throw MockError.unmockedMethodCalled }
+        try mock(clientIds, groupID)
     }
 
     // MARK: - Joining groups

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -41,6 +41,7 @@ class MockMLSController: MLSControllerProtocol {
         var removeMembersFromConversation = [([MLSClientID], MLSGroupID)]()
         var registerPendingJoin = [MLSGroupID]()
         var performPendingJoins: [Void] = []
+        var wipeGroup = [MLSGroupID]()
 
     }
 
@@ -127,6 +128,12 @@ class MockMLSController: MLSControllerProtocol {
 
     func performPendingJoins() {
         calls.performPendingJoins.append(())
+    }
+
+    // MARK: - Wiping group
+
+    func wipeGroup(_ groupID: MLSGroupID) {
+        calls.wipeGroup.append(groupID)
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR introduces support for leaving MLS groups. When leaving an MLS group, we need to follow the same flow as with proteus, but we also need to ask core crypto to wipe the group from the local database. 

We need to make a distinction between removing other participants from the group and removing the self user from the group: 
- When removing others, we ask core crypto to remove members, which returns a commit that we then send to the group. 
- When removing the self user, we should use the `RemoveParticipantAction` which will ask the backend to remove the user. The backend then notifies the user's clients that they've been removed and this is where we'll ask core crypto to wipe the conversation (in RS). 

### Changes

- Added a `wipeGroup` method to `MLSController
- Updated the `removeParticipant` method to use the `RemoveParticipantAction` when it's the self user being removed

### Testing

- Added tests to `MLSController`
- TODO: add tests for the `removeParticipant` method

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
