### PR TITLE
fix(mls): fetch objects from correct thread

### DIFF
--- a/MLS/StaleMLSKeyMaterialDetector.swift
+++ b/MLS/StaleMLSKeyMaterialDetector.swift
@@ -55,11 +55,17 @@ final class StaleMLSKeyDetector: StaleMLSKeyDetectorProtocol {
     }
 
     var groupsWithStaleKeyingMaterial: Set<MLSGroupID> {
-        let result = MLSGroup.fetchAllObjects(in: context).lazy
-            .filter(isKeyingMaterialStale)
-            .map(\.id)
+        var result = Set<MLSGroupID>()
 
-        return Set(result)
+        context.performAndWait {
+            result = Set(
+                MLSGroup.fetchAllObjects(in: context).lazy
+                .filter(isKeyingMaterialStale)
+                .map(\.id)
+            )
+        }
+
+        return result
     }
 
     func keyingMaterialUpdated(for groupID: MLSGroupID) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app was crashing when updating key material.

### Causes

We were fetching core data entities from the wrong thread.

### Solutions

Switch to the correct thread to fetch objects.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
