### PR TITLE
chore: update to Core Crypto 0.5.0 FS-963

### DIFF
--- a/Tests/MLS/MockCoreCrypto.swift
+++ b/Tests/MLS/MockCoreCrypto.swift
@@ -21,392 +21,382 @@ import WireDataModel
 
 class MockCoreCrypto: CoreCryptoProtocol {
 
-    // MARK: - Types
-
-    struct Calls {
-
-        var setCallbacksCount = 0
-        var clientPublicKey: [Void] = []
-        var clientKeypackages = [UInt32]()
-        var clientValidKeypackagesCount: [Void] = []
-        var createConversation = [(conversationId: ConversationId, config: ConversationConfiguration)]()
-        var conversationExists = [ConversationId]()
-        var processWelcomeMessage = [[UInt8]]()
-        var addClientsToConversation = [(conversationId: ConversationId, clients: [Invitee])]()
-        var removeClientsFromConversation = [(conversationId: ConversationId, clients: [ClientId])]()
-        var wipeConversation = [ConversationId]()
-        var decryptMessage = [(conversationId: ConversationId, payload: [UInt8])]()
-        var encryptMessage = [(conversationId: ConversationId, message: [UInt8])]()
-        var newAddProposal = [(conversationId: ConversationId, keyPackage: [UInt8])]()
-        var newUpdateProposal = [ConversationId]()
-        var newRemoveProposal = [(conversationId: ConversationId, clientId: ClientId)]()
-        var newExternalAddProposal = [(conversationId: ConversationId, epoch: UInt64)]()
-        var newExternalRemoveProposal = [(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8])]()
-        var updateKeyingMaterial = [ConversationId]()
-        var joinByExternalCommit = [[UInt8]]()
-        var exportGroupState = [ConversationId]()
-        var mergePendingGroupFromExternalCommit = [(conversationId: ConversationId, config: ConversationConfiguration)]()
-        var randomBytes = [UInt32]()
-        var reseedRng = [[UInt8]]()
-        var commitAccepted = [ConversationId]()
-        var commitPendingProposals = [(ConversationId, Date)]()
-    }
-
-    // MARK: - Properties
-
-    var calls = Calls()
-
     // MARK: - setCallbacks
 
-    var mockErrorForSetCallbacks: CryptoError?
-
     func wire_setCallbacks(callbacks: CoreCryptoCallbacks) throws {
-        calls.setCallbacksCount += 1
 
-        if let error = mockErrorForSetCallbacks {
-            throw error
-        }
     }
 
     // MARK: - clientPublicKey
 
-    var mockResultForClientPublicKey: [UInt8]?
-    var mockErrorForClientPublicKey: CryptoError?
+    var mockClientPublicKey: (() throws -> [UInt8])?
 
     func wire_clientPublicKey() throws -> [UInt8] {
-        calls.clientPublicKey.append(())
-
-        if let error = mockErrorForClientPublicKey {
-            throw error
+        guard let mock = mockClientPublicKey else {
+            fatalError("no mock for `clientPublicKey`")
         }
 
-        return try XCTUnwrap(mockResultForClientPublicKey, "no mocked result for `clientPublicKey`")
+        return try mock()
     }
 
     // MARK: - clientKeypackages
 
-    var mockResultForClientKeypackages: [[UInt8]]?
-    var mockErrorForClientKeypackages: CryptoError?
+    var mockClientKeypackages: ((UInt32) throws -> [[UInt8]])?
 
     func wire_clientKeypackages(amountRequested: UInt32) throws -> [[UInt8]] {
-        calls.clientKeypackages.append(amountRequested)
-
-        if let error = mockErrorForClientKeypackages {
-            throw error
+        guard let mock = mockClientKeypackages else {
+            fatalError("no mock for `clientKeypackages`")
         }
 
-        return try XCTUnwrap(mockResultForClientKeypackages, "no mocked result for `clientKeypackages`")
+        return try mock(amountRequested)
     }
 
     // MARK: - clientValidKeypackagesCount
 
-    var mockResultForClientValidKeypackagesCount: UInt64?
-    var mockErrorForClientValidKeypackagesCount: CryptoError?
+    var mockClientValidKeypackagesCount: (() throws -> UInt64)?
 
     func wire_clientValidKeypackagesCount() throws -> UInt64 {
-        calls.clientValidKeypackagesCount.append(())
-
-        if let error = mockErrorForClientValidKeypackagesCount {
-            throw error
+        guard let mock = mockClientValidKeypackagesCount else {
+            fatalError("no mock for `clientValidKeypackagesCount`")
         }
 
-        return try XCTUnwrap(mockResultForClientValidKeypackagesCount, "no mocked result for `clientValidKeypackagesCount`")
+        return try mock()
     }
 
     // MARK: - createConversation
 
-    var mockErrorForCreateConversation: CryptoError?
+    var mockCreateConversation: ((ConversationId, ConversationConfiguration) throws -> Void)?
 
     func wire_createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
-        calls.createConversation.append((conversationId, config))
-
-        if let error = mockErrorForCreateConversation {
-            throw error
+        guard let mock = mockCreateConversation else {
+            fatalError("no mock for `createConversation`")
         }
+
+        return try mock(conversationId, config)
+    }
+
+    // MARK: - conversationEpoch
+
+    var mockConversationEpoch: ((ConversationId) throws -> UInt64)?
+
+    func wire_conversationEpoch(conversationId: ConversationId) throws -> UInt64 {
+        guard let mock = mockConversationEpoch else {
+            fatalError("no mock for `conversationEpoch`")
+        }
+
+        return try mock(conversationId)
     }
 
     // MARK: - conversationExists
 
-    var mockResultForConversationExists: Bool?
+    var mockConversationExists: ((ConversationId) -> Bool)?
 
     func wire_conversationExists(conversationId: ConversationId) -> Bool {
-        calls.conversationExists.append(conversationId)
+        guard let mock = mockConversationExists else {
+            fatalError("no mock for `conversationExists`")
+        }
 
-        let result = try? XCTUnwrap(mockResultForConversationExists, "no mocked result for `conversationExists`")
-        return result ?? false
+        return mock(conversationId)
     }
 
     // MARK: - processWelcomeMessage
 
-    var mockResultForProcessWelcomeMessage: ConversationId?
-    var mockErrorForProcessWelcomeMessage: CryptoError?
+    var mockProcessWelcomeMessage: (([UInt8]) throws -> ConversationId)?
 
     func wire_processWelcomeMessage(welcomeMessage: [UInt8]) throws -> ConversationId {
-        calls.processWelcomeMessage.append(welcomeMessage)
-
-        if let error = mockErrorForProcessWelcomeMessage {
-            throw error
+        guard let mock = mockProcessWelcomeMessage else {
+            fatalError("no mock for `processWelcomeMessage`")
         }
 
-        return try XCTUnwrap(mockResultForProcessWelcomeMessage, "no mocked result for `processWelcomeMessage`")
+        return try mock(welcomeMessage)
     }
 
     // MARK: - addClientsToConversation
 
-    var mockResultForAddClientsToConversation: MemberAddedMessages?
-    var mockErrorForAddClientsToConversation: CryptoError?
+    var mockAddClientsToConversation: ((ConversationId, [Invitee]) throws -> MemberAddedMessages)?
 
     func wire_addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages {
-        calls.addClientsToConversation.append((conversationId, clients))
-
-        if let error = mockErrorForAddClientsToConversation {
-            throw error
+        guard let mock = mockAddClientsToConversation else {
+            fatalError("no mock for `addClientsToConversation`")
         }
 
-        return try XCTUnwrap(mockResultForAddClientsToConversation, "no mocked result for `addClientsToConversation`")
+        return try mock(conversationId, clients)
     }
 
     // MARK: - removeClientsFromConversation
 
-    var mockResultForRemoveClientsFromConversation: CommitBundle?
-    var mockErrorForRemoveClientsFromConversation: CryptoError?
+    var mockRemoveClientsFromConversation: ((ConversationId, [ClientId]) throws -> CommitBundle)?
 
     func wire_removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> CommitBundle {
-        calls.removeClientsFromConversation.append((conversationId, clients))
-
-        if let error = mockErrorForRemoveClientsFromConversation {
-            throw error
+        guard let mock = mockRemoveClientsFromConversation else {
+            fatalError("no mock for `removeClientsFromConversation`")
         }
 
-        return try XCTUnwrap(mockResultForRemoveClientsFromConversation, "no mocked result for `removeClientsFromConversation`")
-    }
-
-    // MARK: - wipeConversation
-
-    var mockErrorForWipeConversation: CryptoError?
-
-    func wire_wipeConversation(conversationId: ConversationId) throws {
-        calls.wipeConversation.append(conversationId)
-
-        if let error = mockErrorForWipeConversation {
-            throw error
-        }
-    }
-
-    // MARK: - decryptMessage
-
-    var mockResultForDecryptMessage: DecryptedMessage?
-    var mockErrorForDecryptMessage: CryptoError?
-
-    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage {
-        calls.decryptMessage.append((conversationId, payload))
-
-        if let error = mockErrorForDecryptMessage {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForDecryptMessage, "no mocked result for `decryptMessage`")
-    }
-
-    // MARK: - encryptMessage
-
-    var mockResultForEncryptMessage: [UInt8]?
-    var mockErrorForEncryptMessage: CryptoError?
-
-    func wire_encryptMessage(conversationId: ConversationId, message: [UInt8]) throws -> [UInt8] {
-        calls.encryptMessage.append((conversationId, message))
-
-        if let error = mockErrorForEncryptMessage {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForEncryptMessage, "no mocked result for `encryptMessage`")
-    }
-
-    // MARK: - newAddProposal
-
-    var mockResultForNewAddProposal: [UInt8]?
-    var mockErrorForNewAddProposal: CryptoError?
-
-    func wire_newAddProposal(conversationId: ConversationId, keyPackage: [UInt8]) throws -> [UInt8] {
-        calls.newAddProposal.append((conversationId, keyPackage))
-
-        if let error = mockErrorForNewAddProposal {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForNewAddProposal, "no mocked result for `newAddProposal`")
-    }
-
-    // MARK: - newUpdateProposal
-
-    var mockResultForNewUpdateProposal: [UInt8]?
-    var mockErrorForNewUpdateProposal: CryptoError?
-
-    func wire_newUpdateProposal(conversationId: ConversationId) throws -> [UInt8] {
-        calls.newUpdateProposal.append(conversationId)
-
-        if let error = mockErrorForNewUpdateProposal {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForNewUpdateProposal, "no mocked result for `newUpdateProposal`")
-    }
-
-    // MARK: - newRemoveProposal
-
-    var mockResultForNewRemoveProposal: [UInt8]?
-    var mockErrorForNewRemoveProposal: CryptoError?
-
-    func wire_newRemoveProposal(conversationId: ConversationId, clientId: ClientId) throws -> [UInt8] {
-        calls.newRemoveProposal.append((conversationId, clientId))
-
-        if let error = mockErrorForNewRemoveProposal {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForNewRemoveProposal, "no mocked result for `newRemoveProposal`")
-    }
-
-    // MARK: - newExternalAddProposal
-
-    var mockResultForNewExternalAddProposal: [UInt8]?
-    var mockErrorForNewExternalAddProposal: CryptoError?
-
-    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64) throws -> [UInt8] {
-        calls.newExternalAddProposal.append((conversationId, epoch))
-
-        if let error = mockErrorForNewExternalAddProposal {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForNewExternalAddProposal, "no mocked result for `newExternalAddProposal`")
-    }
-
-    // MARK: - newExternalRemoveProposal
-
-    var mockResultForNewExternalRemoveProposal: [UInt8]?
-    var mockErrorForNewExternalRemoveProposal: CryptoError?
-
-    func wire_newExternalRemoveProposal(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8]) throws -> [UInt8] {
-        calls.newExternalRemoveProposal.append((conversationId, epoch, keyPackageRef))
-
-        if let error = mockErrorForNewExternalRemoveProposal {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForNewExternalRemoveProposal, "no mocked result for `newExternalRemoveProposal`")
+        return try mock(conversationId, clients)
     }
 
     // MARK: - updateKeyingMaterial
 
-    var mockResultForUpdateKeyingMaterial: CommitBundle?
-    var mockErrorForUpdateKeyingMaterial: CryptoError?
+    var mockUpdateKeyingMaterial: ((ConversationId) throws -> CommitBundle)?
 
     func wire_updateKeyingMaterial(conversationId: ConversationId) throws -> CommitBundle {
-        calls.updateKeyingMaterial.append(conversationId)
-
-        if let error = mockErrorForUpdateKeyingMaterial {
-            throw error
+        guard let mock = mockUpdateKeyingMaterial else {
+            fatalError("no mock for `updateKeyingMaterial`")
         }
 
-        return try XCTUnwrap(mockResultForUpdateKeyingMaterial, "no mocked result for `updateKeyingMaterial`")
-    }
-
-    // MARK: - joinByExternalCommit
-
-    var mockResultForJoinByExternalCommit: MlsConversationInitMessage?
-    var mockErrorForJoinByExternalCommit: CryptoError?
-
-    func wire_joinByExternalCommit(groupState: [UInt8]) throws -> MlsConversationInitMessage {
-        calls.joinByExternalCommit.append(groupState)
-
-        if let error = mockErrorForJoinByExternalCommit {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForJoinByExternalCommit, "no mocked result for `joinByExternalCommit`")
-    }
-
-    // MARK: - exportGroupState
-
-    var mockResultForExportGroupState: [UInt8]?
-    var mockErrorForExportGroupState: CryptoError?
-
-    func wire_exportGroupState(conversationId: ConversationId) throws -> [UInt8] {
-        calls.exportGroupState.append(conversationId)
-
-        if let error = mockErrorForExportGroupState {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForExportGroupState, "no mocked result for `exportGroupState`")
-    }
-
-    // MARK: - mergePendingGroupFromExternalCommit
-
-    var mockErrorForMergePendingGroupFromExternalCommit: CryptoError?
-
-    func wire_mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
-        calls.mergePendingGroupFromExternalCommit.append((conversationId, config))
-
-        if let error = mockErrorForMergePendingGroupFromExternalCommit {
-            throw error
-        }
-    }
-
-    // MARK: - randomBytes
-
-    var mockResultForRandomBytes: [UInt8]?
-    var mockErrorForRandomBytes: CryptoError?
-
-    func wire_randomBytes(length: UInt32) throws -> [UInt8] {
-        calls.randomBytes.append(length)
-
-        if let error = mockErrorForRandomBytes {
-            throw error
-        }
-
-        return try XCTUnwrap(mockResultForRandomBytes, "no mocked result for `randomBytes`")
-    }
-
-    // MARK: - reseedRng
-
-    var mockErrorForReseedRng: CryptoError?
-
-    func wire_reseedRng(seed: [UInt8]) throws {
-        calls.reseedRng.append(seed)
-
-        if let error = mockErrorForReseedRng {
-            throw error
-        }
-    }
-
-    // MARK: - commitAccepted
-
-    var mockErrorForCommitAccepted: CryptoError?
-
-    func wire_commitAccepted(conversationId: ConversationId) throws {
-        calls.commitAccepted.append(conversationId)
-
-        if let error = mockErrorForCommitAccepted {
-            throw error
-        }
+        return try mock(conversationId)
     }
 
     // MARK: - commitPendingProposals
 
-    var mockResultForCommitPendingProposals: CommitBundle?
-    var mockErrorForCommitPendingProposals: CryptoError?
+    var mockCommitPendingProposals: ((ConversationId) throws -> CommitBundle?)?
 
-    func wire_commitPendingProposals(conversationId: ConversationId) throws -> CommitBundle {
-        calls.commitPendingProposals.append((conversationId, Date()))
-
-        if let error = mockErrorForCommitPendingProposals {
-            throw error
+    func wire_commitPendingProposals(conversationId: ConversationId) throws -> CommitBundle? {
+        guard let mock = mockCommitPendingProposals else {
+            fatalError("no mock for `commitPendingProposals`")
         }
 
-        return try XCTUnwrap(mockResultForCommitPendingProposals, "no mocked result for `commitPendingProposals`")
+        return try mock(conversationId)
+    }
+
+    // MARK: - finalAddClientsToConversation
+
+    var mockFinalAddClientsToConversation: ((ConversationId, [Invitee]) throws -> TlsCommitBundle)?
+
+    func wire_finalAddClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> TlsCommitBundle {
+        guard let mock = mockFinalAddClientsToConversation else {
+            fatalError("no mock for `finalAddClientsToConversation`")
+        }
+
+        return try mock(conversationId, clients)
+    }
+
+    // MARK: - finalRemoveClientsFromConversation
+
+    var mockFinalRemoveClientsFromConversation: ((ConversationId, [ClientId]) throws -> TlsCommitBundle)?
+
+    func wire_finalRemoveClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> TlsCommitBundle {
+        guard let mock = mockFinalRemoveClientsFromConversation else {
+            fatalError("no mock for `finalRemoveClientsFromConversation`")
+        }
+
+        return try mock(conversationId, clients)
+    }
+
+    // MARK: - finalUpdateKeyingMaterial
+
+    var mockFinalUpdateKeyingMaterial: ((ConversationId) throws -> TlsCommitBundle)?
+
+    func wire_finalUpdateKeyingMaterial(conversationId: ConversationId) throws -> TlsCommitBundle {
+        guard let mock = mockFinalUpdateKeyingMaterial else {
+            fatalError("no mock for `finalUpdateKeyingMaterial`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - finalCommitPendingProposals
+
+    var mockFinalCommitPendingProposals: ((ConversationId) throws -> TlsCommitBundle)?
+
+    func wire_finalCommitPendingProposals(conversationId: ConversationId) throws -> TlsCommitBundle? {
+        guard let mock = mockFinalCommitPendingProposals else {
+            fatalError("no mock for `finalCommitPendingProposals`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - wipeConversation
+
+    var mockWipeConversation: ((ConversationId) throws -> Void)?
+
+    func wire_wipeConversation(conversationId: ConversationId) throws {
+        guard let mock = mockWipeConversation else {
+            fatalError("no mock for `wipeConversation`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - decryptMessage
+
+    var mockDecryptMessage: ((ConversationId, [UInt8]) throws -> DecryptedMessage)?
+
+    func wire_decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage {
+        guard let mock = mockDecryptMessage else {
+            fatalError("no mock for `decryptMessage`")
+        }
+
+        return try mock(conversationId, payload)
+    }
+
+    // MARK: - encryptMessage
+
+    var mockEncryptMessage: ((ConversationId, [UInt8]) throws -> [UInt8])?
+
+    func wire_encryptMessage(conversationId: ConversationId, message: [UInt8]) throws -> [UInt8] {
+        guard let mock = mockEncryptMessage else {
+            fatalError("no mock for `encryptMessage`")
+        }
+
+        return try mock(conversationId, message)
+    }
+
+    // MARK: - newAddProposal
+
+    var mockNewAddProposal: ((ConversationId, [UInt8]) throws -> ProposalBundle)?
+
+    func wire_newAddProposal(conversationId: ConversationId, keyPackage: [UInt8]) throws -> ProposalBundle {
+        guard let mock = mockNewAddProposal else {
+            fatalError("no mock for `newAddProposal`")
+        }
+
+        return try mock(conversationId, keyPackage)
+    }
+
+    // MARK: - newUpdateProposal
+
+    var mockNewUpdateProposal: ((ConversationId) throws -> ProposalBundle)?
+
+    func wire_newUpdateProposal(conversationId: ConversationId) throws -> ProposalBundle {
+        guard let mock = mockNewUpdateProposal else {
+            fatalError("no mock for `newUpdateProposal`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - newRemoveProposal
+
+    var mockNewRemoveProposal: ((ConversationId, ClientId) throws -> ProposalBundle)?
+
+    func wire_newRemoveProposal(conversationId: ConversationId, clientId: ClientId) throws -> ProposalBundle {
+        guard let mock = mockNewRemoveProposal else {
+            fatalError("no mock for `newRemoveProposal`")
+        }
+
+        return try mock(conversationId, clientId)
+    }
+
+    // MARK: - newExternalAddProposal
+
+    var mockNewExternalAddProposal: ((ConversationId, UInt64) throws -> [UInt8])?
+
+    func wire_newExternalAddProposal(conversationId: ConversationId, epoch: UInt64) throws -> [UInt8] {
+        guard let mock = mockNewExternalAddProposal else {
+            fatalError("no mock for `newExternalAddProposal`")
+        }
+
+        return try mock(conversationId, epoch)
+    }
+
+    // MARK: - newExternalRemoveProposal
+
+    var mockNewExternalRemoveProposal: ((ConversationId, UInt64, [UInt8]) throws -> [UInt8])?
+
+    func wire_newExternalRemoveProposal(conversationId: ConversationId, epoch: UInt64, keyPackageRef: [UInt8]) throws -> [UInt8] {
+        guard let mock = mockNewExternalRemoveProposal else {
+            fatalError("no mock for `newExternalRemoveProposal`")
+        }
+
+        return try mock(conversationId, epoch, keyPackageRef)
+    }
+
+    // MARK: - joinByExternalCommit
+
+    var mockJoinByExternalCommit: (([UInt8]) throws -> MlsConversationInitMessage)?
+
+    func wire_joinByExternalCommit(groupState: [UInt8]) throws -> MlsConversationInitMessage {
+        guard let mock = mockJoinByExternalCommit else {
+            fatalError("no mock for `joinByExternalCommit`")
+        }
+
+        return try mock(groupState)
+    }
+
+    // MARK: - exportGroupState
+
+    var mockExportGroupState: ((ConversationId) throws -> [UInt8])?
+
+    func wire_exportGroupState(conversationId: ConversationId) throws -> [UInt8] {
+        guard let mock = mockExportGroupState else {
+            fatalError("no mock for `exportGroupState`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - mergePendingGroupFromExternalCommit
+
+    var mockMergePendingGroupFromExternalCommit: ((ConversationId, ConversationConfiguration) throws -> Void)?
+
+    func wire_mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
+        guard let mock = mockMergePendingGroupFromExternalCommit else {
+            fatalError("no mock for `mergePendingGroupFromExternalCommit`")
+        }
+
+        return try mock(conversationId, config)
+    }
+
+    // MARK: - randomBytes
+
+    var mockRandomBytes: ((UInt32) throws -> [UInt8])?
+
+    func wire_randomBytes(length: UInt32) throws -> [UInt8] {
+        guard let mock = mockRandomBytes else {
+            fatalError("no mock for `randomBytes`")
+        }
+
+        return try mock(length)
+    }
+
+    // MARK: - reseedRng
+
+    var mockReseedRng: (([UInt8]) throws -> Void)?
+
+    func wire_reseedRng(seed: [UInt8]) throws {
+        guard let mock = mockReseedRng else {
+            fatalError("no mock for `reseedRng`")
+        }
+
+        return try mock(seed)
+    }
+
+    // MARK: - commitAccepted
+
+    var mockCommitAccepted: ((ConversationId) throws -> Void)?
+
+    func wire_commitAccepted(conversationId: ConversationId) throws {
+        guard let mock = mockCommitAccepted else {
+            fatalError("no mock for `commitAccepted`")
+        }
+
+        return try mock(conversationId)
+    }
+
+    // MARK: - clearPendingProposal
+
+    var mockClearPendingProposal: ((ConversationId, [UInt8]) throws -> Void)?
+
+    func wire_clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
+        guard let mock = mockClearPendingProposal else {
+            fatalError("no mock for `clearPendingProposal`")
+        }
+
+        return try mock(conversationId, proposalRef)
+    }
+
+    // MARK: - clearPendingCommit
+
+    var mockClearPendingCommit: ((ConversationId) throws -> Void)?
+
+    func wire_clearPendingCommit(conversationId: ConversationId) throws {
+        guard let mock = mockClearPendingCommit else {
+            fatalError("no mock for `clearPendingCommit`")
+        }
+
+        return try mock(conversationId)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-963" title="FS-963" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-963</a>  [iOS] Update to Core Crypto 0.5.1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Update Core Crypto to 0.5.0.
- Refactor how we mock Core Crypto: 
  - Instead of providing a mock result or a mock error, provide a mock function
  - Remove the `Calls` struct that counts the invocations of methods... it's hard to maintain and not necessary, since we can make assertions in the mock functions.
- Update tests to account for the new mock approach.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
