### PR TITLE
chore(mls): don't track local modifications

### DIFF
--- a/MLS/MLSGroup.swift
+++ b/MLS/MLSGroup.swift
@@ -30,6 +30,10 @@ public class MLSGroup: ZMManagedObject {
         return nil
     }
 
+    public override class func isTrackingLocalModifications() -> Bool {
+        return false
+    }
+
     // MARK: - Properties
 
     public var id: MLSGroupID {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes because somewhere in the sync logic it tries to call `modifiedKeys` (objc code) on `MLSGroup` (swift code), which isn't implemented. 

### Solutions

Mark `MLSGroup` as not being tracked for local modifications.

### Testing

Tested manually.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
