### PR TITLE
fix(mls): clear pending proposal date if no pending proposals found FS-1055

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -901,6 +901,7 @@ public final class MLSController: MLSControllerProtocol {
             delegate?.mlsControllerDidCommitPendingProposal(for: groupID)
         } catch MLSActionExecutor.Error.noPendingProposals {
             logger.info("no proposals to commit in group (\(groupID))...")
+            clearPendingProposalCommitDate(for: groupID)
         } catch {
             logger.info("failed to commit pending proposals in \(groupID): \(String(describing: error))")
             throw error

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -882,7 +882,7 @@ public final class MLSController: MLSControllerProtocol {
         guard existsPendingPropsals(in: groupID) else { return }
         // Sending a message while there are pending proposals will result in an error,
         // so commit any first.
-        logger.info("preempively committing pending proposals in group (\(groupID))")
+        logger.info("preemptively committing pending proposals in group (\(groupID))")
         try await commitPendingProposals(in: groupID)
         logger.info("success: committed pending proposals in group (\(groupID))")
     }
@@ -932,11 +932,13 @@ public final class MLSController: MLSControllerProtocol {
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync) {
             logger.warn("failed to send commit, syncing then committing pending proposals...")
             await syncStatus.performQuickSync()
+            logger.info("sync finished, committing pending proposals...")
             try await commitPendingProposals(in: groupID)
 
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync) {
             logger.warn("failed to send commit, syncing then retrying operation...")
             await syncStatus.performQuickSync()
+            logger.info("sync finished, retying operation...")
             try await retryOnCommitFailure(for: groupID, operation: operation)
 
         } catch MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp) {

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -809,10 +809,11 @@ public final class MLSController: MLSControllerProtocol {
             return
         }
 
-        logger.info("schedule to commit pending proposals in \(groupID) at \(commitDate)")
-
-        let conversation = ZMConversation.fetch(with: groupID, in: context)
-        conversation?.commitPendingProposalDate = commitDate
+        context.performAndWait {
+            logger.info("schedule to commit pending proposals in \(groupID) at \(commitDate)")
+            let conversation = ZMConversation.fetch(with: groupID, in: context)
+            conversation?.commitPendingProposalDate = commitDate
+        }
     }
 
     enum MLSCommitPendingProposalsError: Error {

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -725,9 +725,10 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     public func encrypt(message: Bytes, for groupID: MLSGroupID) throws -> Bytes {
-        logger.info("encrypting message (\(message.count) bytes) for group (\(groupID))")
+        try await commitPendingProposals(in: groupID)
 
         do {
+            logger.info("encrypting message (\(message.count) bytes) for group (\(groupID))")
             return try coreCrypto.wire_encryptMessage(conversationId: groupID.bytes, message: message)
         } catch let error {
             logger.warn("failed to encrypt message for group (\(groupID)): \(String(describing: error))")

--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -49,6 +49,8 @@ public protocol MLSControllerProtocol {
 
     func commitPendingProposals() async throws
 
+    func commitPendingProposals(in groupID: MLSGroupID) async throws
+
     func scheduleCommitPendingProposals(groupID: MLSGroupID, at commitDate: Date)
 }
 
@@ -725,8 +727,6 @@ public final class MLSController: MLSControllerProtocol {
     }
 
     public func encrypt(message: Bytes, for groupID: MLSGroupID) throws -> Bytes {
-        try await commitPendingProposals(in: groupID)
-
         do {
             logger.info("encrypting message (\(message.count) bytes) for group (\(groupID))")
             return try coreCrypto.wire_encryptMessage(conversationId: groupID.bytes, message: message)
@@ -888,7 +888,7 @@ public final class MLSController: MLSControllerProtocol {
         logger.info("success: committed pending proposals in group (\(groupID))")
     }
 
-    func commitPendingProposals(in groupID: MLSGroupID) async throws {
+    public func commitPendingProposals(in groupID: MLSGroupID) async throws {
         try await retryOnCommitFailure(for: groupID) { [weak self] in
             try await self?.internalCommitPendingProposals(in: groupID)
         }

--- a/Tests/MLS/MockMLSController.swift
+++ b/Tests/MLS/MockMLSController.swift
@@ -40,6 +40,7 @@ class MockMLSController: MLSControllerProtocol {
         var addMembersToConversation = [([MLSUser], MLSGroupID)]()
         var removeMembersFromConversation = [([MLSClientID], MLSGroupID)]()
         var commitPendingProposals: [Void] = []
+        var commitPendingProposalsInGroup = [MLSGroupID]()
         var scheduleCommitPendingProposals: [(MLSGroupID, Date)] = []
         var registerPendingJoin = [MLSGroupID]()
         var performPendingJoins: [Void] = []
@@ -148,6 +149,10 @@ class MockMLSController: MLSControllerProtocol {
 
     func commitPendingProposals() {
         calls.commitPendingProposals.append(())
+    }
+
+    func commitPendingProposals(in groupID: MLSGroupID) async throws {
+        calls.commitPendingProposalsInGroup.append(groupID)
     }
 
     func scheduleCommitPendingProposals(groupID: MLSGroupID, at commitDate: Date) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1055" title="FS-1055" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1055</a>  [iOS] Message sending fails in an mls group when the user left the mls group 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If a user leaves a group, then sometimes the remaining participants can't send messages in the group.


### Causes

There are multiple things going wrong here. First, we sometimes get in a state where we have a conversation marked as having pending proposals, but don't actually have any. This causes the client to repeatedly try to commit pending proposals, but it will always fail.

Secondly, if there is a pending proposal, then no messages can be encrypted until that proposal is committed, it will also result in a failure. 

### Solutions

First, clear the commit date if no pending proposals were found. Secondly, we need to commit pending proposals before encrypting and sending messages. Rather than doing this in the `encryptMessage` method, which is not marked as `async` (and would be very hard to mark it `async`), expose the method to commit pending proposals for a specific group, so that we can call it before sending the message.


### Testing

#### Test Coverage

- added test that we clear the commit date

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
