### PR TITLE
feat(mls): retry operations on commit failure FS-1039

### DIFF
--- a/MLS/Actions/SendMLSMessageAction.swift
+++ b/MLS/Actions/SendMLSMessageAction.swift
@@ -26,51 +26,97 @@ public final class SendMLSMessageAction: EntityAction {
 
     public enum Failure: LocalizedError, Equatable {
 
-        case invalidBody
+        case endpointUnavailable
+        case malformedRequest
+        case malformedResponse
+
+        case mlsGroupConversationMismatch
+        case mlsClientSenderUserMismatch
+        case mlsSelfRemovalNotAllowed
+        case mlsCommitMissingReferences
         case mlsProtocolError
+        case invalidRequestBody
+
         case missingLegalHoldConsent
         case legalHoldNotEnabled
+        case accessDenied
+
         case mlsProposalNotFound
         case mlsKeyPackageRefNotFound
         case noConversation
+        case noConversationMember
+
         case mlsStaleMessage
         case mlsClientMismatch
         case mlsUnsupportedProposal
         case mlsUnsupportedMessage
-        case endpointUnavailable
-        case malformedResponse
-        case unknown(status: Int)
+
+        case unknown(status: Int, label: String, message: String)
 
         public var errorDescription: String? {
             switch self {
-            case .invalidBody:
-                return "Invalid body"
+            case .endpointUnavailable:
+                return "Endpoint not available"
+
+            case .malformedRequest:
+                return "The request could not be formed"
+
+            case .malformedResponse:
+                return "The response payload could not be decoded"
+
+            case .mlsGroupConversationMismatch:
+                return "Conversation ID resolved from group ID does not match submitted conversation ID"
+
+            case .mlsClientSenderUserMismatch:
+                return "User ID resolved from client ID does not match message's sender user ID"
+
+            case .mlsSelfRemovalNotAllowed:
+                return "Self removal from group is not allowed"
+
             case .mlsProtocolError:
                 return "MLS protocol error"
+
+            case .mlsCommitMissingReferences:
+                return "The commit is not referencing all pending proposals"
+
+            case .invalidRequestBody:
+                return "Invalid request body"
+
             case .missingLegalHoldConsent:
                 return "Failed to connect to a user or to invite a user to a group because somebody is under legal hold and somebody else has not granted consent"
+
             case .legalHoldNotEnabled:
                 return "Legal hold is not enabled for this team"
+
+            case .accessDenied:
+                return "Conversation access denied"
+
             case .mlsProposalNotFound:
                 return "A proposal referenced in a commit message could not be found"
+
             case .mlsKeyPackageRefNotFound:
                 return "A referenced key package could not be mapped to a known client"
+
             case .noConversation:
                 return "Conversation not found"
+
+            case .noConversationMember:
+                return "Conversation member not found"
+
             case .mlsStaleMessage:
                 return "The conversation epoch in a message is too old"
+
             case .mlsClientMismatch:
                 return "A proposal of type Add or Remove does not apply to the full list of clients for a user"
+
             case .mlsUnsupportedProposal:
                 return "Unsupported proposal type"
+
             case .mlsUnsupportedMessage:
                 return "Attempted to send a message with an unsupported combination of content type and wire format"
-            case .endpointUnavailable:
-                return "End point not available"
-            case .malformedResponse:
-                return "Malformed response"
-            case .unknown(status: let status):
-                return "Unknown error (response status: \(status))"
+
+            case let .unknown(status, label, message):
+                return "Unknown error (response status: \(status), label: \(label), message: \(message))"
             }
         }
     }

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -1225,10 +1225,3 @@ extension UserDefaults {
         lastKeyPackageCountDate = date
     }
 }
-
-public protocol SyncStatusProtocol {
-
-    func performQuickSync() async
-
-}
-

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -864,10 +864,6 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     func commitPendingProposals(in groupID: MLSGroupID) async throws {
-        guard context != nil else {
-            return
-        }
-
         logger.info("committing pending proposals in: \(groupID)")
 
         do {

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -460,6 +460,7 @@ public final class MLSController: MLSControllerProtocol {
         for groupID: MLSGroupID
     ) async throws {
         do {
+            logger.info("removing members from group (\(groupID)), members: \(clientIds)")
             guard !clientIds.isEmpty else { throw MLSRemoveParticipantsError.noClientsToRemove }
             let clientIds =  clientIds.compactMap { $0.string.utf8Data?.bytes }
             let events = try await mlsActionExecutor.removeClients(clientIds, from: groupID)

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -938,24 +938,9 @@ public final class MLSController: MLSControllerProtocol {
 
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp) {
             logger.warn("failed to send commit, giving up...")
-            // TODO: inform user
+            // TODO: [John] inform user
             throw MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp)
         }
-    }
-
-    private func performQuickSyncThen(_ operation: @escaping (() async throws -> Void)) {
-        operationToRetryAfterQuickSync = operation
-        // Request quick sync
-    }
-
-    private var operationToRetryAfterQuickSync: (() async throws -> Void)?
-
-    public func quickSyncDidFinish() {
-        Task {
-            try? await operationToRetryAfterQuickSync?()
-            operationToRetryAfterQuickSync = nil
-        }
-
     }
 
 }

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -72,6 +72,8 @@ public final class MLSController: MLSControllerProtocol {
     private let logger = Logging.mls
     private var groupsPendingJoin = Set<MLSGroupID>()
 
+    private let syncStatus: SyncStatusProtocol
+
     var backendPublicKeys = BackendMLSPublicKeys()
     var pendingProposalCommitTimers = [MLSGroupID: Timer]()
 
@@ -106,7 +108,8 @@ public final class MLSController: MLSControllerProtocol {
         context: NSManagedObjectContext,
         coreCrypto: CoreCryptoProtocol,
         conversationEventProcessor: ConversationEventProcessorProtocol,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        syncStatus: SyncStatusProtocol
     ) {
         self.init(
             context: context,
@@ -117,7 +120,8 @@ public final class MLSController: MLSControllerProtocol {
                 context: context
             ),
             userDefaults: userDefaults,
-            actionsProvider: MLSActionsProvider()
+            actionsProvider: MLSActionsProvider(),
+            syncStatus: syncStatus
         )
     }
 
@@ -129,7 +133,8 @@ public final class MLSController: MLSControllerProtocol {
         staleKeyMaterialDetector: StaleMLSKeyDetectorProtocol,
         userDefaults: UserDefaults,
         actionsProvider: MLSActionsProviderProtocol = MLSActionsProvider(),
-        delegate: MLSControllerDelegate? = nil
+        delegate: MLSControllerDelegate? = nil,
+        syncStatus: SyncStatusProtocol
     ) {
         self.context = context
         self.coreCrypto = coreCrypto
@@ -143,6 +148,7 @@ public final class MLSController: MLSControllerProtocol {
         self.actionsProvider = actionsProvider
         self.userDefaults = userDefaults
         self.delegate = delegate
+        self.syncStatus = syncStatus
 
         do {
             try coreCrypto.wire_setCallbacks(callbacks: CoreCryptoCallbacksImpl())
@@ -234,25 +240,32 @@ public final class MLSController: MLSControllerProtocol {
         Logging.mls.info("found \(staleGroups.count) groups with stale key material")
 
         for staleGroup in staleGroups {
-            await updateKeyMaterial(for: staleGroup)
+            try? await updateKeyMaterial(for: staleGroup)
         }
     }
 
-    private func updateKeyMaterial(for groupID: MLSGroupID) async {
+    func updateKeyMaterial(for groupID: MLSGroupID) async throws {
+        try await commitPendingProposals(in: groupID)
+        try await retryOnCommitFailure(for: groupID) { [weak self] in
+            try await self?.internalUpdateKeyMaterial(for: groupID)
+        }
+    }
+
+    private func internalUpdateKeyMaterial(for groupID: MLSGroupID) async throws {
         do {
             Logging.mls.info("updating key material for group (\(groupID))")
-            try await commitPendingProposalsIfNeeded(in: groupID)
             let events = try await mlsActionExecutor.updateKeyMaterial(for: groupID)
             staleKeyMaterialDetector.keyingMaterialUpdated(for: groupID)
             conversationEventProcessor.processConversationEvents(events)
         } catch {
             Logging.mls.warn("failed to update key material for group (\(groupID)): \(String(describing: error))")
+            throw error
         }
     }
 
     // MARK: - Group creation
 
-    enum MLSGroupCreationError: Error {
+    enum MLSGroupCreationError: Error, Equatable {
 
         case noParticipantsToAdd
         case failedToClaimKeyPackages
@@ -400,21 +413,26 @@ public final class MLSController: MLSControllerProtocol {
     ///   - groupID: Represents the MLS conversation group ID in which users to be added
 
     public func addMembersToConversation(with users: [MLSUser], for groupID: MLSGroupID) async throws {
-        logger.info("adding members to group (\(groupID)) with users: \(users)")
-
-        guard !users.isEmpty else {
-            throw MLSAddMembersError.noMembersToAdd
+        try await commitPendingProposals(in: groupID)
+        try await retryOnCommitFailure(for: groupID) { [weak self] in
+            try await self?.internalAddMembersToConversation(with: users, for: groupID)
         }
+    }
 
+    private func internalAddMembersToConversation(
+        with users: [MLSUser],
+        for groupID: MLSGroupID
+    ) async throws {
         do {
-            try await commitPendingProposalsIfNeeded(in: groupID)
+            logger.info("adding members to group (\(groupID)) with users: \(users)")
+            guard !users.isEmpty else { throw MLSAddMembersError.noMembersToAdd }
             let keyPackages = try await claimKeyPackages(for: users)
             let invitees = keyPackages.map(Invitee.init(from:))
             let events = try await mlsActionExecutor.addMembers(invitees, to: groupID)
             conversationEventProcessor.processConversationEvents(events)
         } catch {
             logger.warn("failed to add members to group (\(groupID)): \(String(describing: error))")
-            throw MLSAddMembersError.failedToAddMembers
+            throw error
         }
     }
 
@@ -431,20 +449,24 @@ public final class MLSController: MLSControllerProtocol {
         with clientIds: [MLSClientID],
         for groupID: MLSGroupID
     ) async throws {
-        logger.info("removing members from group (\(groupID)), members: \(clientIds)")
-
-        guard !clientIds.isEmpty else {
-            throw MLSRemoveParticipantsError.noClientsToRemove
+        try await commitPendingProposals(in: groupID)
+        try await retryOnCommitFailure(for: groupID) { [weak self] in
+            try await self?.internalRemoveMembersFromConversation(with: clientIds, for: groupID)
         }
+    }
 
+    private func internalRemoveMembersFromConversation(
+        with clientIds: [MLSClientID],
+        for groupID: MLSGroupID
+    ) async throws {
         do {
-            try await commitPendingProposalsIfNeeded(in: groupID)
+            guard !clientIds.isEmpty else { throw MLSRemoveParticipantsError.noClientsToRemove }
             let clientIds =  clientIds.compactMap { $0.string.utf8Data?.bytes }
             let events = try await mlsActionExecutor.removeClients(clientIds, from: groupID)
             conversationEventProcessor.processConversationEvents(events)
         } catch {
             logger.warn("failed to remove members from group (\(groupID)): \(String(describing: error))")
-            throw MLSRemoveParticipantsError.failedToRemoveMembers
+            throw error
         }
     }
 
@@ -864,17 +886,23 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     func commitPendingProposals(in groupID: MLSGroupID) async throws {
-        logger.info("committing pending proposals in: \(groupID)")
+        try await retryOnCommitFailure(for: groupID) { [weak self] in
+            try await self?.internalCommitPendingProposals(in: groupID)
+        }
+    }
 
+    private func internalCommitPendingProposals(in groupID: MLSGroupID) async throws {
         do {
+            logger.info("committing pending proposals in: \(groupID)")
             let events = try await mlsActionExecutor.commitPendingProposals(in: groupID)
             conversationEventProcessor.processConversationEvents(events)
             clearPendingProposalCommitDate(for: groupID)
             delegate?.mlsControllerDidCommitPendingProposal(for: groupID)
+        } catch MLSActionExecutor.Error.noPendingProposals {
+            logger.info("no proposals to commit in group (\(groupID))...")
         } catch {
             logger.info("failed to commit pending proposals in \(groupID): \(String(describing: error))")
-            clearPendingProposalCommitDate(for: groupID)
-            throw MLSCommitPendingProposalsError.failedToCommitPendingProposals
+            throw error
         }
     }
 
@@ -897,14 +925,17 @@ public final class MLSController: MLSControllerProtocol {
     ) async throws {
         do {
             try await operation()
+
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync) {
             logger.warn("failed to send commit, syncing then committing pending proposals...")
-            performQuickSyncThen { [weak self] in
-                try await self?.commitPendingProposals(in: groupID)
-            }
+            await syncStatus.performQuickSync()
+            try await commitPendingProposals(in: groupID)
+
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync) {
             logger.warn("failed to send commit, syncing then retrying operation...")
-            performQuickSyncThen(operation)
+            await syncStatus.performQuickSync()
+            try await retryOnCommitFailure(for: groupID, operation: operation)
+
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp) {
             logger.warn("failed to send commit, giving up...")
             // TODO: inform user
@@ -1194,3 +1225,10 @@ extension UserDefaults {
         lastKeyPackageCountDate = date
     }
 }
+
+public protocol SyncStatusProtocol {
+
+    func performQuickSync() async
+
+}
+

--- a/MLS/SyncStatusProtocol.swift
+++ b/MLS/SyncStatusProtocol.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public protocol SyncStatusProtocol {
+
+    func performQuickSync() async
+
+}

--- a/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
+++ b/Source/ManagedObjectContext/NSManagedObjectContext+MLSController.swift
@@ -34,7 +34,8 @@ extension NSManagedObjectContext {
     public func initializeMLSController(
         coreCrypto: CoreCryptoProtocol,
         conversationEventProcessor: ConversationEventProcessorProtocol,
-        userDefaults: UserDefaults
+        userDefaults: UserDefaults,
+        syncStatus: SyncStatusProtocol
     ) {
         precondition(zm_isSyncContext, "MLSController should only be accessed on the sync context")
 
@@ -42,7 +43,8 @@ extension NSManagedObjectContext {
             context: self,
             coreCrypto: coreCrypto,
             conversationEventProcessor: conversationEventProcessor,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            syncStatus: syncStatus
         )
     }
 

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -25,6 +25,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
     var sut: MLSController!
     var mockCoreCrypto: MockCoreCrypto!
     var mockMLSActionExecutor: MockMLSActionExecutor!
+    var mockSyncStatus: MockSyncStatus!
     var mockActionsProvider: MockMLSActionsProvider!
     var mockConversationEventProcessor: MockConversationEventProcessor!
     var mockStaleMLSKeyDetector: MockStaleMLSKeyDetector!
@@ -36,6 +37,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         super.setUp()
         mockCoreCrypto = MockCoreCrypto()
         mockMLSActionExecutor = MockMLSActionExecutor()
+        mockSyncStatus = MockSyncStatus()
         mockActionsProvider = MockMLSActionsProvider()
         mockConversationEventProcessor = MockConversationEventProcessor()
         mockStaleMLSKeyDetector = MockStaleMLSKeyDetector()
@@ -48,7 +50,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             conversationEventProcessor: mockConversationEventProcessor,
             staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             userDefaults: userDefaultsTestSuite,
-            actionsProvider: mockActionsProvider
+            actionsProvider: mockActionsProvider,
+            syncStatus: mockSyncStatus
         )
 
         sut.delegate = self
@@ -58,6 +61,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         sut = nil
         mockCoreCrypto = nil
         mockMLSActionExecutor = nil
+        mockSyncStatus = nil
         mockActionsProvider = nil
         mockStaleMLSKeyDetector = nil
         super.tearDown()
@@ -81,6 +85,16 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         ]
 
         return ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
+    }
+
+    func createKeyPackage(userID: UUID, domain: String) -> KeyPackage {
+        return KeyPackage(
+            client: Bytes.random(length: 32).base64EncodedString,
+            domain: domain,
+            keyPackage: Bytes.random(length: 32).base64EncodedString,
+            keyPackageRef: Bytes.random(length: 32).base64EncodedString,
+            userID: userID
+        )
     }
 
     // MARK: - MLSControllerDelegate
@@ -122,7 +136,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             conversationEventProcessor: mockConversationEventProcessor,
             staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             userDefaults: userDefaultsTestSuite,
-            actionsProvider: mockActionsProvider
+            actionsProvider: mockActionsProvider,
+            syncStatus: mockSyncStatus
         )
 
         // Then
@@ -337,17 +352,15 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
         let mlsUser = [MLSUser(id: id, domain: domain)]
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // Mock claiming a key package.
         var keyPackage: KeyPackage!
         mockActionsProvider.claimKeyPackagesMocks.append({ userID, _, _ in
-            keyPackage = KeyPackage(
-                client: "client",
-                domain: domain,
-                keyPackage: Data([1, 2, 3]).base64EncodedString(),
-                keyPackageRef: "keyPackageRef",
-                userID: userID
-            )
-
+            keyPackage = self.createKeyPackage(userID: userID, domain: domain)
             return [keyPackage]
         })
 
@@ -407,14 +420,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         // Mock claiming a key package.
         var keyPackage: KeyPackage!
         mockActionsProvider.claimKeyPackagesMocks.append({ userID, _, _ in
-            keyPackage = KeyPackage(
-                client: "client",
-                domain: domain,
-                keyPackage: Data([1, 2, 3]).base64EncodedString(),
-                keyPackageRef: "keyPackageRef",
-                userID: userID
-            )
-
+            keyPackage = self.createKeyPackage(userID: userID, domain: domain)
             return [keyPackage]
         })
 
@@ -456,6 +462,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         // Given
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // when / then
         await assertItThrows(error: MLSController.MLSAddMembersError.noMembersToAdd) {
             try await sut.addMembersToConversation(with: [], for: mlsGroupID)
@@ -469,21 +480,17 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
         let mlsUser: [MLSUser] = [MLSUser(id: id, domain: domain)]
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // No mock for claiming key packages.
 
-        do {
+        // Then
+        await assertItThrows(error: MLSController.MLSGroupCreationError.failedToClaimKeyPackages) {
             // When
             try await sut.addMembersToConversation(with: mlsUser, for: mlsGroupID)
-
-        } catch let error {
-            // Then
-            switch error {
-            case MLSController.MLSAddMembersError.failedToAddMembers:
-                break
-
-            default:
-                XCTFail("Unexpected error: \(String(describing: error))")
-            }
         }
     }
 
@@ -494,18 +501,16 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
         let mlsUser: [MLSUser] = [MLSUser(id: id, domain: domain)]
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // Mock key package.
         var keyPackage: KeyPackage!
 
         mockActionsProvider.claimKeyPackagesMocks.append({ userID, _, _ in
-            keyPackage = KeyPackage(
-                client: "client",
-                domain: domain,
-                keyPackage: Data([1, 2, 3]).base64EncodedString(),
-                keyPackageRef: "keyPackageRef",
-                userID: userID
-            )
-
+            keyPackage = self.createKeyPackage(userID: userID, domain: domain)
             return [keyPackage]
         })
 
@@ -514,7 +519,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         }
 
         // when / then
-        await assertItThrows(error: MLSController.MLSAddMembersError.failedToAddMembers) {
+        await assertItThrows(error: MLSActionExecutor.Error.failedToGenerateCommit) {
             try await sut.addMembersToConversation(with: mlsUser, for: mlsGroupID)
         }
     }
@@ -528,6 +533,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let clientID = UUID.create().uuidString
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
         let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain)
+
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
 
         // Mock removing clients from the group.
         var mockRemoveClientsArguments = [([ClientId], MLSGroupID)]()
@@ -623,6 +633,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         // Given
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // When / Then
         await assertItThrows(error: MLSController.MLSRemoveParticipantsError.noClientsToRemove) {
             try await sut.removeMembersFromConversation(with: [], for: mlsGroupID)
@@ -637,13 +652,18 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
         let mlsClientID = MLSClientID(userID: id, clientID: clientID, domain: domain)
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // Mock executor error.
         mockMLSActionExecutor.mockRemoveClients = { _, _ in
-            throw MLSActionExecutor.Error.failedToSendCommit
+            throw MLSActionExecutor.Error.failedToGenerateCommit
         }
 
         // When / Then
-        await assertItThrows(error: MLSController.MLSRemoveParticipantsError.failedToRemoveMembers) {
+        await assertItThrows(error: MLSActionExecutor.Error.failedToGenerateCommit) {
             try await sut.removeMembersFromConversation(with: [mlsClientID], for: mlsGroupID)
         }
     }
@@ -1105,6 +1125,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         let group1 = MLSGroupID(.random())
         let group2 = MLSGroupID(.random())
 
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
         // Mock stale groups.
         mockStaleMLSKeyDetector.groupsWithStaleKeyingMaterial = [group1, group2]
 
@@ -1128,7 +1153,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             userDefaults: userDefaultsTestSuite,
             actionsProvider: mockActionsProvider,
-            delegate: self
+            delegate: self,
+            syncStatus: mockSyncStatus
         )
 
         // Then
@@ -1215,7 +1241,8 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             staleKeyMaterialDetector: mockStaleMLSKeyDetector,
             userDefaults: userDefaultsTestSuite,
             actionsProvider: mockActionsProvider,
-            delegate: self
+            delegate: self,
+            syncStatus: mockSyncStatus
         )
 
         // Then
@@ -1263,6 +1290,236 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             Date().addingTimeInterval(.oneDay).timeIntervalSinceNow,
             accuracy: 0.1
         )
+    }
+
+    // MARK: - Rety on commit failure
+
+    // Note: these tests are asserting the behavior of the retry mechanism only, which
+    // is used in various operations, such as adding members or removing clients. For
+    // these tests, we will just pick one operation.
+
+    func test_RetryOnCommitFailure_SingleRetry() async throws {
+        // Given a group.
+        let groupID = MLSGroupID.random()
+
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
+        // Mock one failure to update key material, then a success.
+        var mockUpdateKeyMaterialCount = 0
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
+            defer { mockUpdateKeyMaterialCount += 1 }
+            switch mockUpdateKeyMaterialCount {
+            case 0:
+                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+            default:
+                return []
+            }
+        }
+
+        // Mock quick sync.
+        var mockPerformQuickSyncCount = 0
+        mockSyncStatus.mockPerformQuickSync = {
+            mockPerformQuickSyncCount += 1
+        }
+
+        // When
+        try await sut.updateKeyMaterial(for: groupID)
+
+        // Then it attempted to update key material twice.
+        XCTAssertEqual(mockUpdateKeyMaterialCount, 2)
+
+        // Then it performed a quick sync once.
+        XCTAssertEqual(mockPerformQuickSyncCount, 1)
+
+        // Then processed the result once.
+        XCTAssertEqual(mockConversationEventProcessor.calls.processConversationEvents, [[]])
+    }
+
+    func test_RetryOnCommitFailure_MultipleRetries() async throws {
+        // Given a group.
+        let groupID = MLSGroupID.random()
+
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
+        // Mock three failures to update key material, then a success.
+        var mockUpdateKeyMaterialCount = 0
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
+            defer { mockUpdateKeyMaterialCount += 1 }
+            switch mockUpdateKeyMaterialCount {
+            case 0..<3:
+                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+            default:
+                return []
+            }
+        }
+
+        // Mock quick sync.
+        var mockPerformQuickSyncCount = 0
+        mockSyncStatus.mockPerformQuickSync = {
+            mockPerformQuickSyncCount += 1
+        }
+
+        // When
+        try await sut.updateKeyMaterial(for: groupID)
+
+        // Then it attempted to update key material 4 times (3 failed, 1 success).
+        XCTAssertEqual(mockUpdateKeyMaterialCount, 4)
+
+        // Then it performed a quick sync 3 times (for 3 failures).
+        XCTAssertEqual(mockPerformQuickSyncCount, 3)
+
+        // Then processed the result once.
+        XCTAssertEqual(mockConversationEventProcessor.calls.processConversationEvents, [[]])
+    }
+
+    func test_RetryOnCommitFailure_ChainMultipleRecoverableOperations() async throws {
+        // Given a group.
+        let groupID = MLSGroupID.random()
+
+        // Mock two failures to commit pending proposals, then a success.
+        var mockCommitPendingProposalsCount = 0
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            defer { mockCommitPendingProposalsCount += 1 }
+            switch mockCommitPendingProposalsCount {
+            case 0..<2:
+                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+            default:
+                return []
+            }
+        }
+
+        // Mock three failures to update key material, then a success.
+        var mockUpdateKeyMaterialCount = 0
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
+            defer { mockUpdateKeyMaterialCount += 1 }
+            switch mockUpdateKeyMaterialCount {
+            case 0..<3:
+                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+            default:
+                return []
+            }
+        }
+
+        // Mock quick sync.
+        var mockPerformQuickSyncCount = 0
+        mockSyncStatus.mockPerformQuickSync = {
+            mockPerformQuickSyncCount += 1
+        }
+
+        // When
+        try await sut.updateKeyMaterial(for: groupID)
+
+        // Then it attempted to commit pending proposals 3 times (2 failed, 1 success).
+        XCTAssertEqual(mockCommitPendingProposalsCount, 3)
+
+        // Then it attempted to update key material 4 times (3 failed, 1 success).
+        XCTAssertEqual(mockUpdateKeyMaterialCount, 4)
+
+        // Then it performed a quick sync 5 times (for 2 + 3 failures).
+        XCTAssertEqual(mockPerformQuickSyncCount, 5)
+
+        // Then processed the results twice (1 for each success).
+        XCTAssertEqual(mockConversationEventProcessor.calls.processConversationEvents, [[], []])
+    }
+
+    func test_RetryOnCommitFailure_CommitPendingProposalsAfterRetry() async throws {
+        // Given a group.
+        let groupID = MLSGroupID.random()
+
+        // Mock no pending proposals when first trying to update key material, but
+        // then a successful pending proposal commit after the failed commit is migrated
+        // by Core Crypto.
+        var mockCommitPendingProposalsCount = 0
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            defer { mockCommitPendingProposalsCount += 1 }
+            switch mockCommitPendingProposalsCount {
+            case 0:
+                throw MLSActionExecutor.Error.noPendingProposals
+            default:
+                return []
+            }
+        }
+
+        // Mock failures to update key material: but no success since the commit was
+        // migrated to a pending proposal.
+        var mockUpdateKeyMaterialCount = 0
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
+            defer { mockUpdateKeyMaterialCount += 1 }
+            throw MLSActionExecutor.Error.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync)
+        }
+
+        // Mock quick sync.
+        var mockPerformQuickSyncCount = 0
+        mockSyncStatus.mockPerformQuickSync = {
+            mockPerformQuickSyncCount += 1
+        }
+
+        // When
+        try await sut.updateKeyMaterial(for: groupID)
+
+        // Then it attempted to commit pending proposals twice (1 no-op, 1 success).
+        XCTAssertEqual(mockCommitPendingProposalsCount, 2)
+
+        // Then it attempted to update key material once.
+        XCTAssertEqual(mockUpdateKeyMaterialCount, 1)
+
+        // Then it performed a quick sync once.
+        XCTAssertEqual(mockPerformQuickSyncCount, 1)
+
+        // Then processed the result once.
+        XCTAssertEqual(mockConversationEventProcessor.calls.processConversationEvents, [[]])
+    }
+
+    func test_RetryOnCommitFailure_ItGivesUp() async throws {
+        // Given a group.
+        let groupID = MLSGroupID.random()
+
+        // Mock no pending proposals.
+        mockMLSActionExecutor.mockCommitPendingProposals = { _ in
+            throw MLSActionExecutor.Error.noPendingProposals
+        }
+
+        // Mock failures to update key material, no successes.
+        var mockUpdateKeyMaterialCount = 0
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
+            defer { mockUpdateKeyMaterialCount += 1 }
+            throw MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp)
+        }
+
+        // Mock quick sync.
+        var mockPerformQuickSyncCount = 0
+        mockSyncStatus.mockPerformQuickSync = {
+            mockPerformQuickSyncCount += 1
+        }
+
+        // Then
+        await assertItThrows(error: MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp)) {
+            // When
+            try await sut.updateKeyMaterial(for: groupID)
+        }
+
+        // Then it attempted to update key material once.
+        XCTAssertEqual(mockUpdateKeyMaterialCount, 1)
+
+        // Then it didn't perform a quick sync.
+        XCTAssertEqual(mockPerformQuickSyncCount, 0)
+
+        // Then it didn't process any result.
+        XCTAssertEqual(mockConversationEventProcessor.calls.processConversationEvents, [])
+    }
+
+}
+
+extension MLSGroupID {
+
+    static func random() -> MLSGroupID {
+        return MLSGroupID(.random(length: 32))
     }
 
 }

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -510,7 +510,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         })
 
         mockMLSActionExecutor.mockAddMembers = { _, _ in
-            throw MLSActionExecutor.MLSActionExecutorError.failedToGenerateCommit
+            throw MLSActionExecutor.Error.failedToGenerateCommit
         }
 
         // when / then
@@ -639,7 +639,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
 
         // Mock executor error.
         mockMLSActionExecutor.mockRemoveClients = { _, _ in
-            throw MLSActionExecutor.MLSActionExecutorError.failedToSendCommit
+            throw MLSActionExecutor.Error.failedToSendCommit
         }
 
         // When / Then

--- a/Tests/MLS/MockSyncStatus.swift
+++ b/Tests/MLS/MockSyncStatus.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class MockSyncStatus: SyncStatusProtocol {
+
+    var mockPerformQuickSync: (() async -> Void)?
+
+    func performQuickSync() async {
+        guard let mock = mockPerformQuickSync else {
+            fatalError("no mock for `performQuickSync`")
+        }
+
+        await mock()
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		EEE186B2259CC7CD008707CA /* AppLockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
 		EEF0BC3128EEC02400ED16CA /* MockSyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */; };
+		EEF0BC3328EEC53400ED16CA /* SyncStatusProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0BC3228EEC53400ED16CA /* SyncStatusProtocol.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
 		EEF6E3C828D88A33001C1799 /* MLSGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C728D88A33001C1799 /* MLSGroup.swift */; };
 		EEF6E3CA28D89251001C1799 /* StaleMLSKeyDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */; };
@@ -1378,6 +1379,7 @@
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
 		EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncStatus.swift; sourceTree = "<group>"; };
+		EEF0BC3228EEC53400ED16CA /* SyncStatusProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusProtocol.swift; sourceTree = "<group>"; };
 		EEF4010623A9213B007B1A97 /* UserType+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Team.swift"; sourceTree = "<group>"; };
 		EEF6E3C728D88A33001C1799 /* MLSGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSGroup.swift; sourceTree = "<group>"; };
 		EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyDetectorTests.swift; sourceTree = "<group>"; };
@@ -2030,6 +2032,7 @@
 				EEC8064B28CF4BBF00DD58E9 /* BackendMLSPublicKeys.swift */,
 				63D5654A28B4D18D00BDFB49 /* MLSGroupStatus.swift */,
 				EE002F1F2878312F0027D63A /* MessageProtocol.swift */,
+				EEF0BC3228EEC53400ED16CA /* SyncStatusProtocol.swift */,
 				63DA33402869C39D00818C3C /* CoreCryptoKeyProvider.swift */,
 				EE08B344284E2B450022830B /* CoreCryptoTypes.swift */,
 				63121636288089E600FF9A56 /* Bytes.swift */,
@@ -3620,6 +3623,7 @@
 				63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */,
 				A90676EA238EB05F006417AC /* Action.swift in Sources */,
 				EE6A57E025BB1C6800F848DD /* AppLockController.State.swift in Sources */,
+				EEF0BC3328EEC53400ED16CA /* SyncStatusProtocol.swift in Sources */,
 				7AFC6A302876E9BF000FF1A1 /* CountSelfMLSKeyPackagesAction.swift in Sources */,
 				16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */,
 				BF421B2D1EF3F91D0079533A /* Team+Patches.swift in Sources */,

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 		EEDE7DB728EC1618007DC6A3 /* MockMLSActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */; };
 		EEE186B2259CC7CD008707CA /* AppLockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */; };
 		EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */; };
+		EEF0BC3128EEC02400ED16CA /* MockSyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
 		EEF6E3C828D88A33001C1799 /* MLSGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C728D88A33001C1799 /* MLSGroup.swift */; };
 		EEF6E3CA28D89251001C1799 /* StaleMLSKeyDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */; };
@@ -1376,6 +1377,7 @@
 		EEE186B1259CC7CC008707CA /* AppLockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockDelegate.swift; sourceTree = "<group>"; };
 		EEE83B491FBB496B00FC0296 /* ZMMessageTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMessageTimerTests.swift; sourceTree = "<group>"; };
 		EEEE60EC218B393E0032C249 /* zmessaging2.57.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.57.0.xcdatamodel; sourceTree = "<group>"; };
+		EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncStatus.swift; sourceTree = "<group>"; };
 		EEF4010623A9213B007B1A97 /* UserType+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Team.swift"; sourceTree = "<group>"; };
 		EEF6E3C728D88A33001C1799 /* MLSGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSGroup.swift; sourceTree = "<group>"; };
 		EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyDetectorTests.swift; sourceTree = "<group>"; };
@@ -2066,6 +2068,7 @@
 				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
 				EE98879128882C8F002340D2 /* MockMLSController.swift */,
+				EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */,
 				EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */,
 				EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */,
 				EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */,
@@ -3919,6 +3922,7 @@
 				6354BDF62747BF9200880D50 /* ZMConversationTests+Federation.swift in Sources */,
 				5EFE9C0D2126CB7D007932A6 /* UnregisteredUserTests.swift in Sources */,
 				A9536FD323ACD23100CFD528 /* ConversationTests+gapsAndWindows.swift in Sources */,
+				EEF0BC3128EEC02400ED16CA /* MockSyncStatus.swift in Sources */,
 				A93724A226983100005FD532 /* ZMMessageTests.swift in Sources */,
 				EEC3BC76288855C000BFDC35 /* MockMLSActionsProvider.swift in Sources */,
 				168FF330258200AD0066DAE3 /* ZMClientMessageTests+ResetSession.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1039" title="FS-1039" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1039</a>  [iOS] Handle network errors when sending a commit
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR implements retrying operations when the commit fails to be sent to the backend. There are three strategies to take, depending on the type of server error:
- give up:  there is no way to recover, so we just give up and notify the user
- discard the pending commit, perform a quick sync (to process any incoming mls messages), then try the operation again (creating a new commit)
- keep the commit, perform a quick sync, then commit it again as a pending proposal

To implement this, I needed to:
- update the possible error when sending an mls message to the backend
- handle the errors to determine which recovery strategy to use
- bubble up those recovery strategies to the calling point
- handle those recovery strategies to then enact them, by implementing a retry mechanism
- move some code around so that they play nicey with the retry mechanism

The retry mechanism works as follows:
- call the retry function passing in a closure which represents the operation to retry
- the retry function catches commit sending failures and switches over the recovery strategy
- it performs a quick sync, waiting for it to complete, then either retries the operation again or commits pending proposals
- the retry mechanism will repeat as many times necessary until a success
- we can chain several retry operations after each other, and they will retry repeatedly until success then move on to the next retry operation.

### Testing

#### Test Coverage

- Updated existing tests
- Added unit tests for the retry mechanism

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
