### PR TITLE
fix(mls): sharing of assets from web to iOS FS-973

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 public enum MLSDecryptResult: Equatable {
-    case message(_ messageData: Data)
+    case message(_ messageData: Data, _ senderClientID: String)
     case proposal(_ commitDelay: UInt64)
 }
 
@@ -747,8 +747,11 @@ public final class MLSController: MLSControllerProtocol {
                 return MLSDecryptResult.proposal(commitDelay)
             }
 
-            if let message = decryptedMessage.message {
-                return MLSDecryptResult.message(message.data)
+            if let message = decryptedMessage.message,
+               let senderClientID = decryptedMessage.senderClientId,
+               let mlsClientID = MLSClientID(data: senderClientID.data)
+            {
+                return MLSDecryptResult.message(message.data, mlsClientID.clientID)
             }
 
             return nil

--- a/Source/Model/Message/GenericMessage+UpdateEvent.swift
+++ b/Source/Model/Message/GenericMessage+UpdateEvent.swift
@@ -23,9 +23,9 @@ extension GenericMessage {
         let base64Content: String?
 
         switch updateEvent.type {
-        case .conversationClientMessageAdd, .conversationMLSMessageAdd:
+        case .conversationClientMessageAdd:
             base64Content = updateEvent.payload.string(forKey: "data")
-        case .conversationOtrMessageAdd:
+        case .conversationOtrMessageAdd, .conversationMLSMessageAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "text")
         case .conversationOtrAssetAdd:
             base64Content = updateEvent.payload.dictionary(forKey: "data")?.string(forKey: "info")

--- a/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -146,6 +146,7 @@ extension ZMOTRMessage {
                     prefetchResult.add([message])
                 }
             } else if clientMessage?.senderClientID == nil || clientMessage?.senderClientID != updateEvent.senderClientID {
+                zmLog.warn("senderClientID (\(String(describing: clientMessage?.senderClientID))) is missing or different from the update event's senderClientID (\(String(describing: updateEvent.senderClientID)))")
                 return nil
             }
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -215,6 +215,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         syncMOC.performAndWait {
             // Given
             let messageBytes: Bytes = [1, 2, 3]
+            let sender = MLSClientID(
+                userID: UUID.create().transportString(),
+                clientID: "client",
+                domain: "example.com"
+            )
 
             var mockDecryptMessageCount = 0
             self.mockCoreCrypto.mockDecryptMessage = {
@@ -227,7 +232,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
                     message: messageBytes,
                     proposals: [],
                     isActive: false,
-                    commitDelay: nil
+                    commitDelay: nil,
+                    senderClientId: sender.string.data(using: .utf8)!.bytes
                 )
             }
 
@@ -241,7 +247,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
 
             // Then
             XCTAssertEqual(mockDecryptMessageCount, 1)
-            XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data))
+            XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data, sender.clientID))
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-973" title="FS-973" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-973</a>  [iOS]: Sharing of assets in mls group doesn't work from Web to iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Assets sent from web clients fail to be downloaded on iOS clients

### Causes

When assets are sent from web, we receive two messages. The first message lets us know about the asset so we can show a placeholder, and the second message lets us know that the asset was uploaded. These messages have the same identifier.

When we receive the first message as an update event, we create a `ZMAssetClientMessage` and insert it in the managed object context. We also set some of the fields such as the `senderClientID`.

When we receive the second message, the `ZMAssetClientMessage` already exists in the database. So we fetch it and we update the message with the contents of the update event.

However, in the case of MLS messages, we are missing the sender client ID in the update event payload. It makes us unable to set the sender client ID on the message. If there is not sender client ID, we return early before updating the message. This causes us to "miss" the second message about the asset being uploaded, which would contain the metadata necessary to download the asset.

### Solutions

Return the sender client ID in the `MLSDecryptResult` and add it to the update event payload

### Testing

- TODO

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
