### PR TITLE
feat(mls): make commits atomic

### DIFF
--- a/MLS/CoreCryptoActor.swift
+++ b/MLS/CoreCryptoActor.swift
@@ -1,0 +1,120 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+actor CoreCryptoActor {
+
+    // MARK: - Types
+
+    enum Commit {
+
+        case removeClients([ClientId])
+
+    }
+
+    enum CoreCryptoActor: Error {
+
+        case failedToGenerateCommit
+        case failedToSendCommit
+        case failedToMergeCommit
+        case failedToClearCommit
+
+    }
+
+    // MARK: - Properties
+
+    private let coreCrypto: CoreCryptoProtocol
+    private let context: NSManagedObjectContext
+    private let actionsProvider: MLSActionsProviderProtocol
+
+    // MARK: - Life cycle
+
+    init(
+        coreCrypto: CoreCryptoProtocol,
+        context: NSManagedObjectContext,
+        actionsProvider: MLSActionsProviderProtocol = MLSActionsProvider()
+    ) {
+        self.coreCrypto = coreCrypto
+        self.context = context
+        self.actionsProvider = actionsProvider
+    }
+
+    // MARK: - Methods
+
+    func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        do {
+            let commit = try createCommit(.removeClients(clients), in: groupID)
+            let events = try await sendCommit(commit.commit)
+            try mergeCommit(in: groupID)
+            return events
+        } catch CoreCryptoActor.failedToSendCommit {
+            try clearPendingCommit(in: groupID)
+            throw CoreCryptoActor.failedToSendCommit
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createCommit(_ commit: Commit, in groupID: MLSGroupID) throws -> CommitBundle {
+        do {
+            switch commit {
+            case .removeClients(let clients):
+                return try coreCrypto.wire_removeClientsFromConversation(
+                    conversationId: groupID.bytes,
+                    clients: clients
+                )
+            }
+        } catch {
+            throw CoreCryptoActor.failedToGenerateCommit
+        }
+    }
+
+    private func sendCommit(_ bytes: Bytes) async throws -> [ZMUpdateEvent] {
+        var events = [ZMUpdateEvent]()
+
+        do {
+            events = try await actionsProvider.sendMessage(
+                bytes.data,
+                in: context.notificationContext
+            )
+        } catch {
+            throw CoreCryptoActor.failedToSendCommit
+        }
+
+        return events
+    }
+
+
+    private func mergeCommit(in groupID: MLSGroupID) throws {
+        do {
+            try coreCrypto.wire_commitAccepted(conversationId: groupID.bytes)
+        } catch {
+            throw CoreCryptoActor.failedToMergeCommit
+        }
+    }
+
+    private func clearPendingCommit(in groupID: MLSGroupID) throws {
+        do {
+            try coreCrypto.wire_clearPendingCommit(conversationId: groupID.bytes)
+        } catch {
+            throw CoreCryptoActor.failedToClearCommit
+        }
+    }
+
+}

--- a/MLS/MLSActionExecutor.swift
+++ b/MLS/MLSActionExecutor.swift
@@ -18,7 +18,16 @@
 
 import Foundation
 
-actor MLSActionExecutor {
+protocol MLSActionExecutorProtocol {
+
+    func addMembers(_ invitees: [Invitee], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent]
+    func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent]
+    func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent]
+    func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent]
+
+}
+
+actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Types
 

--- a/MLS/MLSActionExecutor.swift
+++ b/MLS/MLSActionExecutor.swift
@@ -136,7 +136,8 @@ actor MLSActionExecutor {
             return events
 
         } catch MLSActionExecutorError.failedToSendCommit {
-            try clearPendingCommit(in: groupID)
+            // TODO: [John] implement proper error handling
+            //try clearPendingCommit(in: groupID)
             throw MLSActionExecutorError.failedToSendCommit
         }
     }

--- a/MLS/MLSActionExecutor.swift
+++ b/MLS/MLSActionExecutor.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-actor CoreCryptoActor {
+actor MLSActionExecutor {
 
     // MARK: - Types
 
@@ -31,7 +31,7 @@ actor CoreCryptoActor {
 
     }
 
-    enum CoreCryptoActorError: Error {
+    enum MLSActionExecutorError: Error {
 
         case failedToGenerateCommit
         case failedToSendCommit
@@ -112,13 +112,13 @@ actor CoreCryptoActor {
                 guard let bundle = try coreCrypto.wire_commitPendingProposals(
                     conversationId: groupID.bytes
                 ) else {
-                    throw CoreCryptoActorError.noPendingProposals
+                    throw MLSActionExecutorError.noPendingProposals
                 }
 
                 return bundle
             }
         } catch {
-            throw CoreCryptoActorError.failedToGenerateCommit
+            throw MLSActionExecutorError.failedToGenerateCommit
         }
     }
 
@@ -135,9 +135,9 @@ actor CoreCryptoActor {
 
             return events
 
-        } catch CoreCryptoActorError.failedToSendCommit {
+        } catch MLSActionExecutorError.failedToSendCommit {
             try clearPendingCommit(in: groupID)
-            throw CoreCryptoActorError.failedToSendCommit
+            throw MLSActionExecutorError.failedToSendCommit
         }
     }
 
@@ -151,7 +151,7 @@ actor CoreCryptoActor {
                 in: context.notificationContext
             )
         } catch {
-            throw CoreCryptoActorError.failedToSendCommit
+            throw MLSActionExecutorError.failedToSendCommit
         }
 
         return events
@@ -164,7 +164,7 @@ actor CoreCryptoActor {
                 in: context.notificationContext
             )
         } catch {
-            throw CoreCryptoActorError.failedToSendWelcome
+            throw MLSActionExecutorError.failedToSendWelcome
         }
     }
 
@@ -174,7 +174,7 @@ actor CoreCryptoActor {
         do {
             try coreCrypto.wire_commitAccepted(conversationId: groupID.bytes)
         } catch {
-            throw CoreCryptoActorError.failedToMergeCommit
+            throw MLSActionExecutorError.failedToMergeCommit
         }
     }
 
@@ -182,7 +182,7 @@ actor CoreCryptoActor {
         do {
             try coreCrypto.wire_clearPendingCommit(conversationId: groupID.bytes)
         } catch {
-            throw CoreCryptoActorError.failedToClearCommit
+            throw MLSActionExecutorError.failedToClearCommit
         }
     }
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -986,7 +986,7 @@ private extension MLSController.MLSSendMessageError {
 
 }
 
-private extension String {
+extension String {
 
     var utf8Data: Data? {
         return data(using: .utf8)

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -420,6 +420,7 @@ public final class MLSController: MLSControllerProtocol {
 
         do {
             // TODO: commit pending proposals
+
             let keyPackages = try await claimKeyPackages(for: users)
             let invitees = keyPackages.map(Invitee.init(from:))
             let events = try await mlsActionExecutor.addMembers(invitees, to: groupID)
@@ -818,9 +819,6 @@ public final class MLSController: MLSControllerProtocol {
         guard context != nil else {
             return
         }
-
-        // Maybe we can split this... overdue.. .commit immediately.
-        // future... collect them all, find the newest, and try again
 
         logger.info("committing any scheduled pending proposals")
 

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -65,7 +65,7 @@ public final class MLSController: MLSControllerProtocol {
 
     private weak var context: NSManagedObjectContext?
     private let coreCrypto: CoreCryptoProtocol
-    private let mlsActionExecutor: MLSActionExecutor
+    private let mlsActionExecutor: MLSActionExecutorProtocol
     private let conversationEventProcessor: ConversationEventProcessorProtocol
     private let staleKeyMaterialDetector: StaleMLSKeyDetectorProtocol
     private let userDefaults: UserDefaults
@@ -124,6 +124,7 @@ public final class MLSController: MLSControllerProtocol {
     init(
         context: NSManagedObjectContext,
         coreCrypto: CoreCryptoProtocol,
+        mlsActionExecutor: MLSActionExecutorProtocol? = nil,
         conversationEventProcessor: ConversationEventProcessorProtocol,
         staleKeyMaterialDetector: StaleMLSKeyDetectorProtocol,
         userDefaults: UserDefaults,
@@ -132,7 +133,7 @@ public final class MLSController: MLSControllerProtocol {
     ) {
         self.context = context
         self.coreCrypto = coreCrypto
-        self.mlsActionExecutor = MLSActionExecutor(
+        self.mlsActionExecutor = mlsActionExecutor ?? MLSActionExecutor(
             coreCrypto: coreCrypto,
             context: context,
             actionsProvider: actionsProvider

--- a/Tests/MLS/MLSActionExecutorTests.swift
+++ b/Tests/MLS/MLSActionExecutorTests.swift
@@ -203,7 +203,6 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         let groupID = MLSGroupID(.random())
 
         let mockCommit = Bytes.random())
-        let mockUpdateEvent = mockMemberJoinUpdateEvent()
 
         // Mock Update key material.
         var mockUpdateKeyMaterialArguments = [Bytes]()
@@ -220,7 +219,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         var mockSendCommitArguments = [Data]()
         mockActionsProvider.sendMessageMocks.append({
             mockSendCommitArguments.append($0)
-            return [mockUpdateEvent]
+            return []
         })
 
         // Mock merge commit.
@@ -253,8 +252,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         // Then no welcome was sent.
         XCTAssertEqual(mockSendWelcomeArguments.count, 0)
 
-        // Then the update event was returned.
-        XCTAssertEqual(updateEvents, [mockUpdateEvent])
+        // Then no update events were returned.
+        XCTAssertEqual(updateEvents, [])
     }
 
     // MARK: - Commit pending proposals

--- a/Tests/MLS/MLSActionExecutorTests.swift
+++ b/Tests/MLS/MLSActionExecutorTests.swift
@@ -1,0 +1,127 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class MLSActionExecutorTests: ZMBaseManagedObjectTest {
+
+    var mockCoreCrypto: MockCoreCrypto!
+    var mockActionsProvider: MockMLSActionsProvider!
+    var sut: MLSActionExecutor!
+
+    override func setUp() {
+        super.setUp()
+        mockCoreCrypto = MockCoreCrypto()
+        mockActionsProvider = MockMLSActionsProvider()
+        sut = MLSActionExecutor(
+            coreCrypto: mockCoreCrypto,
+            context: uiMOC,
+            actionsProvider: mockActionsProvider
+        )
+    }
+
+    override func tearDown() {
+        mockCoreCrypto = nil
+        mockActionsProvider = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func mockUpdateEvent() -> ZMUpdateEvent {
+        let payload: NSDictionary = [
+            "type": "conversation.member-join",
+            "data": "foo"
+        ]
+
+        return ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
+    }
+
+    // MARK: - Add members
+
+    func test_AddMembers() async throws {
+        // Given
+        let groupID = MLSGroupID(.random())
+        let invitees = [Invitee(id: .random(), kp: .random())]
+
+        let mockCommit = Bytes.random()
+        let mockWelcome = Bytes.random()
+        let mockUpdateEvent = mockUpdateEvent()
+
+        // Mock add clients.
+        var mockAddClientsArguments = [(Bytes, [Invitee])]()
+        mockCoreCrypto.mockAddClientsToConversation = {
+            mockAddClientsArguments.append(($0, $1))
+            return MemberAddedMessages(
+                commit: mockCommit,
+                welcome: mockWelcome,
+                publicGroupState: []
+            )
+        }
+
+        // Mock send commit.
+        var mockSendCommitArguments = [Data]()
+        mockActionsProvider.sendMessageMocks.append({
+            mockSendCommitArguments.append($0)
+            return [mockUpdateEvent]
+        })
+
+        // Mock merge commit.
+        var mockCommitAcceptedArguments = [Bytes]()
+        mockCoreCrypto.mockCommitAccepted = {
+            mockCommitAcceptedArguments.append($0)
+        }
+
+        // Mock send welcome message.
+        var mockSendWelcomeArguments = [Data]()
+        mockActionsProvider.sendWelcomeMessageMocks.append({
+            mockSendWelcomeArguments.append($0)
+        })
+
+        // When
+        let updateEvents = try await sut.addMembers(invitees, to: groupID)
+
+        // Then core crypto added the members.
+        XCTAssertEqual(mockAddClientsArguments.count, 1)
+        XCTAssertEqual(mockAddClientsArguments.first?.0, groupID.bytes)
+        XCTAssertEqual(mockAddClientsArguments.first?.1, invitees)
+
+        // Then the commit was sent.
+        XCTAssertEqual(mockSendCommitArguments.count, 1)
+        XCTAssertEqual(mockSendCommitArguments.first, mockCommit.data)
+
+        // Then the commit was merged.
+        XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
+        XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
+
+        // Then the welcome was sent.
+        XCTAssertEqual(mockSendWelcomeArguments.count, 1)
+        XCTAssertEqual(mockSendWelcomeArguments.first, mockWelcome.data)
+
+        // Then the update event was returned.
+        XCTAssertEqual(updateEvents, [mockUpdateEvent])
+    }
+
+    // MARK: - Remove clients
+
+    // MARK: - Update key material
+
+    // MARK: - Commit pending proposals
+
+}

--- a/Tests/MLS/MLSActionExecutorTests.swift
+++ b/Tests/MLS/MLSActionExecutorTests.swift
@@ -141,7 +141,6 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         let clientIds =  [mlsClientID].compactMap { $0.string.utf8Data?.bytes }
 
         let mockCommit = Bytes.random()
-        let mockWelcome = Bytes.random()
         let mockUpdateEvent = mockMemberLeaveUpdateEvent()
 
         // Mock remove clients.
@@ -149,7 +148,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         mockCoreCrypto.mockRemoveClientsFromConversation = {
             mockRemoveClientsArguments.append(($0, $1))
             return CommitBundle(
-                welcome: mockWelcome,
+                welcome: nil,
                 commit: mockCommit,
                 publicGroupState: []
             )
@@ -190,9 +189,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
         XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
 
-        // Then the welcome was sent.
-        XCTAssertEqual(mockSendWelcomeArguments.count, 1)
-        XCTAssertEqual(mockSendWelcomeArguments.first, mockWelcome.data)
+        // Then no welcome was sent.
+        XCTAssertEqual(mockSendWelcomeArguments.count, 0)
 
         // Then the update event was returned.
         XCTAssertEqual(updateEvents, [mockUpdateEvent])
@@ -204,8 +202,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         // Given
         let groupID = MLSGroupID(.random())
 
-        let mockCommit = Bytes.random()
-        let mockWelcome = Bytes.random()
+        let mockCommit = Bytes.random())
         let mockUpdateEvent = mockMemberJoinUpdateEvent()
 
         // Mock Update key material.
@@ -213,7 +210,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         mockCoreCrypto.mockUpdateKeyingMaterial = {
             mockUpdateKeyMaterialArguments.append($0)
             return CommitBundle(
-                welcome: mockWelcome,
+                welcome: nil,
                 commit: mockCommit,
                 publicGroupState: []
             )
@@ -253,9 +250,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
         XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
 
-        // Then the welcome was sent.
-        XCTAssertEqual(mockSendWelcomeArguments.count, 1)
-        XCTAssertEqual(mockSendWelcomeArguments.first, mockWelcome.data)
+        // Then no welcome was sent.
+        XCTAssertEqual(mockSendWelcomeArguments.count, 0)
 
         // Then the update event was returned.
         XCTAssertEqual(updateEvents, [mockUpdateEvent])

--- a/Tests/MLS/MLSActionExecutorTests.swift
+++ b/Tests/MLS/MLSActionExecutorTests.swift
@@ -202,7 +202,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         // Given
         let groupID = MLSGroupID(.random())
 
-        let mockCommit = Bytes.random())
+        let mockCommit = Bytes.random()
 
         // Mock Update key material.
         var mockUpdateKeyMaterialArguments = [Bytes]()

--- a/Tests/MLS/MockMLSActionExecutor.swift
+++ b/Tests/MLS/MockMLSActionExecutor.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+
+class MockMLSActionExecutor: MLSActionExecutorProtocol {
+
+    // MARK: - Add members
+
+    var mockAddMembers: (([Invitee], MLSGroupID) async throws -> [ZMUpdateEvent])?
+
+    func addMembers(_ invitees: [Invitee], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        guard let mock = mockAddMembers else {
+            fatalError("no mock for `addMembers`")
+        }
+
+        return try await mock(invitees, groupID)
+    }
+
+    // MARK: - Remove clients
+
+    var mockRemoveClients: (([ClientId], MLSGroupID) async throws -> [ZMUpdateEvent])?
+
+    func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        guard let mock = mockRemoveClients else {
+            fatalError("no mock for `removeClients`")
+        }
+
+        return try await mock(clients, groupID)
+    }
+
+    // MARK: - Update key material
+
+    var mockUpdateKeyMaterial: ((MLSGroupID) async throws -> [ZMUpdateEvent])?
+
+    func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        guard let mock = mockUpdateKeyMaterial else {
+            fatalError("no mock for `updateKeyMaterial`")
+        }
+
+        return try await mock(groupID)
+    }
+
+    // MARK: - Commit pending proposals
+
+    var mockCommitPendingProposals: ((MLSGroupID) async throws -> [ZMUpdateEvent])?
+
+    func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        guard let mock = mockCommitPendingProposals else {
+            fatalError("no mock for `commitPendingProposals`")
+        }
+
+        return try await mock(groupID)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 		EEDB51DB255410D000F35A29 /* GenericMessageHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */; };
 		EEDD426A28633B2800C9EBC4 /* ZMUser+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */; };
 		EEDE7DB528EAFE45007DC6A3 /* MLSActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB428EAFE45007DC6A3 /* MLSActionExecutor.swift */; };
+		EEDE7DB728EC1618007DC6A3 /* MockMLSActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */; };
 		EEE186B2259CC7CD008707CA /* AppLockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
@@ -1369,6 +1370,7 @@
 		EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageHelperTests.swift; sourceTree = "<group>"; };
 		EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Patches.swift"; sourceTree = "<group>"; };
 		EEDE7DB428EAFE45007DC6A3 /* MLSActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSActionExecutor.swift; sourceTree = "<group>"; };
+		EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSActionExecutor.swift; sourceTree = "<group>"; };
 		EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockDelegate.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2057,6 +2059,7 @@
 			isa = PBXGroup;
 			children = (
 				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
+				EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */,
 				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
 				EE98879128882C8F002340D2 /* MockMLSController.swift */,
@@ -3862,6 +3865,7 @@
 				F9AB395B1CB3AED900A7254F /* BaseTestSwiftHelpers.swift in Sources */,
 				A923D77E239DB87700F47B85 /* ZMConversationTests+SecurityLevel.swift in Sources */,
 				F93C4C7F1E24F832007E9CEE /* NotificationDispatcherTests.swift in Sources */,
+				EEDE7DB728EC1618007DC6A3 /* MockMLSActionExecutor.swift in Sources */,
 				1645ECC2243B643B007A82D6 /* ZMSearchUserTests+TeamUser.swift in Sources */,
 				F9331C521CB3BC6800139ECC /* CryptoBoxTests.swift in Sources */,
 				1693155325A30D4E00709F15 /* UserClientTests+ResetSession.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -536,6 +536,7 @@
 		EEDA9C152513A1DA003A5B27 /* ZMClientMessage+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C132513A0A5003A5B27 /* ZMClientMessage+EncryptionAtRest.swift */; };
 		EEDB51DB255410D000F35A29 /* GenericMessageHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */; };
 		EEDD426A28633B2800C9EBC4 /* ZMUser+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */; };
+		EEDE7DB528EAFE45007DC6A3 /* CoreCryptoActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */; };
 		EEE186B2259CC7CD008707CA /* AppLockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
@@ -1367,6 +1368,7 @@
 		EEDA9C132513A0A5003A5B27 /* ZMClientMessage+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageHelperTests.swift; sourceTree = "<group>"; };
 		EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Patches.swift"; sourceTree = "<group>"; };
+		EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoActor.swift; sourceTree = "<group>"; };
 		EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockDelegate.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 			children = (
 				7AFC6A272876E935000FF1A1 /* Actions */,
 				EE404EA1287317CB00B3653F /* MLSController.swift */,
+				EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */,
 				EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */,
 				EEFAAC3128DDE1D7009940E7 /* CoreCryptoCallbacks.swift */,
 				EEF6E3C728D88A33001C1799 /* MLSGroup.swift */,
@@ -3528,6 +3531,7 @@
 				EE42938E252C460000E70670 /* Changes.swift in Sources */,
 				D5FA30CF2063F8EC00716618 /* Version.swift in Sources */,
 				06D5423C26399C33006B0C5A /* UserType+External.swift in Sources */,
+				EEDE7DB528EAFE45007DC6A3 /* CoreCryptoActor.swift in Sources */,
 				F9DBA5201E28EA8B00BE23C0 /* DependencyKeyStore.swift in Sources */,
 				EEA985982555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift in Sources */,
 				F125BAD71EE9849B0018C2F8 /* ZMConversation+SystemMessages.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		EE6CB3DE24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */; };
 		EE715B7D256D153E00087A22 /* FeatureServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE715B7C256D153E00087A22 /* FeatureServiceTests.swift */; };
 		EE770DAF25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE770DAE25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift */; };
+		EE84227028EC353900B80FE5 /* MLSActionExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE84226F28EC353900B80FE5 /* MLSActionExecutorTests.swift */; };
 		EE8B09AD25B86AB10057E85C /* AppLockError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8B09AC25B86AB10057E85C /* AppLockError.swift */; };
 		EE8B09AF25B86BB20057E85C /* AppLockPasscodePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8B09AE25B86BB20057E85C /* AppLockPasscodePreference.swift */; };
 		EE980FB22834EB3A00CC6B9F /* store2-100-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE980FB12834EB3A00CC6B9F /* store2-100-0.wiredatabase */; };
@@ -1329,6 +1330,7 @@
 		EE6CB3DD24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMGenericMessageDataTests.swift; sourceTree = "<group>"; };
 		EE715B7C256D153E00087A22 /* FeatureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureServiceTests.swift; sourceTree = "<group>"; };
 		EE770DAE25344B4F00163C4A /* NotificationDispatcher.OperationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationDispatcher.OperationMode.swift; sourceTree = "<group>"; };
+		EE84226F28EC353900B80FE5 /* MLSActionExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSActionExecutorTests.swift; sourceTree = "<group>"; };
 		EE8B09AC25B86AB10057E85C /* AppLockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockError.swift; sourceTree = "<group>"; };
 		EE8B09AE25B86BB20057E85C /* AppLockPasscodePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockPasscodePreference.swift; sourceTree = "<group>"; };
 		EE980FB02834EA3200CC6B9F /* zmessaging2.100.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.100.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2059,6 +2061,7 @@
 			isa = PBXGroup;
 			children = (
 				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
+				EE84226F28EC353900B80FE5 /* MLSActionExecutorTests.swift */,
 				EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */,
 				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
@@ -3956,6 +3959,7 @@
 				16925337234F677B0041A8FF /* ZMConversationListDirectoryTests+Labels.swift in Sources */,
 				EE6A57DC25BAE3D700F848DD /* MockLAContext.swift in Sources */,
 				1687C0E22150EE91003099DD /* ZMClientMessageTests+Mentions.swift in Sources */,
+				EE84227028EC353900B80FE5 /* MLSActionExecutorTests.swift in Sources */,
 				F9A708341CAEEB7500C2F5FE /* ManagedObjectContextSaveNotificationTests.m in Sources */,
 				63370CF52431F3ED0072C37F /* CompositeMessageItemContentTests.swift in Sources */,
 				E9C7DD9B27B533D000FB9AE8 /* AccessRoleMappingTests.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -536,7 +536,7 @@
 		EEDA9C152513A1DA003A5B27 /* ZMClientMessage+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C132513A0A5003A5B27 /* ZMClientMessage+EncryptionAtRest.swift */; };
 		EEDB51DB255410D000F35A29 /* GenericMessageHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */; };
 		EEDD426A28633B2800C9EBC4 /* ZMUser+Patches.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */; };
-		EEDE7DB528EAFE45007DC6A3 /* CoreCryptoActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */; };
+		EEDE7DB528EAFE45007DC6A3 /* MLSActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB428EAFE45007DC6A3 /* MLSActionExecutor.swift */; };
 		EEE186B2259CC7CD008707CA /* AppLockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
@@ -1368,7 +1368,7 @@
 		EEDA9C132513A0A5003A5B27 /* ZMClientMessage+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EEDB51DA255410D000F35A29 /* GenericMessageHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMessageHelperTests.swift; sourceTree = "<group>"; };
 		EEDD426928633B2800C9EBC4 /* ZMUser+Patches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Patches.swift"; sourceTree = "<group>"; };
-		EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoActor.swift; sourceTree = "<group>"; };
+		EEDE7DB428EAFE45007DC6A3 /* MLSActionExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSActionExecutor.swift; sourceTree = "<group>"; };
 		EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockDelegate.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
@@ -2014,7 +2014,7 @@
 			children = (
 				7AFC6A272876E935000FF1A1 /* Actions */,
 				EE404EA1287317CB00B3653F /* MLSController.swift */,
-				EEDE7DB428EAFE45007DC6A3 /* CoreCryptoActor.swift */,
+				EEDE7DB428EAFE45007DC6A3 /* MLSActionExecutor.swift */,
 				EE04084B28CA8283009E4B8D /* StaleMLSKeyMaterialDetector.swift */,
 				EEFAAC3128DDE1D7009940E7 /* CoreCryptoCallbacks.swift */,
 				EEF6E3C728D88A33001C1799 /* MLSGroup.swift */,
@@ -3531,7 +3531,7 @@
 				EE42938E252C460000E70670 /* Changes.swift in Sources */,
 				D5FA30CF2063F8EC00716618 /* Version.swift in Sources */,
 				06D5423C26399C33006B0C5A /* UserType+External.swift in Sources */,
-				EEDE7DB528EAFE45007DC6A3 /* CoreCryptoActor.swift in Sources */,
+				EEDE7DB528EAFE45007DC6A3 /* MLSActionExecutor.swift in Sources */,
 				F9DBA5201E28EA8B00BE23C0 /* DependencyKeyStore.swift in Sources */,
 				EEA985982555668A002BEF02 /* ZMUser+AnalyticsIdentifier.swift in Sources */,
 				F125BAD71EE9849B0018C2F8 /* ZMConversation+SystemMessages.swift in Sources */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

It's possible to interleave MLS commits, which results in error. For instance, we may try to commit pending proposals in to 2 different groups. Each action involves generating the commit via CoreCrypto, sending it to the backend, and merging the commit when the backend responds with a success. If we try to generate the second commit before we've merged the first commit, CoreCrypto will throw an error.

### Solutions

Make the flow of `generate commit -> send commit -> merge commit` atomic. From a concurrency point of view, this flow is a critical section where we need to ensure mutual exclusion. To do this, we make use a Swift's `actor` concurrency type to ensure mutual exclusion for specific methods and shared resources. The shared resource in this case would be Core Crypto, the methods are any action that trigger this flow of commits.

`MLSActionExecutor` is an actor that has a reference to Core Crypto and exposes one method for each action that involves commits: adding members, removing clients, updating key material, committing pending proposals.

When each of these methods are called, if the actor is not under contention (no thread is accessing it), then the calling thread will gain exclusive access, and only release it when the method returns (i.e after the commit is merged). If another thread is trying to access the actor that is under contention, then it will wait until it is released, thus not generating a new commit while another needs to be merged.

### Testing

#### Test Coverage 

- Updated `MLSControllerTests`
- TODO: actor tests

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
