### PR TITLE
fix(mls): can't be added to groups when EAR enabled FS-1093

### DIFF
--- a/MLS/MLSController.swift
+++ b/MLS/MLSController.swift
@@ -159,6 +159,7 @@ public final class MLSController: MLSControllerProtocol {
         }
 
         generateClientPublicKeysIfNeeded()
+        uploadKeyPackagesIfNeeded()
         fetchBackendPublicKeys()
         updateKeyMaterialForAllStaleGroupsIfNeeded()
         schedulePeriodicKeyMaterialUpdateCheck()

--- a/Tests/MLS/MLSControllerTests.swift
+++ b/Tests/MLS/MLSControllerTests.swift
@@ -43,6 +43,10 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         mockStaleMLSKeyDetector = MockStaleMLSKeyDetector()
         userDefaultsTestSuite = UserDefaults(suiteName: "com.wire.mls-test-suite")!
 
+        mockCoreCrypto.mockClientValidKeypackagesCount = {
+            return 100
+        }
+
         sut = MLSController(
             context: uiMOC,
             coreCrypto: mockCoreCrypto,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1093" title="FS-1093" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1093</a>  [iOS] MLS groups are not showing on iOS client while creating it from another iOS client or web client 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If encryption at rest (EAR) is enabled, then the self client can't be added to mls groups.

### Causes

When the app is launched and the user logs in, it will create and register an mls client. It will then generate and upload key packages. However, when EAR is enabled, this flow gets interrupted because the user needs to authenticate with biometrics and then enable EAR. As a result, no key packages are uploaded. After EAR is enabled, the mls controller is set up again, however we don't try to upload key packages again until we receive a welcome message. But this won't happen if we don't have key packages in the first place. 

### Solutions

A simple solution is to try upload key packages each time the mls controller is initialized.

### Testing

#### Test Coverage

- Manually tested
- Update existing tests

### Notes

This problem with EAR also affects api negotiation, such that the app can get in a state where no api version is negotiated. This happens when the user takes a long time to authenticate. We may need to think of some better synchronization logic when enabling EAR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
