### PR TITLE
fix(mls): replenish key packages

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -80,7 +80,6 @@ public final class MLSController: MLSControllerProtocol {
     private weak var context: NSManagedObjectContext?
     private let coreCrypto: CoreCryptoProtocol
     private let conversationEventProcessor: ConversationEventProcessorProtocol
-    private let userDefaults: UserDefaults
     private let logger = Logging.mls
     private var groupsPendingJoin = Set<MLSGroupID>()
 
@@ -89,6 +88,7 @@ public final class MLSController: MLSControllerProtocol {
 
     let targetUnclaimedKeyPackageCount = 100
     let actionsProvider: MLSActionsProviderProtocol
+    let userDefaults: UserDefaults
 
     weak var delegate: MLSControllerDelegate?
 
@@ -98,8 +98,8 @@ public final class MLSController: MLSControllerProtocol {
         context: NSManagedObjectContext,
         coreCrypto: CoreCryptoProtocol,
         conversationEventProcessor: ConversationEventProcessorProtocol,
-        actionsProvider: MLSActionsProviderProtocol = MLSActionsProvider(),
-        userDefaults: UserDefaults = UserDefaults(suiteName: "com.wire.mls")!
+        userDefaults: UserDefaults,
+        actionsProvider: MLSActionsProviderProtocol = MLSActionsProvider()
     ) {
         self.context = context
         self.coreCrypto = coreCrypto

--- a/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
@@ -33,14 +33,16 @@ extension NSManagedObjectContext {
 
     public func initializeMLSController(
         coreCrypto: CoreCryptoProtocol,
-        conversationEventProcessor: ConversationEventProcessorProtocol
+        conversationEventProcessor: ConversationEventProcessorProtocol,
+        userDefaults: UserDefaults
     ) {
         precondition(zm_isSyncContext, "MLSController should only be accessed on the sync context")
 
         userInfo[Self.mlsControllerUserInfoKey] = MLSController(
             context: self,
             coreCrypto: coreCrypto,
-            conversationEventProcessor: conversationEventProcessor
+            conversationEventProcessor: conversationEventProcessor,
+            userDefaults: userDefaults
         )
     }
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -41,8 +41,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             context: uiMOC,
             coreCrypto: mockCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
-            actionsProvider: mockActionsProvider,
-            userDefaults: userDefaultsTestSuite
+            userDefaults: userDefaultsTestSuite,
+            actionsProvider: mockActionsProvider
         )
 
         sut.delegate = self
@@ -87,6 +87,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             context: uiMOC,
             coreCrypto: mockCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
+            userDefaults: userDefaultsTestSuite,
             actionsProvider: mockActionsProvider
         )
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -1196,6 +1196,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             coreCrypto: mockCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
             staleKeyMaterialDetector: mockStaleMLSKeyDetector,
+            userDefaults: userDefaultsTestSuite,
             actionsProvider: mockActionsProvider,
             delegate: self
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Key packages were not uploaded when logging in with a new client after logging out

### Causes (Optional)

The decision to replenish key packages depends on the last time we checked if there are enough key packages. If the last check happened less than 24 hours ago, we don't replenish key packages. Otherwise, we do.

We store the date of the last time we checked key packages in the `UserDefaults` under the suite name `com.wire.mls`. This means that the date saved under theses user defaults is shared between all the user's accounts.

What happens then is:
- We have a fresh Wire app
- User A logs in with client A.1. It checks the date in the user defaults, which is nil, and decides to upload key packages
- User A logs out
- User A logs in with client A.2. The date from client A.1 is saved in user defaults already, and is less than 24h ago, so the app doesn't upload key packages.

The same applies if client B.1 (user B's client) logs in instead of A.1

### Solutions

Use the client ID in the suite name of the user defaults to keep the date tied to any specific client

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
