### PR TITLE
fix(mls): can't add participants to existing group FS-876

### DIFF
--- a/MLS/MLSActionExecutor.swift
+++ b/MLS/MLSActionExecutor.swift
@@ -197,7 +197,10 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
                 return bundle
             }
+        } catch Error.noPendingProposals {
+            throw Error.noPendingProposals
         } catch {
+            Logging.mls.warn("failed: generating commit for action (\(String(describing: action))) for group (\(groupID)): \(String(describing: error))")
             throw Error.failedToGenerateCommit
         }
     }

--- a/MLS/MLSActionExecutor.swift
+++ b/MLS/MLSActionExecutor.swift
@@ -110,29 +110,62 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
     // MARK: - Actions
 
     func addMembers(_ invitees: [Invitee], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
-        let bundle = try commitBundle(for: .addMembers(invitees), in: groupID)
-        return try await sendCommitBundle(bundle, for: groupID)
+        do {
+            Logging.mls.info("adding members to group (\(groupID))...")
+            let bundle = try commitBundle(for: .addMembers(invitees), in: groupID)
+            let result = try await sendCommitBundle(bundle, for: groupID)
+            Logging.mls.info("success: adding members to group (\(groupID))")
+            return result
+        } catch {
+            Logging.mls.info("failed: adding members to group (\(groupID)): \(String(describing: error))")
+            throw error
+        }
     }
 
     func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
-        let bundle = try commitBundle(for: .removeClients(clients), in: groupID)
-        return try await sendCommitBundle(bundle, for: groupID)
+        do {
+            Logging.mls.info("removing clients from group (\(groupID))...")
+            let bundle = try commitBundle(for: .removeClients(clients), in: groupID)
+            let result = try await sendCommitBundle(bundle, for: groupID)
+            Logging.mls.info("success: removing clients from group (\(groupID))")
+            return result
+        } catch {
+            Logging.mls.info("error: removing clients from group (\(groupID)): \(String(describing: error))")
+            throw error
+        }
     }
 
     func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
-        let bundle = try commitBundle(for: .updateKeyMaterial, in: groupID)
-        return try await sendCommitBundle(bundle, for: groupID)
+        do {
+            Logging.mls.info("updating key material for group (\(groupID))...")
+            let bundle = try commitBundle(for: .updateKeyMaterial, in: groupID)
+            let result = try await sendCommitBundle(bundle, for: groupID)
+            Logging.mls.info("success: updating key material for group (\(groupID))")
+            return result
+        } catch {
+            Logging.mls.info("error: updating key material for group (\(groupID)): \(String(describing: error))")
+            throw error
+        }
     }
 
     func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
-        let bundle = try commitBundle(for: .proposal, in: groupID)
-        return try await sendCommitBundle(bundle, for: groupID)
+        do {
+            Logging.mls.info("committing pending proposals for group (\(groupID))...")
+            let bundle = try commitBundle(for: .proposal, in: groupID)
+            let result = try await sendCommitBundle(bundle, for: groupID)
+            Logging.mls.info("success: committing pending proposals for group (\(groupID))")
+            return result
+        } catch {
+            Logging.mls.info("error: committing pending proposals for group (\(groupID)): \(String(describing: error))")
+            throw error
+        }
     }
 
     // MARK: - Commit generation
 
     private func commitBundle(for action: Action, in groupID: MLSGroupID) throws -> CommitBundle {
         do {
+            Logging.mls.info("generating commit for action (\(String(describing: action))) for group (\(groupID))...")
             switch action {
             case .addMembers(let clients):
                 let memberAddMessages = try coreCrypto.wire_addClientsToConversation(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-876" title="FS-876" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-876</a>  [iOS] Admin cannot add participants to an existing MLS group through group details page 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When I add participants to an mls group (old or new), it always fails.

### Causes

When adding participants to a group, we first try to commit pending proposals if any exist. None exist, and we throw the error `noPendingProposals`. This error then gets caught and converted to a `failedToGenerateCommit` error. This error gets caught and stops the flow of adding participants.

### Solutions

We shouldn't stop the flow when `noPendingProposals` is thrown, but instead continue to add participants. 

### Testing

#### Test Coverage

- TODO, but in another PR.


### Notes

I've added some logging too to make it easier to diagnose problems.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
