### PR TITLE
fix(mls): iOS devices cannot be removed from conversation FS-1162

### DIFF
--- a/MLS/MLSClientID.swift
+++ b/MLS/MLSClientID.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireTransport
 
 /// An ID representing a identifying a single user client.
 
@@ -36,7 +37,7 @@ public struct MLSClientID: Equatable {
 
     init?(userClient: UserClient) {
         guard
-            let userID = userClient.user?.remoteIdentifier.uuidString,
+            let userID = userClient.user?.remoteIdentifier.transportString(),
             let clientID = userClient.remoteIdentifier,
             let domain = userClient.user?.domain ?? APIVersion.domain
         else {

--- a/MLS/MLSQualifiedClientID.swift
+++ b/MLS/MLSQualifiedClientID.swift
@@ -34,7 +34,7 @@ public struct MLSQualifiedClientID {
             return nil
         }
 
-        return "\(userId.transportString()):\(clientId)@\(domain)"
+        return "\(userId.transportString()):\(clientId)@\(domain)".lowercased()
     }
 
     // MARK: - Methods

--- a/Tests/MLS/MLSClientIdTests.swift
+++ b/Tests/MLS/MLSClientIdTests.swift
@@ -17,29 +17,27 @@
 //
 
 import Foundation
+import XCTest
+@testable import WireDataModel
 
-/// MLS qualified client identifier for initialising Corecrypto
-public struct MLSQualifiedClientID {
+class MLSClientIdTests: ZMConversationTestsBase {
 
-    // MARK: - Properties
+    func test_itCreatesALowercasedClientId() {
+        // GIVEN
+        let userID = "57ce2cb2-601f-11ed-9b6a-0242ac120002"
+        let clientID = "db151d3b837bb92"
+        let domain = "example.wire.com"
 
-    private let user: ZMUser
+        // WHEN
+        let sut = MLSClientID(
+            userID: userID.uppercased(),
+            clientID: clientID.uppercased(),
+            domain: domain.uppercased()
+        )
 
-    public var qualifiedClientId: String? {
-        guard
-            let clientId = user.selfClient()?.remoteIdentifier,
-            let userId = user.remoteIdentifier,
-            let domain = user.domain?.selfOrNilIfEmpty ?? APIVersion.domain
-        else {
-            return nil
-        }
-
-        return "\(userId.transportString()):\(clientId)@\(domain)"
+        // THEN
+        let expectedID = "\(userID):\(clientID)@\(domain)"
+        XCTAssertEqual(sut.string, expectedID)
     }
 
-    // MARK: - Methods
-
-    public init(user: ZMUser) {
-        self.user = user
-    }
 }

--- a/Tests/MLS/MLSQualifiedClientIdTests.swift
+++ b/Tests/MLS/MLSQualifiedClientIdTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class MLSQualifiedClientIdTests: ZMConversationTestsBase {
 
-    func test_itCreatesClientID_WithLowercasedUUID() throws {
+    func test_itCreatesLowercasedMLSQualifiedClientID() throws {
         // GIVEN
         let uuidString = "57ce2cb2-601f-11ed-9b6a-0242ac120002"
         let domain = "example.wire.com"
@@ -40,7 +40,7 @@ class MLSQualifiedClientIdTests: ZMConversationTestsBase {
 
         // THEN
 
-        let expectedId = "\(uuidString):\(clientID)@\(domain)"
+        let expectedId = "\(uuidString):\(clientID)@\(domain)".lowercased()
         XCTAssertNotNil(sut.qualifiedClientId)
         XCTAssertEqual(sut.qualifiedClientId, expectedId)
     }

--- a/Tests/MLS/MLSQualifiedClientIdTests.swift
+++ b/Tests/MLS/MLSQualifiedClientIdTests.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class MLSQualifiedClientIdTests: ZMConversationTestsBase {
+
+    func test_itCreatesClientID_WithLowercasedUUID() throws {
+        // GIVEN
+        let uuidString = "57ce2cb2-601f-11ed-9b6a-0242ac120002"
+        let domain = "example.wire.com"
+
+        createSelfClient()
+
+        let user = ZMUser.selfUser(in: uiMOC)
+        user.remoteIdentifier = try XCTUnwrap(UUID(uuidString: uuidString))
+        user.domain = domain
+
+        let clientID = try XCTUnwrap(user.selfClient()?.remoteIdentifier)
+
+        // WHEN
+        let sut = MLSQualifiedClientID(user: user)
+
+        // THEN
+
+        let expectedId = "\(uuidString):\(clientID)@\(domain)"
+        XCTAssertNotNil(sut.qualifiedClientId)
+        XCTAssertEqual(sut.qualifiedClientId, expectedId)
+    }
+
+}

--- a/WireDataModel.xcodeproj/project.pbxproj
+++ b/WireDataModel.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		630B4C9827D8C920005D6F30 /* APIVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630B4C9727D8C920005D6F30 /* APIVersionTests.swift */; };
 		6312162F287DB7D900FF9A56 /* String+Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6312162E287DB7D900FF9A56 /* String+Bytes.swift */; };
 		63121637288089E600FF9A56 /* Bytes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63121636288089E600FF9A56 /* Bytes.swift */; };
+		63123BCC291BBB7A009A5179 /* MLSQualifiedClientIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63123BCB291BBB79009A5179 /* MLSQualifiedClientIdTests.swift */; };
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
 		63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D992434D04D006B6018 /* GenericMessage+External.swift */; };
@@ -311,6 +312,7 @@
 		63EDDCA128BE3B9200DE212F /* store2-105-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 63EDDCA028BE3B9200DE212F /* store2-105-0.wiredatabase */; };
 		63F376DA2834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F376D92834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift */; };
 		63F65F01246B073900534A69 /* GenericMessage+Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F65F00246B073900534A69 /* GenericMessage+Content.swift */; };
+		63FACD56291BC598003AB25D /* MLSClientIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FACD55291BC598003AB25D /* MLSClientIdTests.swift */; };
 		63FCE54828C78D1F00126D9D /* ZMConversationTests+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FCE54728C78D1F00126D9D /* ZMConversationTests+Predicates.swift */; };
 		70E77B7D273188150021EE70 /* ZMConversation+Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E77B7C273188150021EE70 /* ZMConversation+Role.swift */; };
 		7A2778C6285223D90044A73F /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2778C5285223D90044A73F /* KeychainManager.swift */; };
@@ -1074,6 +1076,7 @@
 		630B4C9727D8C920005D6F30 /* APIVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIVersionTests.swift; sourceTree = "<group>"; };
 		6312162E287DB7D900FF9A56 /* String+Bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Bytes.swift"; sourceTree = "<group>"; };
 		63121636288089E600FF9A56 /* Bytes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bytes.swift; sourceTree = "<group>"; };
+		63123BCB291BBB79009A5179 /* MLSQualifiedClientIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSQualifiedClientIdTests.swift; sourceTree = "<group>"; };
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
 		63298D992434D04D006B6018 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
@@ -1118,6 +1121,7 @@
 		63EDDCA028BE3B9200DE212F /* store2-105-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-105-0.wiredatabase"; sourceTree = "<group>"; };
 		63F376D92834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContextTests+Federation.swift"; sourceTree = "<group>"; };
 		63F65F00246B073900534A69 /* GenericMessage+Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Content.swift"; sourceTree = "<group>"; };
+		63FACD55291BC598003AB25D /* MLSClientIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSClientIdTests.swift; sourceTree = "<group>"; };
 		63FCE54728C78D1F00126D9D /* ZMConversationTests+Predicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Predicates.swift"; sourceTree = "<group>"; };
 		70E77B7C273188150021EE70 /* ZMConversation+Role.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Role.swift"; sourceTree = "<group>"; };
 		7A2778C5285223D90044A73F /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
@@ -2067,6 +2071,7 @@
 			children = (
 				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
 				EE84226F28EC353900B80FE5 /* MLSActionExecutorTests.swift */,
+				63123BCB291BBB79009A5179 /* MLSQualifiedClientIdTests.swift */,
 				EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */,
 				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
@@ -2076,6 +2081,7 @@
 				EE22185D2892C22C008EF6ED /* MockConversationEventProcessor.swift */,
 				EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */,
 				EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */,
+				63FACD55291BC598003AB25D /* MLSClientIdTests.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -3860,6 +3866,7 @@
 				F1B025621E53500400900C65 /* ZMConversationTests+PrepareToSend.swift in Sources */,
 				54F84D041F995B0700ABD7D5 /* DiskDatabaseTests.swift in Sources */,
 				EEC8064E28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift in Sources */,
+				63FACD56291BC598003AB25D /* MLSClientIdTests.swift in Sources */,
 				D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */,
 				54A885A81F62EEB600AFBA95 /* ZMConversationTests+Messages.swift in Sources */,
 				54ED3A9D1F38CB6A0066AD47 /* DatabaseMigrationTests.swift in Sources */,
@@ -4002,6 +4009,7 @@
 				16DF3B5F2289510600D09365 /* ZMConversationTests+Legalhold.swift in Sources */,
 				169FF3AA27157F0100330C2E /* ZMSearchUserTests+Connections.swift in Sources */,
 				EE2BA00925CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift in Sources */,
+				63123BCC291BBB7A009A5179 /* MLSQualifiedClientIdTests.swift in Sources */,
 				EE98878E28882BFF002340D2 /* MLSControllerTests.swift in Sources */,
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				16C391E2214BD438003AB3AD /* MentionTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1162" title="FS-1162" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1162</a>  [iOS] iOS devices cannot be removed from conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

iOS devices cannot be removed from conversation

### Causes

The MLS client identifier passed to core crypto (`userID:clientID@domain`) contains an uppercased userID. However core crypto expects the identifier to be lowercased. This causes mismatches in the identifiers.

### Solutions

make sure the MLS client identifier is lowercased

### Testing

- Added tests for `MLSQualifiedClientID` and `MLSClientID`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
