### PR TITLE
fix(mls): crash when adding a participant FS-876

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -349,7 +349,7 @@ public final class MLSController: MLSControllerProtocol {
             try coreCrypto.wire_commitAccepted(conversationId: groupID.bytes)
         }
 
-        conversationEventProcessor.processConversationEvents(updateEvents)
+        await conversationEventProcessor.processConversationEvents(updateEvents)
     }
 
     private func sendWelcomeMessage(_ bytes:  Bytes) async throws {
@@ -1110,7 +1110,7 @@ private class MLSActionsProvider: MLSActionsProviderProtocol {
 
 public protocol ConversationEventProcessorProtocol {
 
-    func processConversationEvents(_ events: [ZMUpdateEvent])
+    func processConversationEvents(_ events: [ZMUpdateEvent]) async
 
 }
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -349,7 +349,7 @@ public final class MLSController: MLSControllerProtocol {
             try coreCrypto.wire_commitAccepted(conversationId: groupID.bytes)
         }
 
-        await conversationEventProcessor.processConversationEvents(updateEvents)
+        conversationEventProcessor.processConversationEvents(updateEvents)
     }
 
     private func sendWelcomeMessage(_ bytes:  Bytes) async throws {
@@ -1110,7 +1110,7 @@ private class MLSActionsProvider: MLSActionsProviderProtocol {
 
 public protocol ConversationEventProcessorProtocol {
 
-    func processConversationEvents(_ events: [ZMUpdateEvent]) async
+    func processConversationEvents(_ events: [ZMUpdateEvent])
 
 }
 

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -155,7 +155,7 @@ extension ZMConversation {
             action.send(in: context.notificationContext)
 
         case .mls:
-            Logging.mls.info("adding \(participants.count) participants to conversation (\(qualifiedID))")
+            Logging.mls.info("adding \(participants.count) participants to conversation (\(String(describing: qualifiedID)))")
 
             var mlsController: MLSControllerProtocol?
 
@@ -168,7 +168,7 @@ extension ZMConversation {
                 let groupID = mlsGroupID?.base64EncodedString,
                 let mlsGroupID = MLSGroupID(base64Encoded: groupID)
             else {
-                Logging.mls.warn("failed to add participants to conversation (\(qualifiedID)): invalid operation")
+                Logging.mls.warn("failed to add participants to conversation (\(String(describing: qualifiedID))): invalid operation")
                 completion(.failure(.invalidOperation))
                 return
             }

--- a/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -175,6 +175,10 @@ extension ZMConversation {
 
             let mlsUsers = users.compactMap(MLSUser.init(from:))
 
+            // If we don't copy the id here (contexts thread), then the app will
+            // crash if we try to use it in the task (not on the contexts thread).
+            let qualifiedID = self.qualifiedID
+
             Task {
                 do {
                     try await mlsController.addMembersToConversation(with: mlsUsers, for: mlsGroupID)
@@ -184,7 +188,7 @@ extension ZMConversation {
                     }
 
                 } catch {
-                    Logging.mls.error("failed to add members to conversation (\(qualifiedID)): \(String(describing: error))")
+                    Logging.mls.error("failed to add members to conversation (\(String(describing: qualifiedID))): \(String(describing: error))")
 
                     context.perform {
                         completion(.failure(.failedToAddMLSMembers))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-876" title="FS-876" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-876</a>  [iOS] Admin cannot add participants to an existing MLS group through group details page 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If adding a participant failed, the app would crash.

### Causes 

The log message uses a property of a Core Data entity, but we're not on the context's thread.

### Solutions

Capture the property outside of the task.

### Dependencies

### Testing

#### Test Coverage

Manually tested.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
